### PR TITLE
Write system_user_id to Auth0 app_metadata on register

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,13 @@ AUTH0_DOMAIN='your-domain.auth0.com'
 AUTH0_CLIENT_ID='your-client-id'
 AUTH0_CLIENT_SECRET='your-client-secret'
 
+# Auth0 Management API (M2M) - used by /api/register to write
+# system_user_id onto the Auth0 user's app_metadata. The Management API
+# client must have `update:users_app_metadata` and `read:users` permissions.
+# If unset, /api/register still works but the claim won't be populated.
+AUTH0_MGMT_CLIENT_ID='your-m2m-mgmt-client-id'
+AUTH0_MGMT_CLIENT_SECRET='your-m2m-mgmt-client-secret'
+
 # Backend Service URLs
 BC_DATA='http://localhost:9510'
 BC_POSITION='http://localhost:9500'

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@opentelemetry/sdk-trace-base": "^2.6.1",
     "@sentry/nextjs": "^10.47.0",
     "amqplib": "^1.0.3",
+    "auth0": "^5.7.0",
     "critters": "^0.0.25",
     "kafkajs": "^2.2.4",
     "next": "^16.2.2",

--- a/src/lib/utils/auth0Management.ts
+++ b/src/lib/utils/auth0Management.ts
@@ -1,0 +1,63 @@
+import { ManagementClient } from "auth0"
+
+/**
+ * Management API client for writing user metadata back to Auth0.
+ *
+ * Used only from server-side API routes (Next.js /pages/api/*). The credentials
+ * here are M2M (client_credentials flow) against the Auth0 Management API —
+ * distinct from the user-facing AUTH0_CLIENT_ID used in the login flow.
+ *
+ * Required env vars:
+ *   - AUTH0_DOMAIN
+ *   - AUTH0_MGMT_CLIENT_ID
+ *   - AUTH0_MGMT_CLIENT_SECRET
+ *
+ * The M2M client must have `update:users_app_metadata` and `read:users`
+ * granted against the Auth0 Management API.
+ */
+
+let cached: ManagementClient | null = null
+
+function getManagementClient(): ManagementClient {
+  if (cached) return cached
+
+  const domain = process.env.AUTH0_DOMAIN
+  const clientId = process.env.AUTH0_MGMT_CLIENT_ID
+  const clientSecret = process.env.AUTH0_MGMT_CLIENT_SECRET
+
+  if (!domain || !clientId || !clientSecret) {
+    throw new Error(
+      "AUTH0_DOMAIN, AUTH0_MGMT_CLIENT_ID, AUTH0_MGMT_CLIENT_SECRET must be set",
+    )
+  }
+
+  cached = new ManagementClient({ domain, clientId, clientSecret })
+  return cached
+}
+
+/**
+ * Write a `system_user_id` entry onto the given Auth0 user's app_metadata.
+ * The Auth0 post-login Action reads this on subsequent logins and emits
+ * it as the `system_user_id` JWT claim.
+ *
+ * Best-effort: returns true on success, false on failure. Callers should
+ * treat failure as non-fatal — the user will just retry the flow next login.
+ */
+export async function writeSystemUserId(
+  userId: string,
+  systemUserId: string,
+): Promise<boolean> {
+  try {
+    const mgmt = getManagementClient()
+    await mgmt.users.update(userId, {
+      app_metadata: { system_user_id: systemUserId },
+    })
+    return true
+  } catch (err) {
+    console.error(
+      `[auth0Management] failed to write system_user_id for ${userId}:`,
+      err,
+    )
+    return false
+  }
+}

--- a/src/lib/utils/auth0Management.ts
+++ b/src/lib/utils/auth0Management.ts
@@ -49,15 +49,19 @@ export async function writeSystemUserId(
 ): Promise<boolean> {
   try {
     const mgmt = getManagementClient()
-    await mgmt.users.update(userId, {
-      app_metadata: { system_user_id: systemUserId },
-    })
+    await mgmt.users.update(
+      userId,
+      { app_metadata: { system_user_id: systemUserId } },
+      // Bound the best-effort write so an Auth0 outage doesn't hold the
+      // registration response open. v5 defaults to a 60s timeout with 2
+      // automatic retries on 408/429/5xx; we explicitly opt out of both.
+      { timeoutInSeconds: 5, maxRetries: 0 },
+    )
     return true
   } catch (err) {
-    console.error(
-      `[auth0Management] failed to write system_user_id for ${userId}:`,
-      err,
-    )
+    // Intentionally omit userId from the log — Auth0 user_id is a stable
+    // identifier; the error object carries enough context to debug.
+    console.error("[auth0Management] failed to write system_user_id:", err)
     return false
   }
 }

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -10,14 +10,16 @@ const SYSTEM_USER_ID_CLAIM = "https://holdsworth.app/claims/system_user_id"
 
 /**
  * Decode the JWT payload (no verification — Auth0 SDK already verified the
- * token) and check whether the system_user_id claim is already present.
- * If it is, there's no need to rewrite app_metadata this login cycle.
+ * token) and return the system_user_id claim value, or null when absent or
+ * malformed. Callers compare the value against the live SystemUser.id so a
+ * stale claim (e.g., SystemUser re-created or changed) still triggers a
+ * metadata resync.
  */
-function tokenHasSystemUserIdClaim(accessToken: string | undefined): boolean {
-  if (!accessToken) return false
+function getSystemUserIdClaim(accessToken: string | undefined): string | null {
+  if (!accessToken) return null
   try {
     const [, payload] = accessToken.split(".")
-    if (!payload) return false
+    if (!payload) return null
     // JWT segments are base64url-encoded (RFC 7515): convert to standard
     // base64 before decoding (swap chars + pad length to a multiple of 4).
     const base64 = payload.replace(/-/g, "+").replace(/_/g, "/")
@@ -26,9 +28,9 @@ function tokenHasSystemUserIdClaim(accessToken: string | undefined): boolean {
       Buffer.from(padded, "base64").toString("utf8"),
     ) as Record<string, unknown>
     const claim = decoded[SYSTEM_USER_ID_CLAIM]
-    return typeof claim === "string" && claim.length > 0
+    return typeof claim === "string" && claim.length > 0 ? claim : null
   } catch {
-    return false
+    return null
   }
 }
 
@@ -65,9 +67,9 @@ export default async function register(
 
     // Best-effort: write SystemUser.id onto the Auth0 user's app_metadata so
     // the post-login Action can emit it as a JWT claim on the next login.
-    // Skip the Management API call if the current token already carries the
-    // claim — app_metadata is already in sync with the SystemUser, no need
-    // to repeat the PATCH on every page load.
+    // Skip the Management API call when the current token already carries
+    // the *correct* value — comparing against the live SystemUser.id so a
+    // stale claim (e.g. SystemUser re-issued) still triggers a resync.
     // Failure is non-fatal — the user will hit a 401 on the next
     // ownership-gated call and re-login, triggering another attempt.
     const systemUserId = registration.data?.id
@@ -75,7 +77,7 @@ export default async function register(
     if (
       systemUserId &&
       auth0UserId &&
-      !tokenHasSystemUserIdClaim(accessToken)
+      getSystemUserIdClaim(accessToken) !== systemUserId
     ) {
       await writeSystemUserId(auth0UserId, systemUserId)
     }

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -1,9 +1,32 @@
 import { auth0 } from "@lib/auth0"
-import { Registration } from "types/beancounter"
-import handleResponse, { fetchError } from "@utils/api/responseWriter"
+import { writeSystemUserId } from "@lib/auth0Management"
+import { RegistrationResponse } from "types/beancounter"
+import { handleErrors, hasError, fetchError } from "@utils/api/responseWriter"
 import { getDataUrl } from "@utils/api/bcConfig"
 import { requestInit } from "@utils/api/fetchHelper"
 import { NextApiRequest, NextApiResponse } from "next"
+
+const SYSTEM_USER_ID_CLAIM = "https://holdsworth.app/claims/system_user_id"
+
+/**
+ * Decode the JWT payload (no verification — Auth0 SDK already verified the
+ * token) and check whether the system_user_id claim is already present.
+ * If it is, there's no need to rewrite app_metadata this login cycle.
+ */
+function tokenHasSystemUserIdClaim(accessToken: string | undefined): boolean {
+  if (!accessToken) return false
+  try {
+    const [, payload] = accessToken.split(".")
+    if (!payload) return false
+    const decoded = JSON.parse(
+      Buffer.from(payload, "base64").toString("utf8"),
+    ) as Record<string, unknown>
+    const claim = decoded[SYSTEM_USER_ID_CLAIM]
+    return typeof claim === "string" && claim.length > 0
+  } catch {
+    return false
+  }
+}
 
 export default async function register(
   req: NextApiRequest,
@@ -28,7 +51,32 @@ export default async function register(
       ...requestInit(accessToken, "POST", req),
       body: JSON.stringify({ active: true }),
     })
-    await handleResponse<Registration>(response, res)
+
+    if (hasError(response)) {
+      await handleErrors(response)
+      return
+    }
+
+    const registration: RegistrationResponse = await response.json()
+
+    // Best-effort: write SystemUser.id onto the Auth0 user's app_metadata so
+    // the post-login Action can emit it as a JWT claim on the next login.
+    // Skip the Management API call if the current token already carries the
+    // claim — app_metadata is already in sync with the SystemUser, no need
+    // to repeat the PATCH on every page load.
+    // Failure is non-fatal — the user will hit a 401 on the next
+    // ownership-gated call and re-login, triggering another attempt.
+    const systemUserId = registration.data?.id
+    const auth0UserId = session.user?.sub
+    if (
+      systemUserId &&
+      auth0UserId &&
+      !tokenHasSystemUserIdClaim(accessToken)
+    ) {
+      await writeSystemUserId(auth0UserId, systemUserId)
+    }
+
+    res.status(response.status || 200).json(registration)
   } catch (error: unknown) {
     fetchError(req, res, error)
   }

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -18,8 +18,12 @@ function tokenHasSystemUserIdClaim(accessToken: string | undefined): boolean {
   try {
     const [, payload] = accessToken.split(".")
     if (!payload) return false
+    // JWT segments are base64url-encoded (RFC 7515): convert to standard
+    // base64 before decoding (swap chars + pad length to a multiple of 4).
+    const base64 = payload.replace(/-/g, "+").replace(/_/g, "/")
+    const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4)
     const decoded = JSON.parse(
-      Buffer.from(payload, "base64").toString("utf8"),
+      Buffer.from(padded, "base64").toString("utf8"),
     ) as Record<string, unknown>
     const claim = decoded[SYSTEM_USER_ID_CLAIM]
     return typeof claim === "string" && claim.length > 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2867,6 +2867,24 @@ attr-accept@^2.2.4:
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.5.tgz#d7061d958e6d4f97bf8665c68b75851a0713ab5e"
   integrity sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==
 
+"auth0-legacy@npm:auth0@^4.27.0":
+  version "4.37.0"
+  resolved "https://registry.yarnpkg.com/auth0/-/auth0-4.37.0.tgz#828d91d254926579e0fff5b6c060988c5631436f"
+  integrity sha512-+TqJRxh4QvbD4TQIYx1ak2vanykQkG/nIZLuR6o8LoQj425gjVG3tFuUbbOeh/nCpP1rnvU0CCV1ChZHYXLU/A==
+  dependencies:
+    jose "^4.13.2"
+    undici-types "^6.15.0"
+    uuid "^9.0.0"
+
+auth0@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/auth0/-/auth0-5.7.0.tgz#4456f3bc117810c042a49f8578a10551b977ffa9"
+  integrity sha512-1JpxxSHQ5No1/2dGWzPO3592uOlblflEkVI+IXC9TX6Iqe7qgtxOdpf5Er9v42pg0vE0WfLH26iC1Q48+uyXsg==
+  dependencies:
+    auth0-legacy "npm:auth0@^4.27.0"
+    jose "^4.13.2"
+    uuid "^11.1.0"
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -5415,6 +5433,11 @@ jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.1.tgz#178ef2fc9a1a594248c20627cd820187a4d78d92"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
+
+jose@^4.13.2:
+  version "4.15.9"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.9.tgz#9b68eda29e9a0614c042fa29387196c7dd800100"
+  integrity sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==
 
 jose@^6.0.11, jose@^6.1.3:
   version "6.2.2"
@@ -8084,6 +8107,11 @@ unbox-primitive@^1.1.0:
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
 
+undici-types@^6.15.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.25.0.tgz#c877d2a67eaae8e588ac93e4f31fa25d16975df9"
+  integrity sha512-vOw74RVVYFtnooUkZPxsY1GuuNNupSrCcANIAaDekpZ/Dp1sBuLLl5n2UCKpzxgmOwD66S4Jj24MrhmcDG+0vw==
+
 undici-types@~7.16.0:
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
@@ -8201,6 +8229,11 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
## Summary

- After `svc-data POST /register` returns a `SystemUser`, write its `id` to the caller's Auth0 user `app_metadata.system_user_id` via the Management API.
- The post-login Action on the Auth0 side reads `app_metadata` and emits `https://holdsworth.app/claims/system_user_id` as a custom JWT claim on subsequent tokens.
- Keeps svc-data off the public internet: Auth0 only reads `app_metadata`, never reaches into the cluster.

New helper `src/lib/utils/auth0Management.ts` wraps a lazy `ManagementClient` singleton. Writes are best-effort — errors are logged and swallowed (the user just retries next login). `/api/register` now skips the Management API call when the current access token already carries the claim, avoiding a round-trip on every page load once metadata is in sync.

Two new env vars: `AUTH0_MGMT_CLIENT_ID` / `AUTH0_MGMT_CLIENT_SECRET`. The M2M client needs `update:users_app_metadata` on the Auth0 Management API.

## Test plan

- [x] `yarn test` — 1185 tests pass.
- [x] `yarn typecheck && yarn lint` — clean.
- [x] CodeRabbit review — 1 minor in the touched files (base64url decode) addressed.
- [x] Verified end-to-end locally: login → `/api/register` writes `app_metadata.system_user_id` → log out + log in → fresh token carries the claim → decode at jwt.io confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registration now attempts a best-effort sync of internal system user IDs with the external identity provider to keep user identifiers consistent.

* **Chores**
  * Added environment configuration entries for the identity provider management API and introduced the provider client library dependency to support the sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->