### PR TITLE
fix: Trust svc-data for split-adjusted price history

### DIFF
--- a/src/components/features/holdings/PriceChartPopup.tsx
+++ b/src/components/features/holdings/PriceChartPopup.tsx
@@ -253,17 +253,11 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
 
   const series: ChartPoint[] = useMemo(() => {
     const raw = priceData?.prices ?? []
-    // Walk in reverse, accumulating split factors so pre-split rows are
-    // scaled onto the current share basis (e.g. 25:1 => /25 before the ex-date).
-    const factors = new Array<number>(raw.length).fill(1)
-    let cumulative = 1
-    for (let i = raw.length - 1; i >= 0; i--) {
-      factors[i] = cumulative
-      const split = Number(raw[i].split ?? 1)
-      if (split && split !== 1) cumulative *= split
-    }
-    const adjustedCloses = raw.map((p, i) => Number(p.close) / factors[i])
-    const smaSeries = computeSma(adjustedCloses, smaWindow)
+    // svc-data's PriceService returns split-adjusted prices and normalises the
+    // `split` column so only the canonical ex-date row carries a non-1 value.
+    // The chart renders the response as-is.
+    const closes = raw.map((p) => Number(p.close))
+    const smaSeries = computeSma(closes, smaWindow)
     return raw.map((p, i) => {
       const trades = tradesByDate.get(p.priceDate) ?? []
       const buy = trades.find((t) => t.type === "BUY")
@@ -271,13 +265,13 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
       const splitNum = Number(p.split ?? 1)
       return {
         priceDate: p.priceDate,
-        close: adjustedCloses[i],
-        closeRaw: Number(p.close),
-        splitFactor: factors[i],
+        close: closes[i],
+        closeRaw: closes[i],
+        splitFactor: 1,
         split: splitNum !== 1 ? splitNum : undefined,
         sma: smaSeries[i],
-        buyPrice: buy ? buy.price / factors[i] : null,
-        sellPrice: sell ? sell.price / factors[i] : null,
+        buyPrice: buy ? buy.price : null,
+        sellPrice: sell ? sell.price : null,
         buyPriceRaw: buy?.price,
         sellPriceRaw: sell?.price,
         buyQty: buy?.quantity,

--- a/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
@@ -201,31 +201,19 @@ describe("PriceChartPopup", () => {
     expect(screen.getByTestId("scatter-sellPrice")).toBeInTheDocument()
   })
 
-  it("split-adjusts prices and trade markers around a split event", () => {
+  it("renders backend split-adjusted prices and marks the ex-date", () => {
+    // svc-data adjusts pre-split closes server-side and normalises the
+    // `split` column so only the canonical ex-date carries a non-1 value.
+    // The chart renders the response verbatim.
     mockUseSwr.mockImplementation(
       makeRouter({
         pricesResult: {
           data: {
             asset: history.asset,
             prices: [
-              { priceDate: "2026-04-03", close: 5000, split: 1 },
+              { priceDate: "2026-04-03", close: 200, split: 1 },
               { priceDate: "2026-04-06", close: 200, split: 25 },
               { priceDate: "2026-04-07", close: 205, split: 1 },
-            ],
-          },
-          isLoading: false,
-          error: undefined,
-        } as unknown as ReturnType<typeof useSwr>,
-        tradesResult: {
-          data: {
-            data: [
-              {
-                id: "t1",
-                trnType: "BUY",
-                tradeDate: "2026-04-03",
-                quantity: 1,
-                price: 5000,
-              },
             ],
           },
           isLoading: false,
@@ -242,21 +230,15 @@ describe("PriceChartPopup", () => {
     ) as Array<{
       priceDate: string
       close: number
-      closeRaw: number
       splitFactor: number
-      buyPrice: number | null
-      buyPriceRaw?: number
       split?: number
     }>
-    expect(rows[0].splitFactor).toBe(25)
     expect(rows[0].close).toBe(200)
-    expect(rows[0].closeRaw).toBe(5000)
-    expect(rows[0].buyPrice).toBe(200)
-    expect(rows[0].buyPriceRaw).toBe(5000)
+    expect(rows[0].splitFactor).toBe(1)
     expect(rows[1].close).toBe(200)
     expect(rows[1].split).toBe(25)
-    expect(rows[2].splitFactor).toBe(1)
     expect(rows[2].close).toBe(205)
+    expect(rows[2].split).toBeUndefined()
     expect(screen.getByTestId("refline-2026-04-06")).toBeInTheDocument()
   })
 

--- a/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
@@ -220,10 +220,13 @@ describe("PriceChartPopup", () => {
     }>
     expect(rows[0].close).toBe(200)
     expect(rows[0].splitFactor).toBe(1)
+    expect(rows[0].split).toBeUndefined()
     expect(rows[1].close).toBe(200)
     expect(rows[1].split).toBe(25)
     expect(rows[2].close).toBe(205)
     expect(rows[2].split).toBeUndefined()
+    // Backend normalises the split column so only one row keeps the marker.
+    expect(rows.filter((r) => r.split !== undefined)).toHaveLength(1)
     expect(screen.getByTestId("refline-2026-04-06")).toBeInTheDocument()
   })
 

--- a/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import PriceChartPopup from "../PriceChartPopup"
 import useSwr from "swr"
-import { Asset } from "types/beancounter"
+import { makeAsset } from "@test-fixtures/beancounter"
 
 jest.mock("swr", () => ({
   __esModule: true,
@@ -42,30 +42,15 @@ jest.mock("recharts", () => ({
   ),
 }))
 
-const asset: Asset = {
+const asset = makeAsset({
   id: "msft-id",
   code: "MSFT",
   name: "Microsoft",
   assetCategory: { id: "EQUITY", name: "Equity" },
-  market: {
-    code: "NASDAQ",
-    name: "NASDAQ",
-    currency: { code: "USD", symbol: "$", name: "US Dollar" },
-  },
-}
+})
 
 const history = {
-  asset: {
-    id: "msft-id",
-    code: "MSFT",
-    name: "Microsoft",
-    market: {
-      code: "NASDAQ",
-      name: "NASDAQ",
-      currency: { code: "USD", symbol: "$", name: "US Dollar" },
-    },
-    assetCategory: { id: "EQUITY", name: "Equity" },
-  },
+  asset,
   prices: [
     { priceDate: "2026-03-21", close: 400 },
     { priceDate: "2026-04-01", close: 410 },


### PR DESCRIPTION
## Summary
- Drop the chart-side divisor logic; render the response from `/api/prices/history` verbatim. Pairs with monowai/beancounter#800 which now adjusts pre-split rows server-side and normalises the `split` column.
- Trade buy/sell prices flow through unscaled — they're on the same basis as the closes the chart plots.

## Background
VO's 4:1 split on 2026-04-21 surfaced a bug: the backend Alpha enricher's ±1 day fallback stamped split=4 on both 2026-04-21 and 2026-04-22, and the chart's reverse-walk multiplied the divisor for each stamped row, scaling history down by 16× instead of 4×. With adjustment moved server-side the chart can stop second-guessing the response.

## Test plan
- [x] `yarn typecheck && yarn lint && yarn test`
- [ ] After the backend PR deploys: reload VO chart, expect a flat ~\$76-77 line with a single split marker on 2026-04-21 and the price-change percent reading the post-split delta.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Price chart now uses server-provided split-adjusted prices, removing local back-adjustments so displayed closes, indicators and trade markers reflect canonical values; split labels are preserved only where provided (ex-date).
* **Tests**
  * Updated chart tests to use shared fixtures and validate the rendered data series and split-label behavior against split-adjusted payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->