### PR TITLE
refactor: Tidy card layout — pair price with daily change

### DIFF
--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -153,7 +153,6 @@ interface PositionHeaderProps {
   hasDistinctName: boolean
   truncatedName: string
   changePercent: number | undefined
-  isDayPositive: boolean
   onShowNews: () => void
   actionsMenu?: React.ReactNode
 }
@@ -164,7 +163,6 @@ const PositionHeader: React.FC<PositionHeaderProps> = ({
   hasDistinctName,
   truncatedName,
   changePercent,
-  isDayPositive,
   onShowNews,
   actionsMenu,
 }) => (
@@ -182,10 +180,10 @@ const PositionHeader: React.FC<PositionHeaderProps> = ({
       {changePercent !== undefined && (
         <span
           className={`text-sm font-medium tabular-nums ${
-            isDayPositive ? "text-emerald-600" : "text-red-600"
+            changePercent >= 0 ? "text-emerald-600" : "text-red-600"
           }`}
         >
-          {isDayPositive && changePercent > 0 ? "+" : ""}
+          {changePercent > 0 ? "+" : ""}
           {(changePercent * 100).toFixed(2)}%
         </span>
       )}
@@ -273,9 +271,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
 
   const marketValue = convert(values.marketValue)
   const totalGain = convert(values.totalGain)
-  const gainOnDay = convert(values.gainOnDay)
   const isPositive = totalGain >= 0
-  const isDayPositive = gainOnDay >= 0
 
   const displayName = getPositionDisplayName(asset)
 
@@ -366,7 +362,6 @@ const PositionCard: React.FC<PositionCardProps> = ({
         hasDistinctName={hasDistinctName}
         truncatedName={truncatedName}
         changePercent={values.priceData?.changePercent}
-        isDayPositive={isDayPositive}
         onShowNews={() => showNews(asset)}
         actionsMenu={actionsNode}
       />

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -96,6 +96,8 @@ interface PositionFooterProps {
   price: number | undefined
   weight: number
   currencySymbol: string
+  changePercent: number | undefined
+  isDayPositive: boolean
   onPriceClick?: (e: React.MouseEvent) => void
   priceAriaLabel?: string
 }
@@ -106,29 +108,46 @@ const PositionFooter: React.FC<PositionFooterProps> = ({
   price,
   weight,
   currencySymbol,
+  changePercent,
+  isDayPositive,
   onPriceClick,
   priceAriaLabel,
 }) => {
-  const priceText = (
-    <>
+  const priceContent = (
+    <span className="block leading-tight tabular-nums">
       {currencySymbol}
       {price?.toFixed(2) || "-"}
-    </>
+    </span>
   )
-  const priceValue = onPriceClick ? (
+  const priceCore = onPriceClick ? (
     <button
       type="button"
       aria-label={priceAriaLabel}
       className="cursor-pointer hover:text-wealth-700 hover:underline underline-offset-2 decoration-dotted"
       onClick={onPriceClick}
     >
-      {priceText}
+      {priceContent}
     </button>
   ) : (
-    priceText
+    priceContent
+  )
+  const priceValue = (
+    <div className="flex flex-col items-center leading-tight">
+      {priceCore}
+      {changePercent !== undefined && (
+        <span
+          className={`text-[11px] font-medium tabular-nums ${
+            isDayPositive ? "text-emerald-600" : "text-red-600"
+          }`}
+        >
+          {isDayPositive && changePercent > 0 ? "+" : ""}
+          {(changePercent * 100).toFixed(2)}%
+        </span>
+      )}
+    </div>
   )
   return (
-    <div className="mt-3 pt-3 border-t border-gray-100 grid grid-cols-3 gap-2 text-sm">
+    <div className="mt-3 pt-3 border-t border-gray-100 grid grid-cols-3 gap-2 text-sm items-end">
       <PositionMetric
         label="Quantity"
         value={<PrivateQuantity value={quantity} precision={precision} />}
@@ -152,8 +171,6 @@ interface PositionHeaderProps {
   displayName: string
   hasDistinctName: boolean
   truncatedName: string
-  changePercent: number | undefined
-  isDayPositive: boolean
   onShowNews: () => void
   actionsMenu?: React.ReactNode
 }
@@ -163,8 +180,6 @@ const PositionHeader: React.FC<PositionHeaderProps> = ({
   displayName,
   hasDistinctName,
   truncatedName,
-  changePercent,
-  isDayPositive,
   onShowNews,
   actionsMenu,
 }) => (
@@ -178,20 +193,7 @@ const PositionHeader: React.FC<PositionHeaderProps> = ({
         <p className="text-sm text-gray-500 truncate">{truncatedName}</p>
       )}
     </div>
-    <div className="flex items-start gap-1">
-      {changePercent !== undefined && (
-        <div
-          className={`text-right ${isDayPositive ? "text-green-600" : "text-red-600"}`}
-        >
-          <div className="text-sm font-medium">
-            {isDayPositive ? "+" : ""}
-            {(changePercent * 100).toFixed(2)}%
-          </div>
-          <div className="text-xs">today</div>
-        </div>
-      )}
-      {actionsMenu}
-    </div>
+    {actionsMenu && <div className="flex items-start">{actionsMenu}</div>}
   </div>
 )
 
@@ -366,8 +368,6 @@ const PositionCard: React.FC<PositionCardProps> = ({
         displayName={displayName}
         hasDistinctName={hasDistinctName}
         truncatedName={truncatedName}
-        changePercent={values.priceData?.changePercent}
-        isDayPositive={isDayPositive}
         onShowNews={() => showNews(asset)}
         actionsMenu={actionsNode}
       />
@@ -413,6 +413,8 @@ const PositionCard: React.FC<PositionCardProps> = ({
               price={values.priceData?.close}
               weight={values.weight}
               currencySymbol={currencySymbol}
+              changePercent={values.priceData?.changePercent}
+              isDayPositive={isDayPositive}
               onPriceClick={handlePriceClick}
               priceAriaLabel={
                 isChartable

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -96,8 +96,6 @@ interface PositionFooterProps {
   price: number | undefined
   weight: number
   currencySymbol: string
-  changePercent: number | undefined
-  isDayPositive: boolean
   onPriceClick?: (e: React.MouseEvent) => void
   priceAriaLabel?: string
 }
@@ -108,46 +106,29 @@ const PositionFooter: React.FC<PositionFooterProps> = ({
   price,
   weight,
   currencySymbol,
-  changePercent,
-  isDayPositive,
   onPriceClick,
   priceAriaLabel,
 }) => {
-  const priceContent = (
-    <span className="block leading-tight tabular-nums">
+  const priceText = (
+    <>
       {currencySymbol}
       {price?.toFixed(2) || "-"}
-    </span>
+    </>
   )
-  const priceCore = onPriceClick ? (
+  const priceValue = onPriceClick ? (
     <button
       type="button"
       aria-label={priceAriaLabel}
       className="cursor-pointer hover:text-wealth-700 hover:underline underline-offset-2 decoration-dotted"
       onClick={onPriceClick}
     >
-      {priceContent}
+      {priceText}
     </button>
   ) : (
-    priceContent
-  )
-  const priceValue = (
-    <div className="flex flex-col items-center leading-tight">
-      {priceCore}
-      {changePercent !== undefined && (
-        <span
-          className={`text-[11px] font-medium tabular-nums ${
-            isDayPositive ? "text-emerald-600" : "text-red-600"
-          }`}
-        >
-          {isDayPositive && changePercent > 0 ? "+" : ""}
-          {(changePercent * 100).toFixed(2)}%
-        </span>
-      )}
-    </div>
+    priceText
   )
   return (
-    <div className="mt-3 pt-3 border-t border-gray-100 grid grid-cols-3 gap-2 text-sm items-end">
+    <div className="mt-3 pt-3 border-t border-gray-100 grid grid-cols-3 gap-2 text-sm">
       <PositionMetric
         label="Quantity"
         value={<PrivateQuantity value={quantity} precision={precision} />}
@@ -171,6 +152,8 @@ interface PositionHeaderProps {
   displayName: string
   hasDistinctName: boolean
   truncatedName: string
+  changePercent: number | undefined
+  isDayPositive: boolean
   onShowNews: () => void
   actionsMenu?: React.ReactNode
 }
@@ -180,10 +163,12 @@ const PositionHeader: React.FC<PositionHeaderProps> = ({
   displayName,
   hasDistinctName,
   truncatedName,
+  changePercent,
+  isDayPositive,
   onShowNews,
   actionsMenu,
 }) => (
-  <div className="flex justify-between items-start mb-3">
+  <div className="flex justify-between items-center gap-2 mb-3">
     <div className="flex-1 min-w-0">
       <h3 className="font-semibold text-gray-900 text-lg flex items-center gap-1.5">
         {displayName}
@@ -193,7 +178,19 @@ const PositionHeader: React.FC<PositionHeaderProps> = ({
         <p className="text-sm text-gray-500 truncate">{truncatedName}</p>
       )}
     </div>
-    {actionsMenu && <div className="flex items-start">{actionsMenu}</div>}
+    <div className="flex items-center gap-2 shrink-0">
+      {changePercent !== undefined && (
+        <span
+          className={`text-sm font-medium tabular-nums ${
+            isDayPositive ? "text-emerald-600" : "text-red-600"
+          }`}
+        >
+          {isDayPositive && changePercent > 0 ? "+" : ""}
+          {(changePercent * 100).toFixed(2)}%
+        </span>
+      )}
+      {actionsMenu}
+    </div>
   </div>
 )
 
@@ -368,6 +365,8 @@ const PositionCard: React.FC<PositionCardProps> = ({
         displayName={displayName}
         hasDistinctName={hasDistinctName}
         truncatedName={truncatedName}
+        changePercent={values.priceData?.changePercent}
+        isDayPositive={isDayPositive}
         onShowNews={() => showNews(asset)}
         actionsMenu={actionsNode}
       />
@@ -413,8 +412,6 @@ const PositionCard: React.FC<PositionCardProps> = ({
               price={values.priceData?.close}
               weight={values.weight}
               currencySymbol={currencySymbol}
-              changePercent={values.priceData?.changePercent}
-              isDayPositive={isDayPositive}
               onPriceClick={handlePriceClick}
               priceAriaLabel={
                 isChartable


### PR DESCRIPTION
## Summary
- Pull the daily change percent out of the card header's right rail and render it inline next to the actions menu (no \"today\" sub-label, just the colored percent).
- Header collapses to a single row: title + news icon left, change percent + actions menu right. Footer stays the flat 3-col Quantity / Price / Weight.

## Test plan
- [x] \`yarn typecheck && yarn lint && yarn test\`
- [ ] Eyeball the card view: title and change percent share one band, footer columns baseline-aligned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated holdings card header alignment and spacing; streamlined the day-change display into a single-line, tabular-style value for cleaner presentation.

* **Bug Fixes**
  * Fixed the positive-change indicator so a leading "+" appears only for true positive percent changes, preventing incorrect positive signs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->