### PR TITLE
feat(assets/lookup): AI Asset Review CTA on selected lookup result

### DIFF
--- a/src/components/features/assets/AssetReviewPopup.tsx
+++ b/src/components/features/assets/AssetReviewPopup.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useState } from "react"
+import Markdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import Dialog from "@components/ui/Dialog"
+import Spinner from "@components/ui/Spinner"
+import { AgentResponse } from "types/agent"
+
+interface AssetReviewPopupProps {
+  ticker: string
+  market?: string
+  assetName?: string
+  onClose: () => void
+}
+
+// Module-level cache: ticker|market -> { response, fetchedAt }. Mirrors the
+// NewsSentimentPopup cache; reviews are cheaper to refresh than news but
+// repeated opens within minutes shouldn't re-hit the LLM.
+const reviewCache = new Map<string, { response: string; fetchedAt: number }>()
+const inFlight = new Map<string, Promise<string>>()
+const CACHE_TTL_MS = 30 * 60 * 1000 // 30 minutes — reviews change slowly
+
+export function clearReviewCache(): void {
+  reviewCache.clear()
+  inFlight.clear()
+}
+
+const cacheKey = (ticker: string, market?: string): string =>
+  `${ticker}|${market || ""}`
+
+async function performFetch(
+  key: string,
+  ticker: string,
+  market: string | undefined,
+  assetName: string | undefined,
+): Promise<string> {
+  const nameLabel = assetName ? ` (${assetName})` : ""
+  const marketLabel = market ? ` listed on ${market}` : ""
+  const query =
+    `Produce an Asset Review for ${ticker}${nameLabel}${marketLabel}. ` +
+    `Cover company and sector context, current sentiment from recent news, ` +
+    `corporate-action history (dividends and splits in the last 12 months), ` +
+    `and qualitative risk callouts. Stay at the ticker level — do not assume ` +
+    `the user holds it.`
+
+  const res = await fetch("/api/agent/query", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query,
+      context: {
+        page: "Asset Review",
+        description: "Single-asset deep dive from the assets/lookup screen",
+        tickers: ticker,
+        market: market || "",
+        assetName: assetName || "",
+      },
+    }),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new Error(err.message || `HTTP ${res.status}`)
+  }
+  const data: AgentResponse = await res.json()
+  reviewCache.set(key, { response: data.response, fetchedAt: Date.now() })
+  return data.response
+}
+
+function fetchReviewOnce(
+  key: string,
+  ticker: string,
+  market: string | undefined,
+  assetName: string | undefined,
+): Promise<string> {
+  const existing = inFlight.get(key)
+  if (existing) return existing
+
+  const promise = performFetch(key, ticker, market, assetName).finally(() => {
+    inFlight.delete(key)
+  })
+  inFlight.set(key, promise)
+  return promise
+}
+
+export default function AssetReviewPopup({
+  ticker,
+  market,
+  assetName,
+  onClose,
+}: AssetReviewPopupProps): React.ReactElement {
+  const [response, setResponse] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const key = cacheKey(ticker, market)
+    const cached = reviewCache.get(key)
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      setResponse(cached.response)
+      setIsLoading(false)
+      return () => {}
+    }
+
+    let cancelled = false
+    fetchReviewOnce(key, ticker, market, assetName)
+      .then((text) => {
+        if (!cancelled) setResponse(text)
+      })
+      .catch((e: unknown) => {
+        if (!cancelled)
+          setError(e instanceof Error ? e.message : "Failed to fetch review")
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [ticker, market, assetName])
+
+  return (
+    <Dialog
+      title={
+        <span className="flex items-center">
+          <i className="fas fa-microscope text-purple-600 mr-2"></i>
+          Asset Review — {ticker}
+          {market && (
+            <span className="ml-2 text-sm font-normal text-gray-500">
+              ({market})
+            </span>
+          )}
+        </span>
+      }
+      onClose={onClose}
+      maxWidth="4xl"
+      scrollable
+    >
+      {isLoading && (
+        <div className="flex items-center gap-2 text-gray-500 py-12 justify-center">
+          <Spinner />
+          <span>Generating review...</span>
+        </div>
+      )}
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-red-700 text-sm">
+          Sorry, an error occurred: {error}
+        </div>
+      )}
+      {response && (
+        <div
+          className="prose prose-sm sm:prose-base max-w-none
+            prose-headings:text-slate-900 prose-headings:font-semibold
+            prose-h1:text-xl prose-h2:text-lg prose-h3:text-base
+            prose-h2:mt-6 prose-h2:mb-3 prose-h3:mt-4 prose-h3:mb-2
+            prose-p:text-slate-700 prose-p:leading-relaxed
+            prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline
+            prose-strong:text-slate-900
+            prose-ul:my-3 prose-li:my-1
+            prose-table:text-sm"
+        >
+          <Markdown remarkPlugins={[remarkGfm]}>{response}</Markdown>
+        </div>
+      )}
+    </Dialog>
+  )
+}

--- a/src/components/features/assets/__tests__/AssetReviewPopup.test.tsx
+++ b/src/components/features/assets/__tests__/AssetReviewPopup.test.tsx
@@ -1,0 +1,70 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import AssetReviewPopup, { clearReviewCache } from "../AssetReviewPopup"
+
+// react-markdown / remark-gfm are mocked globally in jest.setup.js
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+describe("AssetReviewPopup", () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    clearReviewCache()
+  })
+
+  it("posts to /api/agent/query with page=Asset Review so the backend selectors route to the right prompt and tools", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          response: "Bullish",
+          timestamp: "2026-04-26T00:00:00Z",
+        }),
+    })
+    render(
+      <AssetReviewPopup
+        ticker="AAPL"
+        market="NASDAQ"
+        assetName="Apple Inc."
+        onClose={jest.fn()}
+      />,
+    )
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe("/api/agent/query")
+    const body = JSON.parse(init.body)
+    expect(body.context.page).toBe("Asset Review")
+    expect(body.context.tickers).toBe("AAPL")
+    expect(body.context.market).toBe("NASDAQ")
+    expect(body.context.assetName).toBe("Apple Inc.")
+    expect(body.query).toContain("AAPL")
+  })
+
+  it("renders the agent response as markdown", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          response: "AAPL looks strong",
+          timestamp: "2026-04-26T00:00:00Z",
+        }),
+    })
+    render(<AssetReviewPopup ticker="AAPL" onClose={jest.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByText("AAPL looks strong")).toBeInTheDocument(),
+    )
+  })
+
+  it("shows error on fetch failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ message: "Server error" }),
+    })
+    render(<AssetReviewPopup ticker="AAPL" onClose={jest.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByText(/error/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/features/assets/useAssetReview.tsx
+++ b/src/components/features/assets/useAssetReview.tsx
@@ -1,0 +1,44 @@
+import React, { ReactElement, useCallback, useState } from "react"
+import { AssetOption } from "types/beancounter"
+import AssetReviewPopup from "./AssetReviewPopup"
+
+interface ReviewTarget {
+  ticker: string
+  market?: string
+  assetName?: string
+}
+
+export interface UseAssetReviewReturn {
+  /** Render this where you want the popup to appear; null when not active. */
+  popup: ReactElement | null
+  /** Open the review popup for a selected lookup result. */
+  showReview: (option: AssetOption) => void
+  /** Close the popup. */
+  close: () => void
+}
+
+/**
+ * Manages Asset Review popup state for the assets/lookup screen. Mirrors
+ * useNewsAsset on the holdings side, but takes an AssetOption (the shape
+ * the lookup screen carries) rather than a full Asset.
+ */
+export function useAssetReview(): UseAssetReviewReturn {
+  const [target, setTarget] = useState<ReviewTarget | null>(null)
+  const close = useCallback(() => setTarget(null), [])
+  const showReview = useCallback((option: AssetOption) => {
+    setTarget({
+      ticker: option.symbol,
+      market: option.market,
+      assetName: option.name || option.label,
+    })
+  }, [])
+  const popup = target ? (
+    <AssetReviewPopup
+      ticker={target.ticker}
+      market={target.market}
+      assetName={target.assetName}
+      onClose={close}
+    />
+  ) : null
+  return { popup, showReview, close }
+}

--- a/src/pages/assets/lookup.tsx
+++ b/src/pages/assets/lookup.tsx
@@ -7,6 +7,7 @@ import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import { AssetOption, Market, Portfolio, Position } from "types/beancounter"
 import { ModelsContainingAssetResponse } from "types/rebalance"
 import AssetSearch from "@components/features/assets/AssetSearch"
+import { useAssetReview } from "@components/features/assets/useAssetReview"
 import Spinner from "@components/ui/Spinner"
 
 interface AssetPosition {
@@ -23,6 +24,7 @@ function AssetLookupPage(): React.ReactElement {
   const [selectedMarket, setSelectedMarket] = useState<string>(
     preferences?.defaultMarket || "",
   )
+  const { popup: reviewPopup, showReview } = useAssetReview()
 
   // Fetch available markets
   const { data: marketsData } = useSWR<{ data: Market[] }>(
@@ -153,9 +155,20 @@ function AssetLookupPage(): React.ReactElement {
                 )}
               </div>
             </div>
+            <button
+              type="button"
+              onClick={() => showReview(selectedAsset)}
+              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-purple-600 text-white text-sm font-medium hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-1"
+              aria-label={`Open AI Asset Review for ${selectedAsset.symbol}`}
+              title="AI Asset Review"
+            >
+              <i className="fas fa-microscope"></i>
+              <span>AI Review</span>
+            </button>
           </div>
         </div>
       )}
+      {reviewPopup}
 
       {/* Positions Table */}
       {selectedAsset && (


### PR DESCRIPTION
## Summary

- Adds an **AI Review** button to the right of the selected-asset info box on `/assets/lookup`.
- Click opens \`AssetReviewPopup\` which posts to \`/api/agent/query\` with \`page="Asset Review"\` and a research-style prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added AI-powered asset review feature with "AI Review" button in asset lookup
- Automatic caching of reviews for 30 minutes to optimize performance
- Results displayed in a styled modal dialog supporting markdown formatting
- Prevents duplicate concurrent requests for the same asset

**Tests**
- Comprehensive test coverage for review functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->