### PR TITLE
Fix/chat panel hidden sliver

### DIFF
--- a/src/components/features/chat/ChatFab.tsx
+++ b/src/components/features/chat/ChatFab.tsx
@@ -55,7 +55,11 @@ export default function ChatFab(): React.ReactElement {
           isExpanded
             ? "bottom-6 right-6 w-[48rem] max-w-[calc(100vw-2rem)] h-[calc(100vh-5rem)]"
             : "bottom-24 right-6 w-96 max-w-[calc(100vw-2rem)] h-[600px] max-h-[80vh]"
-        } ${isOpen ? "translate-x-0" : "translate-x-full"}`}
+        } ${
+          isOpen
+            ? "translate-x-0"
+            : "translate-x-[calc(100%+1.5rem)] pointer-events-none"
+        }`}
       >
         <ChatPanel
           messages={messages}

--- a/src/components/features/chat/ChatFab.tsx
+++ b/src/components/features/chat/ChatFab.tsx
@@ -3,10 +3,24 @@ import { useRouter } from "next/router"
 import { useChat } from "@hooks/useChat"
 import ChatPanel from "./ChatPanel"
 import { getPageContext } from "./pageContext"
+import {
+  CORNER_LAYOUT,
+  ChatCorner,
+  loadChatCorner,
+  saveChatCorner,
+} from "./chatPosition"
 
 export default function ChatFab(): React.ReactElement {
   const [isOpen, setIsOpen] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
+  const [corner, setCornerState] = useState<ChatCorner>("BR")
+  // Hydrate from localStorage post-mount to avoid SSR/CSR mismatch.
+  useEffect(() => setCornerState(loadChatCorner()), [])
+  const setCorner = useCallback((next: ChatCorner) => {
+    setCornerState(next)
+    saveChatCorner(next)
+  }, [])
+  const layout = CORNER_LAYOUT[corner]
   const router = useRouter()
   const pageContext = getPageContext(router.pathname)
   const routeParams = router.query
@@ -53,12 +67,12 @@ export default function ChatFab(): React.ReactElement {
         data-testid="chat-panel-container"
         className={`fixed z-40 transition-all duration-300 ease-in-out ${
           isExpanded
-            ? "bottom-6 right-6 w-[48rem] max-w-[calc(100vw-2rem)] h-[calc(100vh-5rem)]"
-            : "bottom-24 right-6 w-96 max-w-[calc(100vw-2rem)] h-[600px] max-h-[80vh]"
+            ? `${layout.panelExpanded} w-[48rem] max-w-[calc(100vw-2rem)] h-[calc(100vh-5rem)]`
+            : `${layout.panel} w-96 max-w-[calc(100vw-2rem)] h-[600px] max-h-[80vh]`
         } ${
           isOpen
             ? "translate-x-0"
-            : "translate-x-[calc(100%+1.5rem)] pointer-events-none"
+            : `${layout.hiddenTransform} pointer-events-none`
         }`}
       >
         <ChatPanel
@@ -69,6 +83,8 @@ export default function ChatFab(): React.ReactElement {
           onExpand={expand}
           placeholder={pageContext.placeholder}
           suggestions={pageContext.suggestions}
+          corner={corner}
+          onMove={setCorner}
           className="h-full"
         />
       </div>
@@ -77,7 +93,7 @@ export default function ChatFab(): React.ReactElement {
       <button
         onClick={() => setIsOpen(!isOpen)}
         aria-label="Chat"
-        className="fixed bottom-6 right-6 z-40 w-14 h-14 rounded-full bg-blue-600 hover:bg-blue-700 text-white shadow-lg flex items-center justify-center transition-colors"
+        className={`fixed ${layout.fab} z-40 w-14 h-14 rounded-full bg-blue-600 hover:bg-blue-700 text-white shadow-lg flex items-center justify-center transition-colors`}
       >
         <i className={`fas ${isOpen ? "fa-times" : "fa-robot"} text-xl`}></i>
       </button>

--- a/src/components/features/chat/ChatFab.tsx
+++ b/src/components/features/chat/ChatFab.tsx
@@ -81,6 +81,7 @@ export default function ChatFab(): React.ReactElement {
           onSend={sendMessage}
           onClear={clearMessages}
           onExpand={expand}
+          onClose={close}
           placeholder={pageContext.placeholder}
           suggestions={pageContext.suggestions}
           corner={corner}
@@ -89,14 +90,16 @@ export default function ChatFab(): React.ReactElement {
         />
       </div>
 
-      {/* FAB button */}
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        aria-label="Chat"
-        className={`fixed ${layout.fab} z-40 w-14 h-14 rounded-full bg-blue-600 hover:bg-blue-700 text-white shadow-lg flex items-center justify-center transition-colors`}
-      >
-        <i className={`fas ${isOpen ? "fa-times" : "fa-robot"} text-xl`}></i>
-      </button>
+      {/* FAB button — only when closed; the in-panel header X handles closing. */}
+      {!isOpen && (
+        <button
+          onClick={() => setIsOpen(true)}
+          aria-label="Chat"
+          className={`fixed ${layout.fab} z-40 w-14 h-14 rounded-full bg-blue-600 hover:bg-blue-700 text-white shadow-lg flex items-center justify-center transition-colors`}
+        >
+          <i className="fas fa-robot text-xl"></i>
+        </button>
+      )}
     </>
   )
 }

--- a/src/components/features/chat/ChatPanel.tsx
+++ b/src/components/features/chat/ChatPanel.tsx
@@ -13,6 +13,8 @@ interface ChatPanelProps {
   placeholder?: string
   suggestions?: string[]
   onExpand?: () => void
+  /** When provided, the header shows a small blue X next to Clear that calls this. */
+  onClose?: () => void
   /** Current FAB corner; pass with onMove to enable the picker. */
   corner?: ChatCorner
   /** Move callback — pairs with corner; opens a 2x2 picker in the header. */
@@ -35,6 +37,7 @@ export default function ChatPanel({
   placeholder = "Ask about your portfolios...",
   suggestions = [],
   onExpand,
+  onClose,
   corner,
   onMove,
 }: ChatPanelProps): React.ReactElement {
@@ -124,13 +127,22 @@ export default function ChatPanel({
               <i className="fas fa-expand-alt"></i>
             </button>
           )}
-          {messages.length > 0 && (
+          <button
+            onClick={onClear}
+            disabled={messages.length === 0}
+            className="text-xs text-gray-400 hover:text-gray-600 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-gray-400 transition-colors"
+            aria-label="Clear chat"
+          >
+            Clear
+          </button>
+          {onClose && (
             <button
-              onClick={onClear}
-              className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
-              aria-label="Clear chat"
+              onClick={onClose}
+              className="text-xs text-blue-600 hover:text-blue-700 transition-colors"
+              aria-label="Close chat"
+              title="Close chat"
             >
-              Clear
+              <i className="fas fa-times"></i>
             </button>
           )}
         </div>

--- a/src/components/features/chat/ChatPanel.tsx
+++ b/src/components/features/chat/ChatPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from "react"
 import { ChatMessage } from "types/agent"
 import ChatBubble from "./ChatBubble"
 import Spinner from "@components/ui/Spinner"
+import { ChatCorner } from "./chatPosition"
 
 interface ChatPanelProps {
   messages: ChatMessage[]
@@ -12,7 +13,18 @@ interface ChatPanelProps {
   placeholder?: string
   suggestions?: string[]
   onExpand?: () => void
+  /** Current FAB corner; pass with onMove to enable the picker. */
+  corner?: ChatCorner
+  /** Move callback — pairs with corner; opens a 2x2 picker in the header. */
+  onMove?: (next: ChatCorner) => void
 }
+
+const CORNER_PICKER: { value: ChatCorner; icon: string; label: string }[] = [
+  { value: "TL", icon: "fa-arrow-up", label: "Top-left" },
+  { value: "TR", icon: "fa-arrow-up", label: "Top-right" },
+  { value: "BL", icon: "fa-arrow-down", label: "Bottom-left" },
+  { value: "BR", icon: "fa-arrow-down", label: "Bottom-right" },
+]
 
 export default function ChatPanel({
   messages,
@@ -23,8 +35,11 @@ export default function ChatPanel({
   placeholder = "Ask about your portfolios...",
   suggestions = [],
   onExpand,
+  corner,
+  onMove,
 }: ChatPanelProps): React.ReactElement {
   const [input, setInput] = useState("")
+  const [showPicker, setShowPicker] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -53,7 +68,52 @@ export default function ChatPanel({
             Holdsworth Assistant
           </span>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 relative">
+          {onMove && corner && (
+            <>
+              <button
+                onClick={() => setShowPicker((v) => !v)}
+                className="text-xs text-gray-400 hover:text-blue-600 transition-colors"
+                aria-label="Move chat panel"
+                title="Move to a different corner"
+              >
+                <i className="fas fa-arrows-alt"></i>
+              </button>
+              {showPicker && (
+                <div
+                  className="absolute right-0 top-7 z-10 bg-white border border-gray-200 rounded-md shadow-md p-1 grid grid-cols-2 gap-1"
+                  role="menu"
+                  aria-label="Choose chat panel corner"
+                >
+                  {CORNER_PICKER.map(({ value, icon, label }) => (
+                    <button
+                      key={value}
+                      onClick={() => {
+                        onMove(value)
+                        setShowPicker(false)
+                      }}
+                      aria-label={label}
+                      title={label}
+                      aria-pressed={corner === value}
+                      className={`w-7 h-7 rounded text-xs flex items-center justify-center transition-colors ${
+                        corner === value
+                          ? "bg-blue-100 text-blue-700"
+                          : "text-gray-500 hover:bg-gray-100"
+                      }`}
+                    >
+                      <i
+                        className={`fas ${icon} ${
+                          value === "TR" || value === "BR"
+                            ? "rotate-45"
+                            : "-rotate-45"
+                        }`}
+                      ></i>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
           {onExpand && (
             <button
               onClick={onExpand}

--- a/src/components/features/chat/__tests__/ChatFab.test.tsx
+++ b/src/components/features/chat/__tests__/ChatFab.test.tsx
@@ -28,14 +28,17 @@ describe("ChatFab", () => {
     expect(screen.getByText("Holdsworth Assistant")).toBeInTheDocument()
   })
 
-  it("closes panel when FAB is clicked again", () => {
+  it("FAB unmounts while the panel is open and the header Close X dismisses it", () => {
     render(<ChatFab />)
     fireEvent.click(screen.getByLabelText("Chat"))
     expect(screen.getByText("Holdsworth Assistant")).toBeInTheDocument()
-    fireEvent.click(screen.getByLabelText("Chat"))
+    expect(screen.queryByLabelText("Chat")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText("Close chat"))
     const panel = screen.getByTestId("chat-panel-container")
     expect(panel.className).toContain("translate-x-[calc(100%+1.5rem)]")
     expect(panel.className).toContain("pointer-events-none")
+    expect(screen.getByLabelText("Chat")).toBeInTheDocument()
   })
 
   it("closes panel on Escape key", () => {

--- a/src/components/features/chat/__tests__/ChatFab.test.tsx
+++ b/src/components/features/chat/__tests__/ChatFab.test.tsx
@@ -34,7 +34,8 @@ describe("ChatFab", () => {
     expect(screen.getByText("Holdsworth Assistant")).toBeInTheDocument()
     fireEvent.click(screen.getByLabelText("Chat"))
     const panel = screen.getByTestId("chat-panel-container")
-    expect(panel.className).toContain("translate-x-full")
+    expect(panel.className).toContain("translate-x-[calc(100%+1.5rem)]")
+    expect(panel.className).toContain("pointer-events-none")
   })
 
   it("closes panel on Escape key", () => {
@@ -43,7 +44,8 @@ describe("ChatFab", () => {
     expect(screen.getByText("Holdsworth Assistant")).toBeInTheDocument()
     fireEvent.keyDown(document, { key: "Escape" })
     const panel = screen.getByTestId("chat-panel-container")
-    expect(panel.className).toContain("translate-x-full")
+    expect(panel.className).toContain("translate-x-[calc(100%+1.5rem)]")
+    expect(panel.className).toContain("pointer-events-none")
   })
 
   it("expand button toggles expanded panel size", () => {

--- a/src/components/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/components/features/chat/__tests__/ChatPanel.test.tsx
@@ -78,6 +78,38 @@ describe("ChatPanel", () => {
     expect(screen.getByText("Thinking...")).toBeInTheDocument()
   })
 
+  it("Clear button is disabled with no messages and enabled with messages", () => {
+    const onClear = jest.fn()
+    const { rerender } = render(
+      <ChatPanel {...defaultProps} onClear={onClear} />,
+    )
+    const clearBtn = screen.getByRole("button", { name: /clear chat/i })
+    expect(clearBtn).toBeDisabled()
+    fireEvent.click(clearBtn)
+    expect(onClear).not.toHaveBeenCalled()
+
+    const messages: ChatMessage[] = [
+      { id: "1", role: "user", content: "hi", timestamp: "t" },
+    ]
+    rerender(
+      <ChatPanel {...defaultProps} onClear={onClear} messages={messages} />,
+    )
+    const enabled = screen.getByRole("button", { name: /clear chat/i })
+    expect(enabled).not.toBeDisabled()
+    fireEvent.click(enabled)
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders Close icon only when onClose provided and calls it", () => {
+    const onClose = jest.fn()
+    const { rerender } = render(<ChatPanel {...defaultProps} />)
+    expect(screen.queryByLabelText("Close chat")).not.toBeInTheDocument()
+
+    rerender(<ChatPanel {...defaultProps} onClose={onClose} />)
+    fireEvent.click(screen.getByLabelText("Close chat"))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   it("renders the move icon and corner picker only when corner+onMove provided", () => {
     const { rerender } = render(<ChatPanel {...defaultProps} />)
     expect(screen.queryByLabelText("Move chat panel")).not.toBeInTheDocument()

--- a/src/components/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/components/features/chat/__tests__/ChatPanel.test.tsx
@@ -77,4 +77,15 @@ describe("ChatPanel", () => {
     render(<ChatPanel {...defaultProps} isLoading={true} />)
     expect(screen.getByText("Thinking...")).toBeInTheDocument()
   })
+
+  it("renders the move icon and corner picker only when corner+onMove provided", () => {
+    const { rerender } = render(<ChatPanel {...defaultProps} />)
+    expect(screen.queryByLabelText("Move chat panel")).not.toBeInTheDocument()
+
+    const onMove = jest.fn()
+    rerender(<ChatPanel {...defaultProps} corner="BR" onMove={onMove} />)
+    fireEvent.click(screen.getByLabelText("Move chat panel"))
+    fireEvent.click(screen.getByLabelText("Top-left"))
+    expect(onMove).toHaveBeenCalledWith("TL")
+  })
 })

--- a/src/components/features/chat/chatPosition.ts
+++ b/src/components/features/chat/chatPosition.ts
@@ -1,0 +1,81 @@
+/**
+ * Corner placement for the floating chat FAB and its slide-out panel.
+ *
+ * Default is BR (bottom-right). Persisted in localStorage so the user's
+ * choice survives reloads — the FAB occasionally covers data in the
+ * lower-right of a page (e.g. action menus on the holdings cards), and
+ * being able to move it out of the way is the cheapest fix.
+ */
+export type ChatCorner = "BR" | "BL" | "TR" | "TL"
+
+const STORAGE_KEY = "bc-chat-corner"
+
+export function isChatCorner(value: unknown): value is ChatCorner {
+  return value === "BR" || value === "BL" || value === "TR" || value === "TL"
+}
+
+export function loadChatCorner(): ChatCorner {
+  if (typeof window === "undefined") return "BR"
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    return isChatCorner(stored) ? stored : "BR"
+  } catch {
+    return "BR"
+  }
+}
+
+export function saveChatCorner(corner: ChatCorner): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, corner)
+  } catch {
+    // Quota exceeded / private mode — silently ignore; the corner just
+    // won't persist across reloads, which is harmless.
+  }
+}
+
+interface CornerLayout {
+  /** Tailwind classes positioning the FAB within the viewport. */
+  fab: string
+  /** Tailwind classes positioning the (collapsed) panel container. */
+  panel: string
+  /** Tailwind classes positioning the expanded panel container. */
+  panelExpanded: string
+  /**
+   * Translate-on-close direction. The offset accounts for the per-corner
+   * inset so no sliver of the panel leaks past the viewport edge.
+   */
+  hiddenTransform: string
+}
+
+/**
+ * Per-corner layout. The FAB lives in the chosen corner; the panel slides
+ * in from that corner's edge. Insets and translate distances stay in sync
+ * so the hidden panel fully clears the viewport (see ChatFab sliver fix).
+ */
+export const CORNER_LAYOUT: Record<ChatCorner, CornerLayout> = {
+  BR: {
+    fab: "bottom-6 right-6",
+    panel: "bottom-24 right-6",
+    panelExpanded: "bottom-6 right-6",
+    hiddenTransform: "translate-x-[calc(100%+1.5rem)]",
+  },
+  BL: {
+    fab: "bottom-6 left-6",
+    panel: "bottom-24 left-6",
+    panelExpanded: "bottom-6 left-6",
+    hiddenTransform: "-translate-x-[calc(100%+1.5rem)]",
+  },
+  TR: {
+    fab: "top-6 right-6",
+    panel: "top-24 right-6",
+    panelExpanded: "top-6 right-6",
+    hiddenTransform: "translate-x-[calc(100%+1.5rem)]",
+  },
+  TL: {
+    fab: "top-6 left-6",
+    panel: "top-24 left-6",
+    panelExpanded: "top-6 left-6",
+    hiddenTransform: "-translate-x-[calc(100%+1.5rem)]",
+  },
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Chat panel can now be repositioned to any corner (top-left, top-right, bottom-left, bottom-right) with automatic persistence across sessions
  - Added close button to the chat panel header

* **Improvements**
  - Clear button is now always visible but disabled when no messages exist

<!-- end of auto-generated comment: release notes by coderabbit.ai -->