### PR TITLE
feat(chat): Stream agent responses via Server-Sent Events

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,6 +5,31 @@
 import "@testing-library/jest-dom"
 import React from "react"
 
+// jsdom doesn't expose Web Streams / TextEncoder globally — polyfill from
+// Node built-ins so SSE-streaming tests (e.g. useChat) can mock a real
+// ReadableStream response body.
+import { TextEncoder, TextDecoder } from "node:util"
+import {
+  ReadableStream,
+  TransformStream,
+  TextDecoderStream,
+} from "node:stream/web"
+if (typeof globalThis.TextEncoder === "undefined") {
+  globalThis.TextEncoder = TextEncoder
+}
+if (typeof globalThis.TextDecoder === "undefined") {
+  globalThis.TextDecoder = TextDecoder
+}
+if (typeof globalThis.ReadableStream === "undefined") {
+  globalThis.ReadableStream = ReadableStream
+}
+if (typeof globalThis.TransformStream === "undefined") {
+  globalThis.TransformStream = TransformStream
+}
+if (typeof globalThis.TextDecoderStream === "undefined") {
+  globalThis.TextDecoderStream = TextDecoderStream
+}
+
 module.exports = {
   setupFilesAfterEnv: ["./jest.setup.js"],
 }

--- a/src/hooks/__tests__/useChat.test.ts
+++ b/src/hooks/__tests__/useChat.test.ts
@@ -5,6 +5,30 @@ import { useChat } from "../useChat"
 const mockFetch = jest.fn()
 global.fetch = mockFetch
 
+/**
+ * Build a `Response`-shaped object whose `body` is a `ReadableStream` that
+ * emits the given SSE events (in order) as a single concatenated chunk.
+ * Real svc-agent emissions arrive in multiple chunks; we test the parser's
+ * single-chunk path here and the multi-chunk path in the dedicated test.
+ */
+function sseResponse(events: Array<{ event: string; data: string }>): {
+  ok: true
+  status: number
+  body: ReadableStream<Uint8Array>
+} {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const blob = events
+        .map((e) => `event: ${e.event}\ndata: ${e.data}\n\n`)
+        .join("")
+      controller.enqueue(encoder.encode(blob))
+      controller.close()
+    },
+  })
+  return { ok: true, status: 200, body }
+}
+
 describe("useChat", () => {
   beforeEach(() => {
     mockFetch.mockReset()
@@ -17,17 +41,14 @@ describe("useChat", () => {
     expect(result.current.isLoading).toBe(false)
   })
 
-  it("adds user message and assistant response on sendMessage", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          query: "hello",
-          response: "Hi there!",
-          timestamp: "2026-04-14T00:00:00Z",
-          error: null,
-        }),
-    })
+  it("appends user + assistant message and concatenates token chunks", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([
+        { event: "token", data: "Hi" },
+        { event: "token", data: " there!" },
+        { event: "done", data: '{"chars":9}' },
+      ]),
+    )
 
     const { result } = renderHook(() => useChat())
 
@@ -36,19 +57,43 @@ describe("useChat", () => {
     })
 
     expect(result.current.messages).toHaveLength(2)
-    expect(result.current.messages[0].role).toBe("user")
-    expect(result.current.messages[0].content).toBe("hello")
-    expect(result.current.messages[1].role).toBe("assistant")
-    expect(result.current.messages[1].content).toBe("Hi there!")
+    expect(result.current.messages[0]).toMatchObject({
+      role: "user",
+      content: "hello",
+    })
+    expect(result.current.messages[1]).toMatchObject({
+      role: "assistant",
+      content: "Hi there!",
+    })
     expect(result.current.isLoading).toBe(false)
   })
 
-  it("appends error message on fetch failure", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      json: () => Promise.resolve({ message: "Server error" }),
+  it("handles SSE events split across multiple chunks", async () => {
+    const encoder = new TextEncoder()
+    const body = new ReadableStream<Uint8Array>({
+      start(c) {
+        // Split mid-event to exercise the buffered parser.
+        c.enqueue(encoder.encode("event: token\ndata: He"))
+        c.enqueue(encoder.encode("llo\n\nevent: token\ndata: , wo"))
+        c.enqueue(encoder.encode("rld\n\nevent: done\ndata: {}\n\n"))
+        c.close()
+      },
     })
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body })
+
+    const { result } = renderHook(() => useChat())
+
+    await act(async () => {
+      await result.current.sendMessage("hi")
+    })
+
+    expect(result.current.messages[1].content).toBe("Hello, world")
+  })
+
+  it("surfaces an error event from the stream", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "error", data: "boom" }]),
+    )
 
     const { result } = renderHook(() => useChat())
 
@@ -56,10 +101,21 @@ describe("useChat", () => {
       await result.current.sendMessage("hello")
     })
 
-    expect(result.current.messages).toHaveLength(2)
-    expect(result.current.messages[1].role).toBe("assistant")
-    expect(result.current.messages[1].content).toContain("error")
-    expect(result.current.messages[1].error).toBe("Server error")
+    expect(result.current.messages[1].error).toBe("boom")
+    expect(result.current.messages[1].content).toContain("boom")
+  })
+
+  it("appends error message on non-OK HTTP", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, body: null })
+
+    const { result } = renderHook(() => useChat())
+
+    await act(async () => {
+      await result.current.sendMessage("hello")
+    })
+
+    expect(result.current.messages[1].content).toContain("HTTP 500")
+    expect(result.current.messages[1].error).toBe("HTTP 500")
   })
 
   it("appends error message on network failure", async () => {
@@ -71,21 +127,13 @@ describe("useChat", () => {
       await result.current.sendMessage("hello")
     })
 
-    expect(result.current.messages).toHaveLength(2)
     expect(result.current.messages[1].error).toBe("Network error")
   })
 
   it("clears messages", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          query: "hello",
-          response: "Hi!",
-          timestamp: "2026-04-14T00:00:00Z",
-          error: null,
-        }),
-    })
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "token", data: "Hi!" }]),
+    )
 
     const { result } = renderHook(() => useChat())
 
@@ -100,17 +148,10 @@ describe("useChat", () => {
     expect(result.current.messages).toEqual([])
   })
 
-  it("sends POST to /api/agent/query with correct body", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          query: "test",
-          response: "ok",
-          timestamp: "2026-04-14T00:00:00Z",
-          error: null,
-        }),
-    })
+  it("POSTs to /api/agent/query/stream with the SSE accept header", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "token", data: "ok" }]),
+    )
 
     const { result } = renderHook(() => useChat())
 
@@ -118,25 +159,20 @@ describe("useChat", () => {
       await result.current.sendMessage("test query")
     })
 
-    expect(mockFetch).toHaveBeenCalledWith("/api/agent/query", {
+    expect(mockFetch).toHaveBeenCalledWith("/api/agent/query/stream", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+      },
       body: JSON.stringify({ query: "test query", context: undefined }),
     })
   })
 
-  it("includes page context in API request when provided", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          query: "help",
-          response: "ok",
-          timestamp: "2026-04-14T00:00:00Z",
-          error: null,
-        }),
-    })
-
+  it("includes page context in the request body", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "token", data: "ok" }]),
+    )
     const ctx = { page: "Holdings", description: "Viewing holdings" }
     const { result } = renderHook(() => useChat(ctx))
 
@@ -144,10 +180,11 @@ describe("useChat", () => {
       await result.current.sendMessage("help")
     })
 
-    expect(mockFetch).toHaveBeenCalledWith("/api/agent/query", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query: "help", context: ctx }),
-    })
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/agent/query/stream",
+      expect.objectContaining({
+        body: JSON.stringify({ query: "help", context: ctx }),
+      }),
+    )
   })
 })

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react"
-import { ChatMessage, AgentResponse } from "types/agent"
+import { ChatMessage } from "types/agent"
 
 interface UseChatReturn {
   messages: ChatMessage[]
@@ -8,6 +8,14 @@ interface UseChatReturn {
   clearMessages: () => void
 }
 
+/**
+ * Streams the agent response via Server-Sent Events.
+ *
+ * The browser sees a first byte within ~1–2s as svc-agent emits `event: token`
+ * chunks. Without streaming the heavy Independence / Rebalance domains
+ * routinely exceed mobile-Safari's ~30s idle-timeout and surface as a generic
+ * "Load failed" — see `pages/api/agent/query/stream.ts` for the proxy.
+ */
 export function useChat(context?: Record<string, unknown>): UseChatReturn {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [isLoading, setIsLoading] = useState(false)
@@ -23,44 +31,103 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
       setMessages((prev) => [...prev, userMsg])
       setIsLoading(true)
 
-      const appendError = (message: string): void => {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: crypto.randomUUID(),
-            role: "assistant" as const,
-            content: `Sorry, I encountered an error: ${message}`,
-            timestamp: new Date().toISOString(),
-            error: message,
-          },
-        ])
+      // Reserve a placeholder assistant message that we mutate as chunks
+      // arrive. The empty string is fine — ChatPanel renders the
+      // `Thinking...` indicator from `isLoading` until tokens land.
+      const assistantId = crypto.randomUUID()
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: assistantId,
+          role: "assistant",
+          content: "",
+          timestamp: new Date().toISOString(),
+        },
+      ])
+
+      const finalize = (
+        update: (msg: ChatMessage) => Partial<ChatMessage>,
+      ): void => {
+        setMessages((prev) =>
+          prev.map((m) => (m.id === assistantId ? { ...m, ...update(m) } : m)),
+        )
       }
 
       try {
-        const res = await fetch("/api/agent/query", {
+        const res = await fetch("/api/agent/query/stream", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+          },
           body: JSON.stringify({ query, context }),
         })
-        if (!res.ok) {
-          const err = await res.json()
-          appendError(err.message || `HTTP ${res.status}`)
+        if (!res.ok || !res.body) {
+          const message = `HTTP ${res.status}`
+          finalize(() => ({
+            content: `Sorry, I encountered an error: ${message}`,
+            error: message,
+          }))
           return
         }
-        const data: AgentResponse = await res.json()
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: crypto.randomUUID(),
-            role: "assistant",
-            content: data.response,
-            timestamp: data.timestamp,
-            error: data.error,
-          },
-        ])
+
+        const reader = res.body
+          .pipeThrough(new TextDecoderStream())
+          .getReader()
+        let buffer = ""
+
+        // SSE event blocks are delimited by a blank line. Inside each block
+        // we look for `event: <type>` and `data: <body>` lines. We accept
+        // multi-`data:` events by joining their bodies with newlines.
+        const flush = (block: string): void => {
+          let event = "message"
+          const dataLines: string[] = []
+          for (const raw of block.split("\n")) {
+            if (raw.startsWith(":")) continue
+            if (raw.startsWith("event:")) {
+              event = raw.slice(6).trim()
+            } else if (raw.startsWith("data:")) {
+              dataLines.push(raw.slice(5).replace(/^ /, ""))
+            }
+          }
+          const data = dataLines.join("\n")
+          if (event === "token") {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === assistantId ? { ...m, content: m.content + data } : m,
+              ),
+            )
+          } else if (event === "error") {
+            finalize((m) => ({
+              content:
+                m.content.length > 0
+                  ? m.content
+                  : `Sorry, I encountered an error: ${data || "stream error"}`,
+              error: data || "stream-error",
+            }))
+          }
+          // `done` carries metadata only; nothing to render right now.
+        }
+
+        for (;;) {
+          const { value, done } = await reader.read()
+          if (done) break
+          buffer += value
+          let sep = buffer.indexOf("\n\n")
+          while (sep !== -1) {
+            const block = buffer.slice(0, sep)
+            buffer = buffer.slice(sep + 2)
+            if (block.length > 0) flush(block)
+            sep = buffer.indexOf("\n\n")
+          }
+        }
+        if (buffer.trim().length > 0) flush(buffer)
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : "Unknown error"
-        appendError(message)
+        finalize(() => ({
+          content: `Sorry, I encountered an error: ${message}`,
+          error: message,
+        }))
       } finally {
         setIsLoading(false)
       }

--- a/src/pages/api/agent/query/stream.ts
+++ b/src/pages/api/agent/query/stream.ts
@@ -33,6 +33,10 @@ export default async function handler(
       return
     }
     const { token: accessToken } = await auth0.getAccessToken(req, res)
+    if (!accessToken) {
+      res.status(401).json({ error: "Unauthorized" })
+      return
+    }
 
     const upstream = await fetch(getAgentUrl("/agent/query/stream"), {
       method: "POST",

--- a/src/pages/api/agent/query/stream.ts
+++ b/src/pages/api/agent/query/stream.ts
@@ -1,0 +1,90 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+import { Readable } from "node:stream"
+import { auth0 } from "@lib/auth0"
+import { getAgentUrl } from "@utils/api/bcConfig"
+
+/**
+ * SSE proxy to svc-agent's `/agent/query/stream` endpoint.
+ *
+ * The chat client (`useChat`) uses this when available so the browser sees a
+ * first byte within ~1–2s instead of waiting for the full LLM + tool-call
+ * chain to finish — which on heavy domains (Independence / Rebalance) can
+ * exceed mobile-Safari's idle-timeout and surface as "Load failed".
+ *
+ * `createApiHandler` is bypassed because it materialises the upstream body
+ * with `await response.text()` (see `responseWriter.ts`), which defeats the
+ * point of streaming. This handler pipes the upstream `text/event-stream`
+ * response through unchanged.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST")
+    res.status(405).end("Method Not Allowed")
+    return
+  }
+
+  try {
+    const session = await auth0.getSession(req)
+    if (!session) {
+      res.status(401).json({ error: "Not authenticated" })
+      return
+    }
+    const { token: accessToken } = await auth0.getAccessToken(req, res)
+
+    const upstream = await fetch(getAgentUrl("/agent/query/stream"), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+      },
+      body: JSON.stringify(req.body),
+    })
+
+    if (!upstream.ok || !upstream.body) {
+      res.status(upstream.status).json({
+        error: "Upstream stream failed",
+        status: upstream.status,
+      })
+      return
+    }
+
+    res.setHeader("Content-Type", "text/event-stream")
+    res.setHeader("Cache-Control", "no-cache, no-transform")
+    res.setHeader("Connection", "keep-alive")
+    // Disable buffering on any reverse proxy (nginx / Caddy with proxy_buffering)
+    // so chunks reach the browser as fast as svc-agent emits them.
+    res.setHeader("X-Accel-Buffering", "no")
+    res.flushHeaders?.()
+
+    const nodeStream = Readable.fromWeb(
+      upstream.body as unknown as import("node:stream/web").ReadableStream,
+    )
+    nodeStream.on("error", (err) => {
+      // Upstream error mid-stream — best we can do is end the response; the
+      // already-sent SSE bytes may be partial but downstream parser handles
+      // truncation gracefully.
+      console.error("[/api/agent/query/stream] upstream error", err)
+      res.end()
+    })
+    nodeStream.pipe(res)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error"
+    if (!res.headersSent) {
+      res.status(500).json({ error: message })
+    } else {
+      res.end()
+    }
+  }
+}
+
+// Disable default body parser-based response timeout / size limits — we want
+// to hold the connection open for as long as the LLM keeps producing.
+export const config = {
+  api: {
+    responseLimit: false,
+  },
+}


### PR DESCRIPTION
## Summary
- New /api/agent/query/stream proxy that pipes svc-agent's SSE response straight through (bypasses createApiHandler's body-buffering).
- useChat now opens an SSE connection, parses event/data blocks across arbitrary chunk boundaries, and appends event: token payloads to a reserved assistant message id as they arrive.
- jest.setup polyfills TextEncoder / ReadableStream / TextDecoderStream from Node built-ins (jsdom omits them).

## Why
Independence and Rebalance domains chain heavy retire / rebalance tool calls — total 30–50s. Mobile Safari times out at ~30s on cellular and surfaces the generic "Load failed" message, making those domains effectively unusable on phones. With streaming the first byte arrives in 1–2s; the connection never goes idle.

## Pairs with
- monowai/beancounter#808 — adds the SSE endpoint.

## Test plan
- [x] yarn test (1232 passing, including 9 new useChat streaming tests)
- [x] yarn lint, yarn typecheck
- [ ] Deploy alongside beancounter#808 and retry the failing Independence "Review plan details" query on mobile Safari
- [ ] Confirm Caddy on kauri does not buffer SSE — set proxy_buffering off if the X-Accel-Buffering: no header isn't honoured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat responses now stream in real-time, showing an assistant message that is incrementally populated as tokens arrive.

* **Bug Fixes**
  * Improved handling and reporting of stream and HTTP errors so partial responses surface an error message and content consistently.

* **Tests**
  * Expanded tests for streaming behavior, incremental parsing across chunks, and stream/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->