### PR TITLE
fix(chat): Preserve leading space in SSE token chunks

### DIFF
--- a/src/hooks/__tests__/useChat.test.ts
+++ b/src/hooks/__tests__/useChat.test.ts
@@ -19,8 +19,11 @@ function sseResponse(events: Array<{ event: string; data: string }>): {
   const encoder = new TextEncoder()
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
+      // Spring's ServerSentEvent writer emits `data:<value>` with NO space
+      // between the colon and the value — match that exact wire format so
+      // the parser exercises the same bytes it sees in production.
       const blob = events
-        .map((e) => `event: ${e.event}\ndata: ${e.data}\n\n`)
+        .map((e) => `event:${e.event}\ndata:${e.data}\n\n`)
         .join("")
       controller.enqueue(encoder.encode(blob))
       controller.close()
@@ -72,10 +75,11 @@ describe("useChat", () => {
     const encoder = new TextEncoder()
     const body = new ReadableStream<Uint8Array>({
       start(c) {
-        // Split mid-event to exercise the buffered parser.
-        c.enqueue(encoder.encode("event: token\ndata: He"))
-        c.enqueue(encoder.encode("llo\n\nevent: token\ndata: , wo"))
-        c.enqueue(encoder.encode("rld\n\nevent: done\ndata: {}\n\n"))
+        // Split mid-event to exercise the buffered parser. Use Spring's
+        // no-space `data:` form to match production wire bytes.
+        c.enqueue(encoder.encode("event:token\ndata:He"))
+        c.enqueue(encoder.encode("llo\n\nevent:token\ndata:, wo"))
+        c.enqueue(encoder.encode("rld\n\nevent:done\ndata:{}\n\n"))
         c.close()
       },
     })
@@ -88,6 +92,33 @@ describe("useChat", () => {
     })
 
     expect(result.current.messages[1].content).toBe("Hello, world")
+  })
+
+  it("preserves leading whitespace in token chunks (Spring SSE writer omits the protocol space)", async () => {
+    // Regression test for the "Theplan / fortwo / verylean" rendering bug:
+    // Spring's ServerSentEvent writer emits `data:<value>` with no space
+    // between the colon and the value, so any leading space on a chunk is
+    // payload and must reach the rendered message verbatim.
+    const encoder = new TextEncoder()
+    const body = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(encoder.encode("event: token\ndata:The\n\n"))
+        c.enqueue(encoder.encode("event: token\ndata: plan\n\n"))
+        c.enqueue(encoder.encode("event: token\ndata: is\n\n"))
+        c.enqueue(encoder.encode("event: token\ndata: realistic\n\n"))
+        c.enqueue(encoder.encode("event: done\ndata: {}\n\n"))
+        c.close()
+      },
+    })
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body })
+
+    const { result } = renderHook(() => useChat())
+
+    await act(async () => {
+      await result.current.sendMessage("hi")
+    })
+
+    expect(result.current.messages[1].content).toBe("The plan is realistic")
   })
 
   it("surfaces an error event from the stream", async () => {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -79,6 +79,13 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
         // SSE event blocks are delimited by a blank line. Inside each block
         // we look for `event: <type>` and `data: <body>` lines. We accept
         // multi-`data:` events by joining their bodies with newlines.
+        //
+        // We deliberately don't strip a leading space from `data:` lines.
+        // The SSE spec lets a server write either `data:foo` or `data: foo`
+        // for content `foo` — Spring's `ServerSentEvent` writer chooses the
+        // first form, so any leading space on a `data:` line IS part of the
+        // payload. Stripping it dropped spaces between adjacent token chunks
+        // and produced run-on words like "Theplan", "fortwo".
         const flush = (block: string): void => {
           let event = "message"
           const dataLines: string[] = []
@@ -87,7 +94,7 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
             if (raw.startsWith("event:")) {
               event = raw.slice(6).trim()
             } else if (raw.startsWith("data:")) {
-              dataLines.push(raw.slice(5).replace(/^ /, ""))
+              dataLines.push(raw.slice(5))
             }
           }
           const data = dataLines.join("\n")


### PR DESCRIPTION
## Summary
- Stop stripping the leading space from \`data:\` lines in \`useChat\`'s SSE parser.
- New regression test asserts \`The\` + \` plan\` + \` is\` + \` realistic\` renders as \`The plan is realistic\`.
- Test fixture (\`sseResponse\`) now matches Spring's actual wire format (\`data:<value>\`, no protocol space).

## Why
Streamed Independence responses were rendering with run-on words ("Theplan", "fortwo", "verylean") on mobile. Spring's \`ServerSentEvent\` writer emits \`data:<value>\` without a separator space, so any leading space on a chunk is payload — and the parser was throwing it away.

## Test plan
- [x] yarn test (1233 passing, including new leading-space regression test)
- [x] yarn lint, yarn typecheck
- [ ] Deploy alongside backend, retry Independence stream on mobile, confirm no run-on words

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where leading whitespace in assistant messages was being incorrectly stripped, causing message text to render without intended spacing.

* **Tests**
  * Added a regression test to ensure whitespace is properly preserved across message chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->