### PR TITLE
fix(wizard): Send empty lifeEvents as '[]' so deletions persist

### DIFF
--- a/src/components/features/independence/WizardContainer.tsx
+++ b/src/components/features/independence/WizardContainer.tsx
@@ -21,6 +21,7 @@ import {
   WIZARD_STEPS,
 } from "@lib/independence/stepConfig"
 import { toDecimal } from "@lib/independence/conversions"
+import { serializeLifeEvents } from "@lib/independence/planHelpers"
 import { WizardFormData, PlanRequest } from "types/independence"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
@@ -210,10 +211,9 @@ export default function WizardContainer({
         socialSecurityMonthly: formData.socialSecurityMonthly,
         benefitsStartAge: formData.benefitsStartAge,
         otherIncomeMonthly: formData.otherIncomeMonthly,
-        lifeEvents:
-          formData.lifeEvents?.length > 0
-            ? JSON.stringify(formData.lifeEvents)
-            : undefined,
+        // Always send the JSON-serialised array (incl. "[]") so the
+        // backend distinguishes "list cleared" from "field omitted".
+        lifeEvents: serializeLifeEvents(formData.lifeEvents),
         manualAssets,
         excludedPortfolioIds: formData.excludedPortfolioIds || [],
         excludedRentalAssetIds: formData.excludedRentalAssetIds || [],

--- a/src/lib/utils/independence/planHelpers.test.ts
+++ b/src/lib/utils/independence/planHelpers.test.ts
@@ -1,0 +1,29 @@
+import { LifeEvent } from "types/independence"
+import { serializeLifeEvents } from "./planHelpers"
+
+describe("serializeLifeEvents", () => {
+  it("serialises a populated array as a JSON string the backend can parse", () => {
+    const events: LifeEvent[] = [
+      {
+        id: "a",
+        age: 62,
+        amount: 60000,
+        description: "tax",
+        eventType: "expense",
+      },
+    ]
+    expect(serializeLifeEvents(events)).toBe(JSON.stringify(events))
+  })
+
+  it("returns the empty-array JSON literal '[]' when no events remain", () => {
+    // Regression: previously the wizard sent `undefined` once the user
+    // deleted the last (or only) life event. The backend's PATCH semantics
+    // treat null/missing as "no change", so the deleted event came back on
+    // refresh. Sending an explicit "[]" tells svc-retire to clear the list.
+    expect(serializeLifeEvents([])).toBe("[]")
+  })
+
+  it("treats undefined as an empty list and serialises '[]'", () => {
+    expect(serializeLifeEvents(undefined)).toBe("[]")
+  })
+})

--- a/src/lib/utils/independence/planHelpers.ts
+++ b/src/lib/utils/independence/planHelpers.ts
@@ -1,5 +1,20 @@
 import { AllocationSlice } from "@lib/allocation/aggregateHoldings"
-import { ManualAssetCategory } from "types/independence"
+import { LifeEvent, ManualAssetCategory } from "types/independence"
+
+/**
+ * Serialise the wizard's life-events array for the plan-update payload.
+ *
+ * Always emits a JSON string — even for an empty list — so svc-retire can
+ * distinguish "user cleared all events" (`"[]"`) from "field not sent"
+ * (`null`, which PATCH treats as "leave existing alone"). Without this,
+ * deleting the last life event silently re-instated the old list on the
+ * next refresh.
+ */
+export function serializeLifeEvents(
+  events: LifeEvent[] | undefined,
+): string {
+  return JSON.stringify(events ?? [])
+}
 
 export const HIDDEN_VALUE = "****"
 


### PR DESCRIPTION
## Summary
- New \`serializeLifeEvents\` helper in \`@lib/independence/planHelpers\` always emits a JSON string, including \`"[]"\` for an empty list.
- \`WizardContainer\` uses it; the inline ternary that produced \`undefined\` is gone.
- 3 helper tests cover populated / empty / undefined paths.

## Why
"Delete tax event → Save → Refresh → it comes back." The wizard sent \`lifeEvents: undefined\` once the array was empty. svc-retire's PATCH semantics treat null/missing as "no change", so the deleted event was silently restored from the prior persisted value.

## Pairs with
- monowai/svc-retire#4 — backend tests locking the empty-vs-null contract.

## Test plan
- [x] yarn test (1236 passing, 3 new helper tests)
- [x] yarn lint, yarn typecheck
- [ ] After deploy: open SGD plan, delete the SGD 60,000 tax event, save, refresh — event must stay deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced life events handling in plan submissions to properly communicate cleared event lists to the backend.

* **Tests**
  * Added comprehensive test coverage for life events serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->