### PR TITLE
feat(chat): Friendly copy for classified agent errors

### DIFF
--- a/src/hooks/__tests__/useChat.test.ts
+++ b/src/hooks/__tests__/useChat.test.ts
@@ -136,6 +136,25 @@ describe("useChat", () => {
     expect(result.current.messages[1].content).toContain("boom")
   })
 
+  it("renders friendly copy for known agent error codes", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "error", data: "provider-quota" }]),
+    )
+    const { result } = renderHook(() => useChat())
+
+    await act(async () => {
+      await result.current.sendMessage("hello")
+    })
+
+    expect(result.current.messages[1].error).toBe("provider-quota")
+    // The user should see actionable copy, not the raw opaque code.
+    expect(result.current.messages[1].content).toContain("AI provider")
+    expect(result.current.messages[1].content).toContain("credit")
+    expect(result.current.messages[1].content).not.toBe(
+      "Sorry, I encountered an error: provider-quota",
+    )
+  })
+
   it("appends error message on non-OK HTTP", async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 500, body: null })
 

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,6 +1,26 @@
 import { useState, useCallback } from "react"
 import { ChatMessage } from "types/agent"
 
+/**
+ * Human-readable rendering of svc-agent's opaque SSE error codes. Codes are
+ * stable contracts emitted by AgentController.classifyError; the message
+ * text is UI copy and may evolve.
+ */
+function describeError(code: string): string {
+  switch (code) {
+    case "provider-quota":
+      return "the AI provider has run out of credit. Please ask the site owner to top up the Anthropic billing balance."
+    case "provider-rate":
+      return "the AI provider is rate-limiting requests. Please wait a moment and try again."
+    case "provider-timeout":
+      return "the AI provider took too long to respond. Please try again — heavy queries may need a second attempt."
+    case "agent-error":
+      return "the agent failed to process your request. Please try again or simplify the question."
+    default:
+      return code
+  }
+}
+
 interface UseChatReturn {
   messages: ChatMessage[]
   isLoading: boolean
@@ -105,12 +125,13 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
               ),
             )
           } else if (event === "error") {
+            const code = data || "stream-error"
             finalize((m) => ({
               content:
                 m.content.length > 0
                   ? m.content
-                  : `Sorry, I encountered an error: ${data || "stream error"}`,
-              error: data || "stream-error",
+                  : `Sorry, I encountered an error: ${describeError(code)}`,
+              error: code,
             }))
           }
           // `done` carries metadata only; nothing to render right now.


### PR DESCRIPTION
## Summary
- New \`describeError(code)\` helper maps svc-agent's classified SSE error codes (\`provider-quota\`, \`provider-rate\`, \`provider-timeout\`, \`agent-error\`) into actionable user copy.
- useChat passes the code through \`describeError\` before rendering.

## Pairs with
- monowai/beancounter#811 — backend classification.

## Test plan
- [x] yarn test (1237 passing, new copy assertion)
- [x] yarn lint, yarn typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for chat functionality. Users now receive friendly, actionable error descriptions instead of raw error codes when experiencing issues. Raw error codes are preserved internally for troubleshooting purposes.

* **Tests**
  * Added test coverage to verify error message translations display user-friendly content with actionable guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->