### PR TITLE
feat(auth): Gate AI surfaces behind beancounter:ai / beancounter:preview

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -97,9 +97,31 @@ jest.mock("@auth0/nextjs-auth0/client", () => {
 // Mock Auth0 types module (v4)
 jest.mock("@auth0/nextjs-auth0/types", () => ({}))
 
-// Mock fetch globally for API calls
-global.fetch = jest.fn(() =>
-  Promise.resolve({
+// Default to permissive Beancounter permissions in tests so AI-gated
+// surfaces render. Tests that exercise denial paths can override via
+// `jest.spyOn(usePermissions, ...)` or `jest.mock(...)` per-suite.
+jest.mock("@hooks/usePermissions", () => ({
+  usePermissions: jest.fn(() => ({
+    ai: true,
+    preview: true,
+    admin: true,
+    isLoading: false,
+  })),
+}))
+
+// Mock fetch globally for API calls. /api/auth/permissions returns a
+// permissive default so component tests don't have to mock the hook
+// individually; tests that care about denial can override per-call.
+global.fetch = jest.fn((input) => {
+  const url = typeof input === "string" ? input : input?.url || ""
+  if (url.includes("/api/auth/permissions")) {
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ai: true, preview: true, admin: true }),
+    })
+  }
+  return Promise.resolve({
+    ok: true,
     json: () => Promise.resolve({ data: [] }),
-  }),
-)
+  })
+})

--- a/src/components/features/chat/ChatFab.tsx
+++ b/src/components/features/chat/ChatFab.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react"
 import { useRouter } from "next/router"
 import { useChat } from "@hooks/useChat"
+import { usePermissions } from "@hooks/usePermissions"
 import ChatPanel from "./ChatPanel"
 import { getPageContext } from "./pageContext"
 import {
@@ -57,8 +58,12 @@ export default function ChatFab(): React.ReactElement {
     return () => document.removeEventListener("keydown", handleKeyDown)
   }, [isOpen, close])
 
+  const { ai: canRunAi, isLoading: permsLoading } = usePermissions()
+
   // Hide FAB on the /chat page — it's redundant there
   if (router.pathname === "/chat") return <></>
+  // Hide entirely until permissions resolve, then only render if user has AI access.
+  if (permsLoading || !canRunAi) return <></>
 
   return (
     <>

--- a/src/components/features/holdings/AssetNewsButton.tsx
+++ b/src/components/features/holdings/AssetNewsButton.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from "react"
 import { Asset } from "types/beancounter"
 import { isCashRelated, stripOwnerPrefix } from "@lib/assets/assetUtils"
+import { usePermissions } from "@hooks/usePermissions"
 
 interface AssetNewsButtonProps {
   asset: Asset
@@ -19,6 +20,8 @@ const AssetNewsButton: React.FC<AssetNewsButtonProps> = ({
   onShow,
   iconClassName = "text-xs",
 }): ReactElement | null => {
+  const { ai: canRunAi, preview: canPreview } = usePermissions()
+  if (!canRunAi && !canPreview) return null
   if (isCashRelated(asset) || asset.market?.code === "PRIVATE") return null
   const ticker = stripOwnerPrefix(asset.code)
   return (

--- a/src/components/features/portfolios/PortfoliosList.tsx
+++ b/src/components/features/portfolios/PortfoliosList.tsx
@@ -7,6 +7,7 @@ import { QuickTooltip } from "@components/ui/Tooltip"
 import PortfolioActions from "./PortfolioActions"
 import PortfolioAIOverview from "./PortfolioAIOverview"
 import { getSortIcon, SortConfig } from "@lib/sortIcon"
+import { usePermissions } from "@hooks/usePermissions"
 
 interface PortfoliosListProps {
   portfolios: Portfolio[]
@@ -137,6 +138,7 @@ const PortfoliosList: React.FC<PortfoliosListProps> = ({
   isInactiveTab = false,
 }) => {
   const router = useRouter()
+  const { ai: canRunAi } = usePermissions()
 
   const [sortConfig, setSortConfig] = useState<SortConfig>({
     key: "code",
@@ -448,14 +450,16 @@ const PortfoliosList: React.FC<PortfoliosListProps> = ({
                   className="flex items-center space-x-4"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <button
-                    onClick={() => toggleExpand(portfolio.code)}
-                    className={`p-1 ${expandedPortfolios.has(portfolio.code) ? "text-purple-700" : "text-purple-500 hover:text-purple-700"}`}
-                    title={"AI Overview"}
-                    aria-expanded={expandedPortfolios.has(portfolio.code)}
-                  >
-                    <i className="fas fa-wand-magic-sparkles"></i>
-                  </button>
+                  {canRunAi && (
+                    <button
+                      onClick={() => toggleExpand(portfolio.code)}
+                      className={`p-1 ${expandedPortfolios.has(portfolio.code) ? "text-purple-700" : "text-purple-500 hover:text-purple-700"}`}
+                      title={"AI Overview"}
+                      aria-expanded={expandedPortfolios.has(portfolio.code)}
+                    >
+                      <i className="fas fa-wand-magic-sparkles"></i>
+                    </button>
+                  )}
                   <button
                     onClick={() => onShareClick(portfolio.id)}
                     className="text-blue-500 hover:text-blue-700 p-1"
@@ -492,7 +496,7 @@ const PortfoliosList: React.FC<PortfoliosListProps> = ({
                 </div>
               </div>
             </div>
-            {expandedPortfolios.has(portfolio.code) && (
+            {canRunAi && expandedPortfolios.has(portfolio.code) && (
               <div className="px-4 pb-4" onClick={(e) => e.stopPropagation()}>
                 <PortfolioAIOverview portfolio={portfolio} />
               </div>
@@ -720,17 +724,21 @@ const PortfoliosList: React.FC<PortfoliosListProps> = ({
                     </td>
                     <td className="px-4 py-3">
                       <div className="action-buttons flex items-center justify-center space-x-3">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            toggleExpand(portfolio.code)
-                          }}
-                          className={`transition-colors ${expandedPortfolios.has(portfolio.code) ? "text-purple-700" : "text-slate-400 hover:text-purple-600"}`}
-                          title={"AI Overview"}
-                          aria-expanded={expandedPortfolios.has(portfolio.code)}
-                        >
-                          <i className="fas fa-wand-magic-sparkles text-lg"></i>
-                        </button>
+                        {canRunAi && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              toggleExpand(portfolio.code)
+                            }}
+                            className={`transition-colors ${expandedPortfolios.has(portfolio.code) ? "text-purple-700" : "text-slate-400 hover:text-purple-600"}`}
+                            title={"AI Overview"}
+                            aria-expanded={expandedPortfolios.has(
+                              portfolio.code,
+                            )}
+                          >
+                            <i className="fas fa-wand-magic-sparkles text-lg"></i>
+                          </button>
+                        )}
                         <button
                           onClick={(e) => {
                             e.stopPropagation()
@@ -775,7 +783,7 @@ const PortfoliosList: React.FC<PortfoliosListProps> = ({
                       </div>
                     </td>
                   </tr>
-                  {expandedPortfolios.has(portfolio.code) && (
+                  {canRunAi && expandedPortfolios.has(portfolio.code) && (
                     <tr
                       className={
                         index % 2 === 0 ? "bg-white" : "bg-slate-50/40"

--- a/src/components/layout/HeaderBrand.tsx
+++ b/src/components/layout/HeaderBrand.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react"
 import { useRouter } from "next/router"
 import Link from "next/link"
 import { useIsAdmin } from "@hooks/useIsAdmin"
+import { usePermissions } from "@hooks/usePermissions"
 
 interface NavItem {
   href: string
@@ -9,6 +10,7 @@ interface NavItem {
   icon: string
   description?: string
   adminOnly?: boolean
+  aiOnly?: boolean
 }
 
 interface NavSection {
@@ -54,7 +56,7 @@ const navSections: NavSection[] = [
   {
     title: "Tools",
     items: [
-      { href: "/chat", label: "Chat", icon: "fa-robot" },
+      { href: "/chat", label: "Chat", icon: "fa-robot", aiOnly: true },
       { href: "/fx", label: "FX Rates", icon: "fa-exchange-alt" },
       { href: "/fx/calculator", label: "FX Calculator", icon: "fa-calculator" },
       { href: "/tax-rates", label: "Tax Rates", icon: "fa-percent" },
@@ -98,10 +100,12 @@ const defaultSectionColor = {
 function DesktopDropdown({
   section,
   isAdmin,
+  canRunAi,
   router,
 }: {
   section: NavSection
   isAdmin: boolean
+  canRunAi: boolean
   router: ReturnType<typeof useRouter>
 }): React.ReactElement {
   const [isOpen, setIsOpen] = useState(false)
@@ -140,7 +144,7 @@ function DesktopDropdown({
   }, [isOpen])
 
   const filteredItems = section.items.filter(
-    (item) => !item.adminOnly || isAdmin,
+    (item) => (!item.adminOnly || isAdmin) && (!item.aiOnly || canRunAi),
   )
   const isActive = filteredItems.some((item) =>
     isActiveRoute(router.pathname, item.href),
@@ -210,6 +214,7 @@ function DesktopDropdown({
 function HeaderBrand(): React.ReactElement {
   const router = useRouter()
   const { isAdmin } = useIsAdmin()
+  const { ai: canRunAi } = usePermissions()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const mobileMenuRef = useRef<HTMLDivElement>(null)
 
@@ -264,7 +269,8 @@ function HeaderBrand(): React.ReactElement {
             <div className="py-2 max-h-[75vh] overflow-y-auto">
               {navSections.map((section, sectionIdx) => {
                 const filteredItems = section.items.filter(
-                  (item) => !item.adminOnly || isAdmin,
+                  (item) =>
+                    (!item.adminOnly || isAdmin) && (!item.aiOnly || canRunAi),
                 )
                 if (filteredItems.length === 0) return null
                 return (
@@ -332,6 +338,7 @@ function HeaderBrand(): React.ReactElement {
             key={section.title}
             section={section}
             isAdmin={isAdmin}
+            canRunAi={canRunAi}
             router={router}
           />
         ))}

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -36,6 +36,13 @@ export function usePermissions(): PermissionsResult {
             preview: !!data.preview,
             admin: !!data.admin,
           })
+        } else {
+          console.error(
+            "Failed to fetch permissions:",
+            response.status,
+            response.statusText,
+          )
+          setPerms(EMPTY)
         }
       } catch (error) {
         console.error("Failed to fetch permissions:", error)

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react"
+
+export interface Permissions {
+  ai: boolean
+  preview: boolean
+  admin: boolean
+}
+
+interface PermissionsResult extends Permissions {
+  isLoading: boolean
+}
+
+const EMPTY: Permissions = { ai: false, preview: false, admin: false }
+
+/**
+ * Reports the Beancounter permissions held by the current user.
+ *  - `ai`      — can run any AI agent review.
+ *  - `preview` — can run the Asset AI Review preview surfaces only.
+ *  - `admin`   — administrative endpoints.
+ *
+ * Use `ai || preview` to gate the Asset Review and per-holding News popups;
+ * use `ai` alone for full-tier surfaces (portfolio overview, chat, etc.).
+ */
+export function usePermissions(): PermissionsResult {
+  const [perms, setPerms] = useState<Permissions>(EMPTY)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    async function fetchPermissions(): Promise<void> {
+      try {
+        const response = await fetch("/api/auth/permissions")
+        if (response.ok) {
+          const data = (await response.json()) as Permissions
+          setPerms({
+            ai: !!data.ai,
+            preview: !!data.preview,
+            admin: !!data.admin,
+          })
+        }
+      } catch (error) {
+        console.error("Failed to fetch permissions:", error)
+        setPerms(EMPTY)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchPermissions()
+  }, [])
+
+  return { ...perms, isLoading }
+}

--- a/src/lib/utils/auth0.ts
+++ b/src/lib/utils/auth0.ts
@@ -7,7 +7,8 @@ export const auth0 = new Auth0Client({
   authorizationParameters: {
     scope:
       "openid profile email offline_access " +
-      "beancounter beancounter:user beancounter:admin",
+      "beancounter beancounter:user beancounter:admin " +
+      "beancounter:ai beancounter:preview",
     audience: "https://holdsworth.app",
     prompt: "login",
   },

--- a/src/pages/api/auth/permissions.ts
+++ b/src/pages/api/auth/permissions.ts
@@ -1,0 +1,59 @@
+import { auth0 } from "@lib/auth0"
+import { NextApiRequest, NextApiResponse } from "next"
+
+interface Permissions {
+  ai: boolean
+  preview: boolean
+  admin: boolean
+}
+
+const NONE: Permissions = { ai: false, preview: false, admin: false }
+
+/**
+ * Decode the access token and report which Beancounter permissions the
+ * caller holds. Used by the bc-view UI to gate AI surfaces (full review,
+ * preview-only) without exposing the access token to the browser.
+ */
+export default async function permissions(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  try {
+    const session = await auth0.getSession(req)
+    if (!session) {
+      return res.status(401).json({ error: "Not authenticated" })
+    }
+
+    const { token: accessToken } = await auth0.getAccessToken(req, res)
+    if (!accessToken) {
+      return res.status(200).json(NONE)
+    }
+
+    const parts = accessToken.split(".")
+    if (parts.length !== 3) {
+      return res.status(200).json(NONE)
+    }
+
+    const payload = JSON.parse(
+      Buffer.from(parts[1], "base64").toString("utf-8"),
+    )
+
+    // Split scope on whitespace so we exact-match tokens — `scope.includes`
+    // would silently approve `beancounter:ai-trainer` against a check for
+    // `beancounter:ai`.
+    const scope: string = payload.scope || ""
+    const scopes = scope.split(/\s+/).filter(Boolean)
+    const permissions: string[] = payload.permissions || []
+    const has = (perm: string): boolean =>
+      scopes.includes(perm) || permissions.includes(perm)
+
+    return res.status(200).json({
+      ai: has("beancounter:ai"),
+      preview: has("beancounter:preview"),
+      admin: has("beancounter:admin"),
+    })
+  } catch (error) {
+    console.error("Permission check error:", error)
+    return res.status(200).json(NONE)
+  }
+}

--- a/src/pages/assets/lookup.tsx
+++ b/src/pages/assets/lookup.tsx
@@ -9,6 +9,7 @@ import { ModelsContainingAssetResponse } from "types/rebalance"
 import AssetSearch from "@components/features/assets/AssetSearch"
 import { useAssetReview } from "@components/features/assets/useAssetReview"
 import Spinner from "@components/ui/Spinner"
+import { usePermissions } from "@hooks/usePermissions"
 
 interface AssetPosition {
   portfolio: Portfolio
@@ -25,6 +26,8 @@ function AssetLookupPage(): React.ReactElement {
     preferences?.defaultMarket || "",
   )
   const { popup: reviewPopup, showReview } = useAssetReview()
+  const { ai: canRunAi, preview: canPreview } = usePermissions()
+  const canReviewAsset = canRunAi || canPreview
 
   // Fetch available markets
   const { data: marketsData } = useSWR<{ data: Market[] }>(
@@ -155,16 +158,18 @@ function AssetLookupPage(): React.ReactElement {
                 )}
               </div>
             </div>
-            <button
-              type="button"
-              onClick={() => showReview(selectedAsset)}
-              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-purple-600 text-white text-sm font-medium hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-1"
-              aria-label={`Open AI Asset Review for ${selectedAsset.symbol}`}
-              title="AI Asset Review"
-            >
-              <i className="fas fa-microscope"></i>
-              <span>AI Review</span>
-            </button>
+            {canReviewAsset && (
+              <button
+                type="button"
+                onClick={() => showReview(selectedAsset)}
+                className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-purple-600 text-white text-sm font-medium hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-1"
+                aria-label={`Open AI Asset Review for ${selectedAsset.symbol}`}
+                title="AI Asset Review"
+              >
+                <i className="fas fa-microscope"></i>
+                <span>AI Review</span>
+              </button>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- New `usePermissions` hook + `/api/auth/permissions` endpoint expose `{ ai, preview, admin }` by decoding the access token (whitespace-split scope check, exact-match per token).
- Request `beancounter:ai` and `beancounter:preview` at login (`src/lib/utils/auth0.ts`).
- Gate Portfolio AI Overview button + panel (card and table views), Chat FAB, and Tools → Chat header link behind `permissions.ai`.
- Gate Asset Review icon and the per-holding News & Sentiment popup behind `permissions.ai || permissions.preview` — these are the only preview-eligible surfaces.
- Mock `usePermissions` permissively in `jest.setup.js` so existing component tests render the gated surfaces; denial paths can be overridden per-suite.

## Pairs with

- beancounter (backend enforcement): https://github.com/monowai/beancounter/pull/new/feat/auth0-ai-permissions

## Auth0 dashboard work (manual)

1. Beancounter API → add permissions `beancounter:ai`, `beancounter:preview`.
2. Add `beancounter:preview` to the default `beancounter` role.
3. Create `beancounter-ai` role; assign permission `beancounter:ai`; assign role to users who get full AI.

## Test plan

- [x] `yarn test` (1237 passed) / `yarn typecheck` / `yarn lint` / `yarn prettier` green
- [ ] User with `beancounter-ai` role: all six AI surfaces render; `/api/agent/query` returns 200
- [ ] User with default role only (`beancounter:preview`): only Asset Review icon and News popup render; backend returns 200 for those, 403 for portfolio/chat surfaces (which are hidden anyway)
- [ ] User with neither: no AI icons; backend returns 403 if `/api/agent/query` is hit directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI and preview permissions now gate Chat, AI Overview, AI Asset Review, navigation items, and related UI controls so they only appear when allowed.

* **Tests**
  * Test setup updated to mock permissions and API responses for predictable permission-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->