### PR TITLE
feat(portfolios): Focus AI overview on biggest movers

### DIFF
--- a/src/components/features/portfolios/PortfolioAIOverview.tsx
+++ b/src/components/features/portfolios/PortfolioAIOverview.tsx
@@ -19,7 +19,7 @@ interface TopHolding {
   gainOnDayPercent: number | null
 }
 
-const MAX_HOLDINGS_IN_PROMPT = 10
+const MAX_MOVERS_PER_SIDE = 5
 const CACHE_TTL_MS = 15 * 60 * 1000
 
 const overviewCache = new Map<string, { response: string; fetchedAt: number }>()
@@ -42,12 +42,17 @@ function safePct(numerator: number, denominator: number): number | null {
   return (numerator / denominator) * 100
 }
 
-function buildTopHoldings(holdings: Holdings | null): TopHolding[] {
-  if (!holdings?.holdingGroups) return []
+interface BiggestMovers {
+  gainers: TopHolding[]
+  losers: TopHolding[]
+}
+
+function buildBiggestMovers(holdings: Holdings | null): BiggestMovers {
+  if (!holdings?.holdingGroups) return { gainers: [], losers: [] }
   const positions: Position[] = Object.values(holdings.holdingGroups).flatMap(
     (g) => g.positions,
   )
-  return positions
+  const movers = positions
     .map<TopHolding>((p) => {
       const marketValue = p.moneyValues?.PORTFOLIO?.marketValue ?? 0
       const gainOnDay = p.moneyValues?.PORTFOLIO?.gainOnDay ?? 0
@@ -61,12 +66,37 @@ function buildTopHoldings(holdings: Holdings | null): TopHolding[] {
         gainOnDayPercent: safePct(gainOnDay, marketValue - gainOnDay),
       }
     })
-    .filter((h) => h.marketValue > 0)
-    .sort((a, b) => b.marketValue - a.marketValue)
-    .slice(0, MAX_HOLDINGS_IN_PROMPT)
+    .filter(
+      (h): h is TopHolding & { gainOnDayPercent: number } =>
+        h.marketValue > 0 && h.gainOnDayPercent !== null,
+    )
+
+  const gainers = [...movers]
+    .filter((h) => h.gainOnDayPercent > 0)
+    .sort((a, b) => b.gainOnDayPercent - a.gainOnDayPercent)
+    .slice(0, MAX_MOVERS_PER_SIDE)
+
+  const losers = [...movers]
+    .filter((h) => h.gainOnDayPercent < 0)
+    .sort((a, b) => a.gainOnDayPercent - b.gainOnDayPercent)
+    .slice(0, MAX_MOVERS_PER_SIDE)
+
+  return { gainers, losers }
 }
 
-function buildQuery(portfolio: Portfolio, top: TopHolding[]): string {
+function formatHolding(h: TopHolding, i: number): string {
+  const marketLabel = h.market ? `.${h.market}` : ""
+  const sectorLabel = h.sector ? ` [${h.sector}]` : ""
+  const dayLabel =
+    h.gainOnDayPercent !== null ? `, day ${h.gainOnDayPercent.toFixed(2)}%` : ""
+  return (
+    `${i + 1}. ${h.code}${marketLabel}${sectorLabel}` +
+    ` — weight ${(h.weight * 100).toFixed(1)}%${dayLabel}` +
+    (h.name ? ` (${h.name})` : "")
+  )
+}
+
+function buildQuery(portfolio: Portfolio, movers: BiggestMovers): string {
   const lines: string[] = []
   lines.push(
     `Provide an AI overview for portfolio ${portfolio.code} (${portfolio.name}).`,
@@ -91,28 +121,25 @@ function buildQuery(portfolio: Portfolio, top: TopHolding[]): string {
         ".",
     )
   }
-  if (top.length) {
-    lines.push(`Top ${top.length} holdings by market value:`)
-    top.forEach((h, i) => {
-      const marketLabel = h.market ? `.${h.market}` : ""
-      const sectorLabel = h.sector ? ` [${h.sector}]` : ""
-      const dayLabel =
-        h.gainOnDayPercent !== null
-          ? `, day ${h.gainOnDayPercent.toFixed(2)}%`
-          : ""
-      lines.push(
-        `${i + 1}. ${h.code}${marketLabel}${sectorLabel}` +
-          ` — weight ${(h.weight * 100).toFixed(1)}%${dayLabel}` +
-          (h.name ? ` (${h.name})` : ""),
-      )
-    })
+  if (movers.gainers.length) {
+    lines.push(`Top gainers today (by % move):`)
+    movers.gainers.forEach((h, i) => lines.push(formatHolding(h, i)))
+  }
+  if (movers.losers.length) {
+    lines.push(`Top losers today (by % move):`)
+    movers.losers.forEach((h, i) => lines.push(formatHolding(h, i)))
+  }
+  if (!movers.gainers.length && !movers.losers.length) {
+    lines.push("(No daily price moves available for the current holdings.)")
   }
   lines.push(
-    "Summarise: (1) key movers today and recent notable news/sentiment across the top holdings, " +
-      "(2) macro-economic factors (rates, inflation, FX, geopolitical themes) that could affect this mix, " +
-      "(3) concentration or sector-exposure observations worth the holder's attention. " +
-      "Where live news is unavailable, clearly label output as general knowledge rather than live news. " +
-      "Use concise markdown with headings.",
+    "Focus on news and corporate events driving today's biggest movers above " +
+      "(both gainers and losers). For each named mover, surface the specific " +
+      "story or event that explains the move where possible. Then briefly note " +
+      "any macro-economic factors (rates, inflation, FX, geopolitical) that " +
+      "tie the movers together. Where live news is unavailable for a ticker, " +
+      "label that section as general knowledge rather than live news. Use " +
+      "concise markdown with one heading per mover.",
   )
   return lines.join("\n")
 }
@@ -138,8 +165,8 @@ async function performFetch(
   asAt: string,
 ): Promise<string> {
   const holdings = await fetchHoldings(portfolio.code, asAt)
-  const top = buildTopHoldings(holdings)
-  const query = buildQuery(portfolio, top)
+  const movers = buildBiggestMovers(holdings)
+  const query = buildQuery(portfolio, movers)
 
   const res = await fetch("/api/agent/query", {
     method: "POST",
@@ -149,13 +176,14 @@ async function performFetch(
       context: {
         page: "Portfolio AI Overview",
         description:
-          "Holistic summary of a user's portfolio — key movers, news, sentiment, macro impact.",
+          "News and events behind today's biggest gainers and losers in the portfolio.",
         portfolioCode: portfolio.code,
         portfolioName: portfolio.name,
         baseCurrency: portfolio.base.code,
         reportingCurrency: portfolio.currency.code,
         asAt,
-        topHoldings: top,
+        topGainers: movers.gainers,
+        topLosers: movers.losers,
       },
     }),
   })

--- a/src/components/features/portfolios/__tests__/PortfolioAIOverview.test.tsx
+++ b/src/components/features/portfolios/__tests__/PortfolioAIOverview.test.tsx
@@ -2,7 +2,13 @@ import React from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import PortfolioAIOverview, { clearOverviewCache } from "../PortfolioAIOverview"
 import { Portfolio } from "types/beancounter"
-import { makePortfolio } from "@test-fixtures/beancounter"
+import {
+  makeAsset,
+  makeHoldingGroup,
+  makeHoldings,
+  makePortfolio,
+  makePosition,
+} from "@test-fixtures/beancounter"
 
 // react-markdown / remark-gfm mocked globally in jest.setup.js
 
@@ -206,44 +212,32 @@ describe("PortfolioAIOverview", () => {
   it("caps gainers and losers at 5 per side", async () => {
     // 12 holdings: 7 winners with rising % moves, 5 losers with falling % moves.
     const positions = [
-      ...Array.from({ length: 7 }, (_, i) => ({
-        asset: {
-          code: `WIN${i}`,
-          name: `Winner ${i}`,
-          market: { code: "NASDAQ" },
-          sector: "Technology",
-        },
-        moneyValues: {
-          PORTFOLIO: {
-            marketValue: 1000,
-            gainOnDay: 10 + i, // larger gain → larger %
-            weight: 0.05,
-          },
-        },
-      })),
-      ...Array.from({ length: 5 }, (_, i) => ({
-        asset: {
-          code: `LOSE${i}`,
-          name: `Loser ${i}`,
-          market: { code: "NASDAQ" },
-          sector: "Technology",
-        },
-        moneyValues: {
-          PORTFOLIO: {
+      ...Array.from({ length: 7 }, (_, i) =>
+        makePosition({
+          asset: makeAsset({ code: `WIN${i}`, name: `Winner ${i}` }),
+          moneyValues: { marketValue: 1000, gainOnDay: 10 + i, weight: 0.05 },
+        }),
+      ),
+      ...Array.from({ length: 5 }, (_, i) =>
+        makePosition({
+          asset: makeAsset({ code: `LOSE${i}`, name: `Loser ${i}` }),
+          moneyValues: {
             marketValue: 1000,
             gainOnDay: -(10 + i),
             weight: 0.05,
           },
-        },
-      })),
+        }),
+      ),
     ]
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
         json: () =>
-          Promise.resolve({
-            holdingGroups: { EQUITY: { positions } },
-          }),
+          Promise.resolve(
+            makeHoldings({
+              holdingGroups: { EQUITY: makeHoldingGroup({ positions }) },
+            }),
+          ),
       })
       .mockResolvedValueOnce(agentResponse("Capped movers"))
     render(<PortfolioAIOverview portfolio={basePortfolio} />)

--- a/src/components/features/portfolios/__tests__/PortfolioAIOverview.test.tsx
+++ b/src/components/features/portfolios/__tests__/PortfolioAIOverview.test.tsx
@@ -132,7 +132,8 @@ describe("PortfolioAIOverview", () => {
       expect(screen.getByText("Overview without holdings")).toBeInTheDocument()
     })
     const agentBody = JSON.parse(mockFetch.mock.calls[1][1].body)
-    expect(agentBody.context.topHoldings).toEqual([])
+    expect(agentBody.context.topGainers).toEqual([])
+    expect(agentBody.context.topLosers).toEqual([])
   })
 
   it("reuses cached response on second mount for the same portfolio", async () => {
@@ -180,55 +181,81 @@ describe("PortfolioAIOverview", () => {
     expect(mockFetch).toHaveBeenCalledTimes(4)
   })
 
-  it("sends top holdings ordered by market value to the agent", async () => {
+  it("splits holdings into top gainers and losers by % move", async () => {
     mockFetch
       .mockResolvedValueOnce(holdingsResponse())
-      .mockResolvedValueOnce(agentResponse("Ranked overview"))
+      .mockResolvedValueOnce(agentResponse("Movers overview"))
     render(<PortfolioAIOverview portfolio={basePortfolio} />)
     await waitFor(() => {
-      expect(screen.getByText("Ranked overview")).toBeInTheDocument()
+      expect(screen.getByText("Movers overview")).toBeInTheDocument()
     })
     const agentCall = mockFetch.mock.calls[1]
     expect(agentCall[0]).toBe("/api/agent/query")
     const body = JSON.parse(agentCall[1].body)
     expect(body.context.portfolioCode).toBe("TEST")
-    expect(body.context.topHoldings[0].code).toBe("AAPL")
-    expect(body.context.topHoldings[1].code).toBe("MSFT")
+    // AAPL up, MSFT down — one of each.
+    expect(body.context.topGainers).toHaveLength(1)
+    expect(body.context.topGainers[0].code).toBe("AAPL")
+    expect(body.context.topLosers).toHaveLength(1)
+    expect(body.context.topLosers[0].code).toBe("MSFT")
     expect(body.query).toContain("TEST")
-    expect(body.query).toContain("AAPL")
+    expect(body.query).toContain("Top gainers")
+    expect(body.query).toContain("Top losers")
   })
 
-  it("caps the prompt at 10 holdings", async () => {
-    const manyPositions = Array.from({ length: 15 }, (_, i) => ({
-      asset: {
-        code: `SYM${i}`,
-        name: `Symbol ${i}`,
-        market: { code: "NASDAQ" },
-        sector: "Technology",
-      },
-      moneyValues: {
-        PORTFOLIO: {
-          marketValue: 1000 * (15 - i),
-          gainOnDay: 10,
-          weight: 0.05,
+  it("caps gainers and losers at 5 per side", async () => {
+    // 12 holdings: 7 winners with rising % moves, 5 losers with falling % moves.
+    const positions = [
+      ...Array.from({ length: 7 }, (_, i) => ({
+        asset: {
+          code: `WIN${i}`,
+          name: `Winner ${i}`,
+          market: { code: "NASDAQ" },
+          sector: "Technology",
         },
-      },
-    }))
+        moneyValues: {
+          PORTFOLIO: {
+            marketValue: 1000,
+            gainOnDay: 10 + i, // larger gain → larger %
+            weight: 0.05,
+          },
+        },
+      })),
+      ...Array.from({ length: 5 }, (_, i) => ({
+        asset: {
+          code: `LOSE${i}`,
+          name: `Loser ${i}`,
+          market: { code: "NASDAQ" },
+          sector: "Technology",
+        },
+        moneyValues: {
+          PORTFOLIO: {
+            marketValue: 1000,
+            gainOnDay: -(10 + i),
+            weight: 0.05,
+          },
+        },
+      })),
+    ]
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
         json: () =>
           Promise.resolve({
-            holdingGroups: { EQUITY: { positions: manyPositions } },
+            holdingGroups: { EQUITY: { positions } },
           }),
       })
-      .mockResolvedValueOnce(agentResponse("Top 10 overview"))
+      .mockResolvedValueOnce(agentResponse("Capped movers"))
     render(<PortfolioAIOverview portfolio={basePortfolio} />)
     await waitFor(() => {
-      expect(screen.getByText("Top 10 overview")).toBeInTheDocument()
+      expect(screen.getByText("Capped movers")).toBeInTheDocument()
     })
     const body = JSON.parse(mockFetch.mock.calls[1][1].body)
-    expect(body.context.topHoldings).toHaveLength(10)
-    expect(body.context.topHoldings[0].code).toBe("SYM0")
+    expect(body.context.topGainers).toHaveLength(5)
+    expect(body.context.topLosers).toHaveLength(5)
+    // Biggest gainer (largest % move) leads the gainers list.
+    expect(body.context.topGainers[0].code).toBe("WIN6")
+    // Biggest loser (most negative % move) leads the losers list.
+    expect(body.context.topLosers[0].code).toBe("LOSE4")
   })
 })


### PR DESCRIPTION
## Summary

The Portfolio AI Overview on \`/portfolios\` now keys off today's biggest movers — both gainers and losers — instead of the largest holdings by market value.

- \`buildBiggestMovers\` splits positions into top 5 gainers and top 5 losers ranked by % day move (signed, not absolute), so positives don't crowd negatives off the list
- Prompt asks the model for the news / corporate event behind each named mover, one heading per mover, with a fallback label when live news is unavailable
- \`context\` now ships \`topGainers\` and \`topLosers\` arrays (replacing \`topHoldings\`) — the \`page\` value remains \`Portfolio AI Overview\` so the existing \`beancounter:ai\` scope check still applies

## Test plan

- [x] \`yarn test\` (1237 passed) — updated \`PortfolioAIOverview.test.tsx\` for the new shape; added a regression test capping at 5 per side
- [x] \`yarn typecheck\`, \`yarn lint\`, \`yarn prettier\` green
- [ ] Manual: open a portfolio with mixed gainers/losers in \`/portfolios\`, expand the AI Overview, confirm the response leads with the movers and explains each

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Portfolio AI overview now highlights biggest daily movers, presenting separate "Top gainers today" and "Top losers today" sections and requester instructions focused on mover/event-based summaries.
* **Tests**
  * Updated tests to expect gainers/losers split, enforce a cap per side, and verify the new prompt semantics and payload shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->