### PR TITLE
fix(portfolios): Read positions from /api/holdings response wrapper

### DIFF
--- a/src/components/features/portfolios/PortfolioAIOverview.tsx
+++ b/src/components/features/portfolios/PortfolioAIOverview.tsx
@@ -3,7 +3,7 @@ import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import Spinner from "@components/ui/Spinner"
 import { AgentResponse } from "types/agent"
-import { Holdings, Portfolio, Position } from "types/beancounter"
+import { HoldingContract, Portfolio, Position } from "types/beancounter"
 
 interface PortfolioAIOverviewProps {
   portfolio: Portfolio
@@ -47,11 +47,11 @@ interface BiggestMovers {
   losers: TopHolding[]
 }
 
-function buildBiggestMovers(holdings: Holdings | null): BiggestMovers {
-  if (!holdings?.holdingGroups) return { gainers: [], losers: [] }
-  const positions: Position[] = Object.values(holdings.holdingGroups).flatMap(
-    (g) => g.positions,
-  )
+function buildBiggestMovers(holdings: HoldingContract | null): BiggestMovers {
+  if (!holdings?.positions) return { gainers: [], losers: [] }
+  // The svc-position contract returns positions as a Record keyed by
+  // owner.asset:bucket — flatten to Position[] before ranking.
+  const positions: Position[] = Object.values(holdings.positions)
   const movers = positions
     .map<TopHolding>((p) => {
       const marketValue = p.moneyValues?.PORTFOLIO?.marketValue ?? 0
@@ -147,13 +147,15 @@ function buildQuery(portfolio: Portfolio, movers: BiggestMovers): string {
 async function fetchHoldings(
   code: string,
   asAt: string,
-): Promise<Holdings | null> {
+): Promise<HoldingContract | null> {
   try {
     const res = await fetch(
       `/api/holdings/${encodeURIComponent(code)}?asAt=${asAt}`,
     )
     if (!res.ok) return null
-    return (await res.json()) as Holdings
+    // svc-position wraps the contract in `{ data: HoldingContract }`.
+    const body = (await res.json()) as { data?: HoldingContract }
+    return body.data ?? null
   } catch {
     return null
   }

--- a/src/components/features/portfolios/__tests__/PortfolioAIOverview.test.tsx
+++ b/src/components/features/portfolios/__tests__/PortfolioAIOverview.test.tsx
@@ -4,8 +4,6 @@ import PortfolioAIOverview, { clearOverviewCache } from "../PortfolioAIOverview"
 import { Portfolio } from "types/beancounter"
 import {
   makeAsset,
-  makeHoldingGroup,
-  makeHoldings,
   makePortfolio,
   makePosition,
 } from "@test-fixtures/beancounter"
@@ -29,44 +27,46 @@ interface MockResponse {
 }
 
 function holdingsResponse(): MockResponse {
+  // svc-position contract: { data: { positions: Record<string, Position> } }.
+  // We hand-build a couple of positions because the shared makePosition
+  // fixture defaults to a single bucket with no daily move, and these tests
+  // need explicit gainOnDay values per holding.
   return {
     ok: true,
     json: () =>
       Promise.resolve({
-        holdingGroups: {
-          EQUITY: {
-            positions: [
-              {
-                asset: {
-                  code: "AAPL",
-                  name: "Apple",
-                  market: { code: "NASDAQ" },
-                  sector: "Technology",
-                },
-                moneyValues: {
-                  PORTFOLIO: {
-                    marketValue: 50000,
-                    gainOnDay: 500,
-                    weight: 0.5,
-                  },
+        data: {
+          positions: {
+            "owner.AAPL:PORTFOLIO": {
+              asset: {
+                code: "AAPL",
+                name: "Apple",
+                market: { code: "NASDAQ" },
+                sector: "Technology",
+              },
+              moneyValues: {
+                PORTFOLIO: {
+                  marketValue: 50000,
+                  gainOnDay: 500,
+                  weight: 0.5,
                 },
               },
-              {
-                asset: {
-                  code: "MSFT",
-                  name: "Microsoft",
-                  market: { code: "NASDAQ" },
-                  sector: "Technology",
-                },
-                moneyValues: {
-                  PORTFOLIO: {
-                    marketValue: 30000,
-                    gainOnDay: -100,
-                    weight: 0.3,
-                  },
+            },
+            "owner.MSFT:PORTFOLIO": {
+              asset: {
+                code: "MSFT",
+                name: "Microsoft",
+                market: { code: "NASDAQ" },
+                sector: "Technology",
+              },
+              moneyValues: {
+                PORTFOLIO: {
+                  marketValue: 30000,
+                  gainOnDay: -100,
+                  weight: 0.3,
                 },
               },
-            ],
+            },
           },
         },
       }),
@@ -211,7 +211,7 @@ describe("PortfolioAIOverview", () => {
 
   it("caps gainers and losers at 5 per side", async () => {
     // 12 holdings: 7 winners with rising % moves, 5 losers with falling % moves.
-    const positions = [
+    const positionList = [
       ...Array.from({ length: 7 }, (_, i) =>
         makePosition({
           asset: makeAsset({ code: `WIN${i}`, name: `Winner ${i}` }),
@@ -229,15 +229,13 @@ describe("PortfolioAIOverview", () => {
         }),
       ),
     ]
+    const positions = Object.fromEntries(
+      positionList.map((p) => [`owner.${p.asset.code}:PORTFOLIO`, p]),
+    )
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: () =>
-          Promise.resolve(
-            makeHoldings({
-              holdingGroups: { EQUITY: makeHoldingGroup({ positions }) },
-            }),
-          ),
+        json: () => Promise.resolve({ data: { positions } }),
       })
       .mockResolvedValueOnce(agentResponse("Capped movers"))
     render(<PortfolioAIOverview portfolio={basePortfolio} />)


### PR DESCRIPTION
## Summary

The Portfolio AI Overview was always reporting **"No daily price moves available for the current holdings"** even when the holdings table on \`/portfolios\` showed live values.

Root cause: \`fetchHoldings\` cast the response to the client-side \`Holdings\` shape (\`{ holdingGroups: Record<…> }\`), but \`/api/holdings/{code}\` proxies straight to svc-position which returns \`{ data: HoldingContract }\` where \`positions\` is a \`Record<string, Position>\`. The client \`holdingGroups\` view is built later by \`calculateHoldings\` on the holdings page — it is *not* in the API response. So \`Object.values(holdings.holdingGroups).flatMap(...)\` walked an undefined map and produced an empty position list, which my mover split correctly bucketed as zero gainers / zero losers.

\`gainOnDay\` is already populated server-side (\`MarketValue.kt:104\`) when the position has a valid previous close, so no svc-position change is needed.

## Changes

- \`fetchHoldings\` returns \`HoldingContract\` from \`body.data\` instead of casting straight to \`Holdings\`
- \`buildBiggestMovers\` walks \`Object.values(contract.positions)\` directly
- Test data rewritten around the real contract: \`{ data: { positions: { "owner.CODE:PORTFOLIO": Position } } }\`

## Test plan

- [x] \`yarn test\` (1237 passed) / \`yarn typecheck\` / \`yarn lint\` / \`yarn prettier\` green
- [x] CodeRabbit \`-t uncommitted\` — 0 findings
- [ ] Manual: open a real portfolio with mixed up/down holdings on kauri, expand AI Overview, confirm the response cites at least one named gainer and one named loser by % move

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored portfolio holdings component to work with the current API data structure.
  * Updated test suite to accurately reflect the current API contract for portfolio holdings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->