### PR TITLE
fix(holdings): Group ACCOUNT/TRADE assets under CASH when grouping by Market

### DIFF
--- a/src/lib/utils/holdings/calculate.test.tsx
+++ b/src/lib/utils/holdings/calculate.test.tsx
@@ -1,4 +1,9 @@
-import { HoldingContract, HoldingGroup, Holdings } from "types/beancounter"
+import {
+  HoldingContract,
+  HoldingGroup,
+  Holdings,
+  Position,
+} from "types/beancounter"
 import * as path from "node:path"
 import * as fs from "node:fs"
 import { GroupBy, ValueIn } from "@components/features/holdings/GroupByOptions"
@@ -250,5 +255,50 @@ describe("Cash grouping behavior", () => {
       (p) => p.asset.assetCategory.id === "EQUITY",
     )
     expect(equityPositions.length).toEqual(2) // BKNG and MCD
+  })
+
+  it("should group ACCOUNT/TRADE assets under CASH market regardless of market.code", () => {
+    // Bank/trade accounts use the PRIVATE market in the backend, but for MARKET
+    // grouping users expect them to sit alongside cash currencies, not under PRIVATE.
+    const contractWithAccount: HoldingContract = JSON.parse(data).data
+    const cashTemplate = contractWithAccount.positions["USD:CASH"]
+    contractWithAccount.positions["BANK:PRIVATE"] = {
+      ...cashTemplate,
+      asset: {
+        ...cashTemplate.asset,
+        code: "user.BANK",
+        id: "bank-account-id",
+        name: "Bank Account",
+        market: { ...cashTemplate.asset.market, code: "PRIVATE" },
+        assetCategory: { id: "ACCOUNT", name: "Bank Account" },
+      },
+    } as unknown as Position
+    contractWithAccount.positions["IBKR:PRIVATE"] = {
+      ...cashTemplate,
+      asset: {
+        ...cashTemplate.asset,
+        code: "user.IBKR",
+        id: "trade-account-id",
+        name: "Trade Account",
+        market: { ...cashTemplate.asset.market, code: "PRIVATE" },
+        assetCategory: { id: "TRADE", name: "Trade Account" },
+      },
+    } as unknown as Position
+
+    const holdings = calculateHoldings(
+      contractWithAccount,
+      hideEmpty,
+      valueIn,
+      GroupBy.MARKET,
+    )
+
+    expect(holdings.holdingGroups["CASH"]).toBeDefined()
+    const cashCategories = holdings.holdingGroups["CASH"].positions.map(
+      (p) => p.asset.assetCategory.id,
+    )
+    expect(cashCategories).toEqual(
+      expect.arrayContaining(["CASH", "ACCOUNT", "TRADE"]),
+    )
+    expect(holdings.holdingGroups["PRIVATE"]).toBeUndefined()
   })
 })

--- a/src/lib/utils/holdings/calculateHoldings.ts
+++ b/src/lib/utils/holdings/calculateHoldings.ts
@@ -7,7 +7,12 @@ import {
   Position,
   Total,
 } from "types/beancounter"
-import { isNonTradeable, isCash, isAccount } from "@lib/assets/assetUtils"
+import {
+  isNonTradeable,
+  isCash,
+  isAccount,
+  isCashRelated,
+} from "@lib/assets/assetUtils"
 import { GroupBy, ValueIn } from "@components/features/holdings/GroupByOptions"
 import { getReportCategory } from "../categoryMapping"
 
@@ -27,7 +32,9 @@ function getPath(path: string, position: Position): string {
  * For MARKET_CURRENCY grouping, Cash assets are grouped by their asset code; non-cash
  *   assets are grouped by their trade currency (not market currency, which is wrong for
  *   PRIVATE market assets that have no inherent currency).
- * For MARKET grouping, Cash assets are grouped by their market (CASH).
+ * For MARKET grouping, cash-like assets (CASH currencies, ACCOUNT bank accounts,
+ *   TRADE accounts) collapse into the CASH group instead of using their backing
+ *   market.code (which is PRIVATE for ACCOUNT/TRADE).
  */
 function getGroupKey(groupBy: GroupBy, position: Position): string {
   if (groupBy === GroupBy.ASSET_CLASS) {
@@ -49,6 +56,14 @@ function getGroupKey(groupBy: GroupBy, position: Position): string {
       position.moneyValues["TRADE"]?.currency?.code ||
       getPath(groupBy, position)
     )
+  }
+  if (groupBy === GroupBy.MARKET) {
+    if (
+      isCashRelated(position.asset) ||
+      position.asset.assetCategory.id === "TRADE"
+    ) {
+      return "CASH"
+    }
   }
   return getPath(groupBy, position)
 }


### PR DESCRIPTION
## Summary
- ACCOUNT/TRADE assets are backed by the PRIVATE market, so grouping by Market rendered them under "PRIVATE" instead of with cash
- Collapse CASH/ACCOUNT/TRADE assets into the CASH group when GroupBy = Market, matching Asset Class behavior
- Added test covering ACCOUNT and TRADE positions on PRIVATE market

## Test plan
- [x] `yarn jest src/lib/utils/holdings/` (29 passed)
- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] Verify holdings view in browser: switch to Group By Market, confirm bank/trade accounts appear under Cash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated holdings grouping logic: Trade and account-related assets now properly consolidate under the cash group.

* **Tests**
  * Added test coverage validating holdings grouping behavior for various asset categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->