### PR TITLE
fix(holdings): Sort Cash group last in Market and Currency views

### DIFF
--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -23,7 +23,11 @@ import {
   supportsBalanceSetting,
 } from "@lib/assets/assetUtils"
 import { useDisplayCurrencyConversion } from "@lib/hooks/useDisplayCurrencyConversion"
-import { compareByReportCategory, compareBySector } from "@lib/categoryMapping"
+import {
+  compareByMarket,
+  compareByReportCategory,
+  compareBySector,
+} from "@lib/categoryMapping"
 import { GroupBy } from "@components/features/holdings/GroupByOptions"
 import { useRouter } from "next/router"
 import AssetNewsButton from "@components/features/holdings/AssetNewsButton"
@@ -468,8 +472,13 @@ const CardView: React.FC<CardViewProps> = ({
 }) => {
   // Group positions by holdingGroups, sorted by group comparator
   const groupedPositions = useMemo((): GroupedPositions[] => {
-    const sorter =
-      groupBy === GroupBy.SECTOR ? compareBySector : compareByReportCategory
+    let sorter: (a: string, b: string) => number = compareByReportCategory
+    if (groupBy === GroupBy.SECTOR) sorter = compareBySector
+    else if (
+      groupBy === GroupBy.MARKET ||
+      groupBy === GroupBy.MARKET_CURRENCY
+    )
+      sorter = compareByMarket
 
     return Object.keys(holdings.holdingGroups)
       .sort(sorter)

--- a/src/components/features/holdings/SummaryView.tsx
+++ b/src/components/features/holdings/SummaryView.tsx
@@ -17,8 +17,20 @@ import {
   AllocationSlice,
   GroupingMode,
 } from "@lib/allocation/aggregateHoldings"
-import { compareByReportCategory, compareBySector } from "@lib/categoryMapping"
+import {
+  compareByMarket,
+  compareByReportCategory,
+  compareBySector,
+} from "@lib/categoryMapping"
 import { useDisplayCurrencyConversion } from "@lib/hooks/useDisplayCurrencyConversion"
+
+function pickGroupComparator(
+  groupBy: GroupingMode,
+): (a: string, b: string) => number {
+  if (groupBy === "sector") return compareBySector
+  if (groupBy === "market") return compareByMarket
+  return compareByReportCategory
+}
 
 // Color palette for report categories
 const CATEGORY_COLORS: Record<string, string> = {
@@ -183,8 +195,7 @@ const SummaryView: React.FC<SummaryViewProps> = ({
 
   // Filter allocation data and sort by predefined order
   const filteredAllocation = useMemo(() => {
-    const sorter =
-      groupBy === "sector" ? compareBySector : compareByReportCategory
+    const sorter = pickGroupComparator(groupBy)
     return allocationData
       .filter((slice) => !excludedCategories.has(slice.key))
       .sort((a, b) => sorter(a.key, b.key))
@@ -461,9 +472,7 @@ const SummaryView: React.FC<SummaryViewProps> = ({
             <tbody>
               {[...allocationData]
                 .sort((a, b) =>
-                  (groupBy === "sector"
-                    ? compareBySector
-                    : compareByReportCategory)(a.key, b.key),
+                  pickGroupComparator(groupBy)(a.key, b.key),
                 )
                 .map((slice, index) => {
                   const isExcluded = excludedCategories.has(slice.key)

--- a/src/components/ui/PerformanceHeatmap.tsx
+++ b/src/components/ui/PerformanceHeatmap.tsx
@@ -6,7 +6,11 @@ import {
   isNonTradeable,
   stripOwnerPrefix,
 } from "@lib/assets/assetUtils"
-import { compareByReportCategory, compareBySector } from "@lib/categoryMapping"
+import {
+  compareByMarket,
+  compareByReportCategory,
+  compareBySector,
+} from "@lib/categoryMapping"
 import { GroupBy } from "@components/features/holdings/GroupByOptions"
 import { ProgressBar } from "@components/ui/ProgressBar"
 import Dialog from "@components/ui/Dialog"
@@ -86,8 +90,10 @@ export const PerformanceHeatmap: React.FC<PerformanceHeatmapProps> = ({
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null)
 
   // Build grouped cells
-  const sorter =
-    groupBy === GroupBy.SECTOR ? compareBySector : compareByReportCategory
+  let sorter: (a: string, b: string) => number = compareByReportCategory
+  if (groupBy === GroupBy.SECTOR) sorter = compareBySector
+  else if (groupBy === GroupBy.MARKET || groupBy === GroupBy.MARKET_CURRENCY)
+    sorter = compareByMarket
 
   const groupedCells: GroupedCells[] = Object.keys(holdingGroups)
     .sort(sorter)

--- a/src/lib/utils/categoryMapping.test.ts
+++ b/src/lib/utils/categoryMapping.test.ts
@@ -3,6 +3,7 @@ import {
   getReportCategory,
   REPORT_CATEGORIES,
   compareByReportCategory,
+  compareByMarket,
 } from "./categoryMapping"
 import { Asset } from "types/beancounter"
 
@@ -140,6 +141,31 @@ describe("categoryMapping", () => {
 
     it("returns 0 for same category", () => {
       expect(compareByReportCategory("Equity", "Equity")).toBe(0)
+    })
+  })
+
+  describe("compareByMarket", () => {
+    it("sorts CASH after market codes", () => {
+      expect(compareByMarket("CASH", "US")).toBeGreaterThan(0)
+      expect(compareByMarket("US", "CASH")).toBeLessThan(0)
+    })
+
+    it("treats Cash and CASH the same", () => {
+      expect(compareByMarket("Cash", "US")).toBeGreaterThan(0)
+    })
+
+    it("sorts non-cash market codes alphabetically", () => {
+      const sorted = ["US", "ASX", "NASDAQ"].sort(compareByMarket)
+      expect(sorted).toEqual(["ASX", "NASDAQ", "US"])
+    })
+
+    it("places CASH last in a mixed list", () => {
+      const sorted = ["US", "CASH", "ASX"].sort(compareByMarket)
+      expect(sorted).toEqual(["ASX", "US", "CASH"])
+    })
+
+    it("returns 0 for same key", () => {
+      expect(compareByMarket("US", "US")).toBe(0)
     })
   })
 })

--- a/src/lib/utils/categoryMapping.ts
+++ b/src/lib/utils/categoryMapping.ts
@@ -113,3 +113,17 @@ export function compareBySector(a: string, b: string): number {
   // Everything else alphabetically
   return a.localeCompare(b)
 }
+
+/**
+ * Comparator for grouping options that key by raw market/currency code
+ * (e.g. MARKET, MARKET_CURRENCY). Cash collapses into a single "CASH"
+ * group (see calculateHoldings.getGroupKey) which should always render
+ * last; remaining keys sort alphabetically.
+ */
+export function compareByMarket(a: string, b: string): number {
+  const aIsCash = a.toUpperCase() === "CASH"
+  const bIsCash = b.toUpperCase() === "CASH"
+  if (aIsCash && !bIsCash) return 1
+  if (!aIsCash && bIsCash) return -1
+  return a.localeCompare(b)
+}


### PR DESCRIPTION
## Summary
- Card / Summary / Heatmap grouped by Market or Currency rendered CASH before real market codes (e.g. `CASH, US`) because `compareByReportCategory` only matches the proper-case "Cash" label
- Added `compareByMarket`: alphabetical for non-cash keys, CASH/Cash always last
- Wired into CardView, SummaryView, and PerformanceHeatmap for `MARKET` / `MARKET_CURRENCY` groupings

## Test plan
- [x] `yarn jest src/lib/utils/categoryMapping.test.ts src/lib/utils/holdings/`
- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] Verify in browser: Card view + Group By Market shows real markets first, CASH last

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Holdings view now supports grouping and sorting by market in addition to existing sector and report category options.
  * Cash holdings automatically sort after non-cash market codes for improved clarity.

* **Tests**
  * Added comprehensive tests for market-based sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->