### PR TITLE
refactor(holdings): Centralise group comparator selection

### DIFF
--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -23,12 +23,7 @@ import {
   supportsBalanceSetting,
 } from "@lib/assets/assetUtils"
 import { useDisplayCurrencyConversion } from "@lib/hooks/useDisplayCurrencyConversion"
-import {
-  compareByMarket,
-  compareByReportCategory,
-  compareBySector,
-} from "@lib/categoryMapping"
-import { GroupBy } from "@components/features/holdings/GroupByOptions"
+import { getGroupComparator } from "@lib/categoryMapping"
 import { useRouter } from "next/router"
 import AssetNewsButton from "@components/features/holdings/AssetNewsButton"
 import { useNewsAsset } from "@components/features/holdings/useNewsAsset"
@@ -472,16 +467,8 @@ const CardView: React.FC<CardViewProps> = ({
 }) => {
   // Group positions by holdingGroups, sorted by group comparator
   const groupedPositions = useMemo((): GroupedPositions[] => {
-    let sorter: (a: string, b: string) => number = compareByReportCategory
-    if (groupBy === GroupBy.SECTOR) sorter = compareBySector
-    else if (
-      groupBy === GroupBy.MARKET ||
-      groupBy === GroupBy.MARKET_CURRENCY
-    )
-      sorter = compareByMarket
-
     return Object.keys(holdings.holdingGroups)
-      .sort(sorter)
+      .sort(getGroupComparator(groupBy ?? ""))
       .map((groupKey) => ({
         groupKey,
         positions: sortPositionsWithinGroup(

--- a/src/components/features/holdings/SummaryView.tsx
+++ b/src/components/features/holdings/SummaryView.tsx
@@ -17,20 +17,8 @@ import {
   AllocationSlice,
   GroupingMode,
 } from "@lib/allocation/aggregateHoldings"
-import {
-  compareByMarket,
-  compareByReportCategory,
-  compareBySector,
-} from "@lib/categoryMapping"
+import { getGroupComparator } from "@lib/categoryMapping"
 import { useDisplayCurrencyConversion } from "@lib/hooks/useDisplayCurrencyConversion"
-
-function pickGroupComparator(
-  groupBy: GroupingMode,
-): (a: string, b: string) => number {
-  if (groupBy === "sector") return compareBySector
-  if (groupBy === "market") return compareByMarket
-  return compareByReportCategory
-}
 
 // Color palette for report categories
 const CATEGORY_COLORS: Record<string, string> = {
@@ -195,7 +183,7 @@ const SummaryView: React.FC<SummaryViewProps> = ({
 
   // Filter allocation data and sort by predefined order
   const filteredAllocation = useMemo(() => {
-    const sorter = pickGroupComparator(groupBy)
+    const sorter = getGroupComparator(groupBy)
     return allocationData
       .filter((slice) => !excludedCategories.has(slice.key))
       .sort((a, b) => sorter(a.key, b.key))
@@ -472,7 +460,7 @@ const SummaryView: React.FC<SummaryViewProps> = ({
             <tbody>
               {[...allocationData]
                 .sort((a, b) =>
-                  pickGroupComparator(groupBy)(a.key, b.key),
+                  getGroupComparator(groupBy)(a.key, b.key),
                 )
                 .map((slice, index) => {
                   const isExcluded = excludedCategories.has(slice.key)

--- a/src/components/ui/PerformanceHeatmap.tsx
+++ b/src/components/ui/PerformanceHeatmap.tsx
@@ -6,12 +6,7 @@ import {
   isNonTradeable,
   stripOwnerPrefix,
 } from "@lib/assets/assetUtils"
-import {
-  compareByMarket,
-  compareByReportCategory,
-  compareBySector,
-} from "@lib/categoryMapping"
-import { GroupBy } from "@components/features/holdings/GroupByOptions"
+import { getGroupComparator } from "@lib/categoryMapping"
 import { ProgressBar } from "@components/ui/ProgressBar"
 import Dialog from "@components/ui/Dialog"
 
@@ -90,10 +85,7 @@ export const PerformanceHeatmap: React.FC<PerformanceHeatmapProps> = ({
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null)
 
   // Build grouped cells
-  let sorter: (a: string, b: string) => number = compareByReportCategory
-  if (groupBy === GroupBy.SECTOR) sorter = compareBySector
-  else if (groupBy === GroupBy.MARKET || groupBy === GroupBy.MARKET_CURRENCY)
-    sorter = compareByMarket
+  const sorter = getGroupComparator(groupBy ?? "")
 
   const groupedCells: GroupedCells[] = Object.keys(holdingGroups)
     .sort(sorter)

--- a/src/lib/utils/categoryMapping.test.ts
+++ b/src/lib/utils/categoryMapping.test.ts
@@ -4,6 +4,8 @@ import {
   REPORT_CATEGORIES,
   compareByReportCategory,
   compareByMarket,
+  compareBySector,
+  getGroupComparator,
 } from "./categoryMapping"
 import { Asset } from "types/beancounter"
 
@@ -166,6 +168,30 @@ describe("categoryMapping", () => {
 
     it("returns 0 for same key", () => {
       expect(compareByMarket("US", "US")).toBe(0)
+    })
+  })
+
+  describe("getGroupComparator", () => {
+    it("returns compareBySector for sector property paths and modes", () => {
+      expect(getGroupComparator("asset.sector")).toBe(compareBySector)
+      expect(getGroupComparator("sector")).toBe(compareBySector)
+    })
+
+    it("returns compareByMarket for market and currency keys", () => {
+      expect(getGroupComparator("asset.market.code")).toBe(compareByMarket)
+      expect(getGroupComparator("asset.market.currency.code")).toBe(
+        compareByMarket,
+      )
+      expect(getGroupComparator("market")).toBe(compareByMarket)
+      expect(getGroupComparator("currency")).toBe(compareByMarket)
+    })
+
+    it("falls back to compareByReportCategory for asset class", () => {
+      expect(getGroupComparator("asset.assetCategory.name")).toBe(
+        compareByReportCategory,
+      )
+      expect(getGroupComparator("category")).toBe(compareByReportCategory)
+      expect(getGroupComparator("")).toBe(compareByReportCategory)
     })
   })
 })

--- a/src/lib/utils/categoryMapping.ts
+++ b/src/lib/utils/categoryMapping.ts
@@ -127,3 +127,17 @@ export function compareByMarket(a: string, b: string): number {
   if (!aIsCash && bIsCash) return -1
   return a.localeCompare(b)
 }
+
+/**
+ * Resolve the right group comparator for a given groupBy. Accepts both
+ * frontend property paths (e.g. "asset.market.code") and shorter mode
+ * tokens (e.g. "market", "sector") used by allocation views.
+ */
+export function getGroupComparator(
+  groupBy: string,
+): (a: string, b: string) => number {
+  const key = groupBy.toLowerCase()
+  if (key.includes("sector")) return compareBySector
+  if (key.includes("market") || key.includes("currency")) return compareByMarket
+  return compareByReportCategory
+}

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -38,8 +38,7 @@ import HoldingActions from "@components/features/holdings/HoldingActions"
 import PerformanceHeatmap from "@components/ui/PerformanceHeatmap"
 import SummaryView from "@components/features/holdings/SummaryView"
 import CardView from "@components/features/holdings/CardView"
-import { compareByReportCategory, compareBySector } from "@lib/categoryMapping"
-import { GroupBy } from "@components/features/holdings/GroupByOptions"
+import { getGroupComparator } from "@lib/categoryMapping"
 import CorporateActionsPopup from "@components/features/holdings/CorporateActionsPopup"
 import TargetWeightDialog from "@components/features/holdings/TargetWeightDialog"
 import SetCashBalanceDialog from "@components/features/holdings/SetCashBalanceDialog"
@@ -469,11 +468,7 @@ function HoldingsPage(): React.ReactElement {
               {(() => {
                 let cumulativeCount = 0
                 return Object.keys(holdings.holdingGroups)
-                  .sort(
-                    holdingState.groupBy.value === GroupBy.SECTOR
-                      ? compareBySector
-                      : compareByReportCategory,
-                  )
+                  .sort(getGroupComparator(holdingState.groupBy.value))
                   .map((groupKey, index) => {
                     const currentCumulative = cumulativeCount
                     cumulativeCount +=

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -20,7 +20,7 @@ import PerformanceHeatmap from "@components/ui/PerformanceHeatmap"
 import SummaryView from "@components/features/holdings/SummaryView"
 import CardView from "@components/features/holdings/CardView"
 import AllocationChart from "@components/features/allocation/AllocationChart"
-import { compareByReportCategory, compareBySector } from "@lib/categoryMapping"
+import { getGroupComparator } from "@lib/categoryMapping"
 import {
   GroupBy,
   useGroupOptions,
@@ -389,11 +389,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
                 {(() => {
                   let cumulativeCount = 0
                   return Object.keys(holdings.holdingGroups)
-                    .sort(
-                      holdingState.groupBy.value === GroupBy.SECTOR
-                        ? compareBySector
-                        : compareByReportCategory,
-                    )
+                    .sort(getGroupComparator(holdingState.groupBy.value))
                     .map((groupKey, index) => {
                       const currentCumulative = cumulativeCount
                       cumulativeCount +=


### PR DESCRIPTION
## Summary
- Extracted `getGroupComparator(groupBy)` in `categoryMapping.ts` covering property-path values and allocation modes
- Five render sites (CardView, SummaryView, PerformanceHeatmap, `holdings/[code]`, `holdings/aggregated`) now call the helper instead of duplicating the if/else
- Side-effect: Table layout (`[code]`, `aggregated`) now also sorts CASH last when Group By Market/Currency, matching the Card layout

## Test plan
- [x] `yarn jest src/lib/utils/categoryMapping.test.ts src/lib/utils/holdings/`
- [x] `yarn typecheck`
- [x] `yarn lint`
- [ ] Verify in browser: Table view + Group By Market shows real markets first, CASH last (matches Card view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)