### PR TITLE
fix(assets): keep search input visible when dropdown opens

### DIFF
--- a/src/components/features/assets/AssetSearch.tsx
+++ b/src/components/features/assets/AssetSearch.tsx
@@ -176,6 +176,8 @@ export default function AssetSearch({
     onInputChange: handleInputChange,
     menuPortalTarget: typeof document !== "undefined" ? document.body : null,
     menuPosition: "fixed" as const,
+    menuPlacement: "bottom" as const,
+    menuShouldScrollIntoView: false,
     styles: {
       control: (base: Record<string, unknown>) => ({
         ...base,

--- a/src/components/features/assets/__tests__/AssetSearch.test.tsx
+++ b/src/components/features/assets/__tests__/AssetSearch.test.tsx
@@ -202,6 +202,54 @@ describe("AssetSearch", () => {
       )
     })
 
+    it("renders and selects an option whose assetId is null (uncached asset)", async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                symbol: "COWZ",
+                name: "PACER US CASH COWS 100 ETF",
+                market: "US",
+                region: "US",
+                assetId: null,
+                currency: null,
+                type: "Mutual Fund",
+              },
+            ],
+          }),
+      })
+
+      render(<AssetSearch onSelect={mockOnSelect} market="US" />)
+
+      const input = screen.getByRole("combobox")
+      await user.type(input, "COWZ")
+      await flushAsync()
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "COWZ - PACER US CASH COWS 100 ETF (US, Mutual Fund)",
+          ),
+        ).toBeInTheDocument()
+      })
+
+      await user.click(
+        screen.getByText("COWZ - PACER US CASH COWS 100 ETF (US, Mutual Fund)"),
+      )
+
+      expect(mockOnSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: "COWZ",
+          market: "US",
+          assetId: null,
+        }),
+      )
+    })
+
     it("calls onSelect with null when cleared", async () => {
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
 


### PR DESCRIPTION
## Summary
- Force `menuPlacement="bottom"` on the asset-search `AsyncSelect` so the dropdown always renders below the input, even when the on-screen keyboard reduces the viewport on mobile.
- Disable `menuShouldScrollIntoView` so opening the menu does not scroll the input under the keyboard or out of view.
- Adds a regression test covering selection of an option whose `assetId` is `null` (e.g. an external FIGI hit like COWZ that is not yet cached locally).

