### PR TITLE
fix(assets): render search dropdown inline so iOS keyboard does not hide input

### DIFF
--- a/src/components/features/assets/AssetSearch.tsx
+++ b/src/components/features/assets/AssetSearch.tsx
@@ -18,6 +18,14 @@ interface AssetSearchProps {
   filterResults?: (results: AssetOption[]) => AssetOption[]
   noResultsHref?: string
   inputId?: string
+  /**
+   * Render the dropdown via a fixed-position body portal. Required when the
+   * search lives inside an element with `overflow: hidden` (e.g. a Dialog).
+   * Avoid in plain page layouts on mobile — iOS Safari positions
+   * `position: fixed` against the layout viewport, so when the keyboard
+   * shrinks the visual viewport the menu drifts up over the input.
+   */
+  usePortal?: boolean
 }
 
 function toOption(result: AssetSearchResult): AssetOption {
@@ -60,6 +68,7 @@ export default function AssetSearch({
   filterResults,
   noResultsHref,
   inputId,
+  usePortal = false,
 }: AssetSearchProps): React.ReactElement {
   const debounceRef = useRef<NodeJS.Timeout | null>(null)
   const [inputText, setInputText] = useState("")
@@ -174,8 +183,9 @@ export default function AssetSearch({
     isClearable,
     inputValue: inputText,
     onInputChange: handleInputChange,
-    menuPortalTarget: typeof document !== "undefined" ? document.body : null,
-    menuPosition: "fixed" as const,
+    menuPortalTarget:
+      usePortal && typeof document !== "undefined" ? document.body : null,
+    menuPosition: (usePortal ? "fixed" : "absolute") as "fixed" | "absolute",
     menuPlacement: "bottom" as const,
     menuShouldScrollIntoView: false,
     styles: {

--- a/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
+++ b/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
@@ -169,6 +169,7 @@ const AddAssetToModelDialog: React.FC<AddAssetToModelDialogProps> = ({
               onSelect={setSelectedAsset}
               filterResults={filterExisting}
               placeholder={"Type asset symbol or name..."}
+              usePortal
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- PR #636 forced \`menuPlacement="bottom"\` but kept the menu rendered in a \`document.body\` portal with \`menuPosition: "fixed"\`. iOS Safari positions \`position: fixed\` against the **layout** viewport, not the visual viewport, so once the on-screen keyboard appeared the menu floated up and overlapped the search input even though it was nominally placed below.
- Make the portal + fixed combination opt-in via a new \`usePortal\` prop and default to inline \`position: absolute\` rendering. The menu now lives in the DOM tree directly below the input and tracks the visual viewport correctly.
- \`AddAssetToModelDialog\` still needs the portal to escape the dialog's overflow, so it opts in. \`TradeInputForm\` is a normal page form and uses the new inline default.

## Test plan
- [ ] On mobile (iOS Safari, viewport ≤ 640px): open \`/assets/lookup\`, select \`US — US Market\`, focus the search input. Type \`COWZ\` — input remains visible above the open keyboard, dropdown renders below the input, and the \`COWZ - PACER US CASH COWS 100 ETF (US, Mutual Fund)\` option is selectable.
- [ ] On desktop: same flow renders normally.
- [ ] Open \`AddAssetToModelDialog\` (rebalance models): asset search dropdown still escapes the dialog overflow correctly.
- [ ] Open \`TradeInputForm\` (new trade): asset search dropdown renders inline below the field without clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced asset search dropdown rendering with improved positioning control for superior visibility and reliable user interactions. The asset search component now offers flexible dropdown placement options that intelligently optimize display behavior in modal dialogs and other constrained layout scenarios, ensuring better usability and more consistent behavior across diverse UI contexts and implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->