### PR TITLE
fix(holdings): open managed portfolios via id, not code

### DIFF
--- a/src/components/features/portfolios/ManagedPortfolios.tsx
+++ b/src/components/features/portfolios/ManagedPortfolios.tsx
@@ -103,8 +103,14 @@ export default function ManagedPortfolios(): React.ReactElement {
               key={share.id}
               className="bg-white rounded-xl shadow-sm border border-gray-200 p-4 cursor-pointer hover:border-wealth-200 hover:shadow-md transition-all"
               onClick={() => {
-                if (share.portfolio?.code) {
-                  router.push(`/holdings/${share.portfolio.code}`)
+                // Route via portfolio.id (?byId=1) — code is only unique
+                // within an owner, so an adviser opening a managed portfolio
+                // could otherwise collide with one of their own with the
+                // same code.
+                if (share.portfolio?.id) {
+                  router.push(
+                    `/holdings/${share.portfolio.id}?byId=1`,
+                  )
                 }
               }}
             >

--- a/src/lib/utils/api/fetchHelper.ts
+++ b/src/lib/utils/api/fetchHelper.ts
@@ -95,6 +95,9 @@ export const eventKey = (portfolioId: string, assetId: string): string =>
 export const holdingKey = (portfolioCode: string, asAt: string): string =>
   `${apiRoot}/holdings/${portfolioCode}?asAt=${asAt}`
 
+export const holdingByIdKey = (portfolioId: string, asAt: string): string =>
+  `${apiRoot}/holdings/id/${portfolioId}?asAt=${asAt}`
+
 export const portfolioKey = (portfolioId: string): string =>
   `${portfoliosBase}/${portfolioId}`
 

--- a/src/pages/api/holdings/id/[id].ts
+++ b/src/pages/api/holdings/id/[id].ts
@@ -1,0 +1,16 @@
+import {
+  createApiHandler,
+  sanitizePathParam,
+} from "@utils/api/createApiHandler"
+import { getPositionsUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: (req) => {
+    const id = sanitizePathParam(req.query.id, "id")
+    const asAt = req.query.asAt as string | undefined
+    const params = new URLSearchParams()
+    if (asAt) params.set("asAt", asAt)
+    const qs = params.toString()
+    return getPositionsUrl(`/id/${id}${qs ? `?${qs}` : ""}`)
+  },
+})

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -18,7 +18,11 @@ import {
 import { useRouter } from "next/router"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import useSwr from "swr"
-import { holdingKey, simpleFetcher } from "@utils/api/fetchHelper"
+import {
+  holdingByIdKey,
+  holdingKey,
+  simpleFetcher,
+} from "@utils/api/fetchHelper"
 import { errorOut } from "@components/errors/ErrorOut"
 import { useHoldingState } from "@lib/holdings/holdingState"
 import { useHoldingsView } from "@lib/holdings/useHoldingsView"
@@ -60,10 +64,16 @@ import { ModelDto, PlanDto } from "types/rebalance"
 function HoldingsPage(): React.ReactElement {
   const router = useRouter()
   const holdingState = useHoldingState()
-  const { data, error, isLoading, mutate } = useSwr(
-    holdingKey(`${router.query.code}`, `${holdingState.asAt}`),
-    simpleFetcher(holdingKey(`${router.query.code}`, `${holdingState.asAt}`)),
-  )
+  // Managed (shared) portfolios route here with `?byId=1` and pass the
+  // portfolio's id in the path slot, because portfolio code is unique only
+  // within an owner — an adviser may also own a portfolio with the same
+  // code as one shared with them.
+  const ref = `${router.query.code}`
+  const url =
+    router.query.byId === "1"
+      ? holdingByIdKey(ref, `${holdingState.asAt}`)
+      : holdingKey(ref, `${holdingState.asAt}`)
+  const { data, error, isLoading, mutate } = useSwr(url, simpleFetcher(url))
 
   // Use shared hook for view state and calculations
   const {


### PR DESCRIPTION
## Summary
- Code is unique per (owner, code) — an adviser may also own a portfolio with the same code as one shared with them. Resolving Managed cards via `/holdings/{code}` is ambiguous server-side and 404s when the adviser doesn't own a portfolio with that code.
- Add `/api/holdings/id/{id}` proxy to svc-position's existing `/id/{id}` endpoint.
