### PR TITLE
feat(portfolios): expose AI Overview and Corporate Actions on Managed cards

### DIFF
--- a/src/components/features/chat/ChatFab.tsx
+++ b/src/components/features/chat/ChatFab.tsx
@@ -30,9 +30,18 @@ export default function ChatFab(): React.ReactElement {
       page: pageContext.page,
       description: pageContext.description,
     }
-    // Include dynamic route params for specificity
-    // e.g., /holdings/[code] -> code: "DBS"
-    if (routeParams.code) ctx.portfolioCode = routeParams.code
+    // Include dynamic route params for specificity. Managed (shared)
+    // portfolios are routed as /holdings/{portfolio.id}?byId=1 — in that
+    // case the dynamic [code] segment is actually the portfolio id, so
+    // expose it as portfolioId for the agent's by-id tools rather than
+    // the by-code ones (which 404 for shared portfolios).
+    if (routeParams.code) {
+      if (routeParams.byId === "1") {
+        ctx.portfolioId = routeParams.code
+      } else {
+        ctx.portfolioCode = routeParams.code
+      }
+    }
     if (routeParams.id) ctx.entityId = routeParams.id
     if (routeParams.modelId) ctx.modelId = routeParams.modelId
     return ctx

--- a/src/components/features/portfolios/ManagedPortfolios.tsx
+++ b/src/components/features/portfolios/ManagedPortfolios.tsx
@@ -13,7 +13,7 @@ import {
   sharesPendingKey,
 } from "@utils/api/fetchHelper"
 import { usePermissions } from "@hooks/usePermissions"
-import PortfolioAIOverview from "./PortfolioAIOverview"
+import PortfolioAIOverview from "@components/features/portfolios/PortfolioAIOverview"
 
 interface ManagedSharesResponse {
   data: PortfolioShare[]

--- a/src/components/features/portfolios/ManagedPortfolios.tsx
+++ b/src/components/features/portfolios/ManagedPortfolios.tsx
@@ -1,13 +1,19 @@
 import React, { useState } from "react"
 import useSwr from "swr"
 import { useRouter } from "next/router"
-import { PortfolioShare, PendingSharesResponse } from "types/beancounter"
+import {
+  Portfolio,
+  PortfolioShare,
+  PendingSharesResponse,
+} from "types/beancounter"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
 import {
   fetcher,
   sharesManagedKey,
   sharesPendingKey,
 } from "@utils/api/fetchHelper"
+import { usePermissions } from "@hooks/usePermissions"
+import PortfolioAIOverview from "./PortfolioAIOverview"
 
 interface ManagedSharesResponse {
   data: PortfolioShare[]
@@ -16,9 +22,27 @@ import { rootLoader } from "@components/ui/PageLoader"
 import PendingSharesPanel from "./PendingSharesPanel"
 import RequestAccessDialog from "./RequestAccessDialog"
 
-export default function ManagedPortfolios(): React.ReactElement {
+interface ManagedPortfoliosProps {
+  /** Open the Portfolio Corporate Actions popup for the chosen portfolio. */
+  onCorporateActions?: (portfolio: Portfolio) => void
+}
+
+export default function ManagedPortfolios({
+  onCorporateActions,
+}: ManagedPortfoliosProps = {}): React.ReactElement {
   const router = useRouter()
+  const { ai: canRunAi } = usePermissions()
   const [showRequestDialog, setShowRequestDialog] = useState(false)
+  const [expandedShares, setExpandedShares] = useState<Set<string>>(new Set())
+
+  const toggleAiExpand = (shareId: string): void => {
+    setExpandedShares((prev) => {
+      const next = new Set(prev)
+      if (next.has(shareId)) next.delete(shareId)
+      else next.add(shareId)
+      return next
+    })
+  }
 
   const {
     data: managedResponse,
@@ -136,7 +160,33 @@ export default function ManagedPortfolios(): React.ReactElement {
                       : "Owner"}
                   </div>
                 </div>
-                <div className="flex items-center space-x-2">
+                <div
+                  className="flex items-center space-x-2"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {canRunAi && share.portfolio && (
+                    <button
+                      onClick={() => toggleAiExpand(share.id)}
+                      className={`p-1 ${
+                        expandedShares.has(share.id)
+                          ? "text-purple-700"
+                          : "text-purple-500 hover:text-purple-700"
+                      }`}
+                      title={"AI Overview"}
+                      aria-expanded={expandedShares.has(share.id)}
+                    >
+                      <i className="fas fa-wand-magic-sparkles"></i>
+                    </button>
+                  )}
+                  {onCorporateActions && share.portfolio && (
+                    <button
+                      onClick={() => onCorporateActions(share.portfolio!)}
+                      className="text-blue-500 hover:text-blue-700 p-1"
+                      title={"Scan Corporate Actions"}
+                    >
+                      <i className="fas fa-calendar-check"></i>
+                    </button>
+                  )}
                   {share.acceptedAt && (
                     <span className="text-xs text-gray-400">
                       {"Since"}{" "}
@@ -152,6 +202,16 @@ export default function ManagedPortfolios(): React.ReactElement {
                   />
                 </div>
               </div>
+              {canRunAi &&
+                share.portfolio &&
+                expandedShares.has(share.id) && (
+                  <div
+                    className="pt-4"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <PortfolioAIOverview portfolio={share.portfolio} />
+                  </div>
+                )}
             </div>
           ))}
         </div>

--- a/src/components/features/portfolios/PortfolioAIOverview.tsx
+++ b/src/components/features/portfolios/PortfolioAIOverview.tsx
@@ -145,12 +145,14 @@ function buildQuery(portfolio: Portfolio, movers: BiggestMovers): string {
 }
 
 async function fetchHoldings(
-  code: string,
+  portfolioId: string,
   asAt: string,
 ): Promise<HoldingContract | null> {
   try {
+    // Use the id-based route so the AI Overview also works for managed
+    // (shared) portfolios — code is unique only within an owner.
     const res = await fetch(
-      `/api/holdings/${encodeURIComponent(code)}?asAt=${asAt}`,
+      `/api/holdings/id/${encodeURIComponent(portfolioId)}?asAt=${asAt}`,
     )
     if (!res.ok) return null
     // svc-position wraps the contract in `{ data: HoldingContract }`.
@@ -166,7 +168,7 @@ async function performFetch(
   portfolio: Portfolio,
   asAt: string,
 ): Promise<string> {
-  const holdings = await fetchHoldings(portfolio.code, asAt)
+  const holdings = await fetchHoldings(portfolio.id, asAt)
   const movers = buildBiggestMovers(holdings)
   const query = buildQuery(portfolio, movers)
 

--- a/src/components/features/portfolios/PortfolioCorporateActionsPopup.tsx
+++ b/src/components/features/portfolios/PortfolioCorporateActionsPopup.tsx
@@ -10,7 +10,7 @@ import {
   Asset,
 } from "types/beancounter"
 import {
-  holdingKey,
+  holdingByIdKey,
   simpleFetcher,
   corporateEventsKey,
 } from "@utils/api/fetchHelper"
@@ -57,10 +57,12 @@ const PortfolioCorporateActionsPopup: React.FC<
   const [processError, setProcessError] = useState<string | null>(null)
   const [processedEvents, setProcessedEvents] = useState<Set<string>>(new Set())
 
-  // Fetch holdings for the portfolio
+  // Fetch holdings for the portfolio. Use the id-based route so the popup
+  // works for managed (shared) portfolios — code is unique only within an
+  // owner so the by-code route 404s when the caller is an adviser.
   const { data: holdingsData } = useSwr(
-    modalOpen ? holdingKey(portfolio.code, today) : null,
-    modalOpen ? simpleFetcher(holdingKey(portfolio.code, today)) : null,
+    modalOpen ? holdingByIdKey(portfolio.id, today) : null,
+    modalOpen ? simpleFetcher(holdingByIdKey(portfolio.id, today)) : null,
   )
 
   // Reset state when modal opens

--- a/src/pages/portfolios/index.tsx
+++ b/src/pages/portfolios/index.tsx
@@ -189,7 +189,9 @@ export default withPageAuthRequired(function Portfolios({
           isInactiveTab
         />
       )}
-      {activeTab === "managed" && <ManagedPortfolios />}
+      {activeTab === "managed" && (
+        <ManagedPortfolios onCorporateActions={setCorporateActionsPortfolio} />
+      )}
 
       {corporateActionsPortfolio && (
         <PortfolioCorporateActionsPopup


### PR DESCRIPTION
## Summary
- Managed portfolio cards now mirror the affordances on the My-portfolios list:
  - Wand-magic AI Overview toggle (gated by `usePermissions().ai`).
  - Scan Corporate Actions button.
- Both buttons stop click propagation so they don't trigger the row-level navigation to `/holdings`.
`ManagedPortfolios` is wired to `setCorporateActionsPortfolio` for the Managed tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI analysis panel available per managed holding (toggle via wand) and an embedded "Scan Corporate Actions" action.

* **Bug Fixes / Improvements**
  * More reliable holdings lookup for managed/shared portfolios.
  * Chat now correctly scopes portfolio context for shared/managed views.
  * Action buttons on portfolio cards no longer trigger card navigation when used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->