### PR TITLE
fix(a11y): add aria-label to icon-only Managed action buttons

### DIFF
--- a/src/components/features/portfolios/ManagedPortfolios.tsx
+++ b/src/components/features/portfolios/ManagedPortfolios.tsx
@@ -173,6 +173,7 @@ export default function ManagedPortfolios({
                           : "text-purple-500 hover:text-purple-700"
                       }`}
                       title={"AI Overview"}
+                      aria-label={"AI Overview"}
                       aria-expanded={expandedShares.has(share.id)}
                     >
                       <i className="fas fa-wand-magic-sparkles"></i>
@@ -183,6 +184,7 @@ export default function ManagedPortfolios({
                       onClick={() => onCorporateActions(share.portfolio!)}
                       className="text-blue-500 hover:text-blue-700 p-1"
                       title={"Scan Corporate Actions"}
+                      aria-label={"Scan Corporate Actions"}
                     >
                       <i className="fas fa-calendar-check"></i>
                     </button>


### PR DESCRIPTION
Address CodeRabbit nit on PR #641 (commit 12da4a7) — icon-only AI Overview / Scan Corporate Actions buttons in ManagedPortfolios had `title` only; screen readers prefer `aria-label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced accessibility by adding ARIA labels to action buttons, improving screen reader support for users with assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->