### PR TITLE
feat(holdings): AI Summary button opens ChatFab expanded with seeded prompt

### DIFF
--- a/src/components/features/chat/ChatFab.tsx
+++ b/src/components/features/chat/ChatFab.tsx
@@ -10,6 +10,7 @@ import {
   loadChatCorner,
   saveChatCorner,
 } from "@components/features/chat/chatPosition"
+import { onChatOpen } from "@components/features/chat/chatBus"
 
 export default function ChatFab(): React.ReactElement {
   const [isOpen, setIsOpen] = useState(false)
@@ -66,6 +67,16 @@ export default function ChatFab(): React.ReactElement {
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
   }, [isOpen, close])
+
+  useEffect(
+    () =>
+      onChatOpen(({ prompt, expanded }) => {
+        setIsOpen(true)
+        if (expanded) setIsExpanded(true)
+        if (prompt) void sendMessage(prompt)
+      }),
+    [sendMessage],
+  )
 
   const { ai: canRunAi, isLoading: permsLoading } = usePermissions()
 

--- a/src/components/features/chat/chatBus.ts
+++ b/src/components/features/chat/chatBus.ts
@@ -1,0 +1,32 @@
+/**
+ * Tiny window-event bus to let any component pop open the global ChatFab
+ * with a pre-seeded prompt and (optionally) the expanded layout — without
+ * having to lift ChatFab's open/expanded/messages state into a context
+ * shared by every page.
+ *
+ * ChatFab subscribes via `useEffect`; callers fire `requestChatOpen({...})`.
+ */
+const EVENT = "bc:chat-open"
+
+export interface ChatOpenDetail {
+  /** If set, immediately submitted as a user message after opening. */
+  prompt?: string
+  /** Open in the wider expanded layout instead of the default panel. */
+  expanded?: boolean
+}
+
+export function requestChatOpen(detail: ChatOpenDetail = {}): void {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new CustomEvent<ChatOpenDetail>(EVENT, { detail }))
+}
+
+export function onChatOpen(
+  handler: (detail: ChatOpenDetail) => void,
+): () => void {
+  if (typeof window === "undefined") return () => {}
+  const listener = (e: Event): void => {
+    handler((e as CustomEvent<ChatOpenDetail>).detail ?? {})
+  }
+  window.addEventListener(EVENT, listener)
+  return () => window.removeEventListener(EVENT, listener)
+}

--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -12,6 +12,13 @@ import {
   useGroupOptions,
 } from "@components/features/holdings/GroupByOptions"
 import { useHoldingState } from "@lib/holdings/holdingState"
+import { usePermissions } from "@hooks/usePermissions"
+import { requestChatOpen } from "@components/features/chat/chatBus"
+
+const HOLDINGS_AI_PROMPT =
+  "Summarise the macro news affecting this portfolio, the biggest movers " +
+  "and shakers in my holdings, and the portfolio construction (allocations, " +
+  "weights, sector and currency concentration)."
 
 // Dropdown Menu Component
 interface DropdownMenuProps {
@@ -325,6 +332,7 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
 }) => {
   const router = useRouter()
   const { isAdmin } = useIsAdmin()
+  const { ai: canRunAi } = usePermissions()
   const holdingState = useHoldingState()
   const groupOptions = useGroupOptions()
   const [tradeModalOpen, setTradeModalOpen] = useState(false)
@@ -585,6 +593,24 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
 
         {/* Right side: Action buttons - hidden on mobile portrait */}
         <div className="mobile-portrait:hidden flex items-center gap-2 flex-shrink-0">
+          {canRunAi && !emptyHoldings && (
+            <button
+              type="button"
+              className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300"
+              onClick={() =>
+                requestChatOpen({
+                  prompt: HOLDINGS_AI_PROMPT,
+                  expanded: true,
+                })
+              }
+              aria-label="AI summary of this portfolio"
+              title="AI summary: macro news, movers and shakers, portfolio construction"
+            >
+              <i className="fas fa-robot text-[10px] text-blue-500"></i>
+              <span className="hidden sm:inline">AI Summary</span>
+              <span className="sm:hidden">AI</span>
+            </button>
+          )}
           {onShare && (
             <button
               className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300"

--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -332,7 +332,7 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
 }) => {
   const router = useRouter()
   const { isAdmin } = useIsAdmin()
-  const { ai: canRunAi } = usePermissions()
+  const { ai: canRunAi, isLoading: permsLoading } = usePermissions()
   const holdingState = useHoldingState()
   const groupOptions = useGroupOptions()
   const [tradeModalOpen, setTradeModalOpen] = useState(false)
@@ -593,7 +593,7 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
 
         {/* Right side: Action buttons - hidden on mobile portrait */}
         <div className="mobile-portrait:hidden flex items-center gap-2 flex-shrink-0">
-          {canRunAi && !emptyHoldings && (
+          {!permsLoading && canRunAi && !emptyHoldings && (
             <button
               type="button"
               className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300"


### PR DESCRIPTION
## Summary
- New **AI Summary** button on the Holdings action bar (gated by `usePermissions().ai`).
- Click opens the ChatFab in expanded layout and auto-sends a portfolio-overview prompt covering macro news, movers and shakers, and portfolio construction.
- Tiny `chatBus.ts` window-event bus avoids lifting ChatFab's open / expanded / messages state into a context shared by every page.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn prettier`
- [x] `yarn test` — 1247 tests passing
- [x] Local browser smoke: navigated to `/holdings/DBS`, clicked the button, ChatFab opened expanded (`w-[48rem]`), prompt rendered as a user message, stream fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "AI Summary" button to holdings actions (permission-gated) to open the chat pre-filled with a holdings summary request.
  * Chat can now be opened via a global event, optionally expanding the panel and auto-sending a provided prompt for immediate interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->