### PR TITLE
feat(chat): deep-think toggle, badge, retry preserves flag

### DIFF
--- a/src/components/features/chat/ChatBubble.tsx
+++ b/src/components/features/chat/ChatBubble.tsx
@@ -5,7 +5,8 @@ import { ChatMessage } from "types/agent"
 
 interface ChatBubbleProps {
   message: ChatMessage
-  onRetry?: (content: string) => void
+  /** Resends the message; preserves the original deep-think state. */
+  onRetry?: (content: string, deepThink: boolean) => void
 }
 
 export default function ChatBubble({
@@ -25,11 +26,21 @@ export default function ChatBubble({
     return (
       <div className="group flex justify-end">
         <div className="max-w-[80%] px-4 py-2 rounded-lg bg-blue-500 text-white text-sm">
+          {message.deepThink && (
+            <span
+              className="inline-block mr-2 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-purple-200 text-purple-800"
+              title="Sent with deep think enabled"
+            >
+              <i className="fas fa-brain mr-1"></i>deep
+            </span>
+          )}
           {message.content}
           <div className="flex justify-end gap-2 mt-1">
             {onRetry && (
               <button
-                onClick={() => onRetry(message.content)}
+                onClick={() =>
+                  onRetry(message.content, message.deepThink ?? false)
+                }
                 className="text-blue-200 hover:text-white opacity-0 group-hover:opacity-100 transition-opacity text-xs"
                 aria-label="Retry message"
                 title="Send again"

--- a/src/components/features/chat/ChatPanel.tsx
+++ b/src/components/features/chat/ChatPanel.tsx
@@ -7,7 +7,14 @@ import { ChatCorner } from "@components/features/chat/chatPosition"
 interface ChatPanelProps {
   messages: ChatMessage[]
   isLoading: boolean
-  onSend: (query: string) => void
+  /**
+   * Submitter receives the trimmed query plus the deep-think toggle state.
+   * `deepThink=true` asks svc-agent to escalate to its DEEP tier (slower,
+   * more analytical, higher cost). The toggle is local to this panel — the
+   * parent does not need to plumb state through unless it wants to persist
+   * the preference across mounts.
+   */
+  onSend: (query: string, deepThink: boolean) => void
   onClear: () => void
   className?: string
   placeholder?: string
@@ -43,6 +50,7 @@ export default function ChatPanel({
 }: ChatPanelProps): React.ReactElement {
   const [input, setInput] = useState("")
   const [showPicker, setShowPicker] = useState(false)
+  const [deepThink, setDeepThink] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -55,7 +63,7 @@ export default function ChatPanel({
     e.preventDefault()
     const trimmed = input.trim()
     if (!trimmed || isLoading) return
-    onSend(trimmed)
+    onSend(trimmed, deepThink)
     setInput("")
   }
 
@@ -164,7 +172,7 @@ export default function ChatPanel({
                 {suggestions.map((suggestion) => (
                   <button
                     key={suggestion}
-                    onClick={() => onSend(suggestion)}
+                    onClick={() => onSend(suggestion, deepThink)}
                     className="text-left text-xs px-3 py-2 rounded-lg border border-gray-200 hover:bg-gray-50 hover:border-blue-300 text-gray-500 hover:text-blue-600 transition-colors"
                   >
                     {suggestion}
@@ -189,6 +197,24 @@ export default function ChatPanel({
       {/* Input */}
       <form onSubmit={handleSubmit} className="border-t border-gray-200 p-3">
         <div className="flex gap-2">
+          <button
+            type="button"
+            aria-label="Deep think"
+            aria-pressed={deepThink}
+            title={
+              deepThink
+                ? "Deep think on — slower, more analytical"
+                : "Deep think off — fast tier"
+            }
+            onClick={() => setDeepThink((v) => !v)}
+            className={`px-3 py-2 text-sm border rounded-lg transition-colors ${
+              deepThink
+                ? "border-purple-600 bg-purple-50 text-purple-700"
+                : "border-gray-300 text-gray-500 hover:text-purple-600 hover:border-purple-400"
+            }`}
+          >
+            <i className="fas fa-brain"></i>
+          </button>
           <input
             type="text"
             value={input}

--- a/src/components/features/chat/__tests__/ChatBubble.test.tsx
+++ b/src/components/features/chat/__tests__/ChatBubble.test.tsx
@@ -38,11 +38,34 @@ describe("ChatBubble", () => {
     expect(screen.getByLabelText("Retry message")).toBeInTheDocument()
   })
 
-  it("retry button re-sends the user message", () => {
+  it("retry button re-sends the user message preserving deepThink state", () => {
     const onRetry = jest.fn()
     render(<ChatBubble message={userMessage} onRetry={onRetry} />)
     fireEvent.click(screen.getByLabelText("Retry message"))
-    expect(onRetry).toHaveBeenCalledWith("Show my portfolios")
+    // userMessage has no deepThink → forwarded as false
+    expect(onRetry).toHaveBeenCalledWith("Show my portfolios", false)
+  })
+
+  it("retry preserves deepThink=true when the original message had it", () => {
+    const onRetry = jest.fn()
+    render(
+      <ChatBubble
+        message={{ ...userMessage, deepThink: true }}
+        onRetry={onRetry}
+      />,
+    )
+    fireEvent.click(screen.getByLabelText("Retry message"))
+    expect(onRetry).toHaveBeenCalledWith("Show my portfolios", true)
+  })
+
+  it("renders a deep-think badge on user messages with deepThink=true", () => {
+    render(
+      <ChatBubble
+        message={{ ...userMessage, deepThink: true }}
+        onRetry={jest.fn()}
+      />,
+    )
+    expect(screen.getByText(/deep/i)).toBeInTheDocument()
   })
 
   it("copies user message content to clipboard", async () => {

--- a/src/components/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/components/features/chat/__tests__/ChatPanel.test.tsx
@@ -35,12 +35,37 @@ describe("ChatPanel", () => {
     expect(screen.getByRole("button", { name: /send/i })).toBeDisabled()
   })
 
-  it("calls onSend when form is submitted", () => {
+  it("calls onSend when form is submitted (deepThink defaults false)", () => {
     render(<ChatPanel {...defaultProps} />)
     const input = screen.getByRole("textbox")
     fireEvent.change(input, { target: { value: "show portfolios" } })
     fireEvent.submit(input.closest("form")!)
-    expect(defaultProps.onSend).toHaveBeenCalledWith("show portfolios")
+    expect(defaultProps.onSend).toHaveBeenCalledWith("show portfolios", false)
+  })
+
+  it("forwards deepThink=true to onSend when the toggle is on", () => {
+    render(<ChatPanel {...defaultProps} />)
+    const toggle = screen.getByRole("button", { name: /deep think/i })
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute("aria-pressed", "true")
+
+    const input = screen.getByRole("textbox")
+    fireEvent.change(input, { target: { value: "analyse my retirement plan" } })
+    fireEvent.submit(input.closest("form")!)
+    expect(defaultProps.onSend).toHaveBeenCalledWith(
+      "analyse my retirement plan",
+      true,
+    )
+  })
+
+  it("toggle starts aria-pressed=false and flips on click", () => {
+    render(<ChatPanel {...defaultProps} />)
+    const toggle = screen.getByRole("button", { name: /deep think/i })
+    expect(toggle).toHaveAttribute("aria-pressed", "false")
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute("aria-pressed", "true")
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute("aria-pressed", "false")
   })
 
   it("clears input after sending", () => {

--- a/src/hooks/__tests__/useChat.test.ts
+++ b/src/hooks/__tests__/useChat.test.ts
@@ -215,7 +215,11 @@ describe("useChat", () => {
         "Content-Type": "application/json",
         Accept: "text/event-stream",
       },
-      body: JSON.stringify({ query: "test query", context: undefined }),
+      body: JSON.stringify({
+        query: "test query",
+        context: undefined,
+        deepThink: false,
+      }),
     })
   })
 
@@ -233,7 +237,29 @@ describe("useChat", () => {
     expect(mockFetch).toHaveBeenCalledWith(
       "/api/agent/query/stream",
       expect.objectContaining({
-        body: JSON.stringify({ query: "help", context: ctx }),
+        body: JSON.stringify({ query: "help", context: ctx, deepThink: false }),
+      }),
+    )
+  })
+
+  it("forwards the deepThink flag in the request body when set", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "token", data: "ok" }]),
+    )
+    const { result } = renderHook(() => useChat())
+
+    await act(async () => {
+      await result.current.sendMessage("explain", true)
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/agent/query/stream",
+      expect.objectContaining({
+        body: JSON.stringify({
+          query: "explain",
+          context: undefined,
+          deepThink: true,
+        }),
       }),
     )
   })

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -24,7 +24,14 @@ function describeError(code: string): string {
 interface UseChatReturn {
   messages: ChatMessage[]
   isLoading: boolean
-  sendMessage: (query: string) => Promise<void>
+  /**
+   * Send a query to svc-agent. `deepThink` (default `false`) escalates the
+   * agent to its DEEP tier — see `AgentQuery.deepThink` in svc-agent. The
+   * caller is responsible for collecting the toggle from the UI; the hook
+   * forwards it verbatim and persists it on the user message via the
+   * `deepThink` field on `ChatMessage` so chat history can render a badge.
+   */
+  sendMessage: (query: string, deepThink?: boolean) => Promise<void>
   clearMessages: () => void
 }
 
@@ -41,12 +48,13 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
   const [isLoading, setIsLoading] = useState(false)
 
   const sendMessage = useCallback(
-    async (query: string) => {
+    async (query: string, deepThink: boolean = false) => {
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
         role: "user",
         content: query,
         timestamp: new Date().toISOString(),
+        deepThink: deepThink || undefined,
       }
       setMessages((prev) => [...prev, userMsg])
       setIsLoading(true)
@@ -80,7 +88,7 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
             "Content-Type": "application/json",
             Accept: "text/event-stream",
           },
-          body: JSON.stringify({ query, context }),
+          body: JSON.stringify({ query, context, deepThink }),
         })
         if (!res.ok || !res.body) {
           const message = `HTTP ${res.status}`

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -1,6 +1,8 @@
 export interface AgentQuery {
   query: string
   context?: Record<string, unknown>
+  /** Caller-driven escalation to svc-agent's DEEP tier. Default false. */
+  deepThink?: boolean
 }
 
 export interface AgentResponse {
@@ -29,4 +31,6 @@ export interface ChatMessage {
   content: string
   timestamp: string
   error?: string | null
+  /** True when the user message was sent with the deep-think toggle on. */
+  deepThink?: boolean
 }


### PR DESCRIPTION
## Summary

- `useChat.sendMessage(query, deepThink=false)` — forwards the flag in the request body and stamps the user message so history can render a badge.
- `ChatPanel` — brain-icon toggle next to Send (aria-pressed, purple highlight when on); both submit and suggestion clicks pass the current state to `onSend(query, deepThink)`.
- `ChatBubble` — deep-think badge on user messages; retry preserves the original `deepThink` so re-asking stays in the same tier.
- `types/agent.ts` — `AgentQuery` and `ChatMessage` gain optional `deepThink: boolean`.

Pairs with monowai/beancounter#826 (deepThink backend) and monowai/beancounter#827 (chat.html toggle).

## Test plan

- [x] `yarn lint && yarn typecheck && yarn test` — 1252/1252 green (32 chat tests, 12 useChat tests)
- [x] `useChat` body carries `deepThink:false` by default and `true` when flag set
- [x] `ChatPanel` aria-pressed toggles, `onSend` receives current flag, suggestion clicks too
- [x] `ChatBubble` renders badge, retry forwards original `deepThink`
- [ ] Manual on kauri once both backend PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Introduced "Deep think" toggle button to the chat input toolbar, allowing users to enable enhanced message processing for each message
* Chat messages sent with deep think enabled now display a visual badge indicator
* Message retry functionality now preserves the original deep think state when resending

<!-- end of auto-generated comment: release notes by coderabbit.ai -->