### PR TITLE
feat(holdings): simplify AI prompt + ship mobile AI button

### DIFF
--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -15,10 +15,17 @@ import { useHoldingState } from "@lib/holdings/holdingState"
 import { usePermissions } from "@hooks/usePermissions"
 import { requestChatOpen } from "@components/features/chat/chatBus"
 
+// Daily-read prompt. Three things only:
+//   1. headwinds / tailwinds moving the portfolio right now
+//   2. key news on the biggest winners and biggest losers
+//   3. macro issues to keep an eye on
+// Deliberately excludes daily XIRR (noise on a day-by-day basis) and
+// concentration / weighting analysis (a structural concern, not a daily one).
 const HOLDINGS_AI_PROMPT =
-  "Summarise the macro news affecting this portfolio, the biggest movers " +
-  "and shakers in my holdings, and the portfolio construction (allocations, " +
-  "weights, sector and currency concentration)."
+  "What are the headwinds and tailwinds moving this portfolio right now? " +
+  "Pull the key news hitting the biggest winners and biggest losers in my " +
+  "holdings. Flag macro-level issues to keep an eye on. Skip daily XIRR and " +
+  "concentration / weighting analysis — neither is meaningful on a daily basis."
 
 // Dropdown Menu Component
 interface DropdownMenuProps {
@@ -605,7 +612,7 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
               })
             }
             aria-label="AI summary of this portfolio"
-            title="AI summary: macro news, movers and shakers, portfolio construction"
+            title="AI summary: headwinds, tailwinds, key news on winners and losers"
           >
             <i className="fas fa-robot text-[10px] text-blue-500"></i>
             <span className="hidden sm:inline">AI Summary</span>

--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -591,26 +591,30 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
           </div>
         )}
 
-        {/* Right side: Action buttons - hidden on mobile portrait */}
+        {/* AI Summary stays visible on mobile portrait — Share / Copy / Trade
+            do not, since they need wider tap targets and clutter the small
+            viewport. */}
+        {!permsLoading && canRunAi && !emptyHoldings && (
+          <button
+            type="button"
+            className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300 flex-shrink-0"
+            onClick={() =>
+              requestChatOpen({
+                prompt: HOLDINGS_AI_PROMPT,
+                expanded: true,
+              })
+            }
+            aria-label="AI summary of this portfolio"
+            title="AI summary: macro news, movers and shakers, portfolio construction"
+          >
+            <i className="fas fa-robot text-[10px] text-blue-500"></i>
+            <span className="hidden sm:inline">AI Summary</span>
+            <span className="sm:hidden">AI</span>
+          </button>
+        )}
+
+        {/* Right side: secondary action buttons - hidden on mobile portrait */}
         <div className="mobile-portrait:hidden flex items-center gap-2 flex-shrink-0">
-          {!permsLoading && canRunAi && !emptyHoldings && (
-            <button
-              type="button"
-              className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300"
-              onClick={() =>
-                requestChatOpen({
-                  prompt: HOLDINGS_AI_PROMPT,
-                  expanded: true,
-                })
-              }
-              aria-label="AI summary of this portfolio"
-              title="AI summary: macro news, movers and shakers, portfolio construction"
-            >
-              <i className="fas fa-robot text-[10px] text-blue-500"></i>
-              <span className="hidden sm:inline">AI Summary</span>
-              <span className="sm:hidden">AI</span>
-            </button>
-          )}
           {onShare && (
             <button
               className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300"

--- a/src/components/features/holdings/__tests__/HoldingActions.test.tsx
+++ b/src/components/features/holdings/__tests__/HoldingActions.test.tsx
@@ -83,6 +83,21 @@ jest.mock("@hooks/useIsAdmin", () => ({
   useIsAdmin: () => ({ isAdmin: false, isLoading: false }),
 }))
 
+// Permissions: grant `ai` so the AI Summary button renders. Mobile-visibility
+// tests don't care about the chat bus side-effect, only the DOM placement.
+jest.mock("@hooks/usePermissions", () => ({
+  usePermissions: () => ({
+    ai: true,
+    preview: true,
+    admin: false,
+    isLoading: false,
+  }),
+}))
+
+jest.mock("@components/features/chat/chatBus", () => ({
+  requestChatOpen: jest.fn(),
+}))
+
 // Mock HoldingContract data
 const mockHoldingResults: HoldingContract = {
   portfolio: {
@@ -192,6 +207,27 @@ describe("HoldingActions Mobile Portrait Tests (TDD)", () => {
       const rebalanceButton = screen.getByText("Rebalance")
       const button = rebalanceButton.closest("button")
       expect(button).toHaveClass("mobile-portrait:hidden")
+    })
+
+    it("should keep the AI Summary button visible (not in a mobile-portrait:hidden ancestor)", () => {
+      render(
+        <HoldingActions
+          holdingResults={mockHoldingResults}
+          columns={mockColumns}
+          valueIn={mockValueIn}
+        />,
+      )
+
+      // Button uses two labels for breakpoints; on portrait it renders both
+      // children but only "AI" is visible. Locate by aria-label which is stable.
+      const aiButton = screen.getByLabelText("AI summary of this portfolio")
+      expect(aiButton).toBeInTheDocument()
+      // Walk ancestors and assert none carry the hide-on-portrait class.
+      let node: HTMLElement | null = aiButton
+      while (node) {
+        expect(node).not.toHaveClass("mobile-portrait:hidden")
+        node = node.parentElement
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

Two related Holdings tweaks:

1. **Mobile AI button (re-ship)** — the AI Summary button is moved out of the \`mobile-portrait:hidden\` actions wrapper so phone-portrait viewports keep one-tap access. Share / Copy / Trade / Rebalance stay hidden on mobile portrait. *(This was already approved on PR #644 but only the chat-toggle commit landed in the merge — re-shipping the mobile commit here.)*

2. **AI prompt focus** — refocus \`HOLDINGS_AI_PROMPT\` on what matters day-to-day:
   - Headwinds and tailwinds moving the portfolio right now
   - Key news on the biggest winners and biggest losers
   - Macro issues to keep an eye on

   Dropped daily XIRR and concentration / weighting analysis — neither is meaningful day-to-day.

## Test plan

- [x] \`yarn lint && yarn typecheck && yarn test\` — clean (HoldingActions: 6/6 including the mobile AI ancestor-walk assertion)
- [ ] Visual on kauri after deploy: tap AI Summary on phone portrait, verify chat opens and the response leads with headwinds/tailwinds + winner/loser news rather than XIRR/concentration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI Summary content now focuses on market headwinds/tailwinds, key winners/losers, and macro insights
  * AI Summary button now visible on mobile devices in portrait mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->