### PR TITLE
fix(chat): readable markdown tables on mobile

### DIFF
--- a/src/components/features/chat/ChatBubble.tsx
+++ b/src/components/features/chat/ChatBubble.tsx
@@ -65,14 +65,26 @@ export default function ChatBubble({
   return (
     <div className="group flex justify-start">
       <div
-        className={`max-w-[80%] px-4 py-2 rounded-lg text-sm border ${
+        className={`max-w-[92%] sm:max-w-[80%] px-4 py-2 rounded-lg text-sm border ${
           message.error
             ? "bg-red-50 border-red-200"
             : "bg-white border-gray-200"
         }`}
       >
-        <div className="prose prose-sm max-w-none">
-          <Markdown remarkPlugins={[remarkGfm]}>{message.content}</Markdown>
+        <div className="prose prose-sm max-w-none prose-table:my-2 prose-th:px-2 prose-th:py-1 prose-td:px-2 prose-td:py-1">
+          <Markdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              table: (props) => (
+                <div className="overflow-x-auto -mx-2 my-2">
+                  <table {...props} className="text-xs" />
+                </div>
+              ),
+              th: (props) => <th {...props} className="whitespace-nowrap" />,
+            }}
+          >
+            {message.content}
+          </Markdown>
         </div>
         <div className="flex justify-end mt-1">
           <button


### PR DESCRIPTION
## Summary
- Wrap markdown tables in `overflow-x-auto` so they scroll horizontally instead of squeezing
- Compact cell padding via prose modifiers, `text-xs` on the table itself
- Bump assistant bubble cap to 92% on small screens (drops back to 80% at `sm:`)
- Header cells get `whitespace-nowrap` to keep column labels intact

## Why
Holdsworth Assistant FAB renders chat content via `react-markdown` + `remark-gfm`. With the 80% bubble cap inside a `w-96` panel, multi-column tables on phone widths became unreadable — the first-column label collapsed to one word per line.

## Test plan
- [ ] Open Holdsworth Assistant FAB on mobile (≤640px) and ask a question that returns a table
- [ ] Confirm table scrolls horizontally inside the bubble
- [ ] Confirm header labels stay on one line
- [ ] Confirm desktop bubble width unchanged at 80%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved chat bubble layout responsiveness across different screen sizes
  * Updated copy button color styling
  * Enhanced Markdown table and header rendering with improved formatting and overflow handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->