### PR TITLE
feat(holdings): AI Summary button on aggregated holdings view

### DIFF
--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -21,7 +21,7 @@ import { requestChatOpen } from "@components/features/chat/chatBus"
 //   3. macro issues to keep an eye on
 // Deliberately excludes daily XIRR (noise on a day-by-day basis) and
 // concentration / weighting analysis (a structural concern, not a daily one).
-const HOLDINGS_AI_PROMPT =
+export const HOLDINGS_AI_PROMPT =
   "What are the headwinds and tailwinds moving this portfolio right now? " +
   "Pull the key news hitting the biggest winners and biggest losers in my " +
   "holdings. Flag macro-level issues to keep an eye on. Skip daily XIRR and " +

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -28,6 +28,9 @@ import {
 import CopyPopup from "@components/ui/CopyPopup"
 import IncomeView from "@components/features/holdings/IncomeView"
 import { ViewMode } from "@components/features/holdings/ViewToggle"
+import { HOLDINGS_AI_PROMPT } from "@components/features/holdings/HoldingActions"
+import { requestChatOpen } from "@components/features/chat/chatBus"
+import { usePermissions } from "@hooks/usePermissions"
 
 /** View mode icon component */
 const ViewModeIcon: React.FC<{ mode: string; className?: string }> = ({
@@ -213,6 +216,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
   const router = useRouter()
   const holdingState = useHoldingState()
   const groupOptions = useGroupOptions()
+  const { ai: canRunAi, isLoading: permsLoading } = usePermissions()
   // Get portfolio codes from URL query parameter
   const codes = router.query.codes as string | undefined
   const portfolioCodes = useMemo(() => (codes ? codes.split(",") : []), [codes])
@@ -337,6 +341,28 @@ function AggregatedHoldingsPage(): React.ReactElement {
               </button>
             ))}
           </div>
+
+          {/* AI Summary stays visible on mobile portrait — Copy / Rebalance
+              do not, since they need wider tap targets and clutter the small
+              viewport. */}
+          {!permsLoading && canRunAi && (
+            <button
+              type="button"
+              className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300 flex-shrink-0"
+              onClick={() =>
+                requestChatOpen({
+                  prompt: HOLDINGS_AI_PROMPT,
+                  expanded: true,
+                })
+              }
+              aria-label="AI summary of aggregated holdings"
+              title="AI summary: headwinds, tailwinds, key news on winners and losers"
+            >
+              <i className="fas fa-robot text-[10px] text-blue-500"></i>
+              <span className="hidden sm:inline">AI Summary</span>
+              <span className="sm:hidden">AI</span>
+            </button>
+          )}
 
           {/* Action buttons - hidden on mobile portrait */}
           <div className="mobile-portrait:hidden flex items-center space-x-2 shrink-0">


### PR DESCRIPTION
## Summary
- Aggregated holdings page (`/holdings/aggregated`) was missing the AI Summary button present on the per-portfolio holdings page
- Imports the same `HOLDINGS_AI_PROMPT` and `requestChatOpen` used by `HoldingActions` for behaviour parity
- Button gated on the `ai` permission via `usePermissions`; visible on mobile portrait alongside view-mode / group-by controls

## Test plan
- [ ] Visit `/holdings/aggregated` as a user with `ai` permission and confirm AI Summary button appears
- [ ] Click button — chat opens expanded with the daily-read prompt pre-seeded
- [ ] Visit as a user without `ai` permission — button hidden
- [ ] Confirm view-mode, group-by, and column sort still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an "AI Summary" button to the holdings page toolbar. Users with appropriate permissions can click this button to generate AI-powered insights about their holdings, which opens in a chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->