### PR TITLE
feat(holdings): portfolio AI Summary modal (streaming + cancel)

### DIFF
--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -13,19 +13,7 @@ import {
 } from "@components/features/holdings/GroupByOptions"
 import { useHoldingState } from "@lib/holdings/holdingState"
 import { usePermissions } from "@hooks/usePermissions"
-import { requestChatOpen } from "@components/features/chat/chatBus"
-
-// Daily-read prompt. Three things only:
-//   1. headwinds / tailwinds moving the portfolio right now
-//   2. key news on the biggest winners and biggest losers
-//   3. macro issues to keep an eye on
-// Deliberately excludes daily XIRR (noise on a day-by-day basis) and
-// concentration / weighting analysis (a structural concern, not a daily one).
-export const HOLDINGS_AI_PROMPT =
-  "What are the headwinds and tailwinds moving this portfolio right now? " +
-  "Pull the key news hitting the biggest winners and biggest losers in my " +
-  "holdings. Flag macro-level issues to keep an eye on. Skip daily XIRR and " +
-  "concentration / weighting analysis — neither is meaningful on a daily basis."
+import { usePortfolioReview } from "./usePortfolioReview"
 
 // Dropdown Menu Component
 interface DropdownMenuProps {
@@ -342,6 +330,7 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
   const { ai: canRunAi, isLoading: permsLoading } = usePermissions()
   const holdingState = useHoldingState()
   const groupOptions = useGroupOptions()
+  const { popup: reviewPopup, showReview } = usePortfolioReview()
   const [tradeModalOpen, setTradeModalOpen] = useState(false)
   const [cashModalOpen, setCashModalOpen] = useState(false)
 
@@ -606,9 +595,11 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
             type="button"
             className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300 flex-shrink-0"
             onClick={() =>
-              requestChatOpen({
-                prompt: HOLDINGS_AI_PROMPT,
-                expanded: true,
+              showReview({
+                kind: "portfolio",
+                id: holdingResults.portfolio.id,
+                code: holdingResults.portfolio.code,
+                name: holdingResults.portfolio.name,
               })
             }
             aria-label="AI summary of this portfolio"
@@ -723,6 +714,7 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
           </div>
         </div>
       )}
+      {reviewPopup}
     </>
   )
 }

--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -13,7 +13,7 @@ import {
 } from "@components/features/holdings/GroupByOptions"
 import { useHoldingState } from "@lib/holdings/holdingState"
 import { usePermissions } from "@hooks/usePermissions"
-import { usePortfolioReview } from "./usePortfolioReview"
+import { usePortfolioReview } from "@components/features/holdings/usePortfolioReview"
 
 // Dropdown Menu Component
 interface DropdownMenuProps {

--- a/src/components/features/holdings/PortfolioReviewPopup.tsx
+++ b/src/components/features/holdings/PortfolioReviewPopup.tsx
@@ -1,0 +1,284 @@
+import React, { useEffect, useRef, useState } from "react"
+import Markdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import Dialog from "@components/ui/Dialog"
+import Spinner from "@components/ui/Spinner"
+
+export type PortfolioReviewTarget =
+  | { kind: "portfolio"; id: string; code: string; name: string }
+  | { kind: "aggregated"; codes: string[] }
+
+interface PortfolioReviewPopupProps {
+  target: PortfolioReviewTarget
+  onClose: () => void
+}
+
+// Daily portfolio briefing prompt. Frames the agent as a financial columnist
+// writing a 250–400 word morning read. Section order is fixed: headline →
+// drivers → patterns → longer arc (XIRR vs day) → what to watch.
+const DAILY_BRIEFING_PROMPT = `Role: You are a financial columnist writing a daily portfolio briefing. Your tone is that of a seasoned markets writer — informed, measured, and contextual. You explain why things moved, not just what moved.
+
+Inputs available to you:
+\t• Portfolio holdings (ETFs and individual stocks) with weights
+\t• Day's return (portfolio and per-holding)
+\t• XIRR (portfolio and per-holding where meaningful)
+\t• News feed for holdings and broader markets
+
+Your brief should cover, in this order:
+\t1. The headline — One or two sentences. How did the portfolio do today, and is that consistent with or divergent from broader market behaviour? Lead with the number, then the context.
+\t2. What drove it — Identify the 2–4 holdings (or sectors/themes) that contributed most to the day's move, positive or negative. Tie movements to news or macro factors where the news feed supports it. Avoid spurious causation — if a stock moved without clear news, say so.
+\t3. Patterns and themes — Step back. Are the day's moves part of a pattern (rate-sensitive names selling off together, a rotation into defensives, concentration risk showing up)? Is the portfolio behaving as a coherent set of bets or as uncorrelated noise?
+\t4. The longer arc — Briefly contrast the day against XIRR. Is today's move material against the long-run trajectory, or noise? Flag any holding whose XIRR is meaningfully diverging from thesis (sustained underperformance, a winner the portfolio is becoming concentrated in).
+\t5. What to watch — One or two forward-looking items from the news feed: an earnings date, a macro print, a pending catalyst. No predictions, just the calendar.
+
+Style rules:
+\t• Front-load every section. The point comes first, the supporting detail after.
+\t• Numbers in context. "Up 0.8%, against the S&P's 1.2%" beats "up 0.8%."
+\t• No hedging filler ("it's worth noting that…", "interestingly…"). Cut it.
+\t• No recommendations to buy or sell. You're a columnist, not an advisor.
+\t• If data is missing or news is thin, say so plainly rather than padding.
+\t• Length: roughly 250–400 words. A morning read, not a research note.`
+
+// Module-level cache: key -> { response, fetchedAt }. Only fully-completed
+// streams populate the cache; aborted runs are not cached so the user can
+// retry by reopening.
+const reviewCache = new Map<string, { response: string; fetchedAt: number }>()
+const CACHE_TTL_MS = 30 * 60 * 1000
+
+export function clearPortfolioReviewCache(): void {
+  reviewCache.clear()
+}
+
+function targetKey(target: PortfolioReviewTarget): string {
+  if (target.kind === "portfolio") return `P|${target.id}`
+  return `A|${[...target.codes].sort().join(",")}`
+}
+
+function targetTitle(target: PortfolioReviewTarget): string {
+  if (target.kind === "portfolio") return target.name
+  if (target.codes.length === 0) return "Aggregated Holdings"
+  if (target.codes.length === 1) return `Aggregated — ${target.codes[0]}`
+  return `Aggregated — ${target.codes.length} portfolios`
+}
+
+function buildRequest(target: PortfolioReviewTarget): {
+  query: string
+  context: Record<string, unknown>
+} {
+  if (target.kind === "portfolio") {
+    return {
+      query: DAILY_BRIEFING_PROMPT,
+      context: {
+        page: "Portfolio Review",
+        description:
+          "AI Summary popup for a single portfolio's holdings (daily-read).",
+        portfolioId: target.id,
+        portfolioCode: target.code,
+        portfolioName: target.name,
+      },
+    }
+  }
+  return {
+    query: DAILY_BRIEFING_PROMPT,
+    context: {
+      page: "Portfolio Review",
+      description:
+        "AI Summary popup for aggregated holdings across portfolios (daily-read).",
+      portfolioCodes: target.codes,
+    },
+  }
+}
+
+function describeStreamError(code: string): string {
+  switch (code) {
+    case "provider-quota":
+      return "the AI provider has run out of credit. Please ask the site owner to top up the Anthropic billing balance."
+    case "provider-rate":
+      return "the AI provider is rate-limiting requests. Please wait a moment and try again."
+    case "provider-timeout":
+      return "the AI provider took too long to respond. Please try again."
+    case "agent-error":
+      return "the agent failed to process your request. Please try again."
+    default:
+      return code
+  }
+}
+
+export default function PortfolioReviewPopup({
+  target,
+  onClose,
+}: PortfolioReviewPopupProps): React.ReactElement {
+  const [response, setResponse] = useState<string>("")
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const key = targetKey(target)
+
+  const cancel = (): void => {
+    abortRef.current?.abort()
+    setIsLoading(false)
+  }
+
+  useEffect(() => {
+    const cached = reviewCache.get(key)
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      setResponse(cached.response)
+      setIsLoading(false)
+      return () => {}
+    }
+
+    const controller = new AbortController()
+    abortRef.current = controller
+    setIsLoading(true)
+    setError(null)
+    setResponse("")
+
+    const run = async (): Promise<void> => {
+      const { query, context } = buildRequest(target)
+      let accumulated = ""
+      let streamError: string | null = null
+      try {
+        const res = await fetch("/api/agent/query/stream", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+          },
+          body: JSON.stringify({ query, context }),
+          signal: controller.signal,
+        })
+        if (!res.ok || !res.body) {
+          throw new Error(`HTTP ${res.status}`)
+        }
+
+        const reader = res.body.pipeThrough(new TextDecoderStream()).getReader()
+        let buffer = ""
+
+        // SSE event blocks delimited by blank line; each block carries an
+        // `event:` line and one or more `data:` lines. Don't strip leading
+        // space from `data:` payloads — Spring's SSE writer treats the space
+        // as content (matches useChat parsing).
+        const flush = (block: string): void => {
+          let event = "message"
+          const dataLines: string[] = []
+          for (const raw of block.split("\n")) {
+            if (raw.startsWith(":")) continue
+            if (raw.startsWith("event:")) {
+              event = raw.slice(6).trim()
+            } else if (raw.startsWith("data:")) {
+              dataLines.push(raw.slice(5))
+            }
+          }
+          const data = dataLines.join("\n")
+          if (event === "token") {
+            accumulated += data
+            setResponse(accumulated)
+          } else if (event === "error") {
+            streamError = data || "stream-error"
+          }
+        }
+
+        for (;;) {
+          const { value, done } = await reader.read()
+          if (done) break
+          buffer += value
+          let sep = buffer.indexOf("\n\n")
+          while (sep !== -1) {
+            const block = buffer.slice(0, sep)
+            buffer = buffer.slice(sep + 2)
+            if (block.length > 0) flush(block)
+            sep = buffer.indexOf("\n\n")
+          }
+        }
+        if (buffer.trim().length > 0) flush(buffer)
+
+        if (streamError) {
+          setError(describeStreamError(streamError))
+        } else if (accumulated.length > 0) {
+          reviewCache.set(key, {
+            response: accumulated,
+            fetchedAt: Date.now(),
+          })
+        }
+      } catch (e: unknown) {
+        if (controller.signal.aborted) return
+        setError(e instanceof Error ? e.message : "Failed to fetch review")
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    }
+
+    void run()
+
+    return () => {
+      controller.abort()
+    }
+  }, [key, target])
+
+  const showSpinner = isLoading && response.length === 0
+
+  const cancelButton = isLoading ? (
+    <button
+      type="button"
+      onClick={cancel}
+      className="px-2 py-1 text-xs font-medium rounded-md bg-slate-100 hover:bg-slate-200 text-slate-700 ring-1 ring-slate-200"
+      aria-label="Cancel summary generation"
+      title="Cancel"
+    >
+      <i className="fas fa-stop text-[10px] mr-1"></i>
+      Cancel
+    </button>
+  ) : null
+
+  return (
+    <Dialog
+      title={
+        <span className="flex items-center">
+          <i className="fas fa-robot text-blue-500 mr-2"></i>
+          AI Summary — {targetTitle(target)}
+        </span>
+      }
+      onClose={onClose}
+      maxWidth="4xl"
+      scrollable
+    >
+      {showSpinner && (
+        <div className="flex flex-col items-center gap-3 text-gray-500 py-12">
+          <div className="flex items-center gap-2">
+            <Spinner />
+            <span>Generating summary...</span>
+          </div>
+          {cancelButton}
+        </div>
+      )}
+      {response.length > 0 && (
+        <div
+          className="prose prose-sm sm:prose-base max-w-none
+            prose-headings:text-slate-900 prose-headings:font-semibold
+            prose-h1:text-xl prose-h2:text-lg prose-h3:text-base
+            prose-h2:mt-6 prose-h2:mb-3 prose-h3:mt-4 prose-h3:mb-2
+            prose-p:text-slate-700 prose-p:leading-relaxed
+            prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline
+            prose-strong:text-slate-900
+            prose-ul:my-3 prose-li:my-1
+            prose-table:text-sm"
+        >
+          <Markdown remarkPlugins={[remarkGfm]}>{response}</Markdown>
+        </div>
+      )}
+      {isLoading && response.length > 0 && (
+        <div className="mt-3 flex items-center gap-2 text-gray-400 text-xs">
+          <Spinner />
+          <span>Streaming…</span>
+          {cancelButton}
+        </div>
+      )}
+      {error && (
+        <div className="mt-3 bg-red-50 border border-red-200 rounded-lg p-3 text-red-700 text-sm">
+          Sorry, an error occurred: {error}
+        </div>
+      )}
+    </Dialog>
+  )
+}

--- a/src/components/features/holdings/PortfolioReviewPopup.tsx
+++ b/src/components/features/holdings/PortfolioReviewPopup.tsx
@@ -156,13 +156,14 @@ export default function PortfolioReviewPopup({
         let buffer = ""
 
         // SSE event blocks delimited by blank line; each block carries an
-        // `event:` line and one or more `data:` lines. Don't strip leading
-        // space from `data:` payloads — Spring's SSE writer treats the space
-        // as content (matches useChat parsing).
+        // `event:` line and one or more `data:` lines. Accept both `\n\n`
+        // and `\r\n\r\n` separators — proxies (CDN / load balancer) may
+        // normalise line endings. Don't strip leading space from `data:`
+        // payloads — Spring's SSE writer treats the space as content.
         const flush = (block: string): void => {
           let event = "message"
           const dataLines: string[] = []
-          for (const raw of block.split("\n")) {
+          for (const raw of block.split(/\r?\n/)) {
             if (raw.startsWith(":")) continue
             if (raw.startsWith("event:")) {
               event = raw.slice(6).trim()
@@ -179,16 +180,29 @@ export default function PortfolioReviewPopup({
           }
         }
 
+        const findSeparator = (
+          buf: string,
+        ): { index: number; len: number } | null => {
+          const lf = buf.indexOf("\n\n")
+          const crlf = buf.indexOf("\r\n\r\n")
+          if (lf === -1 && crlf === -1) return null
+          if (lf === -1) return { index: crlf, len: 4 }
+          if (crlf === -1) return { index: lf, len: 2 }
+          return crlf < lf
+            ? { index: crlf, len: 4 }
+            : { index: lf, len: 2 }
+        }
+
         for (;;) {
           const { value, done } = await reader.read()
           if (done) break
           buffer += value
-          let sep = buffer.indexOf("\n\n")
-          while (sep !== -1) {
-            const block = buffer.slice(0, sep)
-            buffer = buffer.slice(sep + 2)
+          let sep = findSeparator(buffer)
+          while (sep !== null) {
+            const block = buffer.slice(0, sep.index)
+            buffer = buffer.slice(sep.index + sep.len)
             if (block.length > 0) flush(block)
-            sep = buffer.indexOf("\n\n")
+            sep = findSeparator(buffer)
           }
         }
         if (buffer.trim().length > 0) flush(buffer)

--- a/src/components/features/holdings/__tests__/HoldingActions.test.tsx
+++ b/src/components/features/holdings/__tests__/HoldingActions.test.tsx
@@ -94,10 +94,6 @@ jest.mock("@hooks/usePermissions", () => ({
   }),
 }))
 
-jest.mock("@components/features/chat/chatBus", () => ({
-  requestChatOpen: jest.fn(),
-}))
-
 // Mock HoldingContract data
 const mockHoldingResults: HoldingContract = {
   portfolio: {

--- a/src/components/features/holdings/__tests__/PortfolioReviewPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PortfolioReviewPopup.test.tsx
@@ -1,0 +1,183 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import PortfolioReviewPopup, {
+  clearPortfolioReviewCache,
+} from "../PortfolioReviewPopup"
+
+// react-markdown / remark-gfm are mocked globally in jest.setup.js
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+// Build a Response-shaped object whose body is a ReadableStream of SSE events.
+function sseResponse(
+  events: Array<{ event: string; data: string }>,
+  opts: { delayMs?: number } = {},
+): { ok: true; status: number; body: ReadableStream<Uint8Array> } {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for (const e of events) {
+        if (opts.delayMs) {
+          await new Promise((r) => setTimeout(r, opts.delayMs))
+        }
+        controller.enqueue(
+          encoder.encode(`event:${e.event}\ndata:${e.data}\n\n`),
+        )
+      }
+      controller.close()
+    },
+  })
+  return { ok: true, status: 200, body }
+}
+
+describe("PortfolioReviewPopup", () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    clearPortfolioReviewCache()
+  })
+
+  it("posts portfolio context to the streaming endpoint for a single portfolio", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([
+        { event: "token", data: "Hi" },
+        { event: "done", data: "{}" },
+      ]),
+    )
+    render(
+      <PortfolioReviewPopup
+        target={{
+          kind: "portfolio",
+          id: "p-123",
+          code: "TEST",
+          name: "Test Portfolio",
+        }}
+        onClose={jest.fn()}
+      />,
+    )
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe("/api/agent/query/stream")
+    expect(init.headers.Accept).toBe("text/event-stream")
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+    const body = JSON.parse(init.body)
+    expect(body.context.page).toBe("Portfolio Review")
+    expect(body.context.portfolioId).toBe("p-123")
+    expect(body.context.portfolioCode).toBe("TEST")
+    expect(body.context.portfolioName).toBe("Test Portfolio")
+    expect(body.query).toMatch(/financial columnist/i)
+  })
+
+  it("posts portfolioCodes for an aggregated target", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "done", data: "{}" }]),
+    )
+    render(
+      <PortfolioReviewPopup
+        target={{ kind: "aggregated", codes: ["A", "B"] }}
+        onClose={jest.fn()}
+      />,
+    )
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(body.context.portfolioCodes).toEqual(["A", "B"])
+  })
+
+  it("renders streamed token chunks as they arrive", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([
+        { event: "token", data: "Headwinds:" },
+        { event: "token", data: " rates" },
+        { event: "done", data: "{}" },
+      ]),
+    )
+    render(
+      <PortfolioReviewPopup
+        target={{ kind: "portfolio", id: "p-1", code: "X", name: "X" }}
+        onClose={jest.fn()}
+      />,
+    )
+    await waitFor(() =>
+      expect(screen.getByText("Headwinds: rates")).toBeInTheDocument(),
+    )
+  })
+
+  it("shows a Cancel button while loading and aborts the stream when clicked", async () => {
+    mockFetch.mockImplementationOnce(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener("abort", () => {
+            const err = new Error("Aborted")
+            err.name = "AbortError"
+            reject(err)
+          })
+        }),
+    )
+    render(
+      <PortfolioReviewPopup
+        target={{ kind: "portfolio", id: "p-1", code: "X", name: "X" }}
+        onClose={jest.fn()}
+      />,
+    )
+    const cancelBtn = await screen.findByRole("button", {
+      name: /cancel summary generation/i,
+    })
+    await userEvent.click(cancelBtn)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [, init] = mockFetch.mock.calls[0]
+    expect((init.signal as AbortSignal).aborted).toBe(true)
+    // Cancel resets isLoading so the Cancel button disappears immediately.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /cancel summary generation/i }),
+      ).not.toBeInTheDocument(),
+    )
+  })
+
+  it("surfaces stream-level error events", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([
+        { event: "error", data: "provider-quota" },
+        { event: "done", data: "{}" },
+      ]),
+    )
+    render(
+      <PortfolioReviewPopup
+        target={{ kind: "portfolio", id: "p-1", code: "X", name: "X" }}
+        onClose={jest.fn()}
+      />,
+    )
+    await waitFor(() =>
+      expect(screen.getByText(/error/i)).toBeInTheDocument(),
+    )
+    expect(screen.getByText(/run out of credit/i)).toBeInTheDocument()
+  })
+
+  it("caches by target so reopening the same portfolio does not re-fetch", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([
+        { event: "token", data: "Cached" },
+        { event: "done", data: "{}" },
+      ]),
+    )
+    const target = {
+      kind: "portfolio" as const,
+      id: "p-1",
+      code: "X",
+      name: "X",
+    }
+    const { unmount } = render(
+      <PortfolioReviewPopup target={target} onClose={jest.fn()} />,
+    )
+    await waitFor(() =>
+      expect(screen.getByText("Cached")).toBeInTheDocument(),
+    )
+    unmount()
+    render(<PortfolioReviewPopup target={target} onClose={jest.fn()} />)
+    await waitFor(() =>
+      expect(screen.getAllByText("Cached")[0]).toBeInTheDocument(),
+    )
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/features/holdings/__tests__/PortfolioReviewPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PortfolioReviewPopup.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import PortfolioReviewPopup, {
   clearPortfolioReviewCache,
-} from "../PortfolioReviewPopup"
+} from "@components/features/holdings/PortfolioReviewPopup"
 
 // react-markdown / remark-gfm are mocked globally in jest.setup.js
 
@@ -152,6 +152,28 @@ describe("PortfolioReviewPopup", () => {
       expect(screen.getByText(/error/i)).toBeInTheDocument(),
     )
     expect(screen.getByText(/run out of credit/i)).toBeInTheDocument()
+  })
+
+  it("parses SSE frames using \\r\\n\\r\\n separators (proxy-normalised line endings)", async () => {
+    const encoder = new TextEncoder()
+    const body = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(encoder.encode("event:token\r\ndata:Hi\r\n\r\n"))
+        c.enqueue(encoder.encode("event:token\r\ndata: there\r\n\r\n"))
+        c.enqueue(encoder.encode("event:done\r\ndata:{}\r\n\r\n"))
+        c.close()
+      },
+    })
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, body })
+    render(
+      <PortfolioReviewPopup
+        target={{ kind: "portfolio", id: "p-1", code: "X", name: "X" }}
+        onClose={jest.fn()}
+      />,
+    )
+    await waitFor(() =>
+      expect(screen.getByText("Hi there")).toBeInTheDocument(),
+    )
   })
 
   it("caches by target so reopening the same portfolio does not re-fetch", async () => {

--- a/src/components/features/holdings/usePortfolioReview.tsx
+++ b/src/components/features/holdings/usePortfolioReview.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useCallback, useState } from "react"
 import PortfolioReviewPopup, {
   PortfolioReviewTarget,
-} from "./PortfolioReviewPopup"
+} from "@components/features/holdings/PortfolioReviewPopup"
 
 export interface UsePortfolioReviewReturn {
   popup: ReactElement | null

--- a/src/components/features/holdings/usePortfolioReview.tsx
+++ b/src/components/features/holdings/usePortfolioReview.tsx
@@ -1,0 +1,23 @@
+import React, { ReactElement, useCallback, useState } from "react"
+import PortfolioReviewPopup, {
+  PortfolioReviewTarget,
+} from "./PortfolioReviewPopup"
+
+export interface UsePortfolioReviewReturn {
+  popup: ReactElement | null
+  showReview: (target: PortfolioReviewTarget) => void
+  close: () => void
+}
+
+export function usePortfolioReview(): UsePortfolioReviewReturn {
+  const [target, setTarget] = useState<PortfolioReviewTarget | null>(null)
+  const close = useCallback(() => setTarget(null), [])
+  const showReview = useCallback(
+    (next: PortfolioReviewTarget) => setTarget(next),
+    [],
+  )
+  const popup = target ? (
+    <PortfolioReviewPopup target={target} onClose={close} />
+  ) : null
+  return { popup, showReview, close }
+}

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -28,9 +28,8 @@ import {
 import CopyPopup from "@components/ui/CopyPopup"
 import IncomeView from "@components/features/holdings/IncomeView"
 import { ViewMode } from "@components/features/holdings/ViewToggle"
-import { HOLDINGS_AI_PROMPT } from "@components/features/holdings/HoldingActions"
-import { requestChatOpen } from "@components/features/chat/chatBus"
 import { usePermissions } from "@hooks/usePermissions"
+import { usePortfolioReview } from "@components/features/holdings/usePortfolioReview"
 
 /** View mode icon component */
 const ViewModeIcon: React.FC<{ mode: string; className?: string }> = ({
@@ -217,6 +216,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
   const holdingState = useHoldingState()
   const groupOptions = useGroupOptions()
   const { ai: canRunAi, isLoading: permsLoading } = usePermissions()
+  const { popup: reviewPopup, showReview } = usePortfolioReview()
   // Get portfolio codes from URL query parameter
   const codes = router.query.codes as string | undefined
   const portfolioCodes = useMemo(() => (codes ? codes.split(",") : []), [codes])
@@ -350,10 +350,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
               type="button"
               className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300 flex-shrink-0"
               onClick={() =>
-                requestChatOpen({
-                  prompt: HOLDINGS_AI_PROMPT,
-                  expanded: true,
-                })
+                showReview({ kind: "aggregated", codes: portfolioCodes })
               }
               aria-label="AI summary of aggregated holdings"
               title="AI summary: headwinds, tailwinds, key news on winners and losers"
@@ -526,6 +523,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
           modalOpen={copyModalOpen}
           onClose={() => setCopyModalOpen(false)}
         />
+        {reviewPopup}
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- Replaces chat-bus open with a Dialog popup for the Holdings AI Summary button on both per-portfolio (`/holdings/[code]`) and aggregated (`/holdings/aggregated`) views (the latter shipped in #647).
- Streams responses via `/api/agent/query/stream` so first tokens land in ~1–2s; AbortController-backed Cancel button lets the user abandon a generation mid-stream (immediate UI feedback — fix surfaced during code review).
- 30-minute per-target cache on successful streams; aborted runs are not cached so retries work.
- Daily-briefing prompt frames the agent as a financial columnist (fixed section order: headline → drivers → patterns → longer arc → what to watch). Same prompt for single + aggregated; context (`portfolioId` vs `portfolioCodes`) disambiguates.

## Test plan
- [ ] Open `/holdings/[code]` → click AI Summary → tokens stream into the modal as they arrive
- [ ] Click Cancel mid-stream → button + spinner disappear immediately, partial response remains visible
- [ ] Reopen the same portfolio within 30 min → instant render from cache (no fetch)
- [ ] Same flow on `/holdings/aggregated` (with and without `?codes=` filter)
- [ ] Verify dialog body is freely scrollable while streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered daily portfolio briefing with streaming, progressively-updating summaries and a cancel option.
  * “AI Summary” buttons now open a unified portfolio review flow for single or aggregated portfolios.
  * Short-term caching of results to speed repeated requests.

* **Tests**
  * Added coverage for streaming, cancellation, error handling, caching behavior, and aggregated-target flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->