### PR TITLE
feat(build): enable React Compiler

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@
 const path = require("path")
 const nextConfig = {
   reactStrictMode: true,
+  reactCompiler: true,
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "babel-jest": "^30.3.0",
+    "babel-plugin-react-compiler": "^1.0.0",
     "browserslist": "^4.28.2",
     "dotenv": "^17.3.1",
     "eslint": "^9.39.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,7 +295,7 @@
     "@babel/types" "^7.29.0"
     debug "^4.3.1"
 
-"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.6", "@babel/types@^7.29.0":
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.26.0", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.6", "@babel/types@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
   integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
@@ -2941,6 +2941,13 @@ babel-plugin-macros@^3.1.0:
     "@babel/runtime" "^7.12.5"
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
+
+babel-plugin-react-compiler@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz#bdf7360a23a4d5ebfca090255da3893efd07425f"
+  integrity sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==
+  dependencies:
+    "@babel/types" "^7.26.0"
 
 babel-preset-current-node-syntax@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Summary

- Adopt React Compiler 1.0 (stable in Next.js 16) — handles component memoization at build time, reducing the long-term need for manual `useMemo`/`useCallback`
- Aligns with [Thoughtworks Tech Radar — React.js (Adopt)](https://www.thoughtworks.com/en-in/radar/languages-and-frameworks/summary/react-js) guidance
- Two-line change: add `babel-plugin-react-compiler@1.0.0` devDep + set `reactCompiler: true` at top level of `next.config.js` (top-level in Next 16; was `experimental.reactCompiler` in Next 15)

## Trade-off

Babel-driven compile path increases build time (~150s observed locally for `yarn build`). Runtime image unaffected — compiler is build-time only, devDep is not shipped. Dockerfile and CI workflow need no changes.

## Follow-ups (separate PRs)

1. Audit + delete redundant `useMemo`/`useCallback` (363 occurrences across 103 files). Compiler now handles these — keep only deps-correctness escape hatches.
2. Drop dead `@hookstate/core` + `@hookstate/devtools` (1 file uses Hookstate vs 91 files on SWR).
3. Pilot `useOptimistic` on a mutation flow (portfolio create / CSV import).

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn test` — 106 suites, 1260 tests, all passing
- [x] `yarn build` — production build clean, no compiler bailout warnings
- [ ] CI green on this PR
- [ ] Smoke test deployed image on kauri

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled React compiler support in the build configuration to optimize the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->