### PR TITLE
feat(lint): enable React Compiler ESLint rules at warn

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,6 +121,23 @@ export default [
       "@typescript-eslint/ban-ts-ignore": "off",
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
+      // React Compiler rules (eslint-plugin-react-hooks v7).
+      // Surface compiler bailouts so manual memoization can be pruned safely.
+      // Start at "warn" to avoid blocking CI; promote to "error" after cleanup.
+      "react-hooks/preserve-manual-memoization": "warn",
+      "react-hooks/immutability": "warn",
+      "react-hooks/purity": "warn",
+      "react-hooks/refs": "warn",
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/set-state-in-render": "warn",
+      "react-hooks/static-components": "warn",
+      "react-hooks/use-memo": "warn",
+      "react-hooks/error-boundaries": "warn",
+      "react-hooks/gating": "warn",
+      "react-hooks/globals": "warn",
+      "react-hooks/config": "warn",
+      "react-hooks/unsupported-syntax": "warn",
+      "react-hooks/incompatible-library": "warn",
       // Next.js rules
       ...nextPlugin.configs.recommended.rules,
       ...nextPlugin.configs["core-web-vitals"].rules,


### PR DESCRIPTION
## Summary

- Enable the React Compiler rules bundled in `eslint-plugin-react-hooks@7` (already a dependency — no new installs)
- All new rules set to `warn` to avoid blocking CI while findings are triaged
- Acts as the safety net for the upcoming manual-memoization cleanup: anywhere the compiler bails out, lint will tell us before we delete a `useMemo`/`useCallback`

## Initial scan

31 warnings, 0 errors:

| Count | Rule |
| ----: | ---- |
| 19 | `react-hooks/set-state-in-effect` |
| 10 | `react-hooks/preserve-manual-memoization` |
|  1 | `react-hooks/incompatible-library` |
|  1 | `react-hooks/immutability` |
|  1 | `react-hooks/exhaustive-deps` |

The two dominant categories are exactly what we need to address next:

- **`set-state-in-effect`** — derived state being synced via `useEffect`. Belongs in render or `useMemo`. Compiler-incompatible pattern.
- **`preserve-manual-memoization`** — `useMemo` deps don't match what the compiler infers (e.g., `[foo?.data]` vs `foo.data`). Compiler skips optimizing the whole component as a result.

No code changes in this PR — purely lights-on. Cleanup goes in subsequent PRs, batched per feature area.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` — 31 warnings, 0 errors (does not break CI)
- [x] `yarn test` — 1260 tests pass
- [ ] CI green
- [ ] Pick first cleanup target (likely `accounts.tsx` / `holdings/aggregated.tsx` — densest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development tooling configuration to improve code quality analysis and compilation monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->