### PR TITLE
fix(react-compiler): clear preserve-manual-memoization warnings (batch 1)

### DIFF
--- a/src/components/features/portfolios/PortfolioCorporateActionsPopup.tsx
+++ b/src/components/features/portfolios/PortfolioCorporateActionsPopup.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react"
+import React, { useState } from "react"
 import { NumericFormat } from "react-number-format"
 import useSwr from "swr"
 import { stripOwnerPrefix } from "@lib/assets/assetUtils"
@@ -65,21 +65,11 @@ const PortfolioCorporateActionsPopup: React.FC<
     modalOpen ? simpleFetcher(holdingByIdKey(portfolio.id, today)) : null,
   )
 
-  // Reset state when modal opens
-  useEffect(() => {
-    if (modalOpen) {
-      setIsScanning(false)
-      setScanComplete(false)
-      setMissingEvents([])
-      setScanProgress(null)
-      setIsBackfilling(false)
-      setBackfillProgress(null)
-      setProcessError(null)
-      setProcessedEvents(new Set())
-    }
-  }, [modalOpen])
+  // Component is conditionally mounted by the parent based on
+  // corporateActionsPortfolio, so a fresh open always remounts with the
+  // initial useState values — no manual reset useEffect needed.
 
-  const scanForMissingEvents = useCallback(async () => {
+  const scanForMissingEvents = async (): Promise<void> => {
     if (!holdingsData?.data?.positions) return
 
     setIsScanning(true)
@@ -145,7 +135,7 @@ const PortfolioCorporateActionsPopup: React.FC<
     setIsScanning(false)
     setScanComplete(true)
     setScanProgress(null)
-  }, [portfolio.id, holdingsData?.data?.positions, today])
+  }
 
   const handleBackfillAll = async (): Promise<void> => {
     if (missingEvents.length === 0) return

--- a/src/pages/accounts.tsx
+++ b/src/pages/accounts.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from "react"
+import React, { useState, useCallback } from "react"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import useSwr, { mutate } from "swr"
 import { simpleFetcher, ccyKey, categoriesKey } from "@utils/api/fetchHelper"
@@ -60,24 +60,22 @@ function AccountsPage(): React.ReactElement {
   )
 
   // Convert backend categories to select options, filtering to user asset types
-  const categoryOptions = useMemo((): CategoryOption[] => {
-    if (!categoriesData?.data) return []
-    return categoriesData.data
-      .filter((cat: AssetCategory) => USER_ASSET_CATEGORIES.includes(cat.id))
-      .map((cat: AssetCategory) => ({
-        value: cat.id,
-        label: cat.name,
-      }))
-  }, [categoriesData?.data])
+  const categoryOptions: CategoryOption[] = categoriesData?.data
+    ? categoriesData.data
+        .filter((cat: AssetCategory) => USER_ASSET_CATEGORIES.includes(cat.id))
+        .map((cat: AssetCategory) => ({
+          value: cat.id,
+          label: cat.name,
+        }))
+    : []
 
   // Convert sectors to select options
-  const sectorOptions = useMemo((): SectorOption[] => {
-    if (!sectorsData?.data) return []
-    return sectorsData.data.map((sector: SectorInfo) => ({
-      value: sector.name,
-      label: sector.name,
-    }))
-  }, [sectorsData?.data])
+  const sectorOptions: SectorOption[] = sectorsData?.data
+    ? sectorsData.data.map((sector: SectorInfo) => ({
+        value: sector.name,
+        label: sector.name,
+      }))
+    : []
 
   const [editData, setEditData] = useState<EditAccountData | undefined>(
     undefined,
@@ -249,33 +247,31 @@ function AccountsPage(): React.ReactElement {
   }, [])
 
   // Convert accounts data to array
-  const accounts = useMemo(() => {
-    if (!accountsData?.data) return []
-    return Object.values(accountsData.data as Record<string, Asset>)
-  }, [accountsData?.data])
+  const accounts: Asset[] = accountsData?.data
+    ? Object.values(accountsData.data as Record<string, Asset>)
+    : []
 
   // Currency options
-  const ccyOptions = useMemo(() => {
-    if (!ccyData?.data) return []
-    return currencyOptions(ccyData.data)
-  }, [ccyData?.data])
+  const ccyOptions = ccyData?.data ? currencyOptions(ccyData.data) : []
 
   // Filter accounts based on active tab
-  const filteredAccounts = useMemo(() => {
-    if (activeTab === "overview") return []
-    if (activeTab === "all") return accounts
-    return accounts.filter((account) => account.assetCategory?.id === activeTab)
-  }, [accounts, activeTab])
+  let filteredAccounts: Asset[]
+  if (activeTab === "overview") {
+    filteredAccounts = []
+  } else if (activeTab === "all") {
+    filteredAccounts = accounts
+  } else {
+    filteredAccounts = accounts.filter(
+      (account) => account.assetCategory?.id === activeTab,
+    )
+  }
 
   // Tab definitions
-  const tabs = useMemo(
-    (): { id: TabType; label: string }[] => [
-      { id: "overview", label: "Overview" },
-      { id: "all", label: "All" },
-      ...categoryOptions.map((cat) => ({ id: cat.value, label: cat.label })),
-    ],
-    [categoryOptions],
-  )
+  const tabs: { id: TabType; label: string }[] = [
+    { id: "overview", label: "Overview" },
+    { id: "all", label: "All" },
+    ...categoryOptions.map((cat) => ({ id: cat.value, label: cat.label })),
+  ]
 
   if (isLoading || ccyLoading || categoriesLoading || sectorsLoading) {
     return rootLoader("Loading...")


### PR DESCRIPTION
## Summary

First batch of cleanup for the React Compiler ESLint warnings surfaced by #651. Targets the two densest files; long tail covered in follow-up PRs.

| File | Before | After |
| ---- | -----: | ----: |
| `PortfolioCorporateActionsPopup.tsx` | 7 warnings | 0 |
| `accounts.tsx` | 4 warnings | 0 |
| **Project total** | **31** | **20** |

All 10 \`preserve-manual-memoization\` warnings now cleared. Remaining 20 are mostly \`set-state-in-effect\` (18) plus one each of \`incompatible-library\`, \`immutability\`, \`exhaustive-deps\`.

## Approach

**\`PortfolioCorporateActionsPopup.tsx\`**

- Dropped the reset-on-open \`useEffect\`. The parent (\`pages/portfolios/index.tsx\`) conditionally mounts this component when \`corporateActionsPortfolio\` is truthy and unmounts on close, so initial \`useState\` values already give a fresh state on every open. The effect was dead code.
- Dropped the \`useCallback\` wrapping \`scanForMissingEvents\`. Only consumed by an \`onClick\` — no dep-array consumer. Compiler can memoize without us hand-rolling a deps list it can't preserve.

**\`accounts.tsx\`**

- Replaced four \`useMemo\` blocks (\`categoryOptions\`, \`sectorOptions\`, \`accounts\`, \`ccyOptions\`) with plain conditional expressions. All four had optional-chained deps (\`[foo?.data]\`) that the compiler couldn't reconcile with its inferred dependency.
- Dropped the downstream \`filteredAccounts\` and \`tabs\` \`useMemo\` blocks too — once the upstream memos went, those became \`exhaustive-deps\` warnings; the compiler will memoize them now that nothing upstream is hand-memoized.

## Test plan

- [x] \`yarn typecheck\`
- [x] \`yarn lint\` — warnings 31 → 20, all 10 \`preserve-manual-memoization\` cleared
- [x] \`yarn test\` — 1260 tests pass
- [x] \`yarn build\` clean
- [ ] CI green
- [ ] Manual smoke: open Corporate Actions popup on a managed portfolio; verify scan starts fresh on each open. Visit \`/accounts\`; verify category/sector tabs and currency dropdowns populate.

## Follow-up batches

- **Batch 2** — \`set-state-in-effect\` sweep across \`useFxRates\`, \`useDisplayCurrencyConversion\`, \`HoldingActions\`, plus 11 other files with single-warning hits.
- **Batch 3** — single \`immutability\` and \`incompatible-library\` warnings.
- **After warnings = 0** — promote the React Compiler rules from \`warn\` to \`error\` in \`eslint.config.mjs\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal state management in portfolio corporate actions and accounts features without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->