### PR TITLE
fix(react-compiler): refactor FX/plan hooks + promote rules to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,23 +121,26 @@ export default [
       "@typescript-eslint/ban-ts-ignore": "off",
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
-      // React Compiler rules (eslint-plugin-react-hooks v7).
-      // Surface compiler bailouts so manual memoization can be pruned safely.
-      // Start at "warn" to avoid blocking CI; promote to "error" after cleanup.
-      "react-hooks/preserve-manual-memoization": "warn",
-      "react-hooks/immutability": "warn",
-      "react-hooks/purity": "warn",
-      "react-hooks/refs": "warn",
-      "react-hooks/set-state-in-effect": "warn",
-      "react-hooks/set-state-in-render": "warn",
-      "react-hooks/static-components": "warn",
-      "react-hooks/use-memo": "warn",
-      "react-hooks/error-boundaries": "warn",
-      "react-hooks/gating": "warn",
-      "react-hooks/globals": "warn",
-      "react-hooks/config": "warn",
-      "react-hooks/unsupported-syntax": "warn",
-      "react-hooks/incompatible-library": "warn",
+      // React Compiler rules (eslint-plugin-react-hooks v7). All clean as of
+      // the batch-2 cleanup, so they're promoted to "error" — CI now blocks
+      // any new compiler bailouts. Intentional bailouts (SSR hydration,
+      // bidirectional input controllers, URL-driven side effects) are
+      // captured with scoped eslint-disable-next-line directives at the
+      // call site.
+      "react-hooks/preserve-manual-memoization": "error",
+      "react-hooks/immutability": "error",
+      "react-hooks/purity": "error",
+      "react-hooks/refs": "error",
+      "react-hooks/set-state-in-effect": "error",
+      "react-hooks/set-state-in-render": "error",
+      "react-hooks/static-components": "error",
+      "react-hooks/use-memo": "error",
+      "react-hooks/error-boundaries": "error",
+      "react-hooks/gating": "error",
+      "react-hooks/globals": "error",
+      "react-hooks/config": "error",
+      "react-hooks/unsupported-syntax": "error",
+      "react-hooks/incompatible-library": "error",
       // Next.js rules
       ...nextPlugin.configs.recommended.rules,
       ...nextPlugin.configs["core-web-vitals"].rules,

--- a/src/components/features/assets/AssetReviewPopup.tsx
+++ b/src/components/features/assets/AssetReviewPopup.tsx
@@ -81,27 +81,36 @@ function fetchReviewOnce(
   return promise
 }
 
+function readCachedReview(
+  ticker: string,
+  market: string | undefined,
+): string | null {
+  const cached = reviewCache.get(cacheKey(ticker, market))
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.response
+  }
+  return null
+}
+
 export default function AssetReviewPopup({
   ticker,
   market,
   assetName,
   onClose,
 }: AssetReviewPopupProps): React.ReactElement {
-  const [response, setResponse] = useState<string | null>(null)
+  // Parent passes key={ticker|market} so prop changes force a remount and
+  // re-run this lazy initializer. That keeps the cache lookup out of the
+  // useEffect body — only the async fetch on a cache miss runs there.
+  const initial = useState(() => readCachedReview(ticker, market))[0]
+  const [response, setResponse] = useState<string | null>(initial)
   const [error, setError] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(initial === null)
 
   useEffect(() => {
-    const key = cacheKey(ticker, market)
-    const cached = reviewCache.get(key)
-    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
-      setResponse(cached.response)
-      setIsLoading(false)
-      return () => {}
-    }
+    if (initial !== null) return () => {}
 
     let cancelled = false
-    fetchReviewOnce(key, ticker, market, assetName)
+    fetchReviewOnce(cacheKey(ticker, market), ticker, market, assetName)
       .then((text) => {
         if (!cancelled) setResponse(text)
       })
@@ -116,7 +125,7 @@ export default function AssetReviewPopup({
     return () => {
       cancelled = true
     }
-  }, [ticker, market, assetName])
+  }, [initial, ticker, market, assetName])
 
   return (
     <Dialog

--- a/src/components/features/assets/useAssetReview.tsx
+++ b/src/components/features/assets/useAssetReview.tsx
@@ -34,6 +34,7 @@ export function useAssetReview(): UseAssetReviewReturn {
   }, [])
   const popup = target ? (
     <AssetReviewPopup
+      key={`${target.ticker}|${target.market || ""}`}
       ticker={target.ticker}
       market={target.market}
       assetName={target.assetName}

--- a/src/components/features/chat/ChatFab.tsx
+++ b/src/components/features/chat/ChatFab.tsx
@@ -16,8 +16,14 @@ export default function ChatFab(): React.ReactElement {
   const [isOpen, setIsOpen] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const [corner, setCornerState] = useState<ChatCorner>("BR")
-  // Hydrate from localStorage post-mount to avoid SSR/CSR mismatch.
-  useEffect(() => setCornerState(loadChatCorner()), [])
+  // Hydrate from localStorage post-mount to avoid SSR/CSR mismatch. Reading
+  // localStorage during render (or a lazy useState initializer) would diverge
+  // server/client output. The post-mount setState is the canonical pattern.
+  useEffect(
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    () => setCornerState(loadChatCorner()),
+    [],
+  )
   const setCorner = useCallback((next: ChatCorner) => {
     setCornerState(next)
     saveChatCorner(next)

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 import {
   CashTransferData,
   CostAdjustData,
@@ -486,17 +486,13 @@ const CardView: React.FC<CardViewProps> = ({
     )
   }, [groupedPositions])
 
-  // Track collapsed groups - start with first group expanded
+  // Track collapsed groups - start with first group expanded.
+  // Parent passes `key={groupBy}` so this component remounts (and the
+  // initial state below re-runs) whenever groupBy changes — no manual
+  // reset effect needed.
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
     () => new Set(groupedPositions.slice(1).map((g) => g.groupKey)),
   )
-
-  // Collapse all except first group when groupBy changes
-  useEffect(() => {
-    setCollapsedGroups(
-      new Set(groupedPositions.slice(1).map((g) => g.groupKey)),
-    )
-  }, [groupBy]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleGroup = useCallback((groupKey: string) => {
     setCollapsedGroups((prev) => {

--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -334,9 +334,13 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
   const [tradeModalOpen, setTradeModalOpen] = useState(false)
   const [cashModalOpen, setCashModalOpen] = useState(false)
 
-  // Open trade/cash modal via ?action= query parameter (used by mobile header)
+  // Open trade/cash modal via ?action= query parameter (used by mobile
+  // header). Reading router.query during render and rewriting the URL is
+  // the side effect this component is meant to perform — it's not derived
+  // state, so the compiler warning is intentional behaviour.
   useEffect(() => {
     if (router.query.action === "trade") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setTradeModalOpen(true)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { action, ...rest } = router.query
@@ -359,9 +363,12 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
   >(DEFAULT_SUMMARY_COLUMNS)
   const [copied, setCopied] = useState(false)
 
-  // Open trade modal when quick sell data is provided
+  // Open trade modal when quick sell data is provided. quickSellData is an
+  // external trigger from the parent — opening the modal is the side
+  // effect, not derived state.
   useEffect(() => {
     if (quickSellData) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setTradeModalOpen(true)
     }
   }, [quickSellData])

--- a/src/components/features/holdings/NewsSentimentPopup.tsx
+++ b/src/components/features/holdings/NewsSentimentPopup.tsx
@@ -81,27 +81,36 @@ function fetchNewsOnce(
   return promise
 }
 
+function readCachedNews(
+  ticker: string,
+  market: string | undefined,
+): string | null {
+  const cached = newsCache.get(cacheKey(ticker, market))
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.response
+  }
+  return null
+}
+
 export default function NewsSentimentPopup({
   ticker,
   market,
   assetName,
   onClose,
 }: NewsSentimentPopupProps): React.ReactElement {
-  const [response, setResponse] = useState<string | null>(null)
+  // Parent passes key={ticker|market} so prop changes force a remount and
+  // re-run this lazy initializer. That keeps the cache lookup out of the
+  // useEffect body — only the async fetch on a cache miss runs there.
+  const initial = useState(() => readCachedNews(ticker, market))[0]
+  const [response, setResponse] = useState<string | null>(initial)
   const [error, setError] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(initial === null)
 
   useEffect(() => {
-    const key = cacheKey(ticker, market)
-    const cached = newsCache.get(key)
-    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
-      setResponse(cached.response)
-      setIsLoading(false)
-      return () => {}
-    }
+    if (initial !== null) return () => {}
 
     let cancelled = false
-    fetchNewsOnce(key, ticker, market, assetName)
+    fetchNewsOnce(cacheKey(ticker, market), ticker, market, assetName)
       .then((text) => {
         if (!cancelled) setResponse(text)
       })
@@ -116,7 +125,7 @@ export default function NewsSentimentPopup({
     return () => {
       cancelled = true
     }
-  }, [ticker, market, assetName])
+  }, [initial, ticker, market, assetName])
 
   return (
     <Dialog

--- a/src/components/features/holdings/TargetWeightDialog.tsx
+++ b/src/components/features/holdings/TargetWeightDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react"
+import React, { useState, useMemo } from "react"
 import { Asset, Portfolio, RebalanceData } from "types/beancounter"
 import MathInput from "@components/ui/MathInput"
 import Dialog from "@components/ui/Dialog"
@@ -27,14 +27,9 @@ const TargetWeightDialog: React.FC<TargetWeightDialogProps> = ({
   currentQuantity,
   currentPrice,
 }) => {
+  // Parent (pages/holdings/[code].tsx) conditionally mounts this dialog,
+  // so the initial useState already gives fresh state on each open.
   const [targetWeight, setTargetWeight] = useState<number>(currentWeight)
-
-  // Reset target weight when modal opens
-  useEffect(() => {
-    if (modalOpen) {
-      setTargetWeight(currentWeight)
-    }
-  }, [modalOpen, currentWeight])
 
   // Calculate required shares and action type
   const calculation = useMemo(() => {

--- a/src/components/features/holdings/useNewsAsset.tsx
+++ b/src/components/features/holdings/useNewsAsset.tsx
@@ -26,6 +26,7 @@ export function useNewsAsset(): UseNewsAssetReturn {
   )
   const popup = newsAsset ? (
     <NewsSentimentPopup
+      key={`${newsAsset.ticker}|${newsAsset.market || ""}`}
       ticker={newsAsset.ticker}
       market={newsAsset.market}
       assetName={newsAsset.assetName}

--- a/src/components/features/independence/EditPlanDetailsModal.tsx
+++ b/src/components/features/independence/EditPlanDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react"
+import React, { useState, useMemo } from "react"
 import useSwr from "swr"
 import { RetirementPlan } from "types/independence"
 import { Portfolio } from "types/beancounter"
@@ -33,7 +33,6 @@ interface EditFormData {
 }
 
 interface EditPlanDetailsModalProps {
-  isOpen: boolean
   onClose: () => void
   onApply: (overrides: ScenarioOverrides) => void
   plan: RetirementPlan
@@ -88,35 +87,39 @@ function PrivacyMoneyInput({
 }
 
 export default function EditPlanDetailsModal({
-  isOpen,
   onClose,
   onApply,
   plan,
 }: EditPlanDetailsModalProps): React.ReactElement | null {
   const { hideValues } = usePrivacyMode()
   const { data: portfolioData } = useSwr(
-    isOpen ? portfoliosKey : null,
+    portfoliosKey,
     simpleFetcher(portfoliosKey),
   )
   const portfolios: Portfolio[] = portfolioData?.data || []
 
-  const [formData, setFormData] = useState<EditFormData>({
-    pensionMonthly: 0,
-    socialSecurityMonthly: 0,
-    benefitsStartAge: undefined,
-    otherIncomeMonthly: 0,
-    monthlyExpenses: 0,
-    equityReturnRate: 0,
-    cashReturnRate: 0,
-    housingReturnRate: 0,
-    equityAllocation: 0,
-    cashAllocation: 0,
-    housingAllocation: 0,
-    inflationRate: 0,
-    targetBalance: 0,
-    excludedPortfolioIds: [],
-    excludedRentalAssetIds: [],
-  })
+  // Component is conditionally mounted by the parent, so initial state can
+  // be derived directly from `plan`. Parent uses a `key` tied to plan version
+  // to remount when the plan changes while the modal is already open.
+  const [formData, setFormData] = useState<EditFormData>(() => ({
+    pensionMonthly: plan.pensionMonthly,
+    socialSecurityMonthly: plan.socialSecurityMonthly,
+    benefitsStartAge: plan.benefitsStartAge,
+    otherIncomeMonthly: plan.otherIncomeMonthly ?? 0,
+    monthlyExpenses: plan.monthlyExpenses,
+    equityReturnRate: plan.equityReturnRate * 100,
+    cashReturnRate: plan.cashReturnRate * 100,
+    housingReturnRate: plan.housingReturnRate * 100,
+    equityAllocation: plan.equityAllocation * 100,
+    cashAllocation: plan.cashAllocation * 100,
+    housingAllocation: plan.housingAllocation * 100,
+    inflationRate: plan.inflationRate * 100,
+    targetBalance: plan.targetBalance ?? 0,
+    excludedPortfolioIds: parseExcludedPortfolioIds(plan.excludedPortfolioIds),
+    excludedRentalAssetIds: parseExcludedRentalAssetIds(
+      plan.excludedRentalAssetIds,
+    ),
+  }))
 
   // Fetch rental property configs for per-property checkboxes
   const { configs: assetConfigs, assetNames } = usePrivateAssetConfigs()
@@ -134,37 +137,6 @@ export default function EditPlanDetailsModal({
         !excludedAssetIds.has(c.assetId),
     )
   }, [assetConfigs, excludedAssetIds])
-
-  // Initialize form when modal opens or plan changes
-  // Use plan.updatedDate as stable change indicator to avoid re-init on reference changes
-  const planVersion = `${plan.id}-${plan.updatedDate}`
-  useEffect(() => {
-    if (isOpen) {
-      setFormData({
-        pensionMonthly: plan.pensionMonthly,
-        socialSecurityMonthly: plan.socialSecurityMonthly,
-        benefitsStartAge: plan.benefitsStartAge,
-        otherIncomeMonthly: plan.otherIncomeMonthly ?? 0,
-        monthlyExpenses: plan.monthlyExpenses,
-        equityReturnRate: plan.equityReturnRate * 100,
-        cashReturnRate: plan.cashReturnRate * 100,
-        housingReturnRate: plan.housingReturnRate * 100,
-        equityAllocation: plan.equityAllocation * 100,
-        cashAllocation: plan.cashAllocation * 100,
-        housingAllocation: plan.housingAllocation * 100,
-        inflationRate: plan.inflationRate * 100,
-        targetBalance: plan.targetBalance ?? 0,
-        excludedPortfolioIds: parseExcludedPortfolioIds(
-          plan.excludedPortfolioIds,
-        ),
-        excludedRentalAssetIds: parseExcludedRentalAssetIds(
-          plan.excludedRentalAssetIds,
-        ),
-      })
-    }
-  }, [isOpen, planVersion]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  if (!isOpen) return null
 
   const handleApply = (): void => {
     onApply({

--- a/src/components/features/independence/__tests__/EditPlanDetailsModal.test.tsx
+++ b/src/components/features/independence/__tests__/EditPlanDetailsModal.test.tsx
@@ -61,7 +61,6 @@ const mockPlan: RetirementPlan = {
 
 describe("EditPlanDetailsModal", () => {
   const defaultProps = {
-    isOpen: true,
     onClose: jest.fn(),
     onApply: jest.fn(),
     plan: mockPlan,
@@ -71,13 +70,9 @@ describe("EditPlanDetailsModal", () => {
     jest.clearAllMocks()
   })
 
-  it("renders nothing when closed", () => {
-    const { container } = render(
-      <EditPlanDetailsModal {...defaultProps} isOpen={false} />,
-    )
-
-    expect(container.firstChild).toBeNull()
-  })
+  // Open/closed lifecycle is now controlled by the parent via conditional
+  // mounting, so the previous "renders nothing when closed" assertion is no
+  // longer meaningful at this level.
 
   it("renders dialog title when open", () => {
     render(<EditPlanDetailsModal {...defaultProps} />)

--- a/src/components/features/independence/monte-carlo/DepletionHistogram.tsx
+++ b/src/components/features/independence/monte-carlo/DepletionHistogram.tsx
@@ -24,9 +24,14 @@ export function DepletionHistogram({
       .map(([age, count]) => ({ age: Number(age), count }))
       .sort((a, b) => a.age - b.age)
     const depletedCount = distribution.depletedCount
-    let cumulative = 0
-    return sorted.map((entry) => {
-      cumulative += entry.count
+    // Build a prefix-sum array first so the row map() doesn't close over a
+    // reassigned `let` — keeps the compiler from bailing on this component.
+    const cumulatives: number[] = sorted.reduce<number[]>((acc, entry) => {
+      const next = (acc[acc.length - 1] ?? 0) + entry.count
+      return [...acc, next]
+    }, [])
+    return sorted.map((entry, i) => {
+      const cumulative = cumulatives[i]
       return {
         ...entry,
         pctOfTotal: (entry.count / iterations) * 100,

--- a/src/components/features/portfolios/ManagedPortfolios.tsx
+++ b/src/components/features/portfolios/ManagedPortfolios.tsx
@@ -204,7 +204,10 @@ export default function ManagedPortfolios({
               </div>
               {canRunAi && share.portfolio && expandedShares.has(share.id) && (
                 <div className="pt-4" onClick={(e) => e.stopPropagation()}>
-                  <PortfolioAIOverview portfolio={share.portfolio} />
+                  <PortfolioAIOverview
+                    key={share.portfolio.id}
+                    portfolio={share.portfolio}
+                  />
                 </div>
               )}
             </div>

--- a/src/components/features/portfolios/PortfolioAIOverview.tsx
+++ b/src/components/features/portfolios/PortfolioAIOverview.tsx
@@ -215,28 +215,30 @@ function fetchOverviewOnce(
   return promise
 }
 
+function readCachedOverview(portfolioCode: string, asAt: string): string | null {
+  const cached = overviewCache.get(cacheKey(portfolioCode, asAt))
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.response
+  }
+  return null
+}
+
 export default function PortfolioAIOverview({
   portfolio,
 }: PortfolioAIOverviewProps): React.ReactElement {
-  const [response, setResponse] = useState<string | null>(null)
+  // Parent passes key={portfolio.id} so portfolio swaps force a remount
+  // and re-run this lazy initializer. Cache lookup stays out of useEffect.
+  const asAt = todayIso()
+  const initial = useState(() => readCachedOverview(portfolio.code, asAt))[0]
+  const [response, setResponse] = useState<string | null>(initial)
   const [error, setError] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(initial === null)
 
   useEffect(() => {
-    const asAt = todayIso()
-    const key = cacheKey(portfolio.code, asAt)
-    const cached = overviewCache.get(key)
-    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
-      setResponse(cached.response)
-      setIsLoading(false)
-      return () => {}
-    }
+    if (initial !== null) return () => {}
 
     let cancelled = false
-    setIsLoading(true)
-    setError(null)
-    setResponse(null)
-    fetchOverviewOnce(key, portfolio, asAt)
+    fetchOverviewOnce(cacheKey(portfolio.code, asAt), portfolio, asAt)
       .then((text) => {
         if (!cancelled) setResponse(text)
       })
@@ -253,7 +255,7 @@ export default function PortfolioAIOverview({
     return () => {
       cancelled = true
     }
-  }, [portfolio])
+  }, [initial, portfolio, asAt])
 
   return (
     <div className="bg-slate-50 border border-slate-200 rounded-lg p-4">

--- a/src/components/features/portfolios/PortfoliosList.tsx
+++ b/src/components/features/portfolios/PortfoliosList.tsx
@@ -498,7 +498,7 @@ const PortfoliosList: React.FC<PortfoliosListProps> = ({
             </div>
             {canRunAi && expandedPortfolios.has(portfolio.code) && (
               <div className="px-4 pb-4" onClick={(e) => e.stopPropagation()}>
-                <PortfolioAIOverview portfolio={portfolio} />
+                <PortfolioAIOverview key={portfolio.id} portfolio={portfolio} />
               </div>
             )}
           </div>
@@ -790,7 +790,10 @@ const PortfoliosList: React.FC<PortfoliosListProps> = ({
                       }
                     >
                       <td colSpan={8} className="px-4 py-3">
-                        <PortfolioAIOverview portfolio={portfolio} />
+                        <PortfolioAIOverview
+                          key={portfolio.id}
+                          portfolio={portfolio}
+                        />
                       </td>
                     </tr>
                   )}

--- a/src/components/features/rebalance/hooks/__tests__/usePlan.test.ts
+++ b/src/components/features/rebalance/hooks/__tests__/usePlan.test.ts
@@ -1,0 +1,135 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import useSwr from "swr"
+import { usePlan } from "../usePlan"
+
+jest.mock("swr")
+const mockUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+const baseSwr = {
+  isLoading: false,
+  isValidating: false,
+  error: undefined,
+  mutate: jest.fn(),
+}
+
+function swrResult<T>(data: T | undefined): ReturnType<typeof useSwr> {
+  return { ...baseSwr, data } as unknown as ReturnType<typeof useSwr>
+}
+
+describe("usePlan", () => {
+  beforeEach(() => {
+    mockUseSwr.mockReset()
+    mockFetch.mockReset()
+  })
+
+  it("does not call SWR when planId is undefined", () => {
+    mockUseSwr.mockReturnValue(swrResult(undefined))
+
+    renderHook(() => usePlan(undefined))
+
+    // SWR is called, but with a null key — that signals "don't fetch"
+    expect(mockUseSwr).toHaveBeenCalledWith(null, null)
+  })
+
+  it("constructs the SWR key from planId", () => {
+    mockUseSwr.mockReturnValue(swrResult(undefined))
+
+    renderHook(() => usePlan("plan-123"))
+
+    expect(mockUseSwr.mock.calls[0][0]).toContain("plan-123")
+  })
+
+  it("returns plan as-is when there is no items array", () => {
+    const plan = { id: "p1", status: "DRAFT" }
+    mockUseSwr.mockReturnValue(swrResult({ data: plan }))
+
+    const { result } = renderHook(() => usePlan("p1"))
+
+    return waitFor(() => {
+      expect(result.current.plan).toEqual(plan)
+    })
+  })
+
+  it("returns items unchanged when already enriched", async () => {
+    const items = [
+      {
+        assetId: "a1",
+        assetCode: "AAPL",
+        assetName: "Apple Inc",
+      },
+    ]
+    const plan = { id: "p2", items }
+    mockUseSwr.mockReturnValue(swrResult({ data: plan }))
+
+    const { result } = renderHook(() => usePlan("p2"))
+
+    await waitFor(() => {
+      expect(result.current.plan?.items).toEqual(items)
+    })
+    // No fetch needed for asset details since items are already enriched
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("fetches and merges asset details for unenriched items", async () => {
+    const items = [{ assetId: "a2" }]
+    const plan = { id: "p3", items }
+    mockUseSwr.mockReturnValue(swrResult({ data: plan }))
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { code: "MSFT", name: "Microsoft" } }),
+    })
+
+    const { result } = renderHook(() => usePlan("p3"))
+
+    await waitFor(() => {
+      expect(result.current.plan?.items?.[0]).toMatchObject({
+        assetId: "a2",
+        assetCode: "MSFT",
+        assetName: "Microsoft",
+      })
+    })
+    expect(mockFetch).toHaveBeenCalledWith("/api/assets/a2")
+  })
+
+  it("propagates SWR error", () => {
+    const error = new Error("network down")
+    mockUseSwr.mockReturnValue({
+      ...baseSwr,
+      data: undefined,
+      error,
+    } as unknown as ReturnType<typeof useSwr>)
+
+    const { result } = renderHook(() => usePlan("p4"))
+
+    expect(result.current.error).toBe(error)
+  })
+
+  it("forwards SWR isLoading", () => {
+    mockUseSwr.mockReturnValue({
+      ...baseSwr,
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useSwr>)
+
+    const { result } = renderHook(() => usePlan("p5"))
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it("forwards SWR mutate", () => {
+    const mutate = jest.fn()
+    mockUseSwr.mockReturnValue({
+      ...baseSwr,
+      data: undefined,
+      mutate,
+    } as unknown as ReturnType<typeof useSwr>)
+
+    const { result } = renderHook(() => usePlan("p6"))
+
+    expect(result.current.mutate).toBe(mutate)
+  })
+})

--- a/src/components/features/rebalance/hooks/usePlan.ts
+++ b/src/components/features/rebalance/hooks/usePlan.ts
@@ -62,25 +62,32 @@ export function usePlan(planId: string | undefined): UsePlanResult {
     key ? simpleFetcher(key) : null,
   )
 
+  // Enriched plan is only needed when the SWR result has items to enrich.
+  // The "no items" branch derives plan directly from data — no setState in
+  // effect required.
   const [enrichedPlan, setEnrichedPlan] = useState<
     RebalancePlanDto | undefined
   >(undefined)
 
   useEffect(() => {
-    if (data?.data?.items) {
-      enrichPlanItems(data.data.items).then((enrichedItems) => {
-        setEnrichedPlan({
-          ...data.data,
-          items: enrichedItems,
-        })
+    if (!data?.data?.items) return () => {}
+    let cancelled = false
+    enrichPlanItems(data.data.items).then((enrichedItems) => {
+      if (cancelled) return
+      setEnrichedPlan({
+        ...data.data,
+        items: enrichedItems,
       })
-    } else {
-      setEnrichedPlan(data?.data)
+    })
+    return () => {
+      cancelled = true
     }
   }, [data])
 
+  const plan = data?.data?.items ? enrichedPlan : data?.data
+
   return {
-    plan: enrichedPlan,
+    plan,
     error,
     isLoading,
     mutate,

--- a/src/components/features/transactions/CashInputForm.tsx
+++ b/src/components/features/transactions/CashInputForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo, useRef, useCallback } from "react"
-import { Controller, useForm } from "react-hook-form"
+import { Controller, useForm, useWatch } from "react-hook-form"
 import { yupResolver } from "@hookform/resolvers/yup"
 import * as yup from "yup"
 import { FxResponse, Portfolio } from "types/beancounter"
@@ -110,7 +110,6 @@ const CashInputForm: React.FC<{
     control,
     handleSubmit,
     setValue,
-    watch,
     getValues,
     reset,
     formState: { errors, isDirty },
@@ -174,12 +173,17 @@ const CashInputForm: React.FC<{
       console.log("Failed to fetch accounts:", accountsError)
     }
   }, [accountsData, accountsError])
-  const tax = watch("tax")
-  const fees = watch("fees")
-  const type = watch("type")
-  const qty = watch("quantity")
-  const asset = watch("asset")
-  const cashCurrency = watch("cashCurrency")
+  // Use useWatch (a hook) rather than the watch() function returned from
+  // useForm. The function form returns a fresh closure each render, which the
+  // React Compiler can't memoize safely; useWatch is the React-friendly
+  // subscription path and lets the compiler optimize this component.
+  const tax = useWatch({ control, name: "tax" })
+  const fees = useWatch({ control, name: "fees" })
+  const type = useWatch({ control, name: "type" })
+  const qty = useWatch({ control, name: "quantity" })
+  const asset = useWatch({ control, name: "asset" })
+  const cashCurrency = useWatch({ control, name: "cashCurrency" })
+  const cashAmount = useWatch({ control, name: "cashAmount" })
 
   const { showEscapeConfirm, onEscapeConfirm, onEscapeCancel } =
     useEscapeHandler(isDirty, setModalOpen)
@@ -410,8 +414,8 @@ const CashInputForm: React.FC<{
                         Buy
                       </div>
                       <div className="font-bold text-lg text-gray-900">
-                        {(watch("cashAmount") ?? 0) > 0
-                          ? (watch("cashAmount") ?? 0).toLocaleString()
+                        {(cashAmount ?? 0) > 0
+                          ? (cashAmount ?? 0).toLocaleString()
                           : "—"}
                       </div>
                       <div className="text-xs text-gray-500">

--- a/src/components/features/transactions/CashInputForm.tsx
+++ b/src/components/features/transactions/CashInputForm.tsx
@@ -211,9 +211,13 @@ const CashInputForm: React.FC<{
   const [fxRateLoading, setFxRateLoading] = useState(false)
   const [manualBuyAmount, setManualBuyAmount] = useState(false)
 
-  // Fetch FX rate when currencies change (for FX transactions)
+  // Fetch FX rate when currencies change (for FX transactions). The sync
+  // setFxRate(null) early returns are deliberate "clear stale rate" steps;
+  // refactoring to derived state would couple FX results into render and
+  // is out of scope for the compiler-warning sweep.
   useEffect(() => {
     if (type.value !== "FX" || !asset || !cashCurrency?.value) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setFxRate(null)
       return
     }
@@ -243,15 +247,19 @@ const CashInputForm: React.FC<{
       .finally(() => setFxRateLoading(false))
   }, [type.value, asset, cashCurrency?.value, combinedOptions])
 
-  // Auto-calculate buy amount when sell amount or rate changes
+  // Auto-calculate buy amount when sell amount or rate changes. setValue
+  // here pushes derived FX output back into the form so other watchers see
+  // it; this *is* the intended side-effect.
   useEffect(() => {
     if (type.value === "FX" && fxRate && qty > 0 && !manualBuyAmount) {
       setValue("cashAmount", calculateFxBuyAmount(qty, fxRate))
     }
   }, [type.value, fxRate, qty, manualBuyAmount, setValue])
 
-  // Reset manual override when currencies change
+  // Reset the manual-override flag when the user changes currencies so the
+  // auto-calc effect above re-engages. Form coordination, not derived state.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setManualBuyAmount(false)
   }, [asset, cashCurrency?.value])
 
@@ -264,11 +272,14 @@ const CashInputForm: React.FC<{
     [setValue],
   )
 
-  // Update market and currency when asset changes
+  // Update market and currency when asset changes. setSelectedMarket and
+  // the form setValue calls are the intended side effects of an asset
+  // selection — same form-coordination class as the FX rate effect above.
   useEffect(() => {
     if (asset) {
       const resolved = resolveAssetSelection(asset, combinedOptions)
       if (resolved) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setSelectedMarket(resolved.market)
         setValue("tradeCurrency", {
           value: resolved.currency,

--- a/src/components/layout/HeaderBrand.tsx
+++ b/src/components/layout/HeaderBrand.tsx
@@ -233,10 +233,14 @@ function HeaderBrand(): React.ReactElement {
     return () => document.removeEventListener("mousedown", handleClickOutside)
   }, [mobileMenuOpen])
 
-  // Close mobile menu on route change
+  // Close mobile menu on route change. Subscribe to the router event rather
+  // than calling setState synchronously inside an effect body — the event
+  // callback runs only when the route actually changes.
   useEffect(() => {
-    setMobileMenuOpen(false)
-  }, [router.pathname])
+    const close = (): void => setMobileMenuOpen(false)
+    router.events.on("routeChangeStart", close)
+    return () => router.events.off("routeChangeStart", close)
+  }, [router.events])
 
   const handleKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === "Escape") {

--- a/src/components/ui/DecimalInput.tsx
+++ b/src/components/ui/DecimalInput.tsx
@@ -22,9 +22,12 @@ function DecimalInput({
   )
   const focusedRef = useRef(false)
 
-  // Sync from parent when not focused
+  // Sync from parent when not focused. Bidirectional input controller —
+  // user typing and parent value both write `display`, so it can't be pure
+  // derived state. Compiler warning is a false positive.
   useEffect(() => {
     if (!focusedRef.current) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDisplay(value != null && value !== 0 ? String(value) : "")
     }
   }, [value])

--- a/src/components/ui/MathInput.tsx
+++ b/src/components/ui/MathInput.tsx
@@ -199,13 +199,16 @@ export default function MathInput({
   const [isExpression, setIsExpression] = useState(false)
   const isFocusedRef = useRef(false)
 
-  // Sync display value when external value changes (only when not focused)
+  // Sync display value when external value changes (only when not focused).
+  // Skip sync while user is actively typing — their displayValue is authoritative.
+  // Without this, typing "1." triggers onChange(1) which overwrites "1." → "1",
+  // making it impossible to enter decimals. Bidirectional input controllers
+  // cannot be expressed as pure derived state, so the compiler warning is a
+  // false positive here.
   useEffect(() => {
-    // Skip sync while user is actively typing — their displayValue is authoritative.
-    // Without this, typing "1." triggers onChange(1) which overwrites "1." → "1",
-    // making it impossible to enter decimals.
     if (!isExpression && !isFocusedRef.current) {
       // Show empty string for zero values (better UX - cleaner form appearance)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDisplayValue(value === 0 || value === undefined ? "" : String(value))
     }
   }, [value, isExpression])

--- a/src/hooks/__tests__/useFxRates.test.ts
+++ b/src/hooks/__tests__/useFxRates.test.ts
@@ -1,0 +1,188 @@
+import { renderHook, waitFor, act } from "@testing-library/react"
+import { useFxRates } from "../useFxRates"
+import { Currency } from "types/beancounter"
+
+jest.mock("@contexts/UserPreferencesContext", () => ({
+  useUserPreferences: jest.fn(),
+}))
+import { useUserPreferences } from "@contexts/UserPreferencesContext"
+
+const mockUseUserPreferences =
+  useUserPreferences as jest.MockedFunction<typeof useUserPreferences>
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+const USD: Currency = { code: "USD", name: "US Dollar", symbol: "$" } as Currency
+const NZD: Currency = {
+  code: "NZD",
+  name: "NZ Dollar",
+  symbol: "NZ$",
+} as Currency
+const GBP: Currency = {
+  code: "GBP",
+  name: "Pound",
+  symbol: "£",
+} as Currency
+
+function withPreferences(
+  baseCurrencyCode: string | undefined,
+): void {
+  mockUseUserPreferences.mockReturnValue({
+    preferences: baseCurrencyCode ? { baseCurrencyCode } : null,
+  } as ReturnType<typeof useUserPreferences>)
+}
+
+// Stable empty refs so useFxRates' useEffect deps don't tick every render.
+// (The original hook re-runs the effect on every dep ref change, which makes
+// passing a literal `[]` to renderHook spin into an infinite loop until the
+// fix lands.)
+const EMPTY_CURRENCIES: Currency[] = []
+const EMPTY_CODES: string[] = []
+const CCY_USD: Currency[] = [USD]
+const CCY_USD_NZD: Currency[] = [USD, NZD]
+const CCY_USD_NZD_GBP: Currency[] = [USD, NZD, GBP]
+const CCY_NZD_GBP: Currency[] = [NZD, GBP]
+const CODES_NZD: string[] = ["NZD"]
+const CODES_NZD_DUP: string[] = ["NZD", "NZD", "NZD"]
+const CODES_USD_DUP: string[] = ["USD", "USD"]
+
+describe("useFxRates", () => {
+  beforeEach(() => {
+    mockUseUserPreferences.mockReset()
+    mockFetch.mockReset()
+    // Default to "no preferences" so that useUserPreferences() never returns
+    // undefined while a renderHook test is in flight (would crash the
+    // destructure).
+    withPreferences(undefined)
+  })
+
+  describe("default display currency selection", () => {
+    it("returns null displayCurrency when currencies is empty", () => {
+      withPreferences(undefined)
+
+      const { result } = renderHook(() => useFxRates(EMPTY_CURRENCIES, EMPTY_CODES))
+
+      expect(result.current.displayCurrency).toBeNull()
+    })
+
+    it("uses preferred baseCurrencyCode when present in currencies", async () => {
+      withPreferences("NZD")
+
+      const { result } = renderHook(() => useFxRates(CCY_USD_NZD_GBP, EMPTY_CODES))
+
+      await waitFor(() => {
+        expect(result.current.displayCurrency).toEqual(NZD)
+      })
+    })
+
+    it("falls back to USD when preferred currency is not present", async () => {
+      withPreferences("ZZZ")
+
+      const { result } = renderHook(() => useFxRates(CCY_USD_NZD, EMPTY_CODES))
+
+      await waitFor(() => {
+        expect(result.current.displayCurrency).toEqual(USD)
+      })
+    })
+
+    it("falls back to first currency when neither preferred nor USD is present", async () => {
+      withPreferences(undefined)
+
+      const { result } = renderHook(() => useFxRates(CCY_NZD_GBP, EMPTY_CODES))
+
+      await waitFor(() => {
+        expect(result.current.displayCurrency).toEqual(NZD)
+      })
+    })
+
+    it("user override via setDisplayCurrency wins over default", async () => {
+      withPreferences("USD")
+
+      const { result } = renderHook(() => useFxRates(CCY_USD_NZD_GBP, EMPTY_CODES))
+
+      await waitFor(() => {
+        expect(result.current.displayCurrency).toEqual(USD)
+      })
+
+      act(() => {
+        result.current.setDisplayCurrency(GBP)
+      })
+
+      expect(result.current.displayCurrency).toEqual(GBP)
+    })
+  })
+
+  describe("FX rates fetching", () => {
+    it("returns empty rates and ready when no source currencies", async () => {
+      withPreferences("USD")
+
+      const { result } = renderHook(() => useFxRates(CCY_USD, EMPTY_CODES))
+
+      await waitFor(() => {
+        expect(result.current.fxReady).toBe(true)
+      })
+      expect(result.current.fxRates).toEqual({})
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it("returns unit rates when all source currencies match displayCurrency", async () => {
+      withPreferences("USD")
+
+      const { result } = renderHook(() => useFxRates(CCY_USD, CODES_USD_DUP))
+
+      await waitFor(() => {
+        expect(result.current.fxReady).toBe(true)
+      })
+      expect(result.current.fxRates).toEqual({ USD: 1 })
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it("fetches FX rates for source currencies that differ from displayCurrency", async () => {
+      withPreferences("USD")
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: { rates: { "NZD:USD": { rate: 0.6 } } },
+          }),
+      })
+
+      const { result } = renderHook(() => useFxRates(CCY_USD_NZD, CODES_NZD))
+
+      await waitFor(() => {
+        expect(result.current.fxReady).toBe(true)
+      })
+      expect(result.current.fxRates).toEqual({ USD: 1, NZD: 0.6 })
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/fx",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            rateDate: "today",
+            pairs: [{ from: "NZD", to: "USD" }],
+          }),
+        }),
+      )
+    })
+
+    it("deduplicates source currencies before requesting pairs", async () => {
+      withPreferences("USD")
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: { rates: { "NZD:USD": { rate: 0.6 } } },
+          }),
+      })
+
+      renderHook(() => useFxRates(CCY_USD_NZD, CODES_NZD_DUP))
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+      })
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(body.pairs).toEqual([{ from: "NZD", to: "USD" }])
+    })
+  })
+})

--- a/src/hooks/useFxRates.ts
+++ b/src/hooks/useFxRates.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
 import { Currency, FxResponse } from "types/beancounter"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 
@@ -7,6 +7,19 @@ interface UseFxRatesResult {
   setDisplayCurrency: (currency: Currency) => void
   fxRates: Record<string, number>
   fxReady: boolean
+}
+
+const EMPTY_RATES: Record<string, number> = Object.freeze({})
+
+function uniqueCodes(codes: string[]): string[] {
+  return [...new Set(codes)]
+}
+
+function fetchKeyFor(
+  displayCurrency: Currency,
+  uniqueSourceCodes: string[],
+): string {
+  return `${displayCurrency.code}|${uniqueSourceCodes.join(",")}`
 }
 
 /**
@@ -20,54 +33,61 @@ export function useFxRates(
   sourceCurrencyCodes: string[],
 ): UseFxRatesResult {
   const { preferences } = useUserPreferences()
-  const [displayCurrency, setDisplayCurrency] = useState<Currency | null>(null)
-  const [fxRates, setFxRates] = useState<Record<string, number>>({})
-  const [fxReady, setFxReady] = useState(false)
 
-  // Set default display currency from user preferences
-  useEffect(() => {
-    if (currencies.length === 0 || displayCurrency) return
-
-    if (preferences?.baseCurrencyCode) {
-      const preferred = currencies.find(
-        (c) => c.code === preferences.baseCurrencyCode,
-      )
-      if (preferred) {
-        setDisplayCurrency(preferred)
-        return
-      }
+  // Default display currency derived from currencies + user prefs. Compiler
+  // memoizes this — no manual useMemo (whose optional-chain dep would bail
+  // the compiler from optimizing the rest of the hook).
+  const baseCurrencyCode = preferences?.baseCurrencyCode
+  const defaultDisplayCurrency = ((): Currency | null => {
+    if (currencies.length === 0) return null
+    if (baseCurrencyCode) {
+      const preferred = currencies.find((c) => c.code === baseCurrencyCode)
+      if (preferred) return preferred
     }
+    return currencies.find((c) => c.code === "USD") || currencies[0]
+  })()
 
-    const usd = currencies.find((c) => c.code === "USD")
-    setDisplayCurrency(usd || currencies[0])
-  }, [currencies, displayCurrency, preferences?.baseCurrencyCode])
+  // User can override the default; null means "follow default".
+  const [overrideCurrency, setOverrideCurrency] = useState<Currency | null>(
+    null,
+  )
+  const displayCurrency = overrideCurrency ?? defaultDisplayCurrency
 
-  // Fetch FX rates for source currencies → display currency
-  useEffect(() => {
-    if (!displayCurrency) return
-
-    if (sourceCurrencyCodes.length === 0) {
-      setFxRates({})
-      setFxReady(true)
-      return
+  // Trivial fx rate computation that doesn't require a network call:
+  // - no source currencies → empty map
+  // - every source currency equals displayCurrency → unit rates for each
+  // Returns null when an async fetch is required.
+  const trivialRates = ((): Record<string, number> | null => {
+    if (!displayCurrency) return null
+    if (sourceCurrencyCodes.length === 0) return EMPTY_RATES
+    const unique = uniqueCodes(sourceCurrencyCodes)
+    const pairs = unique.filter((code) => code !== displayCurrency.code)
+    if (pairs.length === 0) {
+      const rates: Record<string, number> = {}
+      unique.forEach((code) => {
+        rates[code] = 1
+      })
+      return rates
     }
+    return null
+  })()
 
-    setFxReady(false)
+  const [asyncRates, setAsyncRates] = useState<Record<string, number>>(
+    EMPTY_RATES,
+  )
+  const [asyncFetchKey, setAsyncFetchKey] = useState<string | null>(null)
 
-    const uniqueCurrencies = [...new Set(sourceCurrencyCodes)]
-    const pairs = uniqueCurrencies
+  // Async fetch path. Only runs when trivialRates is null.
+  useEffect(() => {
+    if (!displayCurrency || trivialRates !== null) return () => {}
+
+    const unique = uniqueCodes(sourceCurrencyCodes)
+    const pairs = unique
       .filter((code) => code !== displayCurrency.code)
       .map((code) => ({ from: code, to: displayCurrency.code }))
 
-    if (pairs.length === 0) {
-      const rates: Record<string, number> = {}
-      uniqueCurrencies.forEach((code) => {
-        rates[code] = 1
-      })
-      setFxRates(rates)
-      setFxReady(true)
-      return
-    }
+    const expectedKey = fetchKeyFor(displayCurrency, unique)
+    let cancelled = false
 
     fetch("/api/fx", {
       method: "POST",
@@ -76,20 +96,45 @@ export function useFxRates(
     })
       .then((res) => res.json())
       .then((fxResponse: FxResponse) => {
+        if (cancelled) return
         const rates: Record<string, number> = {}
         rates[displayCurrency.code] = 1
-
         Object.entries(fxResponse.data?.rates || {}).forEach(
           ([key, rateData]) => {
             const [from] = key.split(":")
             rates[from] = rateData.rate
           },
         )
-        setFxRates(rates)
-        setFxReady(true)
+        setAsyncRates(rates)
+        setAsyncFetchKey(expectedKey)
       })
       .catch(console.error)
-  }, [displayCurrency, sourceCurrencyCodes])
 
-  return { displayCurrency, setDisplayCurrency, fxRates, fxReady }
+    return () => {
+      cancelled = true
+    }
+  }, [displayCurrency, sourceCurrencyCodes, trivialRates])
+
+  const fxRates = trivialRates ?? asyncRates
+
+  // Ready iff trivial OR the async result matches the current request key.
+  let fxReady: boolean
+  if (!displayCurrency) {
+    fxReady = false
+  } else if (trivialRates !== null) {
+    fxReady = true
+  } else {
+    const expectedKey = fetchKeyFor(
+      displayCurrency,
+      uniqueCodes(sourceCurrencyCodes),
+    )
+    fxReady = asyncFetchKey === expectedKey
+  }
+
+  return {
+    displayCurrency,
+    setDisplayCurrency: setOverrideCurrency,
+    fxRates,
+    fxReady,
+  }
 }

--- a/src/lib/utils/hooks/__tests__/useDisplayCurrencyConversion.test.ts
+++ b/src/lib/utils/hooks/__tests__/useDisplayCurrencyConversion.test.ts
@@ -1,0 +1,176 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import {
+  useDisplayCurrencyConversion,
+  useCurrencies,
+} from "../useDisplayCurrencyConversion"
+import { Currency, Portfolio } from "types/beancounter"
+
+jest.mock("@lib/holdings/holdingState", () => ({
+  useHoldingState: jest.fn(),
+}))
+import { useHoldingState } from "@lib/holdings/holdingState"
+
+const mockUseHoldingState = useHoldingState as jest.MockedFunction<
+  typeof useHoldingState
+>
+
+const mockFetch = jest.fn()
+global.fetch = mockFetch
+
+const USD: Currency = { code: "USD", name: "US Dollar", symbol: "$" } as Currency
+const NZD: Currency = {
+  code: "NZD",
+  name: "NZ Dollar",
+  symbol: "NZ$",
+} as Currency
+const GBP: Currency = {
+  code: "GBP",
+  name: "Pound",
+  symbol: "£",
+} as Currency
+
+const portfolio = {
+  currency: USD,
+  base: NZD,
+} as Portfolio
+
+type DisplayMode = "PORTFOLIO" | "BASE" | "TRADE" | "CUSTOM"
+
+function withDisplay(mode: DisplayMode, customCode?: string): void {
+  mockUseHoldingState.mockReturnValue({
+    displayCurrency: { mode, customCode },
+  } as ReturnType<typeof useHoldingState>)
+}
+
+describe("useDisplayCurrencyConversion", () => {
+  beforeEach(() => {
+    mockUseHoldingState.mockReset()
+    mockFetch.mockReset()
+  })
+
+  it("PORTFOLIO mode returns portfolio.currency, sync rate of 1", () => {
+    withDisplay("PORTFOLIO")
+
+    const { result } = renderHook(() =>
+      useDisplayCurrencyConversion({ sourceCurrency: USD, portfolio }),
+    )
+
+    expect(result.current.currencyCode).toBe("USD")
+    expect(result.current.currencySymbol).toBe("$")
+    expect(result.current.convert(100)).toBe(100)
+    expect(result.current.isCustomCurrency).toBe(false)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("BASE mode returns portfolio.base", async () => {
+    withDisplay("BASE")
+
+    const { result } = renderHook(() =>
+      // sourceCurrency NZD = portfolio.base NZD → sync rate of 1
+      useDisplayCurrencyConversion({ sourceCurrency: NZD, portfolio }),
+    )
+
+    expect(result.current.currencyCode).toBe("NZD")
+    await waitFor(() => {
+      expect(result.current.convert(100)).toBe(100)
+    })
+  })
+
+  it("TRADE mode returns sourceCurrency", () => {
+    withDisplay("TRADE")
+
+    const { result } = renderHook(() =>
+      useDisplayCurrencyConversion({ sourceCurrency: GBP, portfolio }),
+    )
+
+    expect(result.current.currencyCode).toBe("GBP")
+    expect(result.current.currencySymbol).toBe("£")
+    expect(result.current.convert(100)).toBe(100)
+  })
+
+  it("falls back to sourceCurrency when sourceCurrency is undefined", () => {
+    withDisplay("TRADE")
+
+    const { result } = renderHook(() =>
+      useDisplayCurrencyConversion({ sourceCurrency: undefined, portfolio }),
+    )
+
+    expect(result.current.currencyCode).toBe("")
+    expect(result.current.currencySymbol).toBe("$")
+  })
+
+  it("fetches FX rate when source and target currencies differ", async () => {
+    withDisplay("PORTFOLIO") // target = portfolio.currency = USD; source = NZD
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { rates: { "NZD:USD": { rate: 0.6 } } },
+        }),
+    })
+
+    const { result } = renderHook(() =>
+      useDisplayCurrencyConversion({ sourceCurrency: NZD, portfolio }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.convert(100)).toBeCloseTo(60, 5)
+    })
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/fx",
+      expect.objectContaining({ method: "POST" }),
+    )
+  })
+
+  it("CUSTOM mode fetches currencies list and uses matching code", async () => {
+    withDisplay("CUSTOM", "GBP")
+    // Currencies fetch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: [USD, NZD, GBP] }),
+    })
+    // FX fetch (USD → GBP)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { rates: { "USD:GBP": { rate: 0.79 } } },
+        }),
+    })
+
+    const { result } = renderHook(() =>
+      useDisplayCurrencyConversion({ sourceCurrency: USD, portfolio }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.currencyCode).toBe("GBP")
+    })
+    expect(result.current.isCustomCurrency).toBe(true)
+  })
+})
+
+// useCurrencies has a module-scoped cache so it's stateful across tests; the
+// assertion below targets only post-fetch state (the cache will already be
+// populated from earlier tests in this file in many cases — that's fine, the
+// hook should still return the populated list and report isLoading false).
+describe("useCurrencies", () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    // If cache is empty, this fetch satisfies the first call. If cache is
+    // populated from an earlier test, the hook short-circuits and this is
+    // unused.
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [USD, NZD] }),
+    })
+  })
+
+  it("eventually exposes a non-empty currency list and isLoading=false", async () => {
+    const { result } = renderHook(() => useCurrencies())
+
+    await waitFor(() => {
+      expect(result.current.currencies.length).toBeGreaterThan(0)
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
+})

--- a/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
+++ b/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
@@ -242,15 +242,14 @@ export function useCurrencies(): {
   // it immediately and skip the effect entirely. The "no cache yet" path
   // initialises with [] + isLoading=true and is filled by the effect's
   // async .then() callback.
-  const initial = useState<{
+  const [state, setState] = useState<{
     currencies: Currency[]
     isLoading: boolean
   }>(() =>
     currenciesCache
       ? { currencies: currenciesCache, isLoading: false }
       : { currencies: [], isLoading: true },
-  )[0]
-  const [state, setState] = useState(initial)
+  )
 
   useEffect(() => {
     if (currenciesCache) return () => {}

--- a/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
+++ b/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react"
+import { useEffect, useState } from "react"
 import { Currency, Portfolio, FxResponse } from "types/beancounter"
 import { useHoldingState } from "@lib/holdings/holdingState"
 
@@ -81,13 +81,25 @@ interface UseDisplayCurrencyConversionProps {
   portfolio: Portfolio
 }
 
-/**
+interface AsyncCustom {
+  code: string
+  currency: Currency
+}
 
-* Hook to handle display currency conversion.
-* Centralizes FX rate fetching and caching for consistent behavior across components.
-*
-* Uses synchronous calculation for same-currency cases to prevent "click behind" issues
-* where values show stale rates during React's effect cycle.
+interface AsyncFx {
+  fromCode: string
+  toCode: string
+  rate: number
+}
+
+/**
+ * Hook to handle display currency conversion.
+ * Centralizes FX rate fetching and caching for consistent behavior across
+ * components.
+ *
+ * Uses synchronous calculation for same-currency cases to prevent
+ * "click behind" issues where values show stale rates during React's
+ * effect cycle.
  */
 export function useDisplayCurrencyConversion({
   sourceCurrency,
@@ -95,117 +107,167 @@ export function useDisplayCurrencyConversion({
 }: UseDisplayCurrencyConversionProps): DisplayCurrencyConversion {
   const holdingState = useHoldingState()
   const displayCurrencyOption = holdingState.displayCurrency
+  const mode = displayCurrencyOption.mode
+  const customCode = displayCurrencyOption.customCode
 
-  // State for async operations (CUSTOM mode currency lookup, FX rate fetch)
-  const [customCurrency, setCustomCurrency] = useState<Currency | null>(null)
-  const [asyncFxRate, setAsyncFxRate] = useState<number>(1)
-  const [isLoading, setIsLoading] = useState(false)
+  // Async-fetched currency for CUSTOM mode. We track which code it was
+  // fetched for so a stale value doesn't leak when customCode changes.
+  const [asyncCustom, setAsyncCustom] = useState<AsyncCustom | null>(null)
 
-  // Determine target currency synchronously for non-CUSTOM modes
-  // This prevents "click behind" issues where useEffect runs after render
-  const targetCurrency = useMemo((): Currency | null => {
-    const { mode, customCode } = displayCurrencyOption
+  // Async-fetched FX rate keyed by from/to pair, for the same reason.
+  const [asyncFx, setAsyncFx] = useState<AsyncFx | null>(null)
 
-    if (mode === "TRADE") {
-      return sourceCurrency || null
-    } else if (mode === "PORTFOLIO") {
-      return portfolio.currency
-    } else if (mode === "BASE") {
-      return portfolio.base
-    } else if (mode === "CUSTOM" && customCode) {
-      // For CUSTOM, we need to use the async-fetched currency
-      return customCurrency
-    }
-    return sourceCurrency || null
-  }, [displayCurrencyOption, sourceCurrency, portfolio, customCurrency])
+  const customCurrency =
+    mode === "CUSTOM" && customCode && asyncCustom?.code === customCode
+      ? asyncCustom.currency
+      : null
 
-  // Only fetch custom currency when needed (CUSTOM mode)
+  // Determine target currency synchronously for non-CUSTOM modes.
+  let targetCurrency: Currency | null
+  if (mode === "TRADE") {
+    targetCurrency = sourceCurrency || null
+  } else if (mode === "PORTFOLIO") {
+    targetCurrency = portfolio.currency
+  } else if (mode === "BASE") {
+    targetCurrency = portfolio.base
+  } else if (mode === "CUSTOM" && customCode) {
+    targetCurrency = customCurrency
+  } else {
+    targetCurrency = sourceCurrency || null
+  }
+
+  // Sync FX path: same currency or unresolvable target → rate of 1.
+  // Different currencies → null, signalling that an async fetch is needed.
+  let syncFxRate: number | null
+  if (!sourceCurrency || !targetCurrency) {
+    syncFxRate = 1
+  } else if (sourceCurrency.code === targetCurrency.code) {
+    syncFxRate = 1
+  } else {
+    syncFxRate = null
+  }
+
+  // Fetch CUSTOM-mode currency only when in that mode and we don't already
+  // have a fresh result for the requested code.
   useEffect(() => {
-    const { mode, customCode } = displayCurrencyOption
-
-    if (mode !== "CUSTOM" || !customCode) {
-      setCustomCurrency(null)
-      return
+    if (mode !== "CUSTOM" || !customCode) return () => {}
+    if (asyncCustom?.code === customCode) return () => {}
+    let cancelled = false
+    fetchCurrencies().then((currencies) => {
+      if (cancelled) return
+      const found = currencies.find((c) => c.code === customCode)
+      if (found) setAsyncCustom({ code: customCode, currency: found })
+    })
+    return () => {
+      cancelled = true
     }
+  }, [mode, customCode, asyncCustom])
 
-    setIsLoading(true)
-    fetchCurrencies()
-      .then((currencies) => {
-        const found = currencies.find((c) => c.code === customCode)
-        if (found) setCustomCurrency(found)
-      })
-      .finally(() => setIsLoading(false))
-  }, [displayCurrencyOption])
-
-  // Compute FX rate synchronously when possible (same currency = 1)
-  // Only fetch async when currencies differ
-  const syncFxRate = useMemo((): number | null => {
-    if (!sourceCurrency || !targetCurrency) return 1
-    if (sourceCurrency.code === targetCurrency.code) return 1
-    return null // Need async fetch
-  }, [sourceCurrency, targetCurrency])
-
-  // Fetch FX rate only when currencies differ
+  // Fetch FX rate only when sync path can't satisfy the request.
   useEffect(() => {
-    // If sync rate is available, no async fetch needed
-    if (syncFxRate !== null) {
-      setAsyncFxRate(1)
-      return
+    if (syncFxRate !== null) return () => {}
+    if (!sourceCurrency || !targetCurrency) return () => {}
+    const fromCode = sourceCurrency.code
+    const toCode = targetCurrency.code
+    if (asyncFx?.fromCode === fromCode && asyncFx?.toCode === toCode) {
+      return () => {}
     }
+    let cancelled = false
+    fetchFxRate(fromCode, toCode).then((rate) => {
+      if (cancelled) return
+      setAsyncFx({ fromCode, toCode, rate })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [syncFxRate, sourceCurrency, targetCurrency, asyncFx])
 
-    if (!sourceCurrency || !targetCurrency) return
+  // Resolved FX rate: prefer the synchronous answer; otherwise use the
+  // async result iff it matches the currently-requested pair, else 1 while
+  // the fetch is in flight (preserves existing "no flicker to wrong rate"
+  // semantics).
+  let fxRate: number
+  if (syncFxRate !== null) {
+    fxRate = syncFxRate
+  } else if (
+    sourceCurrency &&
+    targetCurrency &&
+    asyncFx?.fromCode === sourceCurrency.code &&
+    asyncFx?.toCode === targetCurrency.code
+  ) {
+    fxRate = asyncFx.rate
+  } else {
+    fxRate = 1
+  }
 
-    setIsLoading(true)
-    fetchFxRate(sourceCurrency.code, targetCurrency.code)
-      .then(setAsyncFxRate)
-      .finally(() => setIsLoading(false))
-  }, [syncFxRate, sourceCurrency, targetCurrency])
+  // Loading is derived: pending iff we expect an async result we don't yet
+  // have. No setIsLoading(true) / setIsLoading(false) inside an effect.
+  const customFetchPending =
+    mode === "CUSTOM" &&
+    !!customCode &&
+    asyncCustom?.code !== customCode
+  const fxFetchPending =
+    syncFxRate === null &&
+    !!sourceCurrency &&
+    !!targetCurrency &&
+    !(
+      asyncFx?.fromCode === sourceCurrency.code &&
+      asyncFx?.toCode === targetCurrency.code
+    )
+  const isLoading = customFetchPending || fxFetchPending
 
-  // Use sync rate if available, otherwise async rate
-  const fxRate = syncFxRate ?? asyncFxRate
-
-  const convert = useCallback((value: number) => value * fxRate, [fxRate])
+  const convert = (value: number): number => value * fxRate
 
   const currencySymbol = targetCurrency?.symbol || sourceCurrency?.symbol || "$"
   const currencyCode = targetCurrency?.code || sourceCurrency?.code || ""
-  const isCustomCurrency = displayCurrencyOption.mode === "CUSTOM"
+  const isCustomCurrency = mode === "CUSTOM"
 
-  return useMemo(
-    () => ({
-      convert,
-      currencySymbol,
-      currencyCode,
-      isCustomCurrency,
-      isLoading,
-    }),
-    [convert, currencySymbol, currencyCode, isCustomCurrency, isLoading],
-  )
+  return {
+    convert,
+    currencySymbol,
+    currencyCode,
+    isCustomCurrency,
+    isLoading,
+  }
 }
 
 /**
-
-* Get cached currencies list (for use in components that just need the list)
+ * Get cached currencies list (for use in components that just need the list)
  */
 export function useCurrencies(): {
   currencies: Currency[]
   isLoading: boolean
 } {
-  const [currencies, setCurrencies] = useState<Currency[]>(
-    currenciesCache || [],
-  )
-  const [isLoading, setIsLoading] = useState(!currenciesCache)
+  // Lazy initial state: if the module cache is already populated we expose
+  // it immediately and skip the effect entirely. The "no cache yet" path
+  // initialises with [] + isLoading=true and is filled by the effect's
+  // async .then() callback.
+  const initial = useState<{
+    currencies: Currency[]
+    isLoading: boolean
+  }>(() =>
+    currenciesCache
+      ? { currencies: currenciesCache, isLoading: false }
+      : { currencies: [], isLoading: true },
+  )[0]
+  const [state, setState] = useState(initial)
 
   useEffect(() => {
-    if (currenciesCache) {
-      setCurrencies(currenciesCache)
-      return
-    }
-
-    setIsLoading(true)
+    if (currenciesCache) return () => {}
+    let cancelled = false
     fetchCurrencies()
-      .then(setCurrencies)
-      .finally(() => setIsLoading(false))
+      .then((currencies) => {
+        if (cancelled) return
+        setState({ currencies, isLoading: false })
+      })
+      .catch(() => {
+        if (cancelled) return
+        setState({ currencies: [], isLoading: false })
+      })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
-  return { currencies, isLoading }
+  return state
 }

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -535,6 +535,7 @@ function HoldingsPage(): React.ReactElement {
       ) : viewMode === "cards" ? (
         <div className="grid grid-cols-1 gap-3">
           <CardView
+            key={holdingState.groupBy.value}
             holdings={holdings}
             portfolio={holdingResults.portfolio}
             valueIn={holdingState.valueIn.value}

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -457,6 +457,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
         ) : viewMode === "cards" ? (
           <div className="grid grid-cols-1 gap-3">
             <CardView
+              key={holdingState.groupBy.value}
               holdings={holdings}
               portfolio={holdingResults.portfolio}
               valueIn={holdingState.valueIn.value}

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -971,14 +971,16 @@ function PlanView(): React.ReactElement {
         isSaving={isSaving}
       />
 
-      {/* Edit Details Modal - key forces remount after save */}
-      <EditPlanDetailsModal
-        key={`edit-modal-v${planVersion}`}
-        isOpen={showEditDetailsModal}
-        onClose={() => setShowEditDetailsModal(false)}
-        onApply={handleApplyDetails}
-        plan={plan}
-      />
+      {/* Edit Details Modal - conditionally mounted so each open starts
+          with fresh form state derived from the current plan. */}
+      {showEditDetailsModal && (
+        <EditPlanDetailsModal
+          key={`edit-modal-v${planVersion}`}
+          onClose={() => setShowEditDetailsModal(false)}
+          onApply={handleApplyDetails}
+          plan={plan}
+        />
+      )}
 
       {/* What-If Analysis Modal */}
       <WhatIfModal


### PR DESCRIPTION
## Summary

Closes the last six React-Compiler ESLint warnings — all in load-bearing hooks — and promotes the rules from \`warn\` to \`error\` so CI now blocks regressions. Builds on #649, #651, #652, #653.

| | Before | After |
| -- | ----: | ----: |
| Project warnings | 6 | **0** |
| Component-level warnings | 0 | 0 |
| Hook-level warnings | 6 | 0 |
| Test suites | 109 | 112 |
| Tests | 1283 | 1306 |

## Hook refactors (TDD: tests first)

**\`usePlan.ts\`** (1 warning → 0)
- Drop the sync \`setEnrichedPlan(data?.data)\` "no items" branch from the \`useEffect\`. \`plan\` is derived: \`data?.data?.items ? enrichedPlan : data?.data\`. Async enrichment keeps its setState in the promise \`.then()\`, which the rule allows.

**\`useFxRates.ts\`** (2 warnings → 0)
- Replace the "set default display currency" \`useEffect\` with a derived \`defaultDisplayCurrency\`. User overrides go through a separate override state that takes precedence.
- Split FX rate computation into a derived \`trivialRates\` (no-source / same-currency cases) and an async fetch effect that only runs when \`trivialRates\` is null. \`fxReady\` is derived from a \`fetchKey\`/\`asyncFetchKey\` comparison.
- **Side-fix**: original hook had a latent infinite-render bug — passing a literal \`[]\` triggered \`setFxRates({})\` every render because the new \`{}\` ref always differed from the previous. New code returns a frozen \`EMPTY_RATES\` constant, so the loop is structurally impossible.

**\`useDisplayCurrencyConversion.ts\`** (3 warnings → 0)
- Track async-fetched values keyed by their input (\`asyncCustom\` by \`customCode\`, \`asyncFx\` by from/to pair) so a stale value never leaks when inputs change.
- \`customCurrency\`, \`fxRate\` and \`isLoading\` all derive from these keyed states + sync inputs — no \`setIsLoading\` inside an effect, no setState fallbacks for the sync paths.
- Drop the now-unused \`useMemo\` / \`useCallback\` wrappers; React Compiler memoises the resulting computations.
- \`useCurrencies\`: lazy \`useState\` initialiser pulls from the module cache when present (skipping \`isLoading=true\` entirely), and the effect fires only on a true cache miss.

## ESLint rule promotion

\`eslint.config.mjs\`: 14 React-Compiler rules promoted from \`warn\` to \`error\`. CI now blocks any new compiler bailout. Intentional bailouts (SSR hydration, bidirectional input controllers, URL-driven side effects, form coordination) remain opt-in via scoped \`eslint-disable-next-line\` directives at the call site, with comments capturing the rationale.

## Tests added (3 suites, 23 new tests)

- \`src/components/features/rebalance/hooks/__tests__/usePlan.test.ts\` (8)
- \`src/hooks/__tests__/useFxRates.test.ts\` (9)
- \`src/lib/utils/hooks/__tests__/useDisplayCurrencyConversion.test.ts\` (7 — including verifying the rate path for matching currencies, async fetch on currency mismatch, CUSTOM mode lookup, fallback for missing source currency)

Each suite was written against the pre-refactor hook to characterise current behaviour, then re-run unchanged after the refactor.

## Test plan

- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` — 0 warnings, 0 errors at \`error\` severity
- [x] \`yarn test\` — 112 suites, 1306 tests pass
- [x] \`yarn build\` clean
- [ ] CI green
- [ ] Manual smoke:
  - Wealth view loads with non-USD base currency portfolio → confirm FX rates fetched and applied
  - Holdings page → toggle Display Currency between PORTFOLIO / BASE / TRADE / a custom code → confirm values update without flashing wrong rate
  - Rebalance plan view (\`/rebalance/plans/[id]\`) → confirm asset codes/names render after enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized asset review, news sentiment, and portfolio AI data loading through intelligent caching.
  * Improved FX rate calculations and currency conversion efficiency.

* **Improvements**
  * Enhanced plan editor initialization and modal behavior.

* **Chores**
  * Strengthened ESLint rules for React hooks compliance to catch potential issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->