### PR TITLE
fix(react-compiler): clear two more exhaustive-deps bailouts + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,37 @@ yarn test:watch  # Keep running in terminal
 # Write test -> Watch fail -> Implement -> Watch pass -> Refactor
 ```
 
+## React Compiler
+
+React Compiler is enabled (Next 16 / `eslint-plugin-react-hooks` v7). All
+`react-hooks/*` rules are at **error** level in `eslint.config.mjs` — CI
+blocks any new compiler bailout. `yarn lint` is the gate.
+
+**Don't add `"use no memo"` or `@ts-expect-error react-compiler`.** Fix the
+bailout instead. Intentional bailouts are scoped via
+`// eslint-disable-next-line` at the call site, with a comment explaining
+why. Acceptable patterns (currently allowed):
+
+- **External-trigger effects** — modal-open reset, URL `?action=...`
+  side effects, `phases/displayCurrency` mark-stale (`MovePositionDialog`,
+  `HoldingActions`, `StressTestTab`). Listing the omitted dep changes
+  behaviour (re-fires on every state tick), not just shuts the linter up.
+
+**Common false bailouts and how to clear them:**
+
+- **Pure helper inside component** — hoist to module scope, type the arg
+  directly instead of `(typeof someState)[0]`. See `getNetRentalIncome` in
+  `ContributionsStep.tsx`.
+- **Effect dep is a fresh fn from a hook** — wrap the function in
+  `useCallback` inside the source hook (deps must themselves be stable —
+  SWR's `mutate` is). Then the consumer can list it honestly. See
+  `useIndependenceSettings.updateSettings`.
+- **Inline object/array prop causing child re-render** — `useMemo` at the
+  call site or hoist a constant if truly static.
+
+When in doubt: prefer refactoring the *source* (hook author) over
+suppressing at the *consumer* — one fix removes N suppressions.
+
 ## Debugging
 
 ```bash

--- a/src/components/features/holdings/PortfolioReviewPopup.tsx
+++ b/src/components/features/holdings/PortfolioReviewPopup.tsx
@@ -188,9 +188,7 @@ export default function PortfolioReviewPopup({
           if (lf === -1 && crlf === -1) return null
           if (lf === -1) return { index: crlf, len: 4 }
           if (crlf === -1) return { index: lf, len: 2 }
-          return crlf < lf
-            ? { index: crlf, len: 4 }
-            : { index: lf, len: 2 }
+          return crlf < lf ? { index: crlf, len: 4 } : { index: lf, len: 2 }
         }
 
         for (;;) {

--- a/src/components/features/holdings/__tests__/PortfolioReviewPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PortfolioReviewPopup.test.tsx
@@ -148,9 +148,7 @@ describe("PortfolioReviewPopup", () => {
         onClose={jest.fn()}
       />,
     )
-    await waitFor(() =>
-      expect(screen.getByText(/error/i)).toBeInTheDocument(),
-    )
+    await waitFor(() => expect(screen.getByText(/error/i)).toBeInTheDocument())
     expect(screen.getByText(/run out of credit/i)).toBeInTheDocument()
   })
 
@@ -192,9 +190,7 @@ describe("PortfolioReviewPopup", () => {
     const { unmount } = render(
       <PortfolioReviewPopup target={target} onClose={jest.fn()} />,
     )
-    await waitFor(() =>
-      expect(screen.getByText("Cached")).toBeInTheDocument(),
-    )
+    await waitFor(() => expect(screen.getByText("Cached")).toBeInTheDocument())
     unmount()
     render(<PortfolioReviewPopup target={target} onClose={jest.fn()} />)
     await waitFor(() =>

--- a/src/components/features/independence/steps/ContributionsStep.tsx
+++ b/src/components/features/independence/steps/ContributionsStep.tsx
@@ -13,7 +13,7 @@ import { usePrivateAssetConfigs } from "@lib/assets/usePrivateAssetConfigs"
 import { useExcludedAssetIds } from "@hooks/useExcludedAssetIds"
 import { simpleFetcher } from "@utils/api/fetchHelper"
 import { WizardFormData, ContributionFormEntry } from "types/independence"
-import { Asset } from "types/beancounter"
+import { Asset, PrivateAssetConfig } from "types/beancounter"
 import { wizardMessages } from "@lib/independence/messages"
 import Spinner from "@components/ui/Spinner"
 import { useDefinedContribution } from "../useDefinedContribution"
@@ -29,6 +29,22 @@ const msg = wizardMessages.steps.contributions
 
 interface AssetsResponse {
   data: Record<string, Asset>
+}
+
+// Pure helper — hoisted out of the component so the useMemo below can list
+// it as a dependency without churn (its identity is stable across renders).
+function getNetRentalIncome(config: PrivateAssetConfig): number {
+  const percentFee = config.monthlyRentalIncome * config.managementFeePercent
+  const effectiveMgmtFee = Math.max(config.monthlyManagementFee, percentFee)
+  const monthlyPropertyTax = (config.annualPropertyTax || 0) / 12
+  const monthlyInsurance = (config.annualInsurance || 0) / 12
+  const totalExpenses =
+    effectiveMgmtFee +
+    (config.monthlyBodyCorporateFee || 0) +
+    monthlyPropertyTax +
+    monthlyInsurance +
+    (config.monthlyOtherExpenses || 0)
+  return Math.max(0, config.monthlyRentalIncome - totalExpenses)
 }
 
 interface ContributionsStepProps {
@@ -169,21 +185,6 @@ export default function ContributionsStep({
     return rates
   }, [fxData])
 
-  // Calculate net rental income per property (in property currency)
-  const getNetRentalIncome = (config: (typeof rentalProperties)[0]): number => {
-    const percentFee = config.monthlyRentalIncome * config.managementFeePercent
-    const effectiveMgmtFee = Math.max(config.monthlyManagementFee, percentFee)
-    const monthlyPropertyTax = (config.annualPropertyTax || 0) / 12
-    const monthlyInsurance = (config.annualInsurance || 0) / 12
-    const totalExpenses =
-      effectiveMgmtFee +
-      (config.monthlyBodyCorporateFee || 0) +
-      monthlyPropertyTax +
-      monthlyInsurance +
-      (config.monthlyOtherExpenses || 0)
-    return Math.max(0, config.monthlyRentalIncome - totalExpenses)
-  }
-
   // Total rental income converted to plan currency
   const totalRentalIncome = useMemo(() => {
     return rentalProperties
@@ -197,7 +198,7 @@ export default function ContributionsStep({
         const rate = fxRates[rateKey] || 1
         return sum + netIncome * rate
       }, 0)
-  }, [rentalProperties, excludedRentalIds, planCurrency, fxRates]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [rentalProperties, excludedRentalIds, planCurrency, fxRates])
 
   // Watch income-related fields for summary
   const workingIncomeMonthly =

--- a/src/components/features/rebalance/hooks/__tests__/usePlan.test.ts
+++ b/src/components/features/rebalance/hooks/__tests__/usePlan.test.ts
@@ -80,7 +80,8 @@ describe("usePlan", () => {
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ data: { code: "MSFT", name: "Microsoft" } }),
+      json: () =>
+        Promise.resolve({ data: { code: "MSFT", name: "Microsoft" } }),
     })
 
     const { result } = renderHook(() => usePlan("p3"))

--- a/src/hooks/__tests__/useFxRates.test.ts
+++ b/src/hooks/__tests__/useFxRates.test.ts
@@ -7,13 +7,18 @@ jest.mock("@contexts/UserPreferencesContext", () => ({
 }))
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 
-const mockUseUserPreferences =
-  useUserPreferences as jest.MockedFunction<typeof useUserPreferences>
+const mockUseUserPreferences = useUserPreferences as jest.MockedFunction<
+  typeof useUserPreferences
+>
 
 const mockFetch = jest.fn()
 global.fetch = mockFetch
 
-const USD: Currency = { code: "USD", name: "US Dollar", symbol: "$" } as Currency
+const USD: Currency = {
+  code: "USD",
+  name: "US Dollar",
+  symbol: "$",
+} as Currency
 const NZD: Currency = {
   code: "NZD",
   name: "NZ Dollar",
@@ -25,9 +30,7 @@ const GBP: Currency = {
   symbol: "£",
 } as Currency
 
-function withPreferences(
-  baseCurrencyCode: string | undefined,
-): void {
+function withPreferences(baseCurrencyCode: string | undefined): void {
   mockUseUserPreferences.mockReturnValue({
     preferences: baseCurrencyCode ? { baseCurrencyCode } : null,
   } as ReturnType<typeof useUserPreferences>)
@@ -61,7 +64,9 @@ describe("useFxRates", () => {
     it("returns null displayCurrency when currencies is empty", () => {
       withPreferences(undefined)
 
-      const { result } = renderHook(() => useFxRates(EMPTY_CURRENCIES, EMPTY_CODES))
+      const { result } = renderHook(() =>
+        useFxRates(EMPTY_CURRENCIES, EMPTY_CODES),
+      )
 
       expect(result.current.displayCurrency).toBeNull()
     })
@@ -69,7 +74,9 @@ describe("useFxRates", () => {
     it("uses preferred baseCurrencyCode when present in currencies", async () => {
       withPreferences("NZD")
 
-      const { result } = renderHook(() => useFxRates(CCY_USD_NZD_GBP, EMPTY_CODES))
+      const { result } = renderHook(() =>
+        useFxRates(CCY_USD_NZD_GBP, EMPTY_CODES),
+      )
 
       await waitFor(() => {
         expect(result.current.displayCurrency).toEqual(NZD)
@@ -99,7 +106,9 @@ describe("useFxRates", () => {
     it("user override via setDisplayCurrency wins over default", async () => {
       withPreferences("USD")
 
-      const { result } = renderHook(() => useFxRates(CCY_USD_NZD_GBP, EMPTY_CODES))
+      const { result } = renderHook(() =>
+        useFxRates(CCY_USD_NZD_GBP, EMPTY_CODES),
+      )
 
       await waitFor(() => {
         expect(result.current.displayCurrency).toEqual(USD)

--- a/src/hooks/useCompositeProjection.ts
+++ b/src/hooks/useCompositeProjection.ts
@@ -178,7 +178,6 @@ export function useCompositeProjection(
     return () => {
       if (saveTimer.current) clearTimeout(saveTimer.current)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     phases,
     displayCurrency,
@@ -186,6 +185,7 @@ export function useCompositeProjection(
     compositeNarrative,
     compositeWorkScenarioId,
     initialized,
+    updateSettings,
   ])
 
   const toggleExclusion = useCallback(

--- a/src/hooks/useFxRates.ts
+++ b/src/hooks/useFxRates.ts
@@ -72,9 +72,8 @@ export function useFxRates(
     return null
   })()
 
-  const [asyncRates, setAsyncRates] = useState<Record<string, number>>(
-    EMPTY_RATES,
-  )
+  const [asyncRates, setAsyncRates] =
+    useState<Record<string, number>>(EMPTY_RATES)
   const [asyncFetchKey, setAsyncFetchKey] = useState<string | null>(null)
 
   // Async fetch path. Only runs when trivialRates is null.

--- a/src/hooks/useIndependenceSettings.ts
+++ b/src/hooks/useIndependenceSettings.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react"
 import useSwr from "swr"
 import type { KeyedMutator } from "swr"
 import {
@@ -24,19 +25,24 @@ export function useIndependenceSettings(): UseIndependenceSettingsResult {
     simpleFetcher(settingsKey),
   )
 
-  const updateSettings = async (
-    request: UpdateSettingsRequest,
-  ): Promise<UserIndependenceSettings> => {
-    const response = await fetch(settingsKey, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(request),
-    })
-    if (!response.ok) throw new Error("Failed to update settings")
-    const updated = await response.json()
-    mutate(updated, false)
-    return updated
-  }
+  // Stable identity so consumers can list updateSettings in effect deps
+  // without re-firing every render (mutate from SWR is itself stable).
+  const updateSettings = useCallback(
+    async (
+      request: UpdateSettingsRequest,
+    ): Promise<UserIndependenceSettings> => {
+      const response = await fetch(settingsKey, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      })
+      if (!response.ok) throw new Error("Failed to update settings")
+      const updated = await response.json()
+      mutate(updated, false)
+      return updated
+    },
+    [mutate],
+  )
 
   return {
     settings: data,

--- a/src/lib/utils/hooks/__tests__/useDisplayCurrencyConversion.test.ts
+++ b/src/lib/utils/hooks/__tests__/useDisplayCurrencyConversion.test.ts
@@ -17,7 +17,11 @@ const mockUseHoldingState = useHoldingState as jest.MockedFunction<
 const mockFetch = jest.fn()
 global.fetch = mockFetch
 
-const USD: Currency = { code: "USD", name: "US Dollar", symbol: "$" } as Currency
+const USD: Currency = {
+  code: "USD",
+  name: "US Dollar",
+  symbol: "$",
+} as Currency
 const NZD: Currency = {
   code: "NZD",
   name: "NZ Dollar",

--- a/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
+++ b/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
@@ -203,9 +203,7 @@ export function useDisplayCurrencyConversion({
   // Loading is derived: pending iff we expect an async result we don't yet
   // have. No setIsLoading(true) / setIsLoading(false) inside an effect.
   const customFetchPending =
-    mode === "CUSTOM" &&
-    !!customCode &&
-    asyncCustom?.code !== customCode
+    mode === "CUSTOM" && !!customCode && asyncCustom?.code !== customCode
   const fxFetchPending =
     syncFxRate === null &&
     !!sourceCurrency &&


### PR DESCRIPTION
## Summary
- **Hoist `getNetRentalIncome` out of `ContributionsStep`** — pure helper, now at module scope typed on `PrivateAssetConfig`. Drops the `react-hooks/exhaustive-deps` suppression on `totalRentalIncome`.
- **Stabilise `useIndependenceSettings.updateSettings` with `useCallback`** — deps `[mutate]` are SWR-stable. `useCompositeProjection`'s debounced save effect now lists it honestly and drops its suppression.
- **Prettier reformatting** across a handful of hooks and tests (no behaviour change).
- **CLAUDE.md** gains a *React Compiler* section: rule enforcement, allowed bailout patterns and why, and the two refactor moves used here.

Two of the five remaining `react-hooks/exhaustive-deps` suppressions cleared. The other three (`StressTestTab`, `MovePositionDialog`, `HoldingActions`) are intentional external-trigger patterns — listing the omitted dep would change behaviour.

## Test plan
- [x] `yarn typecheck && yarn lint && yarn test` — all green (1274 tests)
- [ ] Manual: load `/independence` → contributions step still totals rental income correctly
- [ ] Manual: composite plan view → debounced settings save still fires once after edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced React Compiler documentation with guidance on bailout patterns, prevention techniques, and recommended refactoring strategies.

* **Refactor**
  * Improved code stability through function abstraction and optimized effect dependencies.

* **Tests**
  * Standardized test setup and mock configurations across hook tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->