### PR TITLE
feat(bc-view): index benchmark overlay on PerformanceChart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,8 +287,8 @@ why. Acceptable patterns (currently allowed):
 - **Inline object/array prop causing child re-render** — `useMemo` at the
   call site or hoist a constant if truly static.
 
-When in doubt: prefer refactoring the *source* (hook author) over
-suppressing at the *consumer* — one fix removes N suppressions.
+When in doubt: prefer refactoring the _source_ (hook author) over
+suppressing at the _consumer_ — one fix removes N suppressions.
 
 ## Debugging
 

--- a/src/components/features/holdings/PerformanceChart.tsx
+++ b/src/components/features/holdings/PerformanceChart.tsx
@@ -1,13 +1,16 @@
 import React, { useState, useMemo, useCallback } from "react"
 import useSwr, { useSWRConfig } from "swr"
 import { simpleFetcher } from "@utils/api/fetchHelper"
-import { PerformanceResponse } from "types/beancounter"
+import { Asset, PerformanceResponse } from "types/beancounter"
 import {
   AreaChart,
   Area,
+  Line,
+  LineChart,
   XAxis,
   YAxis,
   Tooltip,
+  Legend,
   ResponsiveContainer,
   ReferenceLine,
 } from "recharts"
@@ -25,7 +28,11 @@ import {
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 
-type ChartTab = "gain" | "guide"
+type ChartTab = "gain" | "benchmark" | "guide"
+
+interface AssetUpdateResponse {
+  data: Record<string, Asset>
+}
 
 interface PerformanceChartProps {
   portfolioCode: string
@@ -40,6 +47,7 @@ const PerformanceChart: React.FC<PerformanceChartProps> = ({
 }) => {
   const [months, setMonths] = useState(12)
   const [activeChart, setActiveChart] = useState<ChartTab>("gain")
+  const [selectedIndexId, setSelectedIndexId] = useState<string>("")
   const [resetState, setResetState] = useState<"idle" | "resetting" | "done">(
     "idle",
   )
@@ -56,6 +64,27 @@ const PerformanceChart: React.FC<PerformanceChartProps> = ({
     apiUrl,
     simpleFetcher(apiUrl),
   )
+
+  // Lazy: only fetch index list when benchmark tab is active
+  const indexListUrl =
+    activeChart === "benchmark" ? "/api/assets/market/INDEX" : null
+  const { data: indexListData } = useSwr<AssetUpdateResponse>(
+    indexListUrl,
+    indexListUrl ? simpleFetcher(indexListUrl) : null,
+  )
+
+  // Lazy: only fetch benchmark series once an index is picked
+  const benchmarkUrl =
+    activeChart === "benchmark" && selectedIndexId
+      ? `/api/performance/${portfolioCode}/benchmark?indexAssetId=${encodeURIComponent(
+          selectedIndexId,
+        )}&months=${months}`
+      : null
+  const { data: benchmarkData, isLoading: benchmarkLoading } =
+    useSwr<PerformanceResponse>(
+      benchmarkUrl,
+      benchmarkUrl ? simpleFetcher(benchmarkUrl) : null,
+    )
 
   const handleResetCache = useCallback(async () => {
     setResetState("resetting")
@@ -95,6 +124,35 @@ const PerformanceChart: React.FC<PerformanceChartProps> = ({
   }, [portfolioCode, apiUrl, mutate])
 
   const series = useMemo(() => data?.data?.series || [], [data?.data?.series])
+
+  const indexOptions = useMemo(() => {
+    const map = indexListData?.data
+    if (!map) return [] as Asset[]
+    return Object.values(map)
+  }, [indexListData])
+
+  // Merge portfolio + benchmark series by date for the comparison chart.
+  // Portfolio series is rebased here too (Growth-of-1000 already supplied by API).
+  const benchmarkChartData = useMemo(() => {
+    if (series.length === 0) return []
+    const benchmarkSeries = benchmarkData?.data?.series || []
+    const benchmarkByDate = new Map(
+      benchmarkSeries.map((p) => [p.date, p.growthOf1000]),
+    )
+    return series.map((p) => ({
+      date: p.date,
+      portfolio: p.growthOf1000,
+      benchmark: benchmarkByDate.get(p.date) ?? null,
+    }))
+  }, [series, benchmarkData?.data?.series])
+
+  const selectedIndexName = useMemo(() => {
+    if (!selectedIndexId) return ""
+    return (
+      indexOptions.find((a) => a.id === selectedIndexId)?.name ||
+      selectedIndexId
+    )
+  }, [selectedIndexId, indexOptions])
   const firstTradeDate = data?.data?.firstTradeDate
   const currency = data?.data?.currency
   const sym = currency?.symbol || currencySymbol
@@ -454,6 +512,21 @@ const PerformanceChart: React.FC<PerformanceChartProps> = ({
           </button>
           <button
             role="tab"
+            aria-selected={activeChart === "benchmark"}
+            onClick={() => setActiveChart("benchmark")}
+            className={`relative px-3 py-2.5 text-xs font-medium transition-colors ${
+              activeChart === "benchmark"
+                ? "text-gray-900"
+                : "text-gray-400 hover:text-gray-600"
+            }`}
+          >
+            vs Benchmark
+            {activeChart === "benchmark" && (
+              <span className="absolute bottom-0 left-3 right-3 h-0.5 bg-wealth-600 rounded-full" />
+            )}
+          </button>
+          <button
+            role="tab"
             aria-selected={activeChart === "guide"}
             onClick={() => setActiveChart("guide")}
             className={`relative px-3 py-2.5 text-xs font-medium transition-colors ${
@@ -471,7 +544,114 @@ const PerformanceChart: React.FC<PerformanceChartProps> = ({
 
         {/* Chart / Guide area */}
         <div className="p-4">
-          {activeChart === "gain" ? (
+          {activeChart === "benchmark" ? (
+            <div>
+              <div className="flex items-center gap-3 mb-3">
+                <label
+                  htmlFor="benchmark-index"
+                  className="text-xs text-gray-500"
+                >
+                  Compare against:
+                </label>
+                <select
+                  id="benchmark-index"
+                  value={selectedIndexId}
+                  onChange={(e) => setSelectedIndexId(e.target.value)}
+                  className="text-xs border border-gray-200 rounded px-2 py-1 bg-white focus:outline-none focus:ring-2 focus:ring-wealth-500"
+                >
+                  <option value="">— Select index —</option>
+                  {indexOptions.map((idx) => (
+                    <option key={idx.id} value={idx.id}>
+                      {idx.code} — {idx.name || idx.code}
+                    </option>
+                  ))}
+                </select>
+                {selectedIndexId && benchmarkLoading && (
+                  <span className="text-[10px] text-gray-400">loading…</span>
+                )}
+              </div>
+              <div className="h-72">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={benchmarkChartData}>
+                    <XAxis
+                      dataKey="date"
+                      axisLine={false}
+                      tickLine={false}
+                      tick={AXIS_TICK}
+                      tickFormatter={formatAxisDate}
+                      interval="preserveStartEnd"
+                      dy={4}
+                    />
+                    <YAxis
+                      domain={["auto", "auto"]}
+                      axisLine={false}
+                      tickLine={false}
+                      tick={AXIS_TICK}
+                      tickFormatter={(v: number) => v.toFixed(0)}
+                      width={55}
+                    />
+                    <Tooltip
+                      contentStyle={tooltipStyle}
+                      labelFormatter={(label) =>
+                        formatTooltipDate(String(label))
+                      }
+                      formatter={(value, name) => [
+                        value == null ? "—" : Number(value).toFixed(2),
+                        String(name) === "portfolio"
+                          ? "Portfolio"
+                          : selectedIndexName || "Benchmark",
+                      ]}
+                    />
+                    <ReferenceLine
+                      y={1000}
+                      stroke={CHART_COLORS.axis}
+                      strokeDasharray="2 4"
+                      label={{
+                        value: "Start (1000)",
+                        position: "insideTopLeft",
+                        fill: CHART_COLORS.axis,
+                        fontSize: 10,
+                        fontFamily: "var(--font-dm-sans)",
+                      }}
+                    />
+                    <Legend
+                      verticalAlign="top"
+                      height={24}
+                      iconType="plainline"
+                      formatter={(value: string) =>
+                        value === "portfolio"
+                          ? "Portfolio"
+                          : selectedIndexName || "Benchmark"
+                      }
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="portfolio"
+                      stroke={CHART_COLORS.accent}
+                      strokeWidth={2}
+                      dot={false}
+                      activeDot={ACTIVE_DOT}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="benchmark"
+                      stroke={CHART_COLORS.benchmark}
+                      strokeWidth={2}
+                      strokeDasharray="4 3"
+                      dot={false}
+                      connectNulls
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+              {!selectedIndexId && (
+                <p className="text-[11px] text-gray-400 mt-2">
+                  Pick an index to overlay its Growth-of-1000 against your
+                  portfolio.
+                </p>
+              )}
+            </div>
+          ) : activeChart === "gain" ? (
             <div className="h-72">
               <ResponsiveContainer width="100%" height="100%">
                 <AreaChart data={gainSeries}>

--- a/src/components/features/holdings/__tests__/PerformanceChart.test.tsx
+++ b/src/components/features/holdings/__tests__/PerformanceChart.test.tsx
@@ -47,6 +47,13 @@ jest.mock("recharts", () => ({
   Area: ({ dataKey }: { dataKey: string }) => (
     <g data-testid={`area-${dataKey}`} />
   ),
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <svg data-testid="line-chart">{children}</svg>
+  ),
+  Line: ({ dataKey }: { dataKey: string }) => (
+    <g data-testid={`line-${dataKey}`} />
+  ),
+  Legend: () => <g data-testid="legend" />,
   XAxis: () => <g />,
   YAxis: () => <g />,
   Tooltip: () => <g />,
@@ -546,6 +553,141 @@ describe("PerformanceChart", () => {
       expect(
         screen.queryByText(/Portfolio data starts/),
       ).not.toBeInTheDocument()
+    })
+  })
+
+  describe("benchmark overlay", () => {
+    const indexListResponse = {
+      data: {
+        "^GSPC": {
+          id: "^GSPC",
+          code: "^GSPC",
+          name: "S&P 500",
+          marketCode: "INDEX",
+        },
+        "^FTSE": {
+          id: "^FTSE",
+          code: "^FTSE",
+          name: "FTSE 100",
+          marketCode: "INDEX",
+        },
+      },
+    }
+
+    /**
+     * Route useSwr by URL so the perf, index-list, and benchmark calls each
+     * get the right payload. Null keys (lazy fetches) get undefined.
+     */
+    function mockSwrByUrl(benchmarkData?: PerformanceResponse): void {
+      mockUseSwr.mockImplementation((key) => {
+        if (key === null || typeof key !== "string") {
+          return {
+            data: undefined,
+            isLoading: false,
+            error: undefined,
+          } as ReturnType<typeof useSwr>
+        }
+        if (key.startsWith("/api/performance/") && key.includes("benchmark")) {
+          return {
+            data: benchmarkData,
+            isLoading: false,
+            error: undefined,
+          } as ReturnType<typeof useSwr>
+        }
+        if (key === "/api/assets/market/INDEX") {
+          return {
+            data: indexListResponse,
+            isLoading: false,
+            error: undefined,
+          } as ReturnType<typeof useSwr>
+        }
+        return {
+          data: mockPerformanceData,
+          isLoading: false,
+          error: undefined,
+        } as ReturnType<typeof useSwr>
+      })
+    }
+
+    it("renders the vs Benchmark tab", () => {
+      mockSwrByUrl()
+      render(<PerformanceChart portfolioCode="TEST" />)
+      expect(
+        screen.getByRole("tab", { name: "vs Benchmark" }),
+      ).toBeInTheDocument()
+    })
+
+    it("shows index dropdown options when benchmark tab is opened", () => {
+      mockSwrByUrl()
+      render(<PerformanceChart portfolioCode="TEST" />)
+
+      fireEvent.click(screen.getByRole("tab", { name: "vs Benchmark" }))
+
+      const select = screen.getByLabelText("Compare against:")
+      expect(select).toBeInTheDocument()
+      expect(
+        screen.getByRole("option", { name: /S&P 500/ }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("option", { name: /FTSE 100/ }),
+      ).toBeInTheDocument()
+    })
+
+    it("does not fetch the index list until benchmark tab is opened", () => {
+      mockSwrByUrl()
+      render(<PerformanceChart portfolioCode="TEST" />)
+
+      const initialKeys = mockUseSwr.mock.calls.map((c) => c[0])
+      expect(initialKeys).toContain("/api/performance/TEST?months=12")
+      expect(initialKeys).not.toContain("/api/assets/market/INDEX")
+
+      fireEvent.click(screen.getByRole("tab", { name: "vs Benchmark" }))
+
+      const afterKeys = mockUseSwr.mock.calls.map((c) => c[0])
+      expect(afterKeys).toContain("/api/assets/market/INDEX")
+    })
+
+    it("requests benchmark series with selected indexAssetId", async () => {
+      const benchmark: PerformanceResponse = {
+        data: {
+          currency: { code: "USD", symbol: "$", name: "US Dollar" },
+          series: [
+            {
+              date: "2024-01-01",
+              growthOf1000: 1000,
+              marketValue: 0,
+              netContributions: 0,
+              cumulativeReturn: 0,
+              cumulativeDividends: 0,
+            },
+            {
+              date: "2024-12-01",
+              growthOf1000: 1120,
+              marketValue: 0,
+              netContributions: 0,
+              cumulativeReturn: 0.12,
+              cumulativeDividends: 0,
+            },
+          ],
+        },
+      }
+      mockSwrByUrl(benchmark)
+      render(<PerformanceChart portfolioCode="TEST" />)
+
+      fireEvent.click(screen.getByRole("tab", { name: "vs Benchmark" }))
+      fireEvent.change(screen.getByLabelText("Compare against:"), {
+        target: { value: "^GSPC" },
+      })
+
+      await waitFor(() => {
+        const keys = mockUseSwr.mock.calls.map((c) => c[0])
+        expect(keys).toContain(
+          "/api/performance/TEST/benchmark?indexAssetId=%5EGSPC&months=12",
+        )
+      })
+
+      expect(screen.getByTestId("line-portfolio")).toBeInTheDocument()
+      expect(screen.getByTestId("line-benchmark")).toBeInTheDocument()
     })
   })
 })

--- a/src/lib/utils/chart/performanceConstants.ts
+++ b/src/lib/utils/chart/performanceConstants.ts
@@ -13,7 +13,8 @@ export const TIME_RANGES = [
 
 // Recharts requires inline style values — centralise them here for maintainability
 export const CHART_COLORS = {
-  accent: "#10b981", // emerald-500
+  accent: "#10b981", // emerald-500 — primary portfolio series
+  benchmark: "#6366f1", // indigo-500 — benchmark/index overlay
   axis: "#9ca3af", // gray-400
   tooltipBg: "rgba(15, 23, 42, 0.95)", // slate-900 @ 95%
   tooltipText: "#e2e8f0", // slate-200

--- a/src/pages/api/assets/market/[code].ts
+++ b/src/pages/api/assets/market/[code].ts
@@ -1,0 +1,12 @@
+import {
+  createApiHandler,
+  sanitizePathParam,
+} from "@utils/api/createApiHandler"
+import { getDataUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: (req) => {
+    const code = sanitizePathParam(req.query.code, "code")
+    return getDataUrl(`/assets/market/${code}`)
+  },
+})

--- a/src/pages/api/performance/[code]/benchmark.ts
+++ b/src/pages/api/performance/[code]/benchmark.ts
@@ -1,0 +1,27 @@
+import {
+  createApiHandler,
+  sanitizePathParam,
+} from "@utils/api/createApiHandler"
+import { getPositionsUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: (req) => {
+    const code = sanitizePathParam(req.query.code, "code")
+    const indexAssetId = req.query.indexAssetId as string | undefined
+    if (!indexAssetId) {
+      throw new Error("indexAssetId is required")
+    }
+    const monthsRaw = Array.isArray(req.query.months)
+      ? req.query.months[0]
+      : req.query.months
+    const months = Math.max(
+      1,
+      Math.min(120, parseInt(monthsRaw || "12", 10) || 12),
+    )
+    const params = new URLSearchParams({
+      indexAssetId,
+      months: String(months),
+    })
+    return getPositionsUrl(`/${code}/performance/benchmark?${params}`)
+  },
+})


### PR DESCRIPTION
## Summary
- Adds a "vs Benchmark" tab to `PerformanceChart` with an index dropdown (S&P 500, FTSE 100, etc.) and a Recharts `LineChart` overlaying the portfolio's Growth-of-1000 against the selected index.
- Two new Next.js API proxies: `/api/assets/market/[code]` (index listing) and `/api/performance/[code]/benchmark` (benchmark series).

## Why
Comparison against a benchmark is the most-asked context for interpreting portfolio performance. Server-side rebase (in [svc-position PR #832](https://github.com/monowai/beancounter/pull/832)) means both series share the portfolio's date grid — no client-side date alignment needed.

## Wiring
- `PerformanceChart.tsx`:
  - New `ChartTab = "gain" | "benchmark" | "guide"`.
  - Two new SWR fetches keyed by URL or `null` — index list loads only when the tab is opened; benchmark series loads only after an index is picked. Other tabs incur zero extra network.
  - Recharts `LineChart` with portfolio (solid emerald) and benchmark (dashed indigo) lines on shared Y axis; `ReferenceLine` at 1000 marks rebase origin; legend toggles series.
- `performanceConstants.ts`: adds `CHART_COLORS.benchmark` (indigo-500).
- `/api/assets/market/[code].ts`: thin proxy with `sanitizePathParam`.
- `/api/performance/[code]/benchmark.ts`: validates `indexAssetId` present, clamps `months` to [1, 120], URL-encodes.

## Test plan
- [x] `yarn test --testPathPatterns=PerformanceChart` — 39/39 green (4 new):
  - vs Benchmark tab renders.
  - Dropdown options populated from index list.
  - Index list NOT fetched until tab opened (SWR null-key).
  - Selecting `^GSPC` triggers benchmark URL `/api/performance/TEST/benchmark?indexAssetId=%5EGSPC&months=12` and renders both lines.
- [x] `yarn lint`, `yarn typecheck` clean.

## Backend pair
[svc-position PR #832](https://github.com/monowai/beancounter/pull/832) — required for the new endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "vs Benchmark" tab to performance charts enabling portfolio comparison against selected benchmark indices with efficient on-demand data loading
  * Added supporting API endpoints for benchmark data retrieval

* **Tests**
  * Extended test suite with comprehensive coverage for benchmark comparison functionality

* **Documentation**
  * Updated React Compiler guidance

* **Style**
  * Added benchmark color styling for chart visualizations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->