### PR TITLE
fix(independence): default tab to Plans

### DIFF
--- a/src/pages/independence/index.tsx
+++ b/src/pages/independence/index.tsx
@@ -265,7 +265,7 @@ function RetirementPlanning(): React.ReactElement {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [activeView, setActiveView] = useState<
     "profile" | "work" | "plans" | "composite"
-  >("work")
+  >("plans")
   const [isImporting, setIsImporting] = useState(false)
   const [importError, setImportError] = useState<string | null>(null)
   const [showShareDialog, setShowShareDialog] = useState(false)


### PR DESCRIPTION
## Summary
- Switch Independence Planning landing tab from Work to Plans so users see plan cards on entry.

## Test plan
- [ ] Navigate to /independence with multiple plans → Plans tab active by default
- [ ] Tab switching to Profile / Work / Composite still functions
- [ ] Empty-state (no plans) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the independence planning page to display the "plans" tab by default on initial load instead of the "work" tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->