### PR TITLE
fix(chat): scroll-up while streaming + Cancel button

### DIFF
--- a/src/components/features/chat/ChatFab.tsx
+++ b/src/components/features/chat/ChatFab.tsx
@@ -53,7 +53,8 @@ export default function ChatFab(): React.ReactElement {
     if (routeParams.modelId) ctx.modelId = routeParams.modelId
     return ctx
   }, [pageContext.page, pageContext.description, routeParams])
-  const { messages, isLoading, sendMessage, clearMessages } = useChat(context)
+  const { messages, isLoading, sendMessage, clearMessages, cancel } =
+    useChat(context)
 
   const close = useCallback(() => {
     setIsOpen(false)
@@ -111,6 +112,7 @@ export default function ChatFab(): React.ReactElement {
           isLoading={isLoading}
           onSend={sendMessage}
           onClear={clearMessages}
+          onCancel={cancel}
           onExpand={expand}
           onClose={close}
           placeholder={pageContext.placeholder}

--- a/src/components/features/chat/ChatPanel.tsx
+++ b/src/components/features/chat/ChatPanel.tsx
@@ -16,6 +16,12 @@ interface ChatPanelProps {
    */
   onSend: (query: string, deepThink: boolean) => void
   onClear: () => void
+  /**
+   * Aborts an in-flight stream. When provided and `isLoading` is true the
+   * panel renders a Cancel button beside Send. Optional so callers that
+   * don't wire up cancellation still compile.
+   */
+  onCancel?: () => void
   className?: string
   placeholder?: string
   suggestions?: string[]
@@ -27,6 +33,11 @@ interface ChatPanelProps {
   /** Move callback — pairs with corner; opens a 2x2 picker in the header. */
   onMove?: (next: ChatCorner) => void
 }
+
+// How close to the bottom (in pixels) we still consider "stuck to bottom".
+// Browser scroll math has sub-pixel rounding, so anything within ~24px is
+// effectively the bottom for the user.
+const STICK_TO_BOTTOM_THRESHOLD_PX = 24
 
 const CORNER_PICKER: { value: ChatCorner; icon: string; label: string }[] = [
   { value: "TL", icon: "fa-arrow-up", label: "Top-left" },
@@ -40,6 +51,7 @@ export default function ChatPanel({
   isLoading,
   onSend,
   onClear,
+  onCancel,
   className = "",
   placeholder = "Ask about your portfolios...",
   suggestions = [],
@@ -52,8 +64,22 @@ export default function ChatPanel({
   const [showPicker, setShowPicker] = useState(false)
   const [deepThink, setDeepThink] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const messagesContainerRef = useRef<HTMLDivElement>(null)
+  // Auto-scroll only when the user is already at (or near) the bottom. Once
+  // they scroll up to read earlier output we leave them there even as more
+  // tokens stream in — otherwise the page yanks back down on every chunk
+  // and the user can never read the top of a long answer.
+  const stickToBottomRef = useRef(true)
+
+  const handleScroll = (): void => {
+    const el = messagesContainerRef.current
+    if (!el) return
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    stickToBottomRef.current = distanceFromBottom <= STICK_TO_BOTTOM_THRESHOLD_PX
+  }
 
   useEffect(() => {
+    if (!stickToBottomRef.current) return
     if (messagesEndRef.current?.scrollIntoView) {
       messagesEndRef.current.scrollIntoView({ behavior: "smooth" })
     }
@@ -63,6 +89,10 @@ export default function ChatPanel({
     e.preventDefault()
     const trimmed = input.trim()
     if (!trimmed || isLoading) return
+    // Sending a fresh query — re-stick so the user sees their question and
+    // the streaming answer immediately, even if they were scrolled up
+    // reading earlier output.
+    stickToBottomRef.current = true
     onSend(trimmed, deepThink)
     setInput("")
   }
@@ -160,7 +190,11 @@ export default function ChatPanel({
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+      <div
+        ref={messagesContainerRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto p-4 space-y-3"
+      >
         {messages.length === 0 && (
           <div className="flex flex-col items-center justify-center h-full text-gray-400 text-sm">
             <i className="fas fa-comments text-3xl mb-2"></i>
@@ -223,14 +257,26 @@ export default function ChatPanel({
             className="flex-1 px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             disabled={isLoading}
           />
-          <button
-            type="submit"
-            disabled={!input.trim() || isLoading}
-            aria-label="Send"
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <i className="fas fa-paper-plane"></i>
-          </button>
+          {isLoading && onCancel ? (
+            <button
+              type="button"
+              onClick={onCancel}
+              aria-label="Cancel"
+              title="Cancel"
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 transition-colors"
+            >
+              <i className="fas fa-stop"></i>
+            </button>
+          ) : (
+            <button
+              type="submit"
+              disabled={!input.trim() || isLoading}
+              aria-label="Send"
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <i className="fas fa-paper-plane"></i>
+            </button>
+          )}
         </div>
       </form>
     </div>

--- a/src/components/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/components/features/chat/__tests__/ChatPanel.test.tsx
@@ -135,6 +135,27 @@ describe("ChatPanel", () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it("renders Cancel button while loading when onCancel provided, replacing Send", () => {
+    const onCancel = jest.fn()
+    render(
+      <ChatPanel {...defaultProps} isLoading={true} onCancel={onCancel} />,
+    )
+    expect(
+      screen.queryByRole("button", { name: /send/i }),
+    ).not.toBeInTheDocument()
+    const cancelBtn = screen.getByRole("button", { name: /cancel/i })
+    fireEvent.click(cancelBtn)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not render Cancel when onCancel is omitted, even while loading", () => {
+    render(<ChatPanel {...defaultProps} isLoading={true} />)
+    expect(
+      screen.queryByRole("button", { name: /cancel/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument()
+  })
+
   it("renders the move icon and corner picker only when corner+onMove provided", () => {
     const { rerender } = render(<ChatPanel {...defaultProps} />)
     expect(screen.queryByLabelText("Move chat panel")).not.toBeInTheDocument()

--- a/src/hooks/__tests__/useChat.test.ts
+++ b/src/hooks/__tests__/useChat.test.ts
@@ -209,18 +209,21 @@ describe("useChat", () => {
       await result.current.sendMessage("test query")
     })
 
-    expect(mockFetch).toHaveBeenCalledWith("/api/agent/query/stream", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "text/event-stream",
-      },
-      body: JSON.stringify({
-        query: "test query",
-        context: undefined,
-        deepThink: false,
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/agent/query/stream",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "text/event-stream",
+        },
+        body: JSON.stringify({
+          query: "test query",
+          context: undefined,
+          deepThink: false,
+        }),
       }),
-    })
+    )
   })
 
   it("includes page context in the request body", async () => {
@@ -240,6 +243,53 @@ describe("useChat", () => {
         body: JSON.stringify({ query: "help", context: ctx, deepThink: false }),
       }),
     )
+  })
+
+  it("cancel() aborts in-flight stream and keeps partial content", async () => {
+    const encoder = new TextEncoder()
+    const captured: { signal: AbortSignal | null } = { signal: null }
+
+    mockFetch.mockImplementationOnce(
+      (_url: string, init: { signal: AbortSignal }) => {
+        captured.signal = init.signal
+        const body = new ReadableStream<Uint8Array>({
+          start(c) {
+            c.enqueue(encoder.encode("event:token\ndata:partial\n\n"))
+            // Browser-style: when the caller aborts the fetch, the underlying
+            // body stream errors with an AbortError. jsdom's fetch polyfill
+            // doesn't wire that up, so we simulate it on the mock stream so
+            // `reader.read()` stops blocking once cancel() fires.
+            init.signal.addEventListener("abort", () => {
+              c.error(
+                Object.assign(new Error("aborted"), { name: "AbortError" }),
+              )
+            })
+          },
+        })
+        return Promise.resolve({ ok: true, status: 200, body })
+      },
+    )
+
+    const { result } = renderHook(() => useChat())
+
+    let send!: Promise<void>
+    await act(async () => {
+      send = result.current.sendMessage("hi")
+      // Yield so the stream pumps the first token out before we abort.
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      result.current.cancel()
+      await send
+    })
+
+    expect(captured.signal?.aborted).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.messages[1].error).toBe("cancelled")
+    // Partial token survives — we don't blow it away on cancel.
+    expect(result.current.messages[1].content).toBe("partial")
   })
 
   it("forwards the deepThink flag in the request body when set", async () => {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useRef } from "react"
 import { ChatMessage } from "types/agent"
 
 /**
@@ -33,6 +33,11 @@ interface UseChatReturn {
    */
   sendMessage: (query: string, deepThink?: boolean) => Promise<void>
   clearMessages: () => void
+  /**
+   * Aborts the in-flight stream. Any tokens already received remain on the
+   * assistant message; isLoading flips false. No-op when nothing is in flight.
+   */
+  cancel: () => void
 }
 
 /**
@@ -46,6 +51,11 @@ interface UseChatReturn {
 export function useChat(context?: Record<string, unknown>): UseChatReturn {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [isLoading, setIsLoading] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort()
+  }, [])
 
   const sendMessage = useCallback(
     async (query: string, deepThink: boolean = false) => {
@@ -81,6 +91,9 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
         )
       }
 
+      const controller = new AbortController()
+      abortRef.current = controller
+
       try {
         const res = await fetch("/api/agent/query/stream", {
           method: "POST",
@@ -89,6 +102,7 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
             Accept: "text/event-stream",
           },
           body: JSON.stringify({ query, context, deepThink }),
+          signal: controller.signal,
         })
         if (!res.ok || !res.body) {
           const message = `HTTP ${res.status}`
@@ -157,12 +171,22 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
         }
         if (buffer.trim().length > 0) flush(buffer)
       } catch (error: unknown) {
+        if (controller.signal.aborted) {
+          // User cancelled — keep any partial content already streamed and
+          // tag the message so consumers can render a "cancelled" hint.
+          finalize((m) => ({
+            content: m.content.length > 0 ? m.content : "Cancelled.",
+            error: "cancelled",
+          }))
+          return
+        }
         const message = error instanceof Error ? error.message : "Unknown error"
         finalize(() => ({
           content: `Sorry, I encountered an error: ${message}`,
           error: message,
         }))
       } finally {
+        if (abortRef.current === controller) abortRef.current = null
         setIsLoading(false)
       }
     },
@@ -171,5 +195,5 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
 
   const clearMessages = useCallback(() => setMessages([]), [])
 
-  return { messages, isLoading, sendMessage, clearMessages }
+  return { messages, isLoading, sendMessage, clearMessages, cancel }
 }

--- a/src/pages/chat.tsx
+++ b/src/pages/chat.tsx
@@ -5,7 +5,7 @@ import { ChatPanel } from "@components/features/chat"
 import { useChat } from "@hooks/useChat"
 
 function ChatPage(): React.ReactElement {
-  const { messages, isLoading, sendMessage, clearMessages } = useChat()
+  const { messages, isLoading, sendMessage, clearMessages, cancel } = useChat()
 
   return (
     <>
@@ -18,6 +18,7 @@ function ChatPage(): React.ReactElement {
           isLoading={isLoading}
           onSend={sendMessage}
           onClear={clearMessages}
+          onCancel={cancel}
           className="h-full"
         />
       </div>

--- a/src/pages/news.tsx
+++ b/src/pages/news.tsx
@@ -40,7 +40,8 @@ function NewsPage(): React.ReactElement {
     [pageCtx.page, pageCtx.description, activeCode, tickers],
   )
 
-  const { messages, isLoading, sendMessage, clearMessages } = useChat(context)
+  const { messages, isLoading, sendMessage, clearMessages, cancel } =
+    useChat(context)
 
   return (
     <>
@@ -92,6 +93,7 @@ function NewsPage(): React.ReactElement {
             isLoading={isLoading}
             onSend={sendMessage}
             onClear={clearMessages}
+            onCancel={cancel}
             placeholder={pageCtx.placeholder}
             suggestions={pageCtx.suggestions}
             className="h-full"


### PR DESCRIPTION
## Summary
- ChatPanel auto-scroll now sticks to bottom **only when the user is already there** (within 24px). Once the user scrolls up to read earlier output, streaming tokens stop yanking the view back down. Sending a new query re-sticks.
- useChat exposes `cancel()` — wraps fetch in an AbortController. Aborting keeps any partial content already streamed and tags the assistant message with `error: "cancelled"`.
- ChatPanel renders a red Cancel button in place of Send while `isLoading && onCancel`. Wired up in ChatFab, /chat, /news.

## Test plan
- [ ] Open the FAB on any page, send a heavy query, scroll up while it streams → page stays where you scrolled.
- [ ] Send a fresh query while scrolled up → view re-sticks to bottom for the new exchange.
- [ ] Cancel mid-stream → tokens already on screen remain; Send returns; isLoading clears.
- [ ] /chat and /news Cancel buttons behave the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now cancel in-progress chat requests via a red Cancel button that appears while awaiting a response.
  * Improved chat scroll behavior: conversation automatically returns to the latest message when scrolling resumes.
  * Partial message content is preserved if a request is cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->