### PR TITLE
feat(independence): wizard step icons for mobile clarity

### DIFF
--- a/src/components/features/independence/WizardProgress.tsx
+++ b/src/components/features/independence/WizardProgress.tsx
@@ -59,7 +59,11 @@ export default function WizardProgress({
                   ) : isCompleted ? (
                     <i className="fas fa-check text-xs"></i>
                   ) : (
-                    step.id
+                    <i
+                      className={`fas ${step.icon} text-xs`}
+                      aria-label={step.name}
+                      title={step.name}
+                    ></i>
                   )}
                 </div>
                 <span
@@ -72,7 +76,6 @@ export default function WizardProgress({
                   `}
                 >
                   <span className="hidden sm:inline">{step.name}</span>
-                  <span className="sm:hidden">{step.id}</span>
                 </span>
               </div>
               {index < WIZARD_STEPS.length - 1 && (

--- a/src/lib/utils/independence/stepConfig.test.ts
+++ b/src/lib/utils/independence/stepConfig.test.ts
@@ -26,6 +26,12 @@ describe("WIZARD_STEPS", () => {
     })
   })
 
+  it("should have a Font Awesome icon class for each step", () => {
+    WIZARD_STEPS.forEach((step) => {
+      expect(step.icon).toMatch(/^fa-[\w-]+$/)
+    })
+  })
+
   describe("Step 1 - Personal Info", () => {
     it("should contain expected fields", () => {
       const fields = WIZARD_STEPS[0].fields

--- a/src/lib/utils/independence/stepConfig.ts
+++ b/src/lib/utils/independence/stepConfig.ts
@@ -9,6 +9,13 @@ import { wizardMessages } from "./messages"
 export interface WizardStep {
   id: number
   name: string
+  /**
+   * Font Awesome icon class (without the leading `fas`) used by
+   * WizardProgress so the step indicator stays recognisable on narrow
+   * mobile widths where the digit-and-label combination collapsed to an
+   * unhelpful "1, 2, 3...".
+   */
+  icon: string
   fields: (keyof WizardFormData)[]
 }
 
@@ -16,16 +23,19 @@ export const WIZARD_STEPS: WizardStep[] = [
   {
     id: 1,
     name: wizardMessages.steps.personalInfo.name,
+    icon: "fa-user",
     fields: ["planName", "expensesCurrency", "country", "narrative"],
   },
   {
     id: 2,
     name: wizardMessages.steps.assets.name,
+    icon: "fa-piggy-bank",
     fields: ["selectedPortfolioIds", "manualAssets"],
   },
   {
     id: 3,
     name: wizardMessages.steps.assumptions.name,
+    icon: "fa-sliders-h",
     fields: [
       "targetBalance",
       "cashReturnRate",
@@ -40,16 +50,19 @@ export const WIZARD_STEPS: WizardStep[] = [
   {
     id: 4,
     name: wizardMessages.steps.income.name,
+    icon: "fa-hand-holding-usd",
     fields: ["pensionMonthly", "socialSecurityMonthly", "otherIncomeMonthly"],
   },
   {
     id: 5,
     name: wizardMessages.steps.expenses.name,
+    icon: "fa-receipt",
     fields: ["expenses"],
   },
   {
     id: 6,
     name: wizardMessages.steps.lifeEvents.name,
+    icon: "fa-calendar-day",
     fields: ["lifeEvents"],
   },
 ]


### PR DESCRIPTION
## Summary
- WizardProgress shows a Font Awesome glyph in each step indicator instead of the digit (1-6).
- Icons: user / piggy-bank / sliders-h / hand-holding-usd / receipt / calendar-day.
- Mobile-only digit label dropped — the icon now identifies the step on narrow widths where the text label is hidden.
- Completed (check) and error (exclamation) overrides preserved.

## Test plan
- [ ] Open the wizard on desktop → icon + step name beside each indicator.
- [ ] Resize / view on mobile → icons remain recognisable; no digits.
- [ ] Trigger validation error on a step → red exclamation overrides icon.
- [ ] Advance past a step → green check overrides icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wizard progress steps now display visual icons alongside step information for improved clarity.

* **Tests**
  * Added validation to ensure all wizard steps include properly formatted icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->