### PR TITLE
feat(independence): liquid/illiquid life events + downsize wizard

### DIFF
--- a/src/components/features/independence/steps/LifeEventsStep.tsx
+++ b/src/components/features/independence/steps/LifeEventsStep.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-hook-form"
 import { WizardFormData, LifeEvent } from "types/independence"
 import { StepHeader } from "../form"
+import QuickScenarios from "./QuickScenarios"
 
 interface LifeEventsStepProps {
   control: Control<WizardFormData>
@@ -32,6 +33,7 @@ export default function LifeEventsStep({
     amount: 0,
     description: "",
     eventType: "income",
+    assetType: "liquid",
   })
 
   const addLifeEvent = (): void => {
@@ -43,9 +45,16 @@ export default function LifeEventsStep({
       amount: newEvent.amount,
       description: newEvent.description,
       eventType: newEvent.eventType || "income",
+      assetType: newEvent.assetType || "liquid",
     }
     append(event)
-    setNewEvent({ age: 70, amount: 0, description: "", eventType: "income" })
+    setNewEvent({
+      age: 70,
+      amount: 0,
+      description: "",
+      eventType: "income",
+      assetType: "liquid",
+    })
   }
 
   return (
@@ -63,6 +72,10 @@ export default function LifeEventsStep({
           </p>
         </div>
       )}
+
+      <QuickScenarios
+        appendEvents={(events) => events.forEach((e) => append(e))}
+      />
 
       {/* Add new event form */}
       <div className="bg-gray-50 rounded-lg p-4 space-y-4">
@@ -118,7 +131,7 @@ export default function LifeEventsStep({
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
           />
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center gap-4">
           <div className="flex gap-2">
             <button
               type="button"
@@ -143,6 +156,34 @@ export default function LifeEventsStep({
             >
               <i className="fas fa-minus-circle mr-2"></i>
               Expense
+            </button>
+          </div>
+          <div className="flex gap-2" title="Which asset pool this cashflow affects">
+            <button
+              type="button"
+              onClick={() => setNewEvent({ ...newEvent, assetType: "liquid" })}
+              className={`px-3 py-2 rounded-lg text-sm font-medium ${
+                (newEvent.assetType ?? "liquid") === "liquid"
+                  ? "bg-blue-500 text-white"
+                  : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+              }`}
+            >
+              <i className="fas fa-tint mr-2"></i>
+              Liquid
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setNewEvent({ ...newEvent, assetType: "illiquid" })
+              }
+              className={`px-3 py-2 rounded-lg text-sm font-medium ${
+                newEvent.assetType === "illiquid"
+                  ? "bg-amber-600 text-white"
+                  : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+              }`}
+            >
+              <i className="fas fa-home mr-2"></i>
+              Illiquid
             </button>
           </div>
           <button
@@ -227,7 +268,7 @@ export default function LifeEventsStep({
                         }
                         className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500"
                       />
-                      <div className="flex items-center justify-between">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
                         <div className="flex gap-2">
                           <button
                             type="button"
@@ -262,6 +303,40 @@ export default function LifeEventsStep({
                             Expense
                           </button>
                         </div>
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setValue(
+                                `lifeEvents.${index}.assetType`,
+                                "liquid",
+                              )
+                            }
+                            className={`px-3 py-1 rounded text-xs font-medium ${
+                              (event.assetType ?? "liquid") === "liquid"
+                                ? "bg-blue-500 text-white"
+                                : "bg-gray-200 text-gray-700"
+                            }`}
+                          >
+                            Liquid
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setValue(
+                                `lifeEvents.${index}.assetType`,
+                                "illiquid",
+                              )
+                            }
+                            className={`px-3 py-1 rounded text-xs font-medium ${
+                              event.assetType === "illiquid"
+                                ? "bg-amber-600 text-white"
+                                : "bg-gray-200 text-gray-700"
+                            }`}
+                          >
+                            Illiquid
+                          </button>
+                        </div>
                         <button
                           type="button"
                           onClick={() => setEditingIndex(null)}
@@ -292,6 +367,25 @@ export default function LifeEventsStep({
                         >
                           {event.eventType === "income" ? "+" : "-"}$
                           {event.amount?.toLocaleString()}
+                        </span>
+                        <span
+                          className={`text-xs px-1.5 py-0.5 rounded ${
+                            (event.assetType ?? "liquid") === "liquid"
+                              ? "bg-blue-100 text-blue-700"
+                              : "bg-amber-100 text-amber-700"
+                          }`}
+                          title={
+                            (event.assetType ?? "liquid") === "liquid"
+                              ? "Affects spendable / liquid balance"
+                              : "Affects non-spendable / illiquid pool"
+                          }
+                        >
+                          <i
+                            className={`fas ${(event.assetType ?? "liquid") === "liquid" ? "fa-tint" : "fa-home"} mr-1`}
+                          ></i>
+                          {(event.assetType ?? "liquid") === "liquid"
+                            ? "Liquid"
+                            : "Illiquid"}
                         </span>
                       </div>
                       <div className="flex items-center gap-1">

--- a/src/components/features/independence/steps/QuickScenarios.tsx
+++ b/src/components/features/independence/steps/QuickScenarios.tsx
@@ -1,0 +1,265 @@
+import React, { useState } from "react"
+import { LifeEvent } from "types/independence"
+
+interface QuickScenariosProps {
+  appendEvents: (events: LifeEvent[]) => void
+  defaultAge?: number
+}
+
+/**
+ * Quick Scenarios — guided wizards that generate combinations of life events
+ * to model common what-if cases (e.g., selling and downsizing a property).
+ *
+ * The wizard hides the math: user describes the scenario in plain terms,
+ * we emit the paired liquid + illiquid life events that represent it
+ * accurately in the projection engine.
+ */
+export default function QuickScenarios({
+  appendEvents,
+  defaultAge,
+}: QuickScenariosProps): React.ReactElement {
+  const [openPreset, setOpenPreset] = useState<"downsize" | null>(null)
+
+  return (
+    <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-indigo-900">
+          <i className="fas fa-magic mr-2"></i>
+          Quick Scenarios
+        </h3>
+        <span className="text-xs text-indigo-700">
+          Guided wizards for common life events
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() =>
+            setOpenPreset(openPreset === "downsize" ? null : "downsize")
+          }
+          className={`px-3 py-1.5 rounded-lg text-sm font-medium border ${
+            openPreset === "downsize"
+              ? "bg-indigo-600 text-white border-indigo-600"
+              : "bg-white text-indigo-700 border-indigo-300 hover:bg-indigo-100"
+          }`}
+        >
+          <i className="fas fa-home mr-1"></i>
+          Sell &amp; Downsize Property
+        </button>
+      </div>
+      {openPreset === "downsize" && (
+        <SellAndDownsizeForm
+          defaultAge={defaultAge}
+          onCancel={() => setOpenPreset(null)}
+          onGenerate={(events) => {
+            appendEvents(events)
+            setOpenPreset(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+interface SellAndDownsizeFormProps {
+  defaultAge?: number
+  onCancel: () => void
+  onGenerate: (events: LifeEvent[]) => void
+}
+
+function SellAndDownsizeForm({
+  defaultAge,
+  onCancel,
+  onGenerate,
+}: SellAndDownsizeFormProps): React.ReactElement {
+  const [description, setDescription] = useState("Sell and downsize property")
+  const [age, setAge] = useState<number>(defaultAge ?? 65)
+  const [currentValue, setCurrentValue] = useState<number>(0)
+  const [cashRetainedPct, setCashRetainedPct] = useState<number>(50)
+  const [txCostsPct, setTxCostsPct] = useState<number>(5)
+
+  const cashRetained = Math.max(
+    0,
+    currentValue * ((cashRetainedPct - txCostsPct) / 100),
+  )
+  const newPropertyValue = Math.max(
+    0,
+    currentValue * ((100 - cashRetainedPct - txCostsPct) / 100),
+  )
+  const txCostAmount = currentValue * (txCostsPct / 100)
+  const totalsValid = cashRetainedPct + txCostsPct <= 100 && currentValue > 0
+
+  const handleGenerate = (): void => {
+    if (!totalsValid) return
+    const baseId = Date.now()
+    const events: LifeEvent[] = [
+      {
+        id: `${baseId}-disposal`,
+        age,
+        amount: currentValue,
+        description: `${description} — sell existing property`,
+        eventType: "expense",
+        assetType: "illiquid",
+      },
+      {
+        id: `${baseId}-replacement`,
+        age,
+        amount: newPropertyValue,
+        description: `${description} — buy replacement property`,
+        eventType: "income",
+        assetType: "illiquid",
+      },
+      {
+        id: `${baseId}-cash`,
+        age,
+        amount: cashRetained,
+        description: `${description} — cash retained`,
+        eventType: "income",
+        assetType: "liquid",
+      },
+    ]
+    // Skip zero-amount legs (e.g., 100% cash retained → no replacement)
+    onGenerate(events.filter((e) => e.amount > 0))
+  }
+
+  return (
+    <div className="bg-white border border-indigo-300 rounded-lg p-4 space-y-3">
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">
+          Description
+        </label>
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Sale age
+          </label>
+          <input
+            type="number"
+            value={age || ""}
+            onChange={(e) => setAge(parseInt(e.target.value) || 0)}
+            min={18}
+            max={120}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Current property value
+          </label>
+          <div className="relative">
+            <span className="absolute left-3 top-2.5 text-gray-500 text-sm">
+              $
+            </span>
+            <input
+              type="number"
+              value={currentValue || ""}
+              onChange={(e) => setCurrentValue(parseFloat(e.target.value) || 0)}
+              min={0}
+              className="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Free up as cash (%)
+          </label>
+          <input
+            type="number"
+            value={cashRetainedPct}
+            onChange={(e) => setCashRetainedPct(parseFloat(e.target.value) || 0)}
+            min={0}
+            max={100}
+            step={1}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Transaction costs (%)
+          </label>
+          <input
+            type="number"
+            value={txCostsPct}
+            onChange={(e) => setTxCostsPct(parseFloat(e.target.value) || 0)}
+            min={0}
+            max={100}
+            step={0.5}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+      </div>
+
+      {currentValue > 0 && (
+        <div className="bg-gray-50 border border-gray-200 rounded p-3 space-y-1 text-xs text-gray-700">
+          <div className="font-medium text-gray-900 mb-1">
+            Preview at age {age}:
+          </div>
+          <div className="flex justify-between">
+            <span>Sell existing property (illiquid out)</span>
+            <span className="font-mono">
+              -${currentValue.toLocaleString()}
+            </span>
+          </div>
+          {newPropertyValue > 0 && (
+            <div className="flex justify-between">
+              <span>Buy replacement property (illiquid in)</span>
+              <span className="font-mono">
+                +${Math.round(newPropertyValue).toLocaleString()}
+              </span>
+            </div>
+          )}
+          {cashRetained > 0 && (
+            <div className="flex justify-between text-blue-700">
+              <span>Cash retained (liquid in)</span>
+              <span className="font-mono">
+                +${Math.round(cashRetained).toLocaleString()}
+              </span>
+            </div>
+          )}
+          {txCostAmount > 0 && (
+            <div className="flex justify-between text-gray-500">
+              <span>Transaction costs</span>
+              <span className="font-mono">
+                -${Math.round(txCostAmount).toLocaleString()}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!totalsValid && currentValue > 0 && (
+        <div className="text-xs text-red-600">
+          Cash retained + transaction costs must not exceed 100% of property
+          value.
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm font-medium text-gray-700 hover:text-gray-900"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleGenerate}
+          disabled={!totalsValid}
+          className="px-4 py-1.5 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Add events
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/independence/steps/QuickScenarios.tsx
+++ b/src/components/features/independence/steps/QuickScenarios.tsx
@@ -87,7 +87,9 @@ function SellAndDownsizeForm({
     currentValue * ((100 - cashRetainedPct - txCostsPct) / 100),
   )
   const txCostAmount = currentValue * (txCostsPct / 100)
-  const totalsValid = cashRetainedPct + txCostsPct <= 100 && currentValue > 0
+  const ageValid = Number.isFinite(age) && age >= 18 && age <= 120
+  const totalsValid =
+    cashRetainedPct + txCostsPct <= 100 && currentValue > 0 && ageValid
 
   const handleGenerate = (): void => {
     if (!totalsValid) return
@@ -236,12 +238,20 @@ function SellAndDownsizeForm({
         </div>
       )}
 
-      {!totalsValid && currentValue > 0 && (
+      {!ageValid && (
         <div className="text-xs text-red-600">
-          Cash retained + transaction costs must not exceed 100% of property
-          value.
+          Sale age must be between 18 and 120.
         </div>
       )}
+      {ageValid &&
+        !totalsValid &&
+        currentValue > 0 &&
+        cashRetainedPct + txCostsPct > 100 && (
+          <div className="text-xs text-red-600">
+            Cash retained + transaction costs must not exceed 100% of property
+            value.
+          </div>
+        )}
 
       <div className="flex justify-end gap-2">
         <button

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -98,13 +98,21 @@ export interface PlanCopyRequest {
   name: string
 }
 
-// Life event type for one-off income/expense at specific age
+// Life event type for one-off income/expense at specific age.
+//
+// `assetType` indicates which pool the cashflow affects:
+//   - "liquid"   (default): adds to / subtracts from spendable balance
+//   - "illiquid": adds to / subtracts from non-spendable pool (e.g., property
+//                 value at sale or replacement-property purchase)
+// Field is optional for backward compatibility — older records and clients
+// that omit it are treated as "liquid".
 export interface LifeEvent {
   id: string
   age: number
   amount: number
   description: string
   eventType: "income" | "expense"
+  assetType?: "liquid" | "illiquid"
 }
 
 export interface PlanRequest {


### PR DESCRIPTION
## Summary

`LifeEvent` gains optional `assetType: "liquid" | "illiquid"` flag. Liquid events affect the spendable balance; illiquid events flow in/out of the non-spendable pool (e.g., property at sale or replacement-property purchase). Older records / clients that omit the field default to `"liquid"` — backward compatible.

New "Quick Scenarios" panel above the manual life-event form, starting with a **Sell & Downsize Property** preset.

Companion backend PR: https://github.com/monowai/svc-retire/pull/new/feat/life-event-asset-type — required for illiquid events to actually route into the non-spendable pool. Until that ships, illiquid events behave like liquid.

## Wizard inputs

- Description (default editable)
- Sale age
- Current property value
- Free up as cash (%)
- Transaction costs (%)

## Wizard output (3 paired life events)

1. **Illiquid expense** — sell existing property (current value, age N)
2. **Illiquid income** — buy replacement property (`value × (100 − cash% − tx%) / 100`)
3. **Liquid income** — cash retained (`value × (cash% − tx%) / 100`)

Live preview in the form shows the cashflow breakdown before commit. Zero-amount legs are skipped.

## Manual form changes

- Liquid / Illiquid toggle alongside the existing Income / Expense buttons.
- Event list shows a colour-coded badge (💧 Liquid / 🏠 Illiquid).
- Edit mode includes the same toggle.

## Test plan

- [x] `yarn test` green (1282 tests)
- [x] `yarn typecheck` green
- [x] `yarn lint` green
- [ ] Manual: bc-view Independence tab — Thailand scenario via "Sell & Downsize" wizard (1M property, 50% cash retained, 5% costs at age 60). Confirm 3 events created with correct amounts and pool tags.
- [ ] Manual: existing life events without `assetType` still display as Liquid and behave unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Life events now categorize cash flows as liquid or illiquid assets.
  * New "Quick Scenarios" wizard with a "Sell & Downsize Property" preset that auto-generates related events.
  * Asset-type selector (Liquid/Illiquid) added to event creation and editing UI.
  * Event summaries show compact asset-type badges with explanatory tooltips.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/662)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->