### PR TITLE
feat(independence): status colors on wizard step progress

### DIFF
--- a/src/components/features/independence/WizardProgress.tsx
+++ b/src/components/features/independence/WizardProgress.tsx
@@ -48,16 +48,23 @@ export default function WizardProgress({
                   className={`
                     w-7 h-7 sm:w-8 sm:h-8 rounded-full flex items-center justify-center text-xs font-medium transition-all flex-shrink-0
                     ${hasError ? "bg-red-500 text-white ring-2 ring-red-200" : ""}
-                    ${!hasError && isCompleted ? "bg-independence-600 text-white" : ""}
-                    ${!hasError && isCurrent ? "bg-independence-600 text-white ring-2 ring-independence-200" : ""}
+                    ${!hasError && isCompleted ? "bg-orange-500 text-white" : ""}
+                    ${!hasError && isCurrent ? "bg-gray-200 text-gray-700 ring-2 ring-orange-300" : ""}
                     ${!hasError && isUpcoming ? "bg-gray-200 text-gray-500" : ""}
-                    ${isClickable && !isCurrent ? "hover:ring-2 hover:ring-independence-200" : ""}
+                    ${isClickable && !isCurrent ? "hover:ring-2 hover:ring-orange-200" : ""}
                   `}
+                  aria-label={
+                    hasError
+                      ? `${step.name} — needs attention`
+                      : isCompleted
+                        ? `${step.name} — complete`
+                        : isCurrent
+                          ? `${step.name} — current step (not yet reviewed)`
+                          : `${step.name} — not reviewed`
+                  }
                 >
                   {hasError ? (
                     <i className="fas fa-exclamation text-xs"></i>
-                  ) : isCompleted ? (
-                    <i className="fas fa-check text-xs"></i>
                   ) : (
                     <i
                       className={`fas ${step.icon} text-xs`}
@@ -70,9 +77,9 @@ export default function WizardProgress({
                   className={`
                     mt-0.5 sm:mt-1 text-[10px] sm:text-xs font-medium transition-colors text-center truncate max-w-full px-1
                     ${hasError ? "text-red-600" : ""}
-                    ${!hasError && isCurrent ? "text-independence-600" : ""}
+                    ${!hasError && isCurrent ? "text-orange-600" : ""}
                     ${!hasError && !isCurrent ? "text-gray-500" : ""}
-                    ${isClickable ? "hover:text-independence-600" : ""}
+                    ${isClickable ? "hover:text-orange-600" : ""}
                   `}
                 >
                   <span className="hidden sm:inline">{step.name}</span>
@@ -82,7 +89,7 @@ export default function WizardProgress({
                 <div
                   className={`
                     absolute top-3.5 sm:top-4 left-1/2 w-full h-0.5 -translate-y-1/2
-                    ${isCompleted && !stepErrors.has(step.id + 1) ? "bg-independence-600" : "bg-gray-200"}
+                    ${isCompleted && !stepErrors.has(step.id + 1) ? "bg-orange-500" : "bg-gray-200"}
                   `}
                 />
               )}


### PR DESCRIPTION
## Summary

Replace the tick mark on completed wizard steps with the step icon recoloured. State now reads as colour, not glyph:

- 🟠 **Orange** — step complete and valid
- 🔴 **Red** — step requires attention (validation errors)
- ⚪ **Grey** — step not reviewed yet (upcoming or current-but-untouched)

The current step keeps the grey background but gains an orange focus ring so the active position is still obvious without implying validity.

## Why

A tick on a completed step implied "this is correct" even when the user had not actually reviewed it. Colour-only signalling avoids that ambiguity — orange means valid, grey means unreviewed, red means broken.

## Test plan

- [x] `yarn test` green (1282 tests, no WizardProgress assertions)
- [x] `yarn typecheck` green
- [x] `yarn lint` green
- [ ] Manual: bc-view Independence wizard — confirm step colours match state across navigation, especially first-visit (grey current step) and validation-error scenarios (red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style Updates**
  * Refreshed step indicator appearance with an updated orange color scheme for completed and current states.
  * Improved progress connector line styling to reflect the new visual theme.
  * Enhanced accessibility with more descriptive status indicators for clearer user feedback when navigating the wizard.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/663)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->