### PR TITLE
fix(downsize-wizard): cashRetained formula loses extra tx costs

### DIFF
--- a/src/components/features/independence/steps/LifeEventsStep.tsx
+++ b/src/components/features/independence/steps/LifeEventsStep.tsx
@@ -8,6 +8,7 @@ import {
 import { WizardFormData, LifeEvent } from "types/independence"
 import { StepHeader } from "../form"
 import QuickScenarios from "./QuickScenarios"
+import MathInput from "@components/ui/MathInput"
 
 interface LifeEventsStepProps {
   control: Control<WizardFormData>
@@ -102,16 +103,11 @@ export default function LifeEventsStep({
             </label>
             <div className="relative">
               <span className="absolute left-3 top-2.5 text-gray-500">$</span>
-              <input
-                type="number"
+              <MathInput
                 value={newEvent.amount || ""}
-                onChange={(e) =>
-                  setNewEvent({
-                    ...newEvent,
-                    amount: parseFloat(e.target.value),
-                  })
-                }
+                onChange={(v) => setNewEvent({ ...newEvent, amount: v })}
                 min={0}
+                placeholder="e.g. 100k or 1.5m"
                 className="w-full pl-8 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
               />
             </div>
@@ -243,16 +239,13 @@ export default function LifeEventsStep({
                           <label className="block text-xs text-gray-500 mb-1">
                             Amount
                           </label>
-                          <input
-                            type="number"
+                          <MathInput
                             value={event.amount}
-                            onChange={(e) =>
-                              setValue(
-                                `lifeEvents.${index}.amount`,
-                                parseFloat(e.target.value) || 0,
-                              )
+                            onChange={(v) =>
+                              setValue(`lifeEvents.${index}.amount`, v)
                             }
                             min={0}
+                            placeholder="e.g. 100k or 1.5m"
                             className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500"
                           />
                         </div>

--- a/src/components/features/independence/steps/QuickScenarios.tsx
+++ b/src/components/features/independence/steps/QuickScenarios.tsx
@@ -78,10 +78,12 @@ function SellAndDownsizeForm({
   const [cashRetainedPct, setCashRetainedPct] = useState<number>(50)
   const [txCostsPct, setTxCostsPct] = useState<number>(5)
 
-  const cashRetained = Math.max(
-    0,
-    currentValue * ((cashRetainedPct - txCostsPct) / 100),
-  )
+  // Conservation of value across the transaction:
+  //   sale proceeds = cashRetained + replacementProperty + transactionCosts
+  // cashRetainedPct is the user's "free up as cash" share of the sale;
+  // txCostsPct is the share lost to fees / vapour; the remainder buys the
+  // replacement property.
+  const cashRetained = Math.max(0, currentValue * (cashRetainedPct / 100))
   const newPropertyValue = Math.max(
     0,
     currentValue * ((100 - cashRetainedPct - txCostsPct) / 100),

--- a/src/components/features/independence/steps/QuickScenarios.tsx
+++ b/src/components/features/independence/steps/QuickScenarios.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { LifeEvent } from "types/independence"
+import MathInput from "@components/ui/MathInput"
 
 interface QuickScenariosProps {
   appendEvents: (events: LifeEvent[]) => void
@@ -161,14 +162,17 @@ function SellAndDownsizeForm({
             <span className="absolute left-3 top-2.5 text-gray-500 text-sm">
               $
             </span>
-            <input
-              type="number"
+            <MathInput
               value={currentValue || ""}
-              onChange={(e) => setCurrentValue(parseFloat(e.target.value) || 0)}
+              onChange={(v) => setCurrentValue(v)}
               min={0}
+              placeholder="e.g. 1m or 1000000"
               className="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
             />
           </div>
+          <p className="mt-1 text-[10px] text-gray-400">
+            Shorthand: 1m = 1,000,000, 1k = 1,000
+          </p>
         </div>
       </div>
       <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary

The Sell & Downsize preset (added in #662) generated cashRetained values that double-subtracted transaction costs, breaking conservation of value.

For \$1M sale at 50% cash retained / 5% tx costs:

| | Before fix | After fix |
|---|---|---|
| Sell existing (illiquid) | -1,000,000 | -1,000,000 |
| Buy replacement (illiquid) | +450,000 | +450,000 |
| Cash retained (liquid) | **+450,000** ❌ | **+500,000** ✅ |
| Tx costs (vapour) | 50,000 | 50,000 |
| Total accounted | 950,000 ❌ | 1,000,000 ✅ |

## Fix

```ts
// Before — subtracts tx costs twice
cashRetained = currentValue * (cashRetainedPct - txCostsPct) / 100

// After — conservation: cash + property + costs == sale
cashRetained = currentValue * cashRetainedPct / 100
newPropertyValue = currentValue * (100 - cashRetainedPct - txCostsPct) / 100
txCostAmount = currentValue * txCostsPct / 100
```

## Why a new PR

The original `feat/life-event-asset-type` branch was merged in #662 and deleted on the remote. Cherry-picked the fix onto a new branch from current main.

## Test plan

- [x] \`yarn test\` (1282) green
- [x] \`yarn typecheck\` green
- [x] \`yarn lint\` green
- [ ] Manual: open Sell & Downsize wizard, enter \$1M / 50% / 5%, verify preview shows \$500k cash retained, \$450k replacement property, \$50k costs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sell-and-downsize cash allocation so transaction costs are properly included, producing more accurate available cash and replacement-property values.

* **New Features / UX**
  * Replaced plain number inputs with a math-aware input for monetary fields, including formatted placeholders for life-event amounts to improve entry and readability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/664)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->