### PR TITLE
feat(independence): AssetDisposal wizard flow

### DIFF
--- a/src/components/features/independence/WizardContainer.tsx
+++ b/src/components/features/independence/WizardContainer.tsx
@@ -21,7 +21,10 @@ import {
   WIZARD_STEPS,
 } from "@lib/independence/stepConfig"
 import { toDecimal } from "@lib/independence/conversions"
-import { serializeLifeEvents } from "@lib/independence/planHelpers"
+import {
+  serializeAssetDisposals,
+  serializeLifeEvents,
+} from "@lib/independence/planHelpers"
 import { WizardFormData, PlanRequest } from "types/independence"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
@@ -214,6 +217,7 @@ export default function WizardContainer({
         // Always send the JSON-serialised array (incl. "[]") so the
         // backend distinguishes "list cleared" from "field omitted".
         lifeEvents: serializeLifeEvents(formData.lifeEvents),
+        assetDisposals: serializeAssetDisposals(formData.assetDisposals),
         manualAssets,
         excludedPortfolioIds: formData.excludedPortfolioIds || [],
         excludedRentalAssetIds: formData.excludedRentalAssetIds || [],

--- a/src/components/features/independence/steps/LifeEventsStep.tsx
+++ b/src/components/features/independence/steps/LifeEventsStep.tsx
@@ -28,6 +28,11 @@ export default function LifeEventsStep({
     name: "lifeEvents",
   })
 
+  const { append: appendDisposal } = useFieldArray({
+    control,
+    name: "assetDisposals",
+  })
+
   const [editingIndex, setEditingIndex] = useState<number | null>(null)
   const [newEvent, setNewEvent] = useState<Partial<LifeEvent>>({
     age: 70,
@@ -75,7 +80,9 @@ export default function LifeEventsStep({
       )}
 
       <QuickScenarios
-        appendEvents={(events) => events.forEach((e) => append(e))}
+        appendDisposals={(disposals) =>
+          disposals.forEach((d) => appendDisposal(d))
+        }
       />
 
       {/* Add new event form */}

--- a/src/components/features/independence/steps/QuickScenarios.tsx
+++ b/src/components/features/independence/steps/QuickScenarios.tsx
@@ -1,22 +1,23 @@
 import React, { useState } from "react"
-import { LifeEvent } from "types/independence"
+import { AssetDisposal } from "types/independence"
 import MathInput from "@components/ui/MathInput"
 
 interface QuickScenariosProps {
-  appendEvents: (events: LifeEvent[]) => void
+  appendDisposals: (disposals: AssetDisposal[]) => void
   defaultAge?: number
 }
 
 /**
- * Quick Scenarios — guided wizards that generate combinations of life events
- * to model common what-if cases (e.g., selling and downsizing a property).
+ * Quick Scenarios — guided wizards that generate AssetDisposal records
+ * for common what-if cases (e.g., selling and downsizing a property).
  *
  * The wizard hides the math: user describes the scenario in plain terms,
- * we emit the paired liquid + illiquid life events that represent it
- * accurately in the projection engine.
+ * we emit a holding-bound AssetDisposal record. Backend converts that to
+ * the three illiquid/liquid pool transfers and suppresses the disposed
+ * asset's rental income from the chosen disposalAge onward.
  */
 export default function QuickScenarios({
-  appendEvents,
+  appendDisposals,
   defaultAge,
 }: QuickScenariosProps): React.ReactElement {
   const [openPreset, setOpenPreset] = useState<"downsize" | null>(null)
@@ -52,8 +53,8 @@ export default function QuickScenarios({
         <SellAndDownsizeForm
           defaultAge={defaultAge}
           onCancel={() => setOpenPreset(null)}
-          onGenerate={(events) => {
-            appendEvents(events)
+          onGenerate={(disposals) => {
+            appendDisposals(disposals)
             setOpenPreset(null)
           }}
         />
@@ -65,7 +66,7 @@ export default function QuickScenarios({
 interface SellAndDownsizeFormProps {
   defaultAge?: number
   onCancel: () => void
-  onGenerate: (events: LifeEvent[]) => void
+  onGenerate: (disposals: AssetDisposal[]) => void
 }
 
 function SellAndDownsizeForm({
@@ -78,12 +79,13 @@ function SellAndDownsizeForm({
   const [currentValue, setCurrentValue] = useState<number>(0)
   const [cashRetainedPct, setCashRetainedPct] = useState<number>(50)
   const [txCostsPct, setTxCostsPct] = useState<number>(5)
+  // assetId — picker UI lands in a follow-up that introduces a holdings
+  // dropdown. For now users type a stable identifier so the disposal record
+  // is well-formed and round-trips through the backend cleanly.
+  const [assetId, setAssetId] = useState<string>("")
 
-  // Conservation of value across the transaction:
-  //   sale proceeds = cashRetained + replacementProperty + transactionCosts
-  // cashRetainedPct is the user's "free up as cash" share of the sale;
-  // txCostsPct is the share lost to fees / vapour; the remainder buys the
-  // replacement property.
+  // Preview math (engine derives the same splits server-side). Pure UX —
+  // helps the user see where each fraction of the sale value ends up.
   const cashRetained = Math.max(0, currentValue * (cashRetainedPct / 100))
   const newPropertyValue = Math.max(
     0,
@@ -91,40 +93,26 @@ function SellAndDownsizeForm({
   )
   const txCostAmount = currentValue * (txCostsPct / 100)
   const ageValid = Number.isFinite(age) && age >= 18 && age <= 120
+  const assetIdValid = assetId.trim().length > 0
   const totalsValid =
-    cashRetainedPct + txCostsPct <= 100 && currentValue > 0 && ageValid
+    cashRetainedPct + txCostsPct <= 100 &&
+    currentValue > 0 &&
+    ageValid &&
+    assetIdValid
 
   const handleGenerate = (): void => {
     if (!totalsValid) return
-    const baseId = Date.now()
-    const events: LifeEvent[] = [
+    onGenerate([
       {
-        id: `${baseId}-disposal`,
-        age,
-        amount: currentValue,
-        description: `${description} — sell existing property`,
-        eventType: "expense",
-        assetType: "illiquid",
+        assetId: assetId.trim(),
+        disposalAge: age,
+        currentValue,
+        cashRetainedPct,
+        txCostsPct,
+        description: description.trim() || undefined,
+        enabled: true,
       },
-      {
-        id: `${baseId}-replacement`,
-        age,
-        amount: newPropertyValue,
-        description: `${description} — buy replacement property`,
-        eventType: "income",
-        assetType: "illiquid",
-      },
-      {
-        id: `${baseId}-cash`,
-        age,
-        amount: cashRetained,
-        description: `${description} — cash retained`,
-        eventType: "income",
-        assetType: "liquid",
-      },
-    ]
-    // Skip zero-amount legs (e.g., 100% cash retained → no replacement)
-    onGenerate(events.filter((e) => e.amount > 0))
+    ])
   }
 
   return (
@@ -139,6 +127,21 @@ function SellAndDownsizeForm({
           onChange={(e) => setDescription(e.target.value)}
           className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
         />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">
+          Asset ID
+        </label>
+        <input
+          type="text"
+          value={assetId}
+          onChange={(e) => setAssetId(e.target.value)}
+          placeholder="The tracked holding being disposed of (e.g. NZ-APT-AKL)"
+          className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
+        />
+        <p className="mt-1 text-[10px] text-gray-400">
+          Holding-picker UI coming soon — type a stable id for now.
+        </p>
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>

--- a/src/lib/utils/independence/planHelpers.ts
+++ b/src/lib/utils/independence/planHelpers.ts
@@ -1,5 +1,9 @@
 import { AllocationSlice } from "@lib/allocation/aggregateHoldings"
-import { LifeEvent, ManualAssetCategory } from "types/independence"
+import {
+  AssetDisposal,
+  LifeEvent,
+  ManualAssetCategory,
+} from "types/independence"
 
 /**
  * Serialise the wizard's life-events array for the plan-update payload.
@@ -12,6 +16,17 @@ import { LifeEvent, ManualAssetCategory } from "types/independence"
  */
 export function serializeLifeEvents(events: LifeEvent[] | undefined): string {
   return JSON.stringify(events ?? [])
+}
+
+/**
+ * Same contract as [serializeLifeEvents] but for the asset-disposal list.
+ * Always emits a JSON string — `"[]"` for an empty list — so the backend
+ * can distinguish "user cleared all disposals" from "field not sent".
+ */
+export function serializeAssetDisposals(
+  disposals: AssetDisposal[] | undefined,
+): string {
+  return JSON.stringify(disposals ?? [])
 }
 
 export const HIDDEN_VALUE = "****"

--- a/src/lib/utils/independence/schema.ts
+++ b/src/lib/utils/independence/schema.ts
@@ -185,5 +185,6 @@ export const defaultWizardValues = {
   excludedRentalAssetIds: [],
   manualAssets: defaultManualAssets,
   lifeEvents: [],
+  assetDisposals: [],
   contributions: [],
 }

--- a/src/pages/independence/wizard/[planId].tsx
+++ b/src/pages/independence/wizard/[planId].tsx
@@ -9,6 +9,7 @@ import Spinner from "@components/ui/Spinner"
 import WizardContainer from "@components/features/independence/WizardContainer"
 import { toPercent } from "@lib/independence/conversions"
 import {
+  AssetDisposal,
   PlanWithExpensesResponse,
   WizardFormData,
   ManualAssets,
@@ -98,6 +99,19 @@ function EditPlanWizard(): React.ReactElement {
     }
   }
 
+  // Parse assetDisposals from JSON string (same contract as lifeEvents).
+  const parseAssetDisposalsForForm = (): AssetDisposal[] => {
+    if (!plan.assetDisposals) return []
+    if (Array.isArray(plan.assetDisposals)) {
+      return plan.assetDisposals
+    }
+    try {
+      return JSON.parse(plan.assetDisposals)
+    } catch {
+      return []
+    }
+  }
+
   const initialData: Partial<WizardFormData> = {
     planName: plan.name,
     expensesCurrency: plan.expensesCurrency || "NZD",
@@ -128,6 +142,7 @@ function EditPlanWizard(): React.ReactElement {
     ),
     manualAssets: parseManualAssets(),
     lifeEvents: parseLifeEvents(),
+    assetDisposals: parseAssetDisposalsForForm(),
   }
 
   return (

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -81,6 +81,7 @@ export interface RetirementPlan {
   bonusMonthly: number
   investmentAllocationPercent: number
   lifeEvents?: string // JSON array of life events
+  assetDisposals?: string // JSON array of asset disposals
   manualAssets?: Record<string, number> // JSON map of category -> value
   excludedPortfolioIds?: string[] | string // JSON array from backend
   excludedRentalAssetIds?: string[] | string // JSON array from backend
@@ -115,6 +116,30 @@ export interface LifeEvent {
   assetType?: "liquid" | "illiquid"
 }
 
+// Asset disposal — holding-bound alternative to the 3-event downsize
+// LifeEvent pattern. Binds to a specific tracked asset by `assetId` and
+// describes the sale + cash-retention + replacement-property math.
+//
+// At `disposalAge` the backend:
+//   - subtracts the asset's projected value from non-spendable
+//   - routes `cashRetainedPct` to liquid
+//   - routes (100 - cashRetainedPct - txCostsPct) back to non-spendable as
+//     the replacement property
+//   - suppresses the asset's rental income from disposalAge onward
+//
+// `enabled = false` is the per-plan "ignore this disposal" switch — same
+// disposal record can fire in one plan and stay dormant in another for
+// what-if scenarios.
+export interface AssetDisposal {
+  assetId: string
+  disposalAge: number
+  currentValue: number
+  cashRetainedPct: number
+  txCostsPct?: number
+  description?: string
+  enabled?: boolean
+}
+
 export interface PlanRequest {
   name: string
   planningHorizonYears?: number
@@ -140,6 +165,7 @@ export interface PlanRequest {
   bonusMonthly?: number
   investmentAllocationPercent?: number
   lifeEvents?: string
+  assetDisposals?: string
   manualAssets?: Record<string, number> | null
   excludedPortfolioIds?: string[]
   excludedRentalAssetIds?: string[]
@@ -674,6 +700,9 @@ export interface WizardFormData {
   // Life Events (one-off income/expense at specific ages)
   lifeEvents: LifeEvent[]
 
+  // Asset disposals (holding-bound sales / downsizes)
+  assetDisposals: AssetDisposal[]
+
   // Pension/Insurance Contributions
   contributions: ContributionFormEntry[]
 }
@@ -715,6 +744,7 @@ export interface PlanExport {
   investmentAllocationPercent: number
   expenses: ExportedExpense[]
   lifeEvents?: string
+  assetDisposals?: string
   manualAssets?: Record<string, number>
   clientId?: string
   /** Optional country whose values this plan targets. */


### PR DESCRIPTION
## Summary

Switch the **Sell & Downsize** wizard from emitting three illiquid/liquid LifeEvents to writing a single holding-bound **AssetDisposal** record on the plan. The persisted contract is now asset-aware: `assetId`, `disposalAge`, `cashRetainedPct`, `txCostsPct`, and an `enabled` flag (per-plan what-if toggle).

Backend (svc-retire) does the expansion to pool transfers + rental suppression internally — landed in https://github.com/monowai/svc-retire/pull/9.

## Changes

- **`types/independence.d.ts`** — new `AssetDisposal` interface. `assetDisposals` field added to `RetirementPlan`, `PlanRequest`, `WizardFormData`, exported plan shape.
- **`planHelpers.ts`** — new `serializeAssetDisposals` mirrors `serializeLifeEvents` (always emits `"[]"` so backend distinguishes "cleared" from "field omitted").
- **`WizardContainer.tsx`** — submits `formData.assetDisposals` on save.
- **`wizard/[planId].tsx`** — parses `plan.assetDisposals` JSON into the wizard form.
- **`schema.ts`** — default `assetDisposals: []` for new plans.
- **`QuickScenarios.tsx`** — Sell & Downsize form now appends a single `AssetDisposal` record instead of three LifeEvents. New "Asset ID" input — placeholder UX until the holdings-picker lands in a follow-up.
- **`LifeEventsStep.tsx`** — uses `useFieldArray` on `assetDisposals` for the wizard callback; existing LifeEvent flow untouched.

## Test plan

- [x] `yarn test` green (1282 tests)
- [x] `yarn typecheck` green
- [x] `yarn lint` green
- [ ] Manual: open Sell & Downsize wizard, enter assetId + values, save plan, reload — disposal round-trips correctly via the backend.
- [ ] Manual: legacy LifeEvents continue to display and round-trip unchanged.

## Follow-up

- Dedicated AssetDisposal editor (per-asset list view on plan).
- Holdings picker (asset dropdown) to replace the free-text Asset ID.
- bc-data `PrivateAssetConfigDto.name` + `currentValue` for autofill in the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asset disposal tracking to retirement plans, enabling users to model property sales and other asset transactions as part of their planning scenario.
  * New "Asset ID" field allows users to identify specific assets being disposed of.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/666)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->