### PR TITLE
feat(asset-disposal): holdings-picker dropdown in Sell & Downsize wizard

### DIFF
--- a/src/components/features/independence/steps/QuickScenarios.tsx
+++ b/src/components/features/independence/steps/QuickScenarios.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import { AssetDisposal } from "types/independence"
 import MathInput from "@components/ui/MathInput"
+import { usePrivateAssetConfigs } from "@lib/assets/usePrivateAssetConfigs"
 
 interface QuickScenariosProps {
   appendDisposals: (disposals: AssetDisposal[]) => void
@@ -128,21 +129,7 @@ function SellAndDownsizeForm({
           className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
         />
       </div>
-      <div>
-        <label className="block text-xs font-medium text-gray-700 mb-1">
-          Asset ID
-        </label>
-        <input
-          type="text"
-          value={assetId}
-          onChange={(e) => setAssetId(e.target.value)}
-          placeholder="The tracked holding being disposed of (e.g. NZ-APT-AKL)"
-          className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
-        />
-        <p className="mt-1 text-[10px] text-gray-400">
-          Holding-picker UI coming soon — type a stable id for now.
-        </p>
-      </div>
+      <AssetPicker assetId={assetId} onChange={setAssetId} />
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label className="block text-xs font-medium text-gray-700 mb-1">
@@ -279,6 +266,69 @@ function SellAndDownsizeForm({
           Add events
         </button>
       </div>
+    </div>
+  )
+}
+
+interface AssetPickerProps {
+  assetId: string
+  onChange: (assetId: string) => void
+}
+
+/**
+ * Asset picker for the Sell & Downsize wizard. Lists the user's tracked
+ * private-asset configs (rental properties, primary residences), filtered
+ * to non-pension assets. Pensions, CPF and composite policies are
+ * disposal-incompatible — different cashflow semantics.
+ */
+function AssetPicker({
+  assetId,
+  onChange,
+}: AssetPickerProps): React.ReactElement {
+  const { configs, assetNames, isLoading } = usePrivateAssetConfigs()
+  const candidates = configs.filter((c) => !c.isPension)
+
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-700 mb-1">
+        Asset to dispose of
+      </label>
+      {isLoading ? (
+        <div className="px-3 py-2 text-xs text-gray-500 italic">
+          Loading your assets…
+        </div>
+      ) : candidates.length === 0 ? (
+        <div className="px-3 py-2 text-xs text-amber-700 bg-amber-50 rounded border border-amber-200">
+          No disposable assets configured. Add a property in the Assets tab,
+          or enter an Asset ID manually below.
+        </div>
+      ) : (
+        <select
+          value={assetId}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 bg-white"
+        >
+          <option value="">— Pick an asset —</option>
+          {candidates.map((c) => {
+            const name = assetNames[c.assetId] || c.assetId
+            const tag = c.isPrimaryResidence ? " (primary)" : ""
+            return (
+              <option key={c.assetId} value={c.assetId}>
+                {name}
+                {tag}
+              </option>
+            )
+          })}
+        </select>
+      )}
+      {/* Manual override — fallback when no tracked asset exists yet. */}
+      <input
+        type="text"
+        value={assetId}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Or type an asset id"
+        className="mt-1 w-full px-3 py-1.5 text-xs border border-gray-200 rounded-lg focus:ring-2 focus:ring-indigo-400"
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Replaces the free-text "Asset ID" input in the Sell & Downsize wizard with a dropdown of the user's tracked private asset configurations. Names come from the existing `usePrivateAssetConfigs` hook (which already exposes `assetNames` keyed by `assetId`).

## UX

- Dropdown lists non-pension private asset configs — pensions have different cashflow semantics and don't fit the disposal model.
- Primary residences kept (it's the canonical "sell my house and downsize" target) and tagged "(primary)" in the label so users see what they're picking.
- Manual fallback text field preserved below the dropdown — covers users with no tracked configs or assets not yet registered.

## Test plan

- [x] `yarn test` green (1282)
- [x] `yarn typecheck` green
- [x] `yarn lint` green
- [ ] Manual: open Sell & Downsize wizard, pick a tracked property, verify disposal record persists with the chosen `assetId`.
- [ ] Manual: fallback text field still works for users with no configs.

## Follow-up

- Dedicated AssetDisposal editor panel (list + edit + delete on plan).
- Per-asset value compounding at disposalAge (apply housingReturnRate).
- bc-data `currentValue` field for auto-fill (currently user-entered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced "Sell & Downsize Property" form with a new asset picker control. Users can now browse and select from their available private assets instead of manually typing asset IDs. The picker includes a manual entry option for direct asset ID input, along with improved loading and empty-state indicators for better user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/667)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->