### PR TITLE
feat(asset-disposal): editor panel + in-place edit

### DIFF
--- a/src/components/features/independence/steps/AssetDisposalsList.tsx
+++ b/src/components/features/independence/steps/AssetDisposalsList.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import {
   Control,
   useFieldArray,
@@ -7,6 +7,7 @@ import {
 } from "react-hook-form"
 import { AssetDisposal, WizardFormData } from "types/independence"
 import { usePrivateAssetConfigs } from "@lib/assets/usePrivateAssetConfigs"
+import MathInput from "@components/ui/MathInput"
 
 interface AssetDisposalsListProps {
   control: Control<WizardFormData>
@@ -23,7 +24,10 @@ interface AssetDisposalsListProps {
  * underlying values.
  *
  * Add new disposals via the Sell & Downsize wizard above; this panel
- * is the list + edit + delete surface for what's already on the plan.
+ * is the list + in-place edit + delete surface for what's already on
+ * the plan. assetId is intentionally not editable — to change the
+ * underlying asset, remove and re-add through the wizard so the
+ * holding-picker dropdown applies.
  */
 export default function AssetDisposalsList({
   control,
@@ -35,6 +39,7 @@ export default function AssetDisposalsList({
     name: "assetDisposals",
   })
   const { assetNames } = usePrivateAssetConfigs()
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
 
   if (fields.length === 0) return null
 
@@ -51,6 +56,7 @@ export default function AssetDisposalsList({
         const cashPct = disposal.cashRetainedPct ?? 0
         const txPct = disposal.txCostsPct ?? 0
         const replacementPct = Math.max(0, 100 - cashPct - txPct)
+        const isEditing = editingIndex === index
 
         return (
           <div
@@ -61,66 +67,251 @@ export default function AssetDisposalsList({
                 : "bg-gray-50 border-gray-200 opacity-60"
             }`}
           >
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex-1 space-y-1">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <i className="fas fa-home text-amber-600 text-xs"></i>
-                  <span className="text-sm font-medium text-gray-900">
-                    {name}
-                  </span>
-                  <span className="text-xs text-gray-500">
-                    @ age {disposal.disposalAge}
-                  </span>
-                  {!enabled && (
-                    <span className="text-[10px] uppercase tracking-wide text-gray-500 bg-gray-200 px-1.5 py-0.5 rounded">
-                      disabled
-                    </span>
-                  )}
-                </div>
-                {disposal.description && (
-                  <p className="text-xs text-gray-600 italic">
-                    {disposal.description}
-                  </p>
-                )}
-                <div className="text-xs text-gray-700 font-mono">
-                  ${disposal.currentValue.toLocaleString()}
-                  {" → "}
-                  {cashPct}% cash · {replacementPct}% replacement · {txPct}% costs
-                </div>
-              </div>
-              <div className="flex flex-col items-end gap-2 shrink-0">
-                <label className="inline-flex items-center gap-1.5 text-xs text-gray-700 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={enabled}
-                    onChange={(e) =>
-                      setValue(
-                        `assetDisposals.${index}.enabled`,
-                        e.target.checked,
-                      )
+            {isEditing ? (
+              <DisposalEditRow
+                disposal={disposal}
+                index={index}
+                name={name}
+                setValue={setValue}
+                onDone={() => setEditingIndex(null)}
+              />
+            ) : (
+              <div className="flex items-start justify-between gap-3">
+                <div
+                  className="flex-1 space-y-1 cursor-pointer"
+                  onClick={() => setEditingIndex(index)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      setEditingIndex(index)
                     }
-                    className="w-3.5 h-3.5 rounded text-amber-600 focus:ring-amber-500"
-                  />
-                  Enabled
-                </label>
-                <button
-                  type="button"
-                  onClick={() => remove(index)}
-                  className="text-xs text-red-600 hover:text-red-800"
-                  title="Remove disposal"
+                  }}
                 >
-                  <i className="fas fa-trash mr-1"></i>
-                  Remove
-                </button>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <i className="fas fa-home text-amber-600 text-xs"></i>
+                    <span className="text-sm font-medium text-gray-900">
+                      {name}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      @ age {disposal.disposalAge}
+                    </span>
+                    {!enabled && (
+                      <span className="text-[10px] uppercase tracking-wide text-gray-500 bg-gray-200 px-1.5 py-0.5 rounded">
+                        disabled
+                      </span>
+                    )}
+                  </div>
+                  {disposal.description && (
+                    <p className="text-xs text-gray-600 italic">
+                      {disposal.description}
+                    </p>
+                  )}
+                  <div className="text-xs text-gray-700 font-mono">
+                    ${disposal.currentValue.toLocaleString()}
+                    {" → "}
+                    {cashPct}% cash · {replacementPct}% replacement · {txPct}%
+                    costs
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-2 shrink-0">
+                  <label className="inline-flex items-center gap-1.5 text-xs text-gray-700 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={enabled}
+                      onChange={(e) =>
+                        setValue(
+                          `assetDisposals.${index}.enabled`,
+                          e.target.checked,
+                        )
+                      }
+                      className="w-3.5 h-3.5 rounded text-amber-600 focus:ring-amber-500"
+                    />
+                    Enabled
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => setEditingIndex(index)}
+                    className="text-xs text-amber-700 hover:text-amber-900"
+                    title="Edit disposal"
+                  >
+                    <i className="fas fa-edit mr-1"></i>
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => remove(index)}
+                    className="text-xs text-red-600 hover:text-red-800"
+                    title="Remove disposal"
+                  >
+                    <i className="fas fa-trash mr-1"></i>
+                    Remove
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
           </div>
         )
       })}
       <p className="text-[10px] text-gray-400 italic">
-        Toggle Enabled to model &ldquo;what if I don&rsquo;t sell?&rdquo;
-        without losing the disposal record.
+        Click any disposal to edit. Toggle Enabled to model &ldquo;what if I
+        don&rsquo;t sell?&rdquo; without losing the record.
       </p>
+    </div>
+  )
+}
+
+interface DisposalEditRowProps {
+  disposal: AssetDisposal
+  index: number
+  name: string
+  setValue: UseFormSetValue<WizardFormData>
+  onDone: () => void
+}
+
+/**
+ * Inline edit form for a single AssetDisposal record. Updates the
+ * underlying form-array entry via setValue so changes flow into the
+ * persisted plan on save. The asset identity (assetId) is read-only
+ * — changing which asset is being disposed of requires removing
+ * the record and re-adding through the wizard.
+ */
+function DisposalEditRow({
+  disposal,
+  index,
+  name,
+  setValue,
+  onDone,
+}: DisposalEditRowProps): React.ReactElement {
+  const cashPct = disposal.cashRetainedPct ?? 0
+  const txPct = disposal.txCostsPct ?? 0
+  const totalsValid = cashPct + txPct <= 100
+  const ageValid =
+    Number.isFinite(disposal.disposalAge) &&
+    disposal.disposalAge >= 18 &&
+    disposal.disposalAge <= 120
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <i className="fas fa-home text-amber-600 text-xs"></i>
+        <span className="text-sm font-medium text-gray-900">{name}</span>
+        <span className="text-[10px] text-gray-400">
+          (asset locked — remove + re-add to change)
+        </span>
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">
+          Description
+        </label>
+        <input
+          type="text"
+          value={disposal.description || ""}
+          onChange={(e) =>
+            setValue(`assetDisposals.${index}.description`, e.target.value)
+          }
+          className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Sale age
+          </label>
+          <input
+            type="number"
+            value={disposal.disposalAge || ""}
+            onChange={(e) =>
+              setValue(
+                `assetDisposals.${index}.disposalAge`,
+                parseInt(e.target.value) || 0,
+              )
+            }
+            min={18}
+            max={120}
+            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Current value
+          </label>
+          <div className="relative">
+            <span className="absolute left-3 top-2 text-gray-500 text-sm">
+              $
+            </span>
+            <MathInput
+              value={disposal.currentValue || ""}
+              onChange={(v) =>
+                setValue(`assetDisposals.${index}.currentValue`, v)
+              }
+              min={0}
+              className="w-full pl-7 pr-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+            />
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Cash retained (%)
+          </label>
+          <input
+            type="number"
+            value={cashPct}
+            onChange={(e) =>
+              setValue(
+                `assetDisposals.${index}.cashRetainedPct`,
+                parseFloat(e.target.value) || 0,
+              )
+            }
+            min={0}
+            max={100}
+            step={1}
+            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Tx costs (%)
+          </label>
+          <input
+            type="number"
+            value={txPct}
+            onChange={(e) =>
+              setValue(
+                `assetDisposals.${index}.txCostsPct`,
+                parseFloat(e.target.value) || 0,
+              )
+            }
+            min={0}
+            max={100}
+            step={0.5}
+            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+          />
+        </div>
+      </div>
+      {!totalsValid && (
+        <div className="text-xs text-red-600">
+          Cash retained + transaction costs must not exceed 100%.
+        </div>
+      )}
+      {!ageValid && (
+        <div className="text-xs text-red-600">
+          Sale age must be between 18 and 120.
+        </div>
+      )}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onDone}
+          disabled={!totalsValid || !ageValid}
+          className="px-3 py-1 bg-amber-600 text-white rounded text-xs font-medium hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Done
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/components/features/independence/steps/AssetDisposalsList.tsx
+++ b/src/components/features/independence/steps/AssetDisposalsList.tsx
@@ -1,0 +1,126 @@
+import React from "react"
+import {
+  Control,
+  useFieldArray,
+  useWatch,
+  UseFormSetValue,
+} from "react-hook-form"
+import { AssetDisposal, WizardFormData } from "types/independence"
+import { usePrivateAssetConfigs } from "@lib/assets/usePrivateAssetConfigs"
+
+interface AssetDisposalsListProps {
+  control: Control<WizardFormData>
+  setValue: UseFormSetValue<WizardFormData>
+}
+
+/**
+ * Editor for the plan's AssetDisposal records.
+ *
+ * Each disposal is bound to a specific tracked asset and triggers pool
+ * transfers + rental suppression at its `disposalAge`. The `enabled`
+ * toggle is the per-plan "what-if" switch — same disposal record can
+ * fire in one plan and stay dormant in another without editing the
+ * underlying values.
+ *
+ * Add new disposals via the Sell & Downsize wizard above; this panel
+ * is the list + edit + delete surface for what's already on the plan.
+ */
+export default function AssetDisposalsList({
+  control,
+  setValue,
+}: AssetDisposalsListProps): React.ReactElement | null {
+  const disposals = useWatch({ control, name: "assetDisposals" }) || []
+  const { fields, remove } = useFieldArray({
+    control,
+    name: "assetDisposals",
+  })
+  const { assetNames } = usePrivateAssetConfigs()
+
+  if (fields.length === 0) return null
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium text-gray-700">
+        Planned Asset Disposals ({fields.length})
+      </h3>
+      {fields.map((field, index) => {
+        const disposal = disposals[index] as AssetDisposal | undefined
+        if (!disposal) return null
+        const enabled = disposal.enabled !== false
+        const name = assetNames[disposal.assetId] || disposal.assetId
+        const cashPct = disposal.cashRetainedPct ?? 0
+        const txPct = disposal.txCostsPct ?? 0
+        const replacementPct = Math.max(0, 100 - cashPct - txPct)
+
+        return (
+          <div
+            key={field.id}
+            className={`p-3 rounded-lg border ${
+              enabled
+                ? "bg-amber-50 border-amber-200"
+                : "bg-gray-50 border-gray-200 opacity-60"
+            }`}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1 space-y-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <i className="fas fa-home text-amber-600 text-xs"></i>
+                  <span className="text-sm font-medium text-gray-900">
+                    {name}
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    @ age {disposal.disposalAge}
+                  </span>
+                  {!enabled && (
+                    <span className="text-[10px] uppercase tracking-wide text-gray-500 bg-gray-200 px-1.5 py-0.5 rounded">
+                      disabled
+                    </span>
+                  )}
+                </div>
+                {disposal.description && (
+                  <p className="text-xs text-gray-600 italic">
+                    {disposal.description}
+                  </p>
+                )}
+                <div className="text-xs text-gray-700 font-mono">
+                  ${disposal.currentValue.toLocaleString()}
+                  {" → "}
+                  {cashPct}% cash · {replacementPct}% replacement · {txPct}% costs
+                </div>
+              </div>
+              <div className="flex flex-col items-end gap-2 shrink-0">
+                <label className="inline-flex items-center gap-1.5 text-xs text-gray-700 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={enabled}
+                    onChange={(e) =>
+                      setValue(
+                        `assetDisposals.${index}.enabled`,
+                        e.target.checked,
+                      )
+                    }
+                    className="w-3.5 h-3.5 rounded text-amber-600 focus:ring-amber-500"
+                  />
+                  Enabled
+                </label>
+                <button
+                  type="button"
+                  onClick={() => remove(index)}
+                  className="text-xs text-red-600 hover:text-red-800"
+                  title="Remove disposal"
+                >
+                  <i className="fas fa-trash mr-1"></i>
+                  Remove
+                </button>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+      <p className="text-[10px] text-gray-400 italic">
+        Toggle Enabled to model &ldquo;what if I don&rsquo;t sell?&rdquo;
+        without losing the disposal record.
+      </p>
+    </div>
+  )
+}

--- a/src/components/features/independence/steps/LifeEventsStep.tsx
+++ b/src/components/features/independence/steps/LifeEventsStep.tsx
@@ -9,6 +9,7 @@ import { WizardFormData, LifeEvent } from "types/independence"
 import { StepHeader } from "../form"
 import QuickScenarios from "./QuickScenarios"
 import MathInput from "@components/ui/MathInput"
+import AssetDisposalsList from "./AssetDisposalsList"
 
 interface LifeEventsStepProps {
   control: Control<WizardFormData>
@@ -84,6 +85,8 @@ export default function LifeEventsStep({
           disposals.forEach((d) => appendDisposal(d))
         }
       />
+
+      <AssetDisposalsList control={control} setValue={setValue} />
 
       {/* Add new event form */}
       <div className="bg-gray-50 rounded-lg p-4 space-y-4">


### PR DESCRIPTION
## Summary

Two-part addition for the AssetDisposal flow:

1. **AssetDisposalsList panel** (re-included — PR #668 was merged into the picker branch, not main) — list view under the Sell & Downsize wizard with asset name, age, value, split breakdown, per-row Enabled toggle, Remove.
2. **In-place edit** — clicking any disposal row (or the Edit button) expands it into an inline form with editable fields:
   - description
   - sale age (validated 18..120)
   - current value (MathInput supports `1m` / `500k` shorthand)
   - cash retained % / transaction costs % (validated `cash + tx ≤ 100`)

Changes write straight back to `formData.assetDisposals[i]` via `setValue` so they flow into the persisted plan on save. Done collapses the row.

`assetId` is read-only while editing — re-binding to a different holding requires removing the record and re-adding through the wizard so the holding-picker dropdown applies.

## Why this PR carries the editor panel

PR #668 was merged into `feat/asset-disposal-picker`, which then merged to main as PR #667. The editor commit didn't survive the squash. Cherry-picked here so the file lands on main alongside the in-place edit work.

## Test plan

- [x] `yarn test` green (1282)
- [x] `yarn typecheck` green
- [x] `yarn lint` green
- [ ] Manual: add a disposal via wizard, confirm it appears in the list.
- [ ] Manual: click a row, edit age/values/%s, hit Done, save plan, reload — changes persist.
- [ ] Manual: toggle Enabled off, save, run projection — disposal not applied; toggle back, applied again.
- [ ] Manual: invalid totals (cash + tx > 100) keep Done disabled.

## Follow-up

- `currentValue` autofill from positions (upstream svc-data / svc-position extension).
- Editable assetId via in-place asset picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added asset disposal management capabilities enabling users to track multiple asset disposals with details including disposal age, current value, cash retention percentage, and transaction costs. Users can toggle disposals on/off and edit disposal information inline with real-time validation to ensure valid cost allocation and age ranges.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/669)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->