### PR TITLE
feat(asset-disposal): autofill currentValue from /assets/values

### DIFF
--- a/src/components/features/independence/steps/QuickScenarios.tsx
+++ b/src/components/features/independence/steps/QuickScenarios.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react"
 import { AssetDisposal } from "types/independence"
 import MathInput from "@components/ui/MathInput"
 import { usePrivateAssetConfigs } from "@lib/assets/usePrivateAssetConfigs"
+import { useAssetValues } from "@lib/assets/useAssetValues"
 
 interface QuickScenariosProps {
   appendDisposals: (disposals: AssetDisposal[]) => void
@@ -129,7 +130,18 @@ function SellAndDownsizeForm({
           className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
         />
       </div>
-      <AssetPicker assetId={assetId} onChange={setAssetId} />
+      <AssetPicker
+        assetId={assetId}
+        onChange={(id, value) => {
+          setAssetId(id)
+          // Autofill currentValue from svc-retire on pick. Only overwrite
+          // when we have a non-zero value AND the user hasn't already typed
+          // a custom one — keeps the field editable after autofill.
+          if (value && value > 0 && currentValue === 0) {
+            setCurrentValue(value)
+          }
+        }}
+      />
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label className="block text-xs font-medium text-gray-700 mb-1">
@@ -272,7 +284,13 @@ function SellAndDownsizeForm({
 
 interface AssetPickerProps {
   assetId: string
-  onChange: (assetId: string) => void
+  /**
+   * Fires when the selection changes. `value` is the autofilled current
+   * market value (from svc-retire's `/assets/values`) when available;
+   * `undefined` when no value is known (e.g. manual text entry, asset
+   * not tracked in svc-position).
+   */
+  onChange: (assetId: string, value?: number) => void
 }
 
 /**
@@ -280,12 +298,16 @@ interface AssetPickerProps {
  * private-asset configs (rental properties, primary residences), filtered
  * to non-pension assets. Pensions, CPF and composite policies are
  * disposal-incompatible — different cashflow semantics.
+ *
+ * On selection, looks up the asset's current market value via
+ * `useAssetValues` so the wizard can autofill its currentValue field.
  */
 function AssetPicker({
   assetId,
   onChange,
 }: AssetPickerProps): React.ReactElement {
   const { configs, assetNames, isLoading } = usePrivateAssetConfigs()
+  const { values: assetValues } = useAssetValues()
   const candidates = configs.filter((c) => !c.isPension)
 
   return (
@@ -305,17 +327,20 @@ function AssetPicker({
       ) : (
         <select
           value={assetId}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => onChange(e.target.value, assetValues[e.target.value])}
           className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 bg-white"
         >
           <option value="">— Pick an asset —</option>
           {candidates.map((c) => {
             const name = assetNames[c.assetId] || c.assetId
             const tag = c.isPrimaryResidence ? " (primary)" : ""
+            const value = assetValues[c.assetId]
+            const valueLabel = value ? ` — $${Math.round(value).toLocaleString()}` : ""
             return (
               <option key={c.assetId} value={c.assetId}>
                 {name}
                 {tag}
+                {valueLabel}
               </option>
             )
           })}
@@ -325,7 +350,7 @@ function AssetPicker({
       <input
         type="text"
         value={assetId}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => onChange(e.target.value, assetValues[e.target.value])}
         placeholder="Or type an asset id"
         className="mt-1 w-full px-3 py-1.5 text-xs border border-gray-200 rounded-lg focus:ring-2 focus:ring-indigo-400"
       />

--- a/src/components/features/independence/steps/QuickScenarios.tsx
+++ b/src/components/features/independence/steps/QuickScenarios.tsx
@@ -79,6 +79,11 @@ function SellAndDownsizeForm({
   const [description, setDescription] = useState("Sell and downsize property")
   const [age, setAge] = useState<number>(defaultAge ?? 65)
   const [currentValue, setCurrentValue] = useState<number>(0)
+  // Distinguishes user-typed edits from picker-driven autofills. Once true,
+  // the picker stops overwriting the field on subsequent asset selections —
+  // the user's explicit number wins. Picking a different asset BEFORE any
+  // edit refreshes the autofill (reflecting the new asset's market value).
+  const [isCurrentValueDirty, setIsCurrentValueDirty] = useState(false)
   const [cashRetainedPct, setCashRetainedPct] = useState<number>(50)
   const [txCostsPct, setTxCostsPct] = useState<number>(5)
   // assetId — picker UI lands in a follow-up that introduces a holdings
@@ -134,10 +139,11 @@ function SellAndDownsizeForm({
         assetId={assetId}
         onChange={(id, value) => {
           setAssetId(id)
-          // Autofill currentValue from svc-retire on pick. Only overwrite
-          // when we have a non-zero value AND the user hasn't already typed
-          // a custom one — keeps the field editable after autofill.
-          if (value && value > 0 && currentValue === 0) {
+          // Autofill from svc-retire on pick. Only overwrite when the user
+          // hasn't typed a custom value yet — tracked explicitly via
+          // isCurrentValueDirty so switching assets still refreshes the
+          // autofill as long as the field hasn't been edited.
+          if (value && value > 0 && !isCurrentValueDirty) {
             setCurrentValue(value)
           }
         }}
@@ -166,7 +172,10 @@ function SellAndDownsizeForm({
             </span>
             <MathInput
               value={currentValue || ""}
-              onChange={(v) => setCurrentValue(v)}
+              onChange={(v) => {
+                setCurrentValue(v)
+                setIsCurrentValueDirty(true)
+              }}
               min={0}
               placeholder="e.g. 1m or 1000000"
               className="w-full pl-7 pr-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500"
@@ -346,11 +355,14 @@ function AssetPicker({
           })}
         </select>
       )}
-      {/* Manual override — fallback when no tracked asset exists yet. */}
+      {/* Manual override — fallback when no tracked asset exists yet.
+          No value lookup here: a manually typed assetId is for unknown
+          / unregistered assets, and the wizard's currentValue field is
+          left for the user to fill. */}
       <input
         type="text"
         value={assetId}
-        onChange={(e) => onChange(e.target.value, assetValues[e.target.value])}
+        onChange={(e) => onChange(e.target.value)}
         placeholder="Or type an asset id"
         className="mt-1 w-full px-3 py-1.5 text-xs border border-gray-200 rounded-lg focus:ring-2 focus:ring-indigo-400"
       />

--- a/src/lib/utils/assets/useAssetValues.ts
+++ b/src/lib/utils/assets/useAssetValues.ts
@@ -1,0 +1,43 @@
+import useSWR from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+
+interface AssetValuesResponse {
+  data: Record<string, number>
+  currency?: string
+}
+
+interface UseAssetValuesResult {
+  /** Map of assetId → current market value summed across the user's portfolios. */
+  values: Record<string, number>
+  /** Currency the values are expressed in, when known. */
+  currency: string | undefined
+  isLoading: boolean
+  error: Error | undefined
+}
+
+/**
+ * Per-asset current market values from svc-retire's `/assets/values`
+ * endpoint. Used by the AssetDisposal wizard's holdings picker to
+ * autofill `currentValue` when the user selects a tracked asset.
+ *
+ * One fetch on mount, cached by SWR. Pass `targetCurrency` to receive
+ * values pre-converted by svc-position; otherwise each portfolio's
+ * native currency is summed naively (avoid for mixed-currency users).
+ */
+export function useAssetValues(targetCurrency?: string): UseAssetValuesResult {
+  const url = targetCurrency
+    ? `/api/assets/values?currency=${encodeURIComponent(targetCurrency)}`
+    : "/api/assets/values"
+
+  const { data, error, isLoading } = useSWR<AssetValuesResponse>(
+    url,
+    simpleFetcher(url),
+  )
+
+  return {
+    values: data?.data || {},
+    currency: data?.currency,
+    isLoading,
+    error,
+  }
+}

--- a/src/pages/api/assets/values.ts
+++ b/src/pages/api/assets/values.ts
@@ -1,0 +1,16 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getRetireUrl } from "@utils/api/bcConfig"
+
+/**
+ * Proxies `GET /assets/values` to svc-retire. Returns the authenticated
+ * user's per-asset market values keyed by `assetId`, used by the
+ * AssetDisposal wizard to autofill `currentValue` when an asset is
+ * selected from the holdings picker.
+ *
+ * Optional `?currency=NZD` query parameter forwards to svc-retire for
+ * pre-conversion.
+ */
+export default createApiHandler({
+  url: getRetireUrl("/assets/values"),
+  methods: ["GET"],
+})


### PR DESCRIPTION
## Summary

Closes the disposal-wizard's "user has to retype today's market value" hole. The Sell & Downsize picker now consults svc-retire's `GET /assets/values` endpoint, looks up the selected holding's current market value, and populates the wizard's `currentValue` field on selection.

Backend dependency: [svc-retire #11](https://github.com/monowai/svc-retire/pull/11) (merged).