### PR TITLE
feat(holdings): Trade action in row menu, mobile flip-up

### DIFF
--- a/src/components/features/chat/ChatPanel.tsx
+++ b/src/components/features/chat/ChatPanel.tsx
@@ -75,7 +75,8 @@ export default function ChatPanel({
     const el = messagesContainerRef.current
     if (!el) return
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-    stickToBottomRef.current = distanceFromBottom <= STICK_TO_BOTTOM_THRESHOLD_PX
+    stickToBottomRef.current =
+      distanceFromBottom <= STICK_TO_BOTTOM_THRESHOLD_PX
   }
 
   useEffect(() => {

--- a/src/components/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/components/features/chat/__tests__/ChatPanel.test.tsx
@@ -137,9 +137,7 @@ describe("ChatPanel", () => {
 
   it("renders Cancel button while loading when onCancel provided, replacing Send", () => {
     const onCancel = jest.fn()
-    render(
-      <ChatPanel {...defaultProps} isLoading={true} onCancel={onCancel} />,
-    )
+    render(<ChatPanel {...defaultProps} isLoading={true} onCancel={onCancel} />)
     expect(
       screen.queryByRole("button", { name: /send/i }),
     ).not.toBeInTheDocument()

--- a/src/components/features/holdings/ActionsMenus.tsx
+++ b/src/components/features/holdings/ActionsMenus.tsx
@@ -183,6 +183,14 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
     useDropdownMenu()
   const assetCode = stripOwnerPrefix(asset.code)
 
+  const tradePayload = (): QuickSellData => ({
+    asset: assetCode,
+    market: asset.market.code,
+    quantity,
+    price,
+    held,
+  })
+
   const handle =
     (fn: () => void): ((e: React.MouseEvent) => void) =>
     (e) => {
@@ -216,30 +224,14 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
                 <MenuItem
                   iconClass="fas fa-right-left text-emerald-500 w-4"
                   label="Trade"
-                  onClick={handle(() =>
-                    onTrade({
-                      asset: assetCode,
-                      market: asset.market.code,
-                      quantity,
-                      price,
-                      held,
-                    }),
-                  )}
+                  onClick={handle(() => onTrade(tradePayload()))}
                 />
               )}
               {onQuickSell && (
                 <MenuItem
                   iconClass="fas fa-money-bill-transfer text-red-500 w-4"
                   label="Quick Sell"
-                  onClick={handle(() =>
-                    onQuickSell({
-                      asset: assetCode,
-                      market: asset.market.code,
-                      quantity,
-                      price,
-                      held,
-                    }),
-                  )}
+                  onClick={handle(() => onQuickSell(tradePayload()))}
                 />
               )}
               {onCorporateActions && (

--- a/src/components/features/holdings/ActionsMenus.tsx
+++ b/src/components/features/holdings/ActionsMenus.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
 import { createPortal } from "react-dom"
 import {
   Asset,
@@ -55,6 +61,21 @@ const useDropdownMenu = (): UseDropdownMenuResult => {
       setMenuPos({ top: rect.bottom + 4, left })
     }
   }, [])
+
+  // Flip above the button if menu overflows below. useLayoutEffect avoids
+  // a paint with menu rendered below before reposition (common on mobile
+  // when trigger sits in the last visible row).
+  useLayoutEffect(() => {
+    if (!isOpen || !menuRef.current || !buttonRef.current) return
+    const rect = buttonRef.current.getBoundingClientRect()
+    const menuH = menuRef.current.offsetHeight
+    const spaceBelow = window.innerHeight - rect.bottom - VIEWPORT_MARGIN
+    const spaceAbove = rect.top - VIEWPORT_MARGIN
+    if (menuH > spaceBelow && spaceAbove > spaceBelow) {
+      const top = Math.max(VIEWPORT_MARGIN, rect.top - menuH - 4)
+      setMenuPos((prev) => (prev.top === top ? prev : { ...prev, top }))
+    }
+  }, [isOpen])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent): void => {
@@ -124,6 +145,7 @@ export interface ActionsMenuProps {
   tradeCurrency: { code: string; symbol: string; name: string }
   valueIn: string
   held?: Record<string, number>
+  onTrade?: (data: QuickSellData) => void
   onQuickSell?: (data: QuickSellData) => void
   onCorporateActions?: (data: CorporateActionsData) => void
   onSetPrice?: (data: SetPriceData) => void
@@ -146,6 +168,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
   costBasis,
   tradeCurrency,
   held,
+  onTrade,
   onQuickSell,
   onCorporateActions,
   onSetPrice,
@@ -185,10 +208,25 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
         createPortal(
           <div
             ref={menuRef}
-            className="fixed w-48 bg-white rounded-lg shadow-xl z-50 border border-slate-200"
+            className="fixed w-48 max-h-[80vh] overflow-y-auto bg-white rounded-lg shadow-xl z-50 border border-slate-200"
             style={{ top: menuPos.top, left: menuPos.left }}
           >
             <div className="py-1">
+              {onTrade && (
+                <MenuItem
+                  iconClass="fas fa-right-left text-emerald-500 w-4"
+                  label="Trade"
+                  onClick={handle(() =>
+                    onTrade({
+                      asset: assetCode,
+                      market: asset.market.code,
+                      quantity,
+                      price,
+                      held,
+                    }),
+                  )}
+                />
+              )}
               {onQuickSell && (
                 <MenuItem
                   iconClass="fas fa-money-bill-transfer text-red-500 w-4"
@@ -354,7 +392,7 @@ export const CashActionsMenu: React.FC<CashActionsMenuProps> = ({
         createPortal(
           <div
             ref={menuRef}
-            className="fixed w-48 bg-white rounded-lg shadow-xl z-50 border border-slate-200"
+            className="fixed w-48 max-h-[80vh] overflow-y-auto bg-white rounded-lg shadow-xl z-50 border border-slate-200"
             style={{ top: menuPos.top, left: menuPos.left }}
           >
             <div className="py-1">

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -36,6 +36,7 @@ import {
 } from "@components/features/holdings/ActionsMenus"
 
 interface SharedActionHandlers {
+  onTrade?: (data: QuickSellData) => void
   onQuickSell?: (data: QuickSellData) => void
   onCorporateActions?: (data: CorporateActionsData) => void
   onSetPrice?: (data: SetPriceData) => void
@@ -241,6 +242,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
   portfolio,
   valueIn,
   sourceCurrency,
+  onTrade,
   onQuickSell,
   onCorporateActions,
   onSetPrice,
@@ -283,7 +285,8 @@ const PositionCard: React.FC<PositionCardProps> = ({
 
   const hasActions =
     (!isCashRelated(asset) &&
-      (!!onQuickSell ||
+      (!!onTrade ||
+        !!onQuickSell ||
         !!onCorporateActions ||
         !!onCostAdjust ||
         !!onMovePosition ||
@@ -319,6 +322,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
             costBasis={tradeMoney?.costBasis || 0}
             tradeCurrency={tradeCurrency}
             valueIn={valueIn}
+            onTrade={isCashRelated(asset) ? undefined : onTrade}
             onQuickSell={isCashRelated(asset) ? undefined : onQuickSell}
             onCorporateActions={
               isCashRelated(asset) ? undefined : onCorporateActions
@@ -451,6 +455,7 @@ const CardView: React.FC<CardViewProps> = ({
   valueIn,
   groupBy,
   isMixedCurrencies = false,
+  onTrade,
   onQuickSell,
   onCorporateActions,
   onSetPrice,
@@ -678,6 +683,7 @@ const CardView: React.FC<CardViewProps> = ({
                     portfolio={portfolio}
                     valueIn={valueIn}
                     sourceCurrency={sourceCurrency}
+                    onTrade={onTrade}
                     onQuickSell={onQuickSell}
                     onCorporateActions={onCorporateActions}
                     onSetPrice={onSetPrice}

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -50,6 +50,7 @@ export interface PriceChartData {
 
 interface RowsProps extends HoldingValues {
   onColumnsChange: (columns: string[]) => void
+  onTrade?: (data: QuickSellData) => void
   onQuickSell?: (data: QuickSellData) => void
   onCorporateActions?: (data: CorporateActionsData) => void
   onWeightClick?: (data: WeightClickData) => void
@@ -78,6 +79,7 @@ export default function Rows({
   groupBy,
   valueIn,
   onColumnsChange,
+  onTrade,
   onQuickSell,
   onCorporateActions,
   onWeightClick,
@@ -183,7 +185,8 @@ export default function Rows({
                   )}
                 </div>
                 {(!isCashRelated(asset) &&
-                  (onQuickSell ||
+                  (onTrade ||
+                    onQuickSell ||
                     onCorporateActions ||
                     onCostAdjust ||
                     onRecordIncome ||
@@ -209,6 +212,7 @@ export default function Rows({
                       }
                       valueIn={valueIn}
                       held={held}
+                      onTrade={isCashRelated(asset) ? undefined : onTrade}
                       onQuickSell={
                         isCashRelated(asset) ? undefined : onQuickSell
                       }

--- a/src/components/features/holdings/__tests__/QuickSell.test.tsx
+++ b/src/components/features/holdings/__tests__/QuickSell.test.tsx
@@ -58,9 +58,74 @@ const tradedPosition = (
 describe("Quick Sell Feature via Actions Menu", () => {
   const mockOnColumnsChange = jest.fn()
   const mockOnQuickSell = jest.fn()
+  const mockOnTrade = jest.fn()
 
   beforeEach(() => {
     jest.clearAllMocks()
+  })
+
+  describe("Trade menu item", () => {
+    it("renders Trade above Quick Sell and calls onTrade with position data", () => {
+      const positions = [tradedPosition("AAPL", "NASDAQ", 100, 150)]
+
+      render(
+        <table>
+          <Rows
+            portfolio={mockPortfolio}
+            groupBy="Equity"
+            holdingGroup={makeHoldingGroup({ positions })}
+            valueIn={ValueIn.PORTFOLIO}
+            onColumnsChange={mockOnColumnsChange}
+            onQuickSell={mockOnQuickSell}
+            onTrade={mockOnTrade}
+          />
+        </table>,
+      )
+
+      const actionsButton = screen.getByRole("button", { name: /actions/i })
+      fireEvent.click(actionsButton)
+
+      const tradeItem = screen.getByRole("button", { name: /^trade$/i })
+      const sellItem = screen.getByRole("button", { name: /quick sell/i })
+
+      // Trade rendered before Quick Sell
+      expect(
+        tradeItem.compareDocumentPosition(sellItem) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).not.toBe(0)
+
+      fireEvent.click(tradeItem)
+      expect(mockOnTrade).toHaveBeenCalledTimes(1)
+      // Menu forwards position data only. Caller (handleTrade in
+      // holdings/[code].tsx) applies `type: "BUY"`.
+      expect(mockOnTrade).toHaveBeenCalledWith({
+        asset: "AAPL",
+        market: "NASDAQ",
+        quantity: 100,
+        price: 150,
+        held: undefined,
+      })
+    })
+
+    it("does not render Trade item when onTrade not provided", () => {
+      const positions = [tradedPosition("AAPL", "NASDAQ", 100, 150)]
+
+      render(
+        <table>
+          <Rows
+            portfolio={mockPortfolio}
+            groupBy="Equity"
+            holdingGroup={makeHoldingGroup({ positions })}
+            valueIn={ValueIn.PORTFOLIO}
+            onColumnsChange={mockOnColumnsChange}
+            onQuickSell={mockOnQuickSell}
+          />
+        </table>,
+      )
+
+      fireEvent.click(screen.getByRole("button", { name: /actions/i }))
+      expect(screen.queryByRole("button", { name: /^trade$/i })).toBeNull()
+    })
   })
 
   describe("Desktop/Tablet Mode", () => {

--- a/src/components/features/independence/steps/LifeEventsStep.tsx
+++ b/src/components/features/independence/steps/LifeEventsStep.tsx
@@ -164,7 +164,10 @@ export default function LifeEventsStep({
               Expense
             </button>
           </div>
-          <div className="flex gap-2" title="Which asset pool this cashflow affects">
+          <div
+            className="flex gap-2"
+            title="Which asset pool this cashflow affects"
+          >
             <button
               type="button"
               onClick={() => setNewEvent({ ...newEvent, assetType: "liquid" })}

--- a/src/components/features/independence/steps/QuickScenarios.tsx
+++ b/src/components/features/independence/steps/QuickScenarios.tsx
@@ -194,7 +194,9 @@ function SellAndDownsizeForm({
           <input
             type="number"
             value={cashRetainedPct}
-            onChange={(e) => setCashRetainedPct(parseFloat(e.target.value) || 0)}
+            onChange={(e) =>
+              setCashRetainedPct(parseFloat(e.target.value) || 0)
+            }
             min={0}
             max={100}
             step={1}
@@ -224,9 +226,7 @@ function SellAndDownsizeForm({
           </div>
           <div className="flex justify-between">
             <span>Sell existing property (illiquid out)</span>
-            <span className="font-mono">
-              -${currentValue.toLocaleString()}
-            </span>
+            <span className="font-mono">-${currentValue.toLocaleString()}</span>
           </div>
           {newPropertyValue > 0 && (
             <div className="flex justify-between">
@@ -330,13 +330,15 @@ function AssetPicker({
         </div>
       ) : candidates.length === 0 ? (
         <div className="px-3 py-2 text-xs text-amber-700 bg-amber-50 rounded border border-amber-200">
-          No disposable assets configured. Add a property in the Assets tab,
-          or enter an Asset ID manually below.
+          No disposable assets configured. Add a property in the Assets tab, or
+          enter an Asset ID manually below.
         </div>
       ) : (
         <select
           value={assetId}
-          onChange={(e) => onChange(e.target.value, assetValues[e.target.value])}
+          onChange={(e) =>
+            onChange(e.target.value, assetValues[e.target.value])
+          }
           className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 bg-white"
         >
           <option value="">— Pick an asset —</option>
@@ -344,7 +346,9 @@ function AssetPicker({
             const name = assetNames[c.assetId] || c.assetId
             const tag = c.isPrimaryResidence ? " (primary)" : ""
             const value = assetValues[c.assetId]
-            const valueLabel = value ? ` — $${Math.round(value).toLocaleString()}` : ""
+            const valueLabel = value
+              ? ` — $${Math.round(value).toLocaleString()}`
+              : ""
             return (
               <option key={c.assetId} value={c.assetId}>
                 {name}

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -144,6 +144,11 @@ function HoldingsPage(): React.ReactElement {
     setQuickSellData(data)
   }, [])
 
+  // Trade action — opens trade modal pre-filled, defaulting to BUY
+  const handleTrade = useCallback((data: QuickSellData) => {
+    setQuickSellData({ ...data, type: "BUY" })
+  }, [])
+
   // Clear quick sell data when modal closes
   const handleQuickSellHandled = useCallback(() => {
     setQuickSellData(undefined)
@@ -498,6 +503,7 @@ function HoldingsPage(): React.ReactElement {
                           holdingGroup={holdings.holdingGroups[groupKey]}
                           valueIn={holdingState.valueIn.value}
                           onColumnsChange={setColumns}
+                          onTrade={handleTrade}
                           onQuickSell={handleQuickSell}
                           onCorporateActions={handleCorporateActions}
                           onWeightClick={handleWeightClick}
@@ -541,6 +547,7 @@ function HoldingsPage(): React.ReactElement {
             valueIn={holdingState.valueIn.value}
             groupBy={holdingState.groupBy.value}
             isMixedCurrencies={holdingResults.isMixedCurrencies}
+            onTrade={handleTrade}
             onQuickSell={handleQuickSell}
             onCorporateActions={handleCorporateActions}
             onSetPrice={handleSetPrice}


### PR DESCRIPTION
## Summary

- **Trade** menu item added above Quick Sell on every holding row/card. Opens the existing `TradeInputForm` pre-filled with the asset, defaulting to BUY — no more toggling from Sell to add to a position.
- **Mobile flip-up**: `ActionsMenu` now flips above the trigger when the dropdown would overflow below. Fixes menu cutoff on the last row in mobile viewports. `useLayoutEffect` placement to avoid a paint with menu below before reposition.
- **Scrollable fallback** (`max-h-[80vh] overflow-y-auto`) on `ActionsMenu` and `CashActionsMenu` for screens too short to fit a flipped menu either way.
- Plumbed `onTrade` callback through `Rows`, `CardView` (incl. `PositionCard`, `SharedActionHandlers`), and `pages/holdings/[code].tsx` (`handleTrade` sets `type: "BUY"`).
- Tests in `QuickSell.test.tsx` cover ordering (Trade above Quick Sell), payload forwarded to caller, and absence when `onTrade` not provided.

## Test plan

- [x] `yarn test` — 1284 passing
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] Browser-verified at localhost (bc-view pointed at kauri): Trade item opens form with BUY pre-selected, asset prefilled
- [ ] Visual check on a real mobile device for last-row flip-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Trade action to holdings/position menus with quick access to the trade modal (pre-fills trade details).
  * Dropdowns now auto-reposition when space is limited and support vertical scrolling for long menus.

* **Minor Improvements**
  * Small UI/presentation refinements across chat, life-events, and scenario flows.

* **Tests**
  * Added tests covering the new Trade menu behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/671)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->