### PR TITLE
fix(wealth): period-relative TWR for 1y Wealth Performance

### DIFF
--- a/src/components/features/wealth/WealthPerformanceChart.tsx
+++ b/src/components/features/wealth/WealthPerformanceChart.tsx
@@ -56,8 +56,9 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
       returnPct: last.cumulativeReturn * 100,
       growthOf1000: last.growthOf1000,
       marketValue: last.marketValue,
-      contributed: last.netContributions,
-      gain: last.investmentGain,
+      contributed: last.netContributions, // period-only
+      lifetimeContributed: last.lifetimeContributions,
+      gain: last.investmentGain, // period gain
     }
   }, [series])
 
@@ -163,8 +164,11 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
                   <div className="text-2xl font-mono font-bold tracking-tight text-gray-900">
                     {fmtCompact(stats.marketValue)}
                   </div>
-                  <div className="text-xs text-gray-400 font-mono mt-0.5">
-                    {fmtCompact(stats.contributed)} contributed
+                  <div
+                    className="text-xs text-gray-400 font-mono mt-0.5"
+                    title={`Lifetime contributed: ${fmtFull(stats.lifetimeContributed)}`}
+                  >
+                    {fmtCompact(stats.contributed)} contributed (period)
                   </div>
                 </div>
 
@@ -180,8 +184,8 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
                     {fmtCompact(stats.gain)}
                   </div>
                   <div className="text-xs text-gray-400 font-mono mt-0.5">
-                    {stats.contributed !== 0
-                      ? `${((stats.gain / Math.abs(stats.contributed)) * 100).toFixed(1)}% on cost`
+                    {stats.lifetimeContributed !== 0
+                      ? `${((stats.gain / Math.abs(stats.lifetimeContributed)) * 100).toFixed(1)}% on cost`
                       : "\u00A0"}
                   </div>
                 </div>

--- a/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
+++ b/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
@@ -51,7 +51,8 @@ const mockSeries = [
   {
     date: "2024-01-01",
     marketValue: 100000,
-    netContributions: 100000,
+    netContributions: 0,
+    lifetimeContributions: 100000,
     cumulativeDividends: 0,
     investmentGain: 0,
     growthOf1000: 1000,
@@ -60,7 +61,8 @@ const mockSeries = [
   {
     date: "2024-06-01",
     marketValue: 112000,
-    netContributions: 105000,
+    netContributions: 5000,
+    lifetimeContributions: 105000,
     cumulativeDividends: 500,
     investmentGain: 7000,
     growthOf1000: 1120,
@@ -69,7 +71,8 @@ const mockSeries = [
   {
     date: "2024-12-01",
     marketValue: 125000,
-    netContributions: 110000,
+    netContributions: 10000,
+    lifetimeContributions: 110000,
     cumulativeDividends: 1200,
     investmentGain: 15000,
     growthOf1000: 1250,

--- a/src/hooks/__tests__/useAggregatedPerformance.test.ts
+++ b/src/hooks/__tests__/useAggregatedPerformance.test.ts
@@ -23,6 +23,23 @@ const makePortfolio = (code: string, currencyCode: string): Portfolio => ({
   irr: 0.05,
 })
 
+type CapturedFetcher = (() => Promise<unknown>) | null
+
+const captureFetcher = (): { ref: { current: CapturedFetcher } } => {
+  const ref: { current: CapturedFetcher } = { current: null }
+  mockUseSwr.mockImplementation((_key: unknown, fetcher: unknown) => {
+    if (typeof fetcher === "function") {
+      ref.current = fetcher as () => Promise<unknown>
+    }
+    return {
+      data: undefined,
+      isLoading: false,
+      error: undefined,
+    } as ReturnType<typeof useSwr>
+  })
+  return { ref }
+}
+
 describe("useAggregatedPerformance", () => {
   beforeEach(() => {
     mockUseSwr.mockReset()
@@ -39,7 +56,6 @@ describe("useAggregatedPerformance", () => {
       useAggregatedPerformance([], 12, {}, "USD", true),
     )
 
-    // Key should be null (disabled) → no fetch
     expect(mockUseSwr).toHaveBeenCalledWith(
       null,
       expect.any(Function),
@@ -61,7 +77,6 @@ describe("useAggregatedPerformance", () => {
       useAggregatedPerformance(portfolios, 12, { USD: 1 }, "USD", false),
     )
 
-    // Key should be null when disabled
     expect(mockUseSwr).toHaveBeenCalledWith(
       null,
       expect.any(Function),
@@ -112,44 +127,6 @@ describe("useAggregatedPerformance", () => {
     expect(result.current.series).toEqual([])
   })
 
-  it("returns series data from SWR", () => {
-    const mockData = [
-      {
-        date: "2025-01-01",
-        marketValue: 8000,
-        netContributions: 8000,
-        cumulativeDividends: 0,
-        investmentGain: 0,
-        growthOf1000: 1000,
-        cumulativeReturn: 0,
-      },
-      {
-        date: "2025-02-01",
-        marketValue: 8500,
-        netContributions: 8000,
-        cumulativeDividends: 50,
-        investmentGain: 500,
-        growthOf1000: 1063,
-        cumulativeReturn: 0.0625,
-      },
-    ]
-
-    mockUseSwr.mockReturnValue({
-      data: mockData,
-      isLoading: false,
-      error: undefined,
-    } as unknown as ReturnType<typeof useSwr>)
-
-    const portfolios = [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")]
-    const { result } = renderHook(() =>
-      useAggregatedPerformance(portfolios, 12, { USD: 1 }, "USD", true),
-    )
-
-    expect(result.current.series).toHaveLength(2)
-    expect(result.current.series[0].marketValue).toBe(8000)
-    expect(result.current.series[1].investmentGain).toBe(500)
-  })
-
   it("returns error from SWR", () => {
     const err = new Error("Network failure")
     mockUseSwr.mockReturnValue({
@@ -167,186 +144,441 @@ describe("useAggregatedPerformance", () => {
     expect(result.current.series).toEqual([])
   })
 
-  it("exercises the SWR fetcher for two same-currency portfolios", async () => {
-    // Capture the fetcher that useAggregatedPerformance passes to useSwr
-    let capturedFetcher: (() => Promise<unknown>) | null = null
-    mockUseSwr.mockImplementation((_key: unknown, fetcher: unknown) => {
-      if (typeof fetcher === "function") {
-        capturedFetcher = fetcher as () => Promise<unknown>
-      }
-      return {
-        data: undefined,
-        isLoading: false,
-        error: undefined,
-      } as ReturnType<typeof useSwr>
-    })
-
-    const portfolios = [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")]
-
-    renderHook(() =>
-      useAggregatedPerformance(portfolios, 12, { USD: 1 }, "USD", true),
-    )
-
-    expect(capturedFetcher).not.toBeNull()
-
-    // Mock global fetch
-    const dates = ["2025-01-01", "2025-02-01"]
-    const makeSeries = (mv: number): object[] =>
-      dates.map((date, i) => ({
-        date,
-        growthOf1000: 1000 + i * 10,
-        marketValue: mv + i * 100,
-        netContributions: mv,
-        cumulativeReturn: (i * 100) / mv,
-        cumulativeDividends: i * 5,
-      }))
-
-    const originalFetch = global.fetch
-    global.fetch = jest.fn().mockImplementation((url: string) => {
-      const data = url.includes("P1")
-        ? { data: { currency: makeCurrency("USD"), series: makeSeries(5000) } }
-        : { data: { currency: makeCurrency("USD"), series: makeSeries(3000) } }
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(data) })
-    })
-
-    try {
-      const result = await capturedFetcher!()
-      const series = result as Array<{
+  describe("period-relative aggregation", () => {
+    const mockFetchSingle = (
+      series: Array<{
+        date: string
+        growthOf1000: number
         marketValue: number
         netContributions: number
+        cumulativeDividends: number
+        cumulativeReturn: number
+      }>,
+      currency = "USD",
+    ): void => {
+      global.fetch = jest.fn().mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: { currency: makeCurrency(currency), series },
+            }),
+        }),
+      ) as unknown as typeof global.fetch
+    }
+
+    let originalFetch: typeof global.fetch
+    beforeEach(() => {
+      originalFetch = global.fetch
+    })
+    afterEach(() => {
+      global.fetch = originalFetch
+    })
+
+    it("period netContributions = 0 at first snapshot (lifetime baseline removed)", async () => {
+      const { ref } = captureFetcher()
+      mockFetchSingle([
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 100000,
+          netContributions: 80000, // lifetime contributions before window
+          cumulativeDividends: 0,
+          cumulativeReturn: 0,
+        },
+        {
+          date: "2025-12-01",
+          growthOf1000: 1100,
+          marketValue: 115000,
+          netContributions: 85000, // +5000 deposited during window
+          cumulativeDividends: 500,
+          cumulativeReturn: 0.1,
+        },
+      ])
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("P1", "USD")],
+          12,
+          { USD: 1 },
+          "USD",
+          true,
+        ),
+      )
+
+      const result = (await ref.current!()) as Array<{
+        netContributions: number
+        lifetimeContributions: number
+      }>
+      expect(result[0].netContributions).toBe(0)
+      expect(result[1].netContributions).toBe(5000)
+      expect(result[0].lifetimeContributions).toBe(80000)
+      expect(result[1].lifetimeContributions).toBe(85000)
+    })
+
+    it("investmentGain is period MV change minus period contributions, not MV - lifetime contrib", async () => {
+      const { ref } = captureFetcher()
+      mockFetchSingle([
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 100000,
+          netContributions: 80000, // historical contributions
+          cumulativeDividends: 0,
+          cumulativeReturn: 0,
+        },
+        {
+          date: "2025-12-01",
+          growthOf1000: 1100,
+          marketValue: 115000, // +15k MV with +5k deposit -> +10k pure gain
+          netContributions: 85000,
+          cumulativeDividends: 0,
+          cumulativeReturn: 0.1,
+        },
+      ])
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("P1", "USD")],
+          12,
+          { USD: 1 },
+          "USD",
+          true,
+        ),
+      )
+
+      const result = (await ref.current!()) as Array<{ investmentGain: number }>
+      // Period gain = (115000 - 100000) - 5000 = 10000 (NOT 115000 - 85000 = 30000)
+      expect(result[1].investmentGain).toBe(10000)
+      // Bug repro guard: must not equal lifetime-style gain
+      expect(result[1].investmentGain).not.toBe(30000)
+    })
+
+    it("cumulativeReturn uses backend TWR, not naive MV/MV0 ratio", async () => {
+      // Backend's growthOf1000 already neutralises cash flows.
+      // MV doubles (100k -> 200k) because of deposit, not investment performance.
+      // TWR = 0%; naive MV/MV0 = 100%.
+      const { ref } = captureFetcher()
+      mockFetchSingle([
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 100000,
+          netContributions: 50000,
+          cumulativeDividends: 0,
+          cumulativeReturn: 0,
+        },
+        {
+          date: "2025-12-01",
+          growthOf1000: 1000, // no investment performance
+          marketValue: 200000, // 100k deposit
+          netContributions: 150000,
+          cumulativeDividends: 0,
+          cumulativeReturn: 0,
+        },
+      ])
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("P1", "USD")],
+          12,
+          { USD: 1 },
+          "USD",
+          true,
+        ),
+      )
+
+      const result = (await ref.current!()) as Array<{
+        cumulativeReturn: number
+        growthOf1000: number
+      }>
+      expect(result[1].cumulativeReturn).toBeCloseTo(0, 6)
+      expect(result[1].growthOf1000).toBeCloseTo(1000, 6)
+    })
+
+    it("composite TWR is beginning-AUM weighted across portfolios", async () => {
+      // P1 starts 60k, ends with TWR +20% (growthOf1000 1200)
+      // P2 starts 40k, ends with TWR +5%  (growthOf1000 1050)
+      // weight P1=0.6, P2=0.4
+      // composite growth factor = 0.6*1.20 + 0.4*1.05 = 0.72 + 0.42 = 1.14
+      // composite cumulativeReturn = 0.14 (NOT 0.125 equal-weighted)
+      const { ref } = captureFetcher()
+
+      const seriesP1 = [
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 60000,
+          netContributions: 60000,
+          cumulativeDividends: 0,
+          cumulativeReturn: 0,
+        },
+        {
+          date: "2025-12-01",
+          growthOf1000: 1200,
+          marketValue: 72000,
+          netContributions: 60000,
+          cumulativeDividends: 0,
+          cumulativeReturn: 0.2,
+        },
+      ]
+      const seriesP2 = [
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 40000,
+          netContributions: 40000,
+          cumulativeDividends: 0,
+          cumulativeReturn: 0,
+        },
+        {
+          date: "2025-12-01",
+          growthOf1000: 1050,
+          marketValue: 42000,
+          netContributions: 40000,
+          cumulativeDividends: 0,
+          cumulativeReturn: 0.05,
+        },
+      ]
+
+      global.fetch = jest.fn().mockImplementation((url: string) =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                currency: makeCurrency("USD"),
+                series: url.includes("P1") ? seriesP1 : seriesP2,
+              },
+            }),
+        }),
+      ) as unknown as typeof global.fetch
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
+          12,
+          { USD: 1 },
+          "USD",
+          true,
+        ),
+      )
+
+      const result = (await ref.current!()) as Array<{
+        cumulativeReturn: number
+        growthOf1000: number
+        marketValue: number
+      }>
+      expect(result[1].cumulativeReturn).toBeCloseTo(0.14, 5)
+      expect(result[1].growthOf1000).toBeCloseTo(1140, 2)
+      expect(result[1].marketValue).toBe(114000)
+    })
+
+    it("composite TWR weights by display-currency initial MV (FX-aware)", async () => {
+      // P_USD 50k USD @ TWR +10%
+      // P_NZD 100k NZD @ 0.6 = 60k USD initial @ TWR +20%
+      // weight USD = 50/110, NZD = 60/110
+      // composite = 50/110 * 1.10 + 60/110 * 1.20 = 0.55 + 0.7272727... = 1.15454...
+      const { ref } = captureFetcher()
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        const series = url.includes("US_PORT")
+          ? [
+              {
+                date: "2025-01-01",
+                growthOf1000: 1000,
+                marketValue: 50000,
+                netContributions: 50000,
+                cumulativeDividends: 0,
+                cumulativeReturn: 0,
+              },
+              {
+                date: "2025-12-01",
+                growthOf1000: 1100,
+                marketValue: 55000,
+                netContributions: 50000,
+                cumulativeDividends: 0,
+                cumulativeReturn: 0.1,
+              },
+            ]
+          : [
+              {
+                date: "2025-01-01",
+                growthOf1000: 1000,
+                marketValue: 100000,
+                netContributions: 100000,
+                cumulativeDividends: 0,
+                cumulativeReturn: 0,
+              },
+              {
+                date: "2025-12-01",
+                growthOf1000: 1200,
+                marketValue: 120000,
+                netContributions: 100000,
+                cumulativeDividends: 0,
+                cumulativeReturn: 0.2,
+              },
+            ]
+        const ccy = url.includes("US_PORT") ? "USD" : "NZD"
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: { currency: makeCurrency(ccy), series },
+            }),
+        })
+      }) as unknown as typeof global.fetch
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("US_PORT", "USD"), makePortfolio("NZ_PORT", "NZD")],
+          12,
+          { USD: 1, NZD: 0.6 },
+          "USD",
+          true,
+        ),
+      )
+
+      const result = (await ref.current!()) as Array<{
+        cumulativeReturn: number
+        marketValue: number
+      }>
+      // Expected composite return
+      const expected = (50 / 110) * 1.1 + (60 / 110) * 1.2 - 1
+      expect(result[1].cumulativeReturn).toBeCloseTo(expected, 5)
+      // Initial MV in USD = 50000 + 100000*0.6 = 110000
+      expect(result[0].marketValue).toBe(110000)
+      // End MV in USD = 55000 + 120000*0.6 = 127000
+      expect(result[1].marketValue).toBe(127000)
+    })
+
+    it("aggregates same-currency portfolios — period contrib summed, lifetime summed", async () => {
+      const { ref } = captureFetcher()
+      const dates = ["2025-01-01", "2025-02-01"]
+      const makeSeries = (mv: number): object[] =>
+        dates.map((date, i) => ({
+          date,
+          growthOf1000: 1000 + i * 10,
+          marketValue: mv + i * 100,
+          netContributions: mv,
+          cumulativeReturn: (i * 10) / 1000,
+          cumulativeDividends: i * 5,
+        }))
+
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        const data = url.includes("P1")
+          ? {
+              data: { currency: makeCurrency("USD"), series: makeSeries(5000) },
+            }
+          : {
+              data: { currency: makeCurrency("USD"), series: makeSeries(3000) },
+            }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(data) })
+      }) as unknown as typeof global.fetch
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
+          12,
+          { USD: 1 },
+          "USD",
+          true,
+        ),
+      )
+
+      const series = (await ref.current!()) as Array<{
+        marketValue: number
+        netContributions: number
+        lifetimeContributions: number
       }>
 
-      // First date: 5000 + 3000 = 8000
       expect(series[0].marketValue).toBe(8000)
-      expect(series[0].netContributions).toBe(8000)
-      // Second date: 5100 + 3100 = 8200
+      // Period contribution at t0 = 0 (no flows within window)
+      expect(series[0].netContributions).toBe(0)
+      // Lifetime sum = 5000 + 3000 = 8000
+      expect(series[0].lifetimeContributions).toBe(8000)
       expect(series[1].marketValue).toBe(8200)
-    } finally {
-      global.fetch = originalFetch
-    }
-  })
-
-  it("exercises the SWR fetcher with FX conversion", async () => {
-    let capturedFetcher: (() => Promise<unknown>) | null = null
-    mockUseSwr.mockImplementation((_key: unknown, fetcher: unknown) => {
-      if (typeof fetcher === "function") {
-        capturedFetcher = fetcher as () => Promise<unknown>
-      }
-      return {
-        data: undefined,
-        isLoading: false,
-        error: undefined,
-      } as ReturnType<typeof useSwr>
     })
 
-    const portfolios = [
-      makePortfolio("US_PORT", "USD"),
-      makePortfolio("NZ_PORT", "NZD"),
-    ]
-
-    renderHook(() =>
-      useAggregatedPerformance(
-        portfolios,
-        12,
-        { USD: 1, NZD: 0.6 },
-        "USD",
-        true,
-      ),
-    )
-
-    const dates = ["2025-01-01"]
-    const originalFetch = global.fetch
-    global.fetch = jest.fn().mockImplementation((url: string) => {
-      const mv = url.includes("US_PORT") ? 5000 : 10000
-      const ccy = url.includes("US_PORT") ? "USD" : "NZD"
-      return Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            data: {
-              currency: makeCurrency(ccy),
-              series: dates.map((date) => ({
-                date,
-                growthOf1000: 1000,
-                marketValue: mv,
-                netContributions: mv,
-                cumulativeReturn: 0,
-                cumulativeDividends: 0,
-              })),
-            },
-          }),
-      })
-    })
-
-    try {
-      const result = await capturedFetcher!()
-      const series = result as Array<{ marketValue: number }>
-      // USD 5000 + NZD 10000 * 0.6 = 11000
-      expect(series[0].marketValue).toBe(11000)
-    } finally {
-      global.fetch = originalFetch
-    }
-  })
-
-  it("exercises the SWR fetcher with one portfolio failing", async () => {
-    let capturedFetcher: (() => Promise<unknown>) | null = null
-    mockUseSwr.mockImplementation((_key: unknown, fetcher: unknown) => {
-      if (typeof fetcher === "function") {
-        capturedFetcher = fetcher as () => Promise<unknown>
-      }
-      return {
-        data: undefined,
-        isLoading: false,
-        error: undefined,
-      } as ReturnType<typeof useSwr>
-    })
-
-    const portfolios = [
-      makePortfolio("OK", "USD"),
-      makePortfolio("FAIL", "USD"),
-    ]
-
-    renderHook(() =>
-      useAggregatedPerformance(portfolios, 12, { USD: 1 }, "USD", true),
-    )
-
-    const originalFetch = global.fetch
-    global.fetch = jest.fn().mockImplementation((url: string) => {
-      if (url.includes("FAIL")) {
+    it("FX-converts MV when aggregating multi-currency portfolios", async () => {
+      const { ref } = captureFetcher()
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        const mv = url.includes("US_PORT") ? 5000 : 10000
+        const ccy = url.includes("US_PORT") ? "USD" : "NZD"
         return Promise.resolve({
-          ok: false,
-          json: () => Promise.resolve({}),
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                currency: makeCurrency(ccy),
+                series: [
+                  {
+                    date: "2025-01-01",
+                    growthOf1000: 1000,
+                    marketValue: mv,
+                    netContributions: mv,
+                    cumulativeReturn: 0,
+                    cumulativeDividends: 0,
+                  },
+                ],
+              },
+            }),
         })
-      }
-      return Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            data: {
-              currency: makeCurrency("USD"),
-              series: [
-                {
-                  date: "2025-01-01",
-                  growthOf1000: 1000,
-                  marketValue: 5000,
-                  netContributions: 5000,
-                  cumulativeReturn: 0,
-                  cumulativeDividends: 0,
-                },
-              ],
-            },
-          }),
-      })
+      }) as unknown as typeof global.fetch
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("US_PORT", "USD"), makePortfolio("NZ_PORT", "NZD")],
+          12,
+          { USD: 1, NZD: 0.6 },
+          "USD",
+          true,
+        ),
+      )
+
+      const series = (await ref.current!()) as Array<{ marketValue: number }>
+      expect(series[0].marketValue).toBe(11000)
     })
 
-    try {
-      const result = await capturedFetcher!()
-      const series = result as Array<{ marketValue: number }>
-      // Only the OK portfolio data
+    it("drops failed portfolios silently", async () => {
+      const { ref } = captureFetcher()
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.includes("FAIL")) {
+          return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                currency: makeCurrency("USD"),
+                series: [
+                  {
+                    date: "2025-01-01",
+                    growthOf1000: 1000,
+                    marketValue: 5000,
+                    netContributions: 5000,
+                    cumulativeReturn: 0,
+                    cumulativeDividends: 0,
+                  },
+                ],
+              },
+            }),
+        })
+      }) as unknown as typeof global.fetch
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("OK", "USD"), makePortfolio("FAIL", "USD")],
+          12,
+          { USD: 1 },
+          "USD",
+          true,
+        ),
+      )
+
+      const series = (await ref.current!()) as Array<{ marketValue: number }>
       expect(series).toHaveLength(1)
       expect(series[0].marketValue).toBe(5000)
-    } finally {
-      global.fetch = originalFetch
-    }
+    })
   })
 })

--- a/src/hooks/useAggregatedPerformance.ts
+++ b/src/hooks/useAggregatedPerformance.ts
@@ -4,10 +4,17 @@ import { Portfolio, PerformanceResponse } from "types/beancounter"
 export interface AggregatedDataPoint {
   date: string
   marketValue: number
+  /** Period-relative net external cash flows (deposits − withdrawals) WITHIN the requested window. */
   netContributions: number
+  /** Lifetime-cumulative net external cash flows up to this date (for context/tooltip). */
+  lifetimeContributions: number
+  /** Period-relative dividends. */
   cumulativeDividends: number
+  /** Period gain: (MV − MV₀) − periodContributions. */
   investmentGain: number
+  /** Composite TWR growth-of-1000, beginning-AUM weighted across portfolios. */
   growthOf1000: number
+  /** Composite TWR as decimal (0.10 = +10%). */
   cumulativeReturn: number
 }
 
@@ -17,9 +24,30 @@ export interface AggregatedPerformance {
   error: Error | undefined
 }
 
+interface PortfolioSeriesFx {
+  /** FX-converted into display currency. */
+  startMv: number
+  byDate: Map<
+    string,
+    {
+      growthFactor: number // backend growthOf1000 / 1000
+      mv: number // display ccy
+      contrib: number // lifetime, display ccy
+      divs: number // lifetime, display ccy
+    }
+  >
+}
+
 /**
  * Fetch performance data for all portfolios in parallel, FX-convert,
  * and aggregate into a single time series.
+ *
+ * Returns period-relative values aligned with GIPS composite TWR conventions:
+ * - cumulativeReturn / growthOf1000: beginning-AUM weighted composite TWR (uses
+ *   the backend's per-portfolio TWR `growthOf1000`, not a naïve MV ratio).
+ * - netContributions: cash flows within the requested window only.
+ * - lifetimeContributions: total inception-to-date contributions, for tooltip.
+ * - investmentGain: (MV_t − MV_0) − periodContributions.
  */
 export function useAggregatedPerformance(
   portfolios: Portfolio[],
@@ -28,7 +56,6 @@ export function useAggregatedPerformance(
   displayCurrencyCode: string | null,
   enabled: boolean,
 ): AggregatedPerformance {
-  // Build a stable SWR key — null disables fetching
   const key =
     enabled && portfolios.length > 0 && displayCurrencyCode
       ? `aggregated-perf:${portfolios.map((p) => p.code).join(",")}:${months}:${displayCurrencyCode}`
@@ -37,7 +64,6 @@ export function useAggregatedPerformance(
   const { data, isLoading, error } = useSwr<AggregatedDataPoint[]>(
     key,
     async () => {
-      // Fetch all portfolios in parallel
       const results = await Promise.allSettled(
         portfolios.map(async (portfolio) => {
           const res = await fetch(
@@ -49,55 +75,101 @@ export function useAggregatedPerformance(
         }),
       )
 
-      // Collect successful results with FX conversion
-      const seriesMap = new Map<string, AggregatedDataPoint>()
+      // Per-portfolio normalised series in display currency
+      const perPortfolio: PortfolioSeriesFx[] = []
+      const allDates = new Set<string>()
 
       for (const result of results) {
         if (result.status !== "fulfilled") continue
         const { portfolio, series } = result.value
+        if (series.length === 0) continue
         const rate = fxRates[portfolio.currency.code] ?? 1
 
+        const byDate = new Map<
+          string,
+          PortfolioSeriesFx["byDate"] extends Map<string, infer V> ? V : never
+        >()
         for (const point of series) {
-          const existing = seriesMap.get(point.date)
-          const mv = point.marketValue * rate
-          const contrib = point.netContributions * rate
-          const divs = point.cumulativeDividends * rate
-
-          if (existing) {
-            existing.marketValue += mv
-            existing.netContributions += contrib
-            existing.cumulativeDividends += divs
-          } else {
-            seriesMap.set(point.date, {
-              date: point.date,
-              marketValue: mv,
-              netContributions: contrib,
-              cumulativeDividends: divs,
-              investmentGain: 0, // computed below
-              growthOf1000: 0,
-              cumulativeReturn: 0,
-            })
-          }
+          allDates.add(point.date)
+          byDate.set(point.date, {
+            growthFactor: point.growthOf1000 / 1000,
+            mv: point.marketValue * rate,
+            contrib: point.netContributions * rate,
+            divs: point.cumulativeDividends * rate,
+          })
         }
+
+        const firstDate = series[0].date
+        const firstEntry = byDate.get(firstDate)
+        perPortfolio.push({
+          startMv: firstEntry?.mv ?? 0,
+          byDate,
+        })
       }
 
-      // Sort by date and compute derived metrics
-      const sorted = Array.from(seriesMap.values()).sort((a, b) =>
-        a.date.localeCompare(b.date),
+      if (perPortfolio.length === 0) return []
+
+      const totalStartMv = perPortfolio.reduce((sum, p) => sum + p.startMv, 0)
+      const sortedDates = Array.from(allDates).sort((a, b) =>
+        a.localeCompare(b),
       )
 
-      if (sorted.length === 0) return []
+      // Build aggregated series
+      const aggregated: AggregatedDataPoint[] = []
+      let baselineMv = 0
+      let baselineContrib = 0
+      let baselineDivs = 0
 
-      const initialMv = sorted[0].marketValue
-      for (const point of sorted) {
-        point.investmentGain = point.marketValue - point.netContributions
-        if (initialMv !== 0) {
-          point.growthOf1000 = 1000 * (point.marketValue / initialMv)
-          point.cumulativeReturn = point.marketValue / initialMv - 1
+      for (let i = 0; i < sortedDates.length; i++) {
+        const date = sortedDates[i]
+        let mv = 0
+        let contrib = 0
+        let divs = 0
+        let compositeGrowth = 0
+        let weightSumPresent = 0
+
+        for (const p of perPortfolio) {
+          const point = p.byDate.get(date)
+          if (!point) continue
+          mv += point.mv
+          contrib += point.contrib
+          divs += point.divs
+          if (totalStartMv > 0) {
+            const w = p.startMv / totalStartMv
+            compositeGrowth += w * point.growthFactor
+            weightSumPresent += w
+          }
         }
+
+        // Renormalise composite growth if some portfolios have no data at this date
+        const growthFactor =
+          weightSumPresent > 0 ? compositeGrowth / weightSumPresent : 1
+        const growthOf1000 = 1000 * growthFactor
+        const cumulativeReturn = growthFactor - 1
+
+        if (i === 0) {
+          baselineMv = mv
+          baselineContrib = contrib
+          baselineDivs = divs
+        }
+
+        const periodContrib = contrib - baselineContrib
+        const periodDivs = divs - baselineDivs
+        const investmentGain = mv - baselineMv - periodContrib
+
+        aggregated.push({
+          date,
+          marketValue: mv,
+          netContributions: periodContrib,
+          lifetimeContributions: contrib,
+          cumulativeDividends: periodDivs,
+          investmentGain,
+          growthOf1000,
+          cumulativeReturn,
+        })
       }
 
-      return sorted
+      return aggregated
     },
     {
       revalidateOnFocus: false,


### PR DESCRIPTION
## Summary

Two compounding bugs made the Wealth Performance widget show **lifetime** investment gain as if it were the selected period's gain — a long-tenured account looked like it had gained six figures over the last 12 months.

- **Bug 1 — naïve return formula.** `cumulativeReturn = MV / MV₀ − 1`. A pure cash deposit doubled MV and produced a phantom 100% return, even though the label read "Aggregate TWR". Backend already computes proper TWR per portfolio (`growthOf1000`); the hook was discarding it.
- **Bug 2 — lifetime contributions leaked into period view.** Backend `netContributions[0]` is lifetime-cumulative (the initial snapshot accumulates every pre-window external cash flow). `investmentGain = MV − netContributions` therefore equalled inception-to-date gain, not 1y gain.

## Fix (GIPS-aligned)

- Composite TWR across portfolios: beginning-AUM weighted using backend's per-portfolio `growthOf1000`, FX-converted into the display currency.
- `netContributions` is now period-only: `contrib(t) − contrib(0)`.
- `investmentGain(t) = (MV(t) − MV(0)) − periodContrib(t)`.
- New `lifetimeContributions` field exposed for tooltip/"on cost" denominator.
- UI: "contributed (period)" subtitle with `title=` tooltip showing lifetime total. "% on cost" divides by lifetime contributions (true cost basis).

## Scope

Frontend-only — backend `PerformanceService` already computes TWR correctly; only the aggregation hook was wrong.

## Test plan

- [x] `yarn test` — 1286 passed (added 8 new tests in `useAggregatedPerformance.test.ts` covering period contrib, period gain, TWR vs naïve MV ratio, beginning-AUM weighting, FX-aware weighting)
- [x] `yarn prettier && yarn lint && yarn typecheck` — clean
- [ ] Manual: open Wealth page on kauri, confirm 1Y / 5Y figures look sane for a long-term account
- [ ] Manual: hover "contributed (period)" — lifetime total appears in tooltip
- [ ] Manual: toggle display currency — composite TWR stable, MV converts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wealth Performance Chart now displays period contributions separately from lifetime contributions with explicit labeling for clarity
  * Added tooltip for lifetime contributions reference

* **Improvements**
  * Refined investment gain calculations and percentage metrics for greater accuracy
  * Enhanced multi-currency portfolio aggregation and performance metric calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/673)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->