### PR TITLE
fix(wealth): forward-fill snapshots across portfolios in aggregation

### DIFF
--- a/src/hooks/__tests__/useAggregatedPerformance.test.ts
+++ b/src/hooks/__tests__/useAggregatedPerformance.test.ts
@@ -539,6 +539,175 @@ describe("useAggregatedPerformance", () => {
       expect(series[0].marketValue).toBe(11000)
     })
 
+    it("forward-fills missing snapshots when portfolios have different date sets", async () => {
+      // Real-world case: P1 cash flow on Feb-15 creates a valuation date that
+      // P2 doesn't have. Without fill, MV at Feb-15 would drop to P2-only,
+      // producing the sawtooth-spike chart artefact.
+      const { ref } = captureFetcher()
+      const seriesP1 = [
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 100000,
+          netContributions: 100000,
+          cumulativeReturn: 0,
+          cumulativeDividends: 0,
+        },
+        // No Feb-15 snapshot for P1
+        {
+          date: "2025-03-01",
+          growthOf1000: 1100,
+          marketValue: 115000,
+          netContributions: 105000,
+          cumulativeReturn: 0.1,
+          cumulativeDividends: 0,
+        },
+      ]
+      const seriesP2 = [
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 50000,
+          netContributions: 50000,
+          cumulativeReturn: 0,
+          cumulativeDividends: 0,
+        },
+        {
+          date: "2025-02-15",
+          growthOf1000: 1050,
+          marketValue: 52500,
+          netContributions: 50000,
+          cumulativeReturn: 0.05,
+          cumulativeDividends: 0,
+        },
+        {
+          date: "2025-03-01",
+          growthOf1000: 1080,
+          marketValue: 54000,
+          netContributions: 50000,
+          cumulativeReturn: 0.08,
+          cumulativeDividends: 0,
+        },
+      ]
+
+      global.fetch = jest.fn().mockImplementation((url: string) =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                currency: makeCurrency("USD"),
+                series: url.includes("P1") ? seriesP1 : seriesP2,
+              },
+            }),
+        }),
+      ) as unknown as typeof global.fetch
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
+          12,
+          { USD: 1 },
+          "USD",
+          true,
+        ),
+      )
+
+      const series = (await ref.current!()) as Array<{
+        date: string
+        marketValue: number
+        growthOf1000: number
+        lifetimeContributions: number
+      }>
+
+      // Union dates: Jan-01, Feb-15, Mar-01
+      expect(series.map((s) => s.date)).toEqual([
+        "2025-01-01",
+        "2025-02-15",
+        "2025-03-01",
+      ])
+      // Jan-01: 100k + 50k = 150k
+      expect(series[0].marketValue).toBe(150000)
+      // Feb-15: P1 missing -> forward-fill 100k; P2 = 52500 -> 152500
+      // NOT 52500 (which would be the sawtooth bug)
+      expect(series[1].marketValue).toBe(152500)
+      // Mar-01: real snapshots both = 115000 + 54000 = 169000
+      expect(series[2].marketValue).toBe(169000)
+
+      // Lifetime contributions also forward-fill: Feb-15 = 100k (P1) + 50k (P2) = 150k
+      expect(series[1].lifetimeContributions).toBe(150000)
+
+      // Composite TWR at Feb-15: P1 carried 1.0, P2 1.05, weights 100/150=0.667 & 50/150=0.333
+      // composite = 0.667*1.0 + 0.333*1.05 = 1.01667
+      expect(series[1].growthOf1000).toBeCloseTo(1016.67, 1)
+    })
+
+    it("handles portfolio first appearing after window start (no negative skew)", async () => {
+      // P2 starts mid-window. Before its first snapshot, only P1 contributes.
+      const { ref } = captureFetcher()
+      const seriesP1 = [
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 100000,
+          netContributions: 100000,
+          cumulativeReturn: 0,
+          cumulativeDividends: 0,
+        },
+        {
+          date: "2025-06-01",
+          growthOf1000: 1100,
+          marketValue: 110000,
+          netContributions: 100000,
+          cumulativeReturn: 0.1,
+          cumulativeDividends: 0,
+        },
+      ]
+      const seriesP2 = [
+        {
+          date: "2025-06-01",
+          growthOf1000: 1000,
+          marketValue: 20000,
+          netContributions: 20000,
+          cumulativeReturn: 0,
+          cumulativeDividends: 0,
+        },
+      ]
+
+      global.fetch = jest.fn().mockImplementation((url: string) =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                currency: makeCurrency("USD"),
+                series: url.includes("P1") ? seriesP1 : seriesP2,
+              },
+            }),
+        }),
+      ) as unknown as typeof global.fetch
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
+          12,
+          { USD: 1 },
+          "USD",
+          true,
+        ),
+      )
+
+      const series = (await ref.current!()) as Array<{
+        date: string
+        marketValue: number
+      }>
+
+      // Jan-01: only P1 active -> 100k (not 0)
+      expect(series[0].marketValue).toBe(100000)
+      // Jun-01: both -> 110k + 20k = 130k
+      expect(series[1].marketValue).toBe(130000)
+    })
+
     it("drops failed portfolios silently", async () => {
       const { ref } = captureFetcher()
       global.fetch = jest.fn().mockImplementation((url: string) => {

--- a/src/hooks/useAggregatedPerformance.ts
+++ b/src/hooks/useAggregatedPerformance.ts
@@ -24,18 +24,19 @@ export interface AggregatedPerformance {
   error: Error | undefined
 }
 
+interface PortfolioSnapshot {
+  date: string
+  growthFactor: number // backend growthOf1000 / 1000
+  mv: number // display ccy
+  contrib: number // lifetime, display ccy
+  divs: number // lifetime, display ccy
+}
+
 interface PortfolioSeriesFx {
   /** FX-converted into display currency. */
   startMv: number
-  byDate: Map<
-    string,
-    {
-      growthFactor: number // backend growthOf1000 / 1000
-      mv: number // display ccy
-      contrib: number // lifetime, display ccy
-      divs: number // lifetime, display ccy
-    }
-  >
+  /** Snapshots sorted by date ascending. Used for forward-fill on union dates. */
+  snapshots: PortfolioSnapshot[]
 }
 
 /**
@@ -85,25 +86,22 @@ export function useAggregatedPerformance(
         if (series.length === 0) continue
         const rate = fxRates[portfolio.currency.code] ?? 1
 
-        const byDate = new Map<
-          string,
-          PortfolioSeriesFx["byDate"] extends Map<string, infer V> ? V : never
-        >()
-        for (const point of series) {
-          allDates.add(point.date)
-          byDate.set(point.date, {
-            growthFactor: point.growthOf1000 / 1000,
-            mv: point.marketValue * rate,
-            contrib: point.netContributions * rate,
-            divs: point.cumulativeDividends * rate,
+        const snapshots: PortfolioSnapshot[] = series
+          .map((point) => {
+            allDates.add(point.date)
+            return {
+              date: point.date,
+              growthFactor: point.growthOf1000 / 1000,
+              mv: point.marketValue * rate,
+              contrib: point.netContributions * rate,
+              divs: point.cumulativeDividends * rate,
+            }
           })
-        }
+          .sort((a, b) => a.date.localeCompare(b.date))
 
-        const firstDate = series[0].date
-        const firstEntry = byDate.get(firstDate)
         perPortfolio.push({
-          startMv: firstEntry?.mv ?? 0,
-          byDate,
+          startMv: snapshots[0].mv,
+          snapshots,
         })
       }
 
@@ -114,7 +112,13 @@ export function useAggregatedPerformance(
         a.localeCompare(b),
       )
 
-      // Build aggregated series
+      // Forward-fill state per portfolio: cursor advances as we walk union dates.
+      // When a portfolio has no snapshot on date d, we carry the last-seen snapshot.
+      // Required because each portfolio's valuation dates differ (cash-flow dates
+      // are portfolio-specific) — without fill, the aggregated MV would zigzag
+      // wildly between $0 and full value as portfolios drop in and out.
+      const cursors: number[] = perPortfolio.map(() => 0)
+
       const aggregated: AggregatedDataPoint[] = []
       let baselineMv = 0
       let baselineContrib = 0
@@ -128,9 +132,20 @@ export function useAggregatedPerformance(
         let compositeGrowth = 0
         let weightSumPresent = 0
 
-        for (const p of perPortfolio) {
-          const point = p.byDate.get(date)
-          if (!point) continue
+        for (let pi = 0; pi < perPortfolio.length; pi++) {
+          const p = perPortfolio[pi]
+          // Advance cursor while next snapshot is on/before this date
+          while (
+            cursors[pi] + 1 < p.snapshots.length &&
+            p.snapshots[cursors[pi] + 1].date <= date
+          ) {
+            cursors[pi]++
+          }
+          const point = p.snapshots[cursors[pi]]
+          // Skip portfolios whose first snapshot is later than this date (they
+          // didn't exist yet within the requested window).
+          if (point.date > date) continue
+
           mv += point.mv
           contrib += point.contrib
           divs += point.divs
@@ -141,7 +156,7 @@ export function useAggregatedPerformance(
           }
         }
 
-        // Renormalise composite growth if some portfolios have no data at this date
+        // Renormalise composite growth if some portfolios are not yet active
         const growthFactor =
           weightSumPresent > 0 ? compositeGrowth / weightSumPresent : 1
         const growthOf1000 = 1000 * growthFactor


### PR DESCRIPTION
## Summary

Follow-up to #673. The merged TWR fix was correct for the headline summary numbers but the chart still showed a sawtooth between ~$0 and ~$1.4M because each portfolio has its own valuation date set.

**Root cause:** the backend creates a valuation snapshot on every external cash-flow date — and those dates are *portfolio-specific*. P1's cash flow on Feb-15 produces a Feb-15 snapshot for P1 but not P2. Aggregating the union of dates without forward-fill drops the missing portfolio's contribution on that date, so MV / lifetime contributions / TWR composite all collapse to only the portfolios that happened to have a snapshot — then bounce back on the next date when both report. Hence the spiky chart.

**Fix:** carry-forward each portfolio's last known snapshot when a union date has no matching snapshot. A portfolio whose first snapshot is *after* the current date is skipped (it didn't yet exist within the window), preventing an artificially low opening MV.

## Test plan

- [x] `yarn test` — 1288 passed (+2 new)
  - New: forward-fill across non-aligned cash-flow dates
  - New: portfolio first appearing after window start
- [x] `yarn prettier && yarn lint && yarn typecheck` — clean
- [ ] Manual on kauri: 1Y / 5Y chart should be smooth (no $0↔$1.4M spikes)
- [ ] Manual on kauri: headline stats still match the underlying math

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved aggregated performance calculations to properly handle portfolios with non-overlapping valuation dates.
  * Fixed aggregation logic to prevent portfolio data gaps from skewing initial combined market value.
  * Enhanced snapshot processing to forward-fill missing valuation dates across portfolio datasets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/674)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->