### PR TITLE
fix(wealth): exclude property-dominated portfolios from performance widget

### DIFF
--- a/src/components/features/wealth/WealthPerformanceChart.tsx
+++ b/src/components/features/wealth/WealthPerformanceChart.tsx
@@ -21,6 +21,7 @@ import {
   formatTooltipDate,
 } from "@lib/chart/performanceConstants"
 import { useAggregatedPerformance } from "@hooks/useAggregatedPerformance"
+import { isLiquidPortfolio } from "@lib/wealth/liquidityGroups"
 
 interface WealthPerformanceChartProps {
   portfolios: Portfolio[]
@@ -40,8 +41,17 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
   const [months, setMonths] = useState(12)
   const sym = displayCurrency?.symbol || "$"
 
+  // Restrict to liquid portfolios — Property-dominated portfolios distort TWR
+  // because illiquid valuations move with appraisal cycles, not market prices.
+  // Mirrors svc-retire's housing exclusion (HOUSING_CATEGORIES = {Property}).
+  const liquidPortfolios = useMemo(
+    () => portfolios.filter(isLiquidPortfolio),
+    [portfolios],
+  )
+  const excludedCount = portfolios.length - liquidPortfolios.length
+
   const { series, isLoading, error } = useAggregatedPerformance(
-    portfolios,
+    liquidPortfolios,
     months,
     fxRates,
     displayCurrency?.code ?? null,
@@ -78,6 +88,14 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
         ></i>
         <i className="fas fa-chart-line text-gray-400 mr-2"></i>
         Wealth Performance
+        {excludedCount > 0 && (
+          <span
+            className="ml-2 text-xs font-normal text-gray-400"
+            title={`Excludes ${excludedCount} property-dominated portfolio${excludedCount === 1 ? "" : "s"}. Tracking liquid AUM only.`}
+          >
+            (liquid only)
+          </span>
+        )}
       </button>
 
       {!collapsed && (

--- a/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
+++ b/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
@@ -37,7 +37,10 @@ const makeCurrency = (code: string): Currency => ({
   symbol: "$",
 })
 
-const makePortfolio = (code: string): Portfolio => ({
+const makePortfolio = (
+  code: string,
+  classification?: Record<string, number>,
+): Portfolio => ({
   id: code,
   code,
   name: code,
@@ -45,6 +48,7 @@ const makePortfolio = (code: string): Portfolio => ({
   base: makeCurrency("USD"),
   marketValue: 50000,
   irr: 0.05,
+  assetClassification: classification,
 })
 
 const mockSeries = [
@@ -203,5 +207,50 @@ describe("WealthPerformanceChart", () => {
     const { container } = render(<>{false}</>)
 
     expect(container.textContent).toBe("")
+  })
+
+  it("passes only liquid portfolios to the aggregation hook", () => {
+    const liquid = makePortfolio("EQT", { Equity: 100000, Cash: 5000 })
+    const property = makePortfolio("HOUSE", { Property: 500000 })
+    const hookSpy = jest.fn().mockReturnValue({
+      series: mockSeries,
+      isLoading: false,
+      error: undefined,
+    })
+    mockUseAggregatedPerformance.useAggregatedPerformance = hookSpy
+
+    render(
+      <WealthPerformanceChart
+        {...defaultProps}
+        portfolios={[liquid, property]}
+      />,
+    )
+
+    const passedPortfolios = hookSpy.mock.calls[0][0] as Portfolio[]
+    expect(passedPortfolios.map((p) => p.code)).toEqual(["EQT"])
+  })
+
+  it("shows '(liquid only)' annotation when property portfolios are excluded", () => {
+    setHookReturn({ series: mockSeries, isLoading: false, error: undefined })
+    const liquid = makePortfolio("EQT", { Equity: 100000 })
+    const property = makePortfolio("HOUSE", { Property: 500000 })
+
+    render(
+      <WealthPerformanceChart
+        {...defaultProps}
+        portfolios={[liquid, property]}
+      />,
+    )
+
+    expect(screen.getByText("(liquid only)")).toBeInTheDocument()
+  })
+
+  it("omits the '(liquid only)' annotation when all portfolios are liquid", () => {
+    setHookReturn({ series: mockSeries, isLoading: false, error: undefined })
+    const liquid = makePortfolio("EQT", { Equity: 100000 })
+
+    render(<WealthPerformanceChart {...defaultProps} portfolios={[liquid]} />)
+
+    expect(screen.queryByText("(liquid only)")).not.toBeInTheDocument()
   })
 })

--- a/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
+++ b/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
@@ -2,8 +2,9 @@ import React from "react"
 import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import WealthPerformanceChart from "../WealthPerformanceChart"
-import { Portfolio, Currency } from "types/beancounter"
+import { Portfolio } from "types/beancounter"
 import { AggregatedPerformance } from "@hooks/useAggregatedPerformance"
+import { USD, makePortfolio } from "@test-fixtures/beancounter"
 
 // Mock the aggregation hook
 jest.mock("@hooks/useAggregatedPerformance")
@@ -30,26 +31,6 @@ jest.mock("recharts", () => ({
   ),
   ReferenceLine: () => <g />,
 }))
-
-const makeCurrency = (code: string): Currency => ({
-  code,
-  name: code,
-  symbol: "$",
-})
-
-const makePortfolio = (
-  code: string,
-  classification?: Record<string, number>,
-): Portfolio => ({
-  id: code,
-  code,
-  name: code,
-  currency: makeCurrency("USD"),
-  base: makeCurrency("USD"),
-  marketValue: 50000,
-  irr: 0.05,
-  assetClassification: classification,
-})
 
 const mockSeries = [
   {
@@ -85,9 +66,12 @@ const mockSeries = [
 ]
 
 const defaultProps = {
-  portfolios: [makePortfolio("P1"), makePortfolio("P2")],
+  portfolios: [
+    makePortfolio({ id: "P1", code: "P1", name: "P1" }),
+    makePortfolio({ id: "P2", code: "P2", name: "P2" }),
+  ],
   fxRates: { USD: 1 },
-  displayCurrency: makeCurrency("USD"),
+  displayCurrency: USD,
   collapsed: false,
   onToggle: jest.fn(),
 }
@@ -210,8 +194,14 @@ describe("WealthPerformanceChart", () => {
   })
 
   it("passes only liquid portfolios to the aggregation hook", () => {
-    const liquid = makePortfolio("EQT", { Equity: 100000, Cash: 5000 })
-    const property = makePortfolio("HOUSE", { Property: 500000 })
+    const liquid = makePortfolio({
+      code: "EQT",
+      assetClassification: { Equity: 100000, Cash: 5000 },
+    })
+    const property = makePortfolio({
+      code: "HOUSE",
+      assetClassification: { Property: 500000 },
+    })
     const hookSpy = jest.fn().mockReturnValue({
       series: mockSeries,
       isLoading: false,
@@ -232,8 +222,14 @@ describe("WealthPerformanceChart", () => {
 
   it("shows '(liquid only)' annotation when property portfolios are excluded", () => {
     setHookReturn({ series: mockSeries, isLoading: false, error: undefined })
-    const liquid = makePortfolio("EQT", { Equity: 100000 })
-    const property = makePortfolio("HOUSE", { Property: 500000 })
+    const liquid = makePortfolio({
+      code: "EQT",
+      assetClassification: { Equity: 100000 },
+    })
+    const property = makePortfolio({
+      code: "HOUSE",
+      assetClassification: { Property: 500000 },
+    })
 
     render(
       <WealthPerformanceChart
@@ -247,7 +243,10 @@ describe("WealthPerformanceChart", () => {
 
   it("omits the '(liquid only)' annotation when all portfolios are liquid", () => {
     setHookReturn({ series: mockSeries, isLoading: false, error: undefined })
-    const liquid = makePortfolio("EQT", { Equity: 100000 })
+    const liquid = makePortfolio({
+      code: "EQT",
+      assetClassification: { Equity: 100000 },
+    })
 
     render(<WealthPerformanceChart {...defaultProps} portfolios={[liquid]} />)
 

--- a/src/lib/utils/wealth/__tests__/liquidityGroups.test.ts
+++ b/src/lib/utils/wealth/__tests__/liquidityGroups.test.ts
@@ -26,7 +26,7 @@ describe("isLiquidPortfolio", () => {
     expect(isLiquidPortfolio(makePortfolio("P1", {}))).toBe(true)
   })
 
-  it("excludes portfolio dominated by Property", () => {
+  it("excludes portfolio with any Property exposure", () => {
     expect(
       isLiquidPortfolio(
         makePortfolio("HOUSE", { Property: 500000, Cash: 1000 }),
@@ -34,35 +34,53 @@ describe("isLiquidPortfolio", () => {
     ).toBe(false)
   })
 
-  it("excludes portfolio under raw 'RE' category name", () => {
+  it("excludes portfolio under raw 'RE' category id", () => {
     expect(isLiquidPortfolio(makePortfolio("HOUSE", { RE: 500000 }))).toBe(
       false,
     )
   })
 
-  it("excludes portfolio under 'Real Estate' category name", () => {
+  it("excludes portfolio under 'Real Estate' raw name", () => {
     expect(
       isLiquidPortfolio(makePortfolio("HOUSE", { "Real Estate": 500000 })),
     ).toBe(false)
   })
 
-  it("keeps portfolio when Cash dominates over Property", () => {
+  it("excludes commingled portfolio even when Cash dominates", () => {
+    // Any PRIVATE+RE exposure pollutes aggregate TWR signal.
     expect(
       isLiquidPortfolio(makePortfolio("MIX", { Cash: 5000, Property: 4000 })),
+    ).toBe(false)
+  })
+
+  it("keeps RE-ETF holdings — they classify as ETF, not Property", () => {
+    expect(
+      isLiquidPortfolio(
+        makePortfolio("REIT", {
+          "Exchange Traded Fund": 100000,
+          Cash: 5000,
+        }),
+      ),
     ).toBe(true)
   })
 
-  it("keeps Equity-dominated portfolio", () => {
+  it("keeps Equity-only portfolio", () => {
     expect(
       isLiquidPortfolio(makePortfolio("EQT", { Equity: 100000, Cash: 5000 })),
     ).toBe(true)
   })
 
-  it("keeps Retirement-dominated portfolio (liquid for performance purposes)", () => {
+  it("keeps Retirement-fund portfolio", () => {
     expect(
       isLiquidPortfolio(
         makePortfolio("PEN", { "Retirement Fund": 80000, Cash: 1000 }),
       ),
+    ).toBe(true)
+  })
+
+  it("keeps portfolio when Property entry is present but zero", () => {
+    expect(
+      isLiquidPortfolio(makePortfolio("EDGE", { Property: 0, Equity: 100000 })),
     ).toBe(true)
   })
 })

--- a/src/lib/utils/wealth/__tests__/liquidityGroups.test.ts
+++ b/src/lib/utils/wealth/__tests__/liquidityGroups.test.ts
@@ -1,0 +1,68 @@
+import { isLiquidPortfolio } from "@lib/wealth/liquidityGroups"
+import { Portfolio } from "types/beancounter"
+
+function makePortfolio(
+  code: string,
+  classification: Record<string, number> | undefined,
+): Portfolio {
+  return {
+    id: code,
+    code,
+    name: code,
+    currency: { code: "USD", name: "USD", symbol: "$" },
+    base: { code: "USD", name: "USD", symbol: "$" },
+    marketValue: Object.values(classification ?? {}).reduce((s, v) => s + v, 0),
+    irr: 0,
+    assetClassification: classification,
+  }
+}
+
+describe("isLiquidPortfolio", () => {
+  it("treats portfolio with no assetClassification as liquid", () => {
+    expect(isLiquidPortfolio(makePortfolio("P1", undefined))).toBe(true)
+  })
+
+  it("treats portfolio with empty assetClassification as liquid", () => {
+    expect(isLiquidPortfolio(makePortfolio("P1", {}))).toBe(true)
+  })
+
+  it("excludes portfolio dominated by Property", () => {
+    expect(
+      isLiquidPortfolio(
+        makePortfolio("HOUSE", { Property: 500000, Cash: 1000 }),
+      ),
+    ).toBe(false)
+  })
+
+  it("excludes portfolio under raw 'RE' category name", () => {
+    expect(isLiquidPortfolio(makePortfolio("HOUSE", { RE: 500000 }))).toBe(
+      false,
+    )
+  })
+
+  it("excludes portfolio under 'Real Estate' category name", () => {
+    expect(
+      isLiquidPortfolio(makePortfolio("HOUSE", { "Real Estate": 500000 })),
+    ).toBe(false)
+  })
+
+  it("keeps portfolio when Cash dominates over Property", () => {
+    expect(
+      isLiquidPortfolio(makePortfolio("MIX", { Cash: 5000, Property: 4000 })),
+    ).toBe(true)
+  })
+
+  it("keeps Equity-dominated portfolio", () => {
+    expect(
+      isLiquidPortfolio(makePortfolio("EQT", { Equity: 100000, Cash: 5000 })),
+    ).toBe(true)
+  })
+
+  it("keeps Retirement-dominated portfolio (liquid for performance purposes)", () => {
+    expect(
+      isLiquidPortfolio(
+        makePortfolio("PEN", { "Retirement Fund": 80000, Cash: 1000 }),
+      ),
+    ).toBe(true)
+  })
+})

--- a/src/lib/utils/wealth/__tests__/liquidityGroups.test.ts
+++ b/src/lib/utils/wealth/__tests__/liquidityGroups.test.ts
@@ -1,64 +1,71 @@
 import { isLiquidPortfolio } from "@lib/wealth/liquidityGroups"
-import { Portfolio } from "types/beancounter"
-
-function makePortfolio(
-  code: string,
-  classification: Record<string, number> | undefined,
-): Portfolio {
-  return {
-    id: code,
-    code,
-    name: code,
-    currency: { code: "USD", name: "USD", symbol: "$" },
-    base: { code: "USD", name: "USD", symbol: "$" },
-    marketValue: Object.values(classification ?? {}).reduce((s, v) => s + v, 0),
-    irr: 0,
-    assetClassification: classification,
-  }
-}
+import { makePortfolio } from "@test-fixtures/beancounter"
 
 describe("isLiquidPortfolio", () => {
   it("treats portfolio with no assetClassification as liquid", () => {
-    expect(isLiquidPortfolio(makePortfolio("P1", undefined))).toBe(true)
+    expect(isLiquidPortfolio(makePortfolio())).toBe(true)
   })
 
   it("treats portfolio with empty assetClassification as liquid", () => {
-    expect(isLiquidPortfolio(makePortfolio("P1", {}))).toBe(true)
+    expect(isLiquidPortfolio(makePortfolio({ assetClassification: {} }))).toBe(
+      true,
+    )
   })
 
   it("excludes portfolio with any Property exposure", () => {
     expect(
       isLiquidPortfolio(
-        makePortfolio("HOUSE", { Property: 500000, Cash: 1000 }),
+        makePortfolio({
+          code: "HOUSE",
+          assetClassification: { Property: 500000, Cash: 1000 },
+        }),
       ),
     ).toBe(false)
   })
 
   it("excludes portfolio under raw 'RE' category id", () => {
-    expect(isLiquidPortfolio(makePortfolio("HOUSE", { RE: 500000 }))).toBe(
-      false,
-    )
+    expect(
+      isLiquidPortfolio(
+        makePortfolio({
+          code: "HOUSE",
+          assetClassification: { RE: 500000 },
+        }),
+      ),
+    ).toBe(false)
   })
 
   it("excludes portfolio under 'Real Estate' raw name", () => {
     expect(
-      isLiquidPortfolio(makePortfolio("HOUSE", { "Real Estate": 500000 })),
+      isLiquidPortfolio(
+        makePortfolio({
+          code: "HOUSE",
+          assetClassification: { "Real Estate": 500000 },
+        }),
+      ),
     ).toBe(false)
   })
 
   it("excludes commingled portfolio even when Cash dominates", () => {
     // Any PRIVATE+RE exposure pollutes aggregate TWR signal.
     expect(
-      isLiquidPortfolio(makePortfolio("MIX", { Cash: 5000, Property: 4000 })),
+      isLiquidPortfolio(
+        makePortfolio({
+          code: "MIX",
+          assetClassification: { Cash: 5000, Property: 4000 },
+        }),
+      ),
     ).toBe(false)
   })
 
   it("keeps RE-ETF holdings — they classify as ETF, not Property", () => {
     expect(
       isLiquidPortfolio(
-        makePortfolio("REIT", {
-          "Exchange Traded Fund": 100000,
-          Cash: 5000,
+        makePortfolio({
+          code: "REIT",
+          assetClassification: {
+            "Exchange Traded Fund": 100000,
+            Cash: 5000,
+          },
         }),
       ),
     ).toBe(true)
@@ -66,21 +73,34 @@ describe("isLiquidPortfolio", () => {
 
   it("keeps Equity-only portfolio", () => {
     expect(
-      isLiquidPortfolio(makePortfolio("EQT", { Equity: 100000, Cash: 5000 })),
+      isLiquidPortfolio(
+        makePortfolio({
+          code: "EQT",
+          assetClassification: { Equity: 100000, Cash: 5000 },
+        }),
+      ),
     ).toBe(true)
   })
 
   it("keeps Retirement-fund portfolio", () => {
     expect(
       isLiquidPortfolio(
-        makePortfolio("PEN", { "Retirement Fund": 80000, Cash: 1000 }),
+        makePortfolio({
+          code: "PEN",
+          assetClassification: { "Retirement Fund": 80000, Cash: 1000 },
+        }),
       ),
     ).toBe(true)
   })
 
   it("keeps portfolio when Property entry is present but zero", () => {
     expect(
-      isLiquidPortfolio(makePortfolio("EDGE", { Property: 0, Equity: 100000 })),
+      isLiquidPortfolio(
+        makePortfolio({
+          code: "EDGE",
+          assetClassification: { Property: 0, Equity: 100000 },
+        }),
+      ),
     ).toBe(true)
   })
 })

--- a/src/lib/utils/wealth/liquidityGroups.ts
+++ b/src/lib/utils/wealth/liquidityGroups.ts
@@ -1,45 +1,36 @@
 import type { Portfolio } from "types/beancounter"
 
 /**
- * Liquidity groups that represent illiquid wealth — excluded from
- * the Wealth Performance widget which tracks marketable AUM only.
+ * Asset-classification keys representing PRIVATE-market real estate —
+ * the user's own home and similar non-marketable property. Public
+ * RE products (REITs, RE-ETFs) classify as Equity / ETF and stay liquid.
  *
- * Mirrors svc-retire's `HOUSING_CATEGORIES` (svc-position
- * AllocationService.kt) and `NON_SPENDABLE_CATEGORIES` (svc-retire
- * CalculationService.kt) — RE / Property maps to non-spendable.
+ * Mirrors svc-retire's HOUSING_CATEGORIES (svc-position AllocationService)
+ * and NON_SPENDABLE_CATEGORIES (svc-retire CalculationService).
  */
-const ILLIQUID_GROUPS = new Set<string>(["Property"])
+const ILLIQUID_CATEGORY_KEYS = new Set<string>([
+  "Property", // REPORT_PROPERTY (svc-position effectiveReportCategory)
+  "Real Estate", // raw category name fallback
+  "RE", // raw asset category id (AssetCategory.RE)
+])
 
 /**
- * Returns true when the portfolio's dominant liquidity group is liquid.
+ * Returns false when the portfolio has any PRIVATE+RE exposure.
  *
- * A portfolio is treated as illiquid (and excluded from Wealth Performance)
- * when more of its base-currency market value falls into an illiquid group
- * (Property/RE) than any single liquid group. Portfolios with no
+ * Any non-zero entry under an illiquid category key disqualifies the
+ * portfolio from Wealth Performance — illiquid valuations move on
+ * appraisal cycles, not market prices, and pollute aggregate TWR even
+ * when commingled with marketable assets. Portfolios with no
  * `assetClassification` (legacy / unvalued) are treated as liquid.
  */
 export function isLiquidPortfolio(portfolio: Portfolio): boolean {
   const classification = portfolio.assetClassification
   if (!classification) return true
-  const entries = Object.entries(classification)
-  if (entries.length === 0) return true
-
-  const groupTotals = new Map<string, number>()
-  for (const [category, value] of entries) {
-    const group = mapToLiquidityGroup(category)
-    groupTotals.set(group, (groupTotals.get(group) ?? 0) + value)
+  for (const key of ILLIQUID_CATEGORY_KEYS) {
+    const value = classification[key]
+    if (value !== undefined && value > 0) return false
   }
-
-  let dominantGroup = ""
-  let dominantValue = -Infinity
-  for (const [group, value] of groupTotals) {
-    if (value > dominantValue) {
-      dominantGroup = group
-      dominantValue = value
-    }
-  }
-
-  return !ILLIQUID_GROUPS.has(dominantGroup)
+  return true
 }
 
 export function mapToLiquidityGroup(categoryName: string): string {

--- a/src/lib/utils/wealth/liquidityGroups.ts
+++ b/src/lib/utils/wealth/liquidityGroups.ts
@@ -1,3 +1,47 @@
+import type { Portfolio } from "types/beancounter"
+
+/**
+ * Liquidity groups that represent illiquid wealth — excluded from
+ * the Wealth Performance widget which tracks marketable AUM only.
+ *
+ * Mirrors svc-retire's `HOUSING_CATEGORIES` (svc-position
+ * AllocationService.kt) and `NON_SPENDABLE_CATEGORIES` (svc-retire
+ * CalculationService.kt) — RE / Property maps to non-spendable.
+ */
+const ILLIQUID_GROUPS = new Set<string>(["Property"])
+
+/**
+ * Returns true when the portfolio's dominant liquidity group is liquid.
+ *
+ * A portfolio is treated as illiquid (and excluded from Wealth Performance)
+ * when more of its base-currency market value falls into an illiquid group
+ * (Property/RE) than any single liquid group. Portfolios with no
+ * `assetClassification` (legacy / unvalued) are treated as liquid.
+ */
+export function isLiquidPortfolio(portfolio: Portfolio): boolean {
+  const classification = portfolio.assetClassification
+  if (!classification) return true
+  const entries = Object.entries(classification)
+  if (entries.length === 0) return true
+
+  const groupTotals = new Map<string, number>()
+  for (const [category, value] of entries) {
+    const group = mapToLiquidityGroup(category)
+    groupTotals.set(group, (groupTotals.get(group) ?? 0) + value)
+  }
+
+  let dominantGroup = ""
+  let dominantValue = -Infinity
+  for (const [group, value] of groupTotals) {
+    if (value > dominantValue) {
+      dominantGroup = group
+      dominantValue = value
+    }
+  }
+
+  return !ILLIQUID_GROUPS.has(dominantGroup)
+}
+
 export function mapToLiquidityGroup(categoryName: string): string {
   switch (categoryName) {
     case "Equity":


### PR DESCRIPTION
## Summary
- Aggregate TWR was being dragged down by Property portfolios whose appraisal-cycle valuations don't reflect investable returns.
- New `isLiquidPortfolio` helper drops portfolios whose dominant liquidity group is Property/RE, mirroring svc-retire's `HOUSING_CATEGORIES` (`svc-position/AllocationService.kt`) and `NON_SPENDABLE_CATEGORIES` (`svc-retire/CalculationService.kt`).
- Widget shows `(liquid only)` annotation with hover tooltip when any portfolios are excluded; TWR, Total Value, and Investment Gain all recompute over liquid AUM only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wealth Performance chart now excludes property-dominated portfolios from performance calculations to improve accuracy and prevent property holdings from skewing results.
  * Shows a "(liquid only)" indicator next to the Wealth Performance title when property portfolios are excluded.

* **New Features**
  * Added a portfolio liquidity filter used to determine which portfolios contribute to aggregated performance.

* **Tests**
  * Added tests covering liquidity classification and the chart's conditional behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/675)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->