### PR TITLE
feat(wealth): consume backend aggregate composite TWR endpoint

### DIFF
--- a/src/components/features/wealth/WealthPerformanceChart.tsx
+++ b/src/components/features/wealth/WealthPerformanceChart.tsx
@@ -25,7 +25,6 @@ import { isLiquidPortfolio } from "@lib/wealth/liquidityGroups"
 
 interface WealthPerformanceChartProps {
   portfolios: Portfolio[]
-  fxRates: Record<string, number>
   displayCurrency: Currency | null
   collapsed: boolean
   onToggle: () => void
@@ -33,7 +32,6 @@ interface WealthPerformanceChartProps {
 
 const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
   portfolios,
-  fxRates,
   displayCurrency,
   collapsed,
   onToggle,
@@ -53,7 +51,6 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
   const { series, isLoading, error } = useAggregatedPerformance(
     liquidPortfolios,
     months,
-    fxRates,
     displayCurrency?.code ?? null,
     !collapsed,
   )

--- a/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
+++ b/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
@@ -70,7 +70,6 @@ const defaultProps = {
     makePortfolio({ id: "P1", code: "P1", name: "P1" }),
     makePortfolio({ id: "P2", code: "P2", name: "P2" }),
   ],
-  fxRates: { USD: 1 },
   displayCurrency: USD,
   collapsed: false,
   onToggle: jest.fn(),

--- a/src/hooks/__tests__/useAggregatedPerformance.test.ts
+++ b/src/hooks/__tests__/useAggregatedPerformance.test.ts
@@ -642,8 +642,130 @@ describe("useAggregatedPerformance", () => {
       expect(series[1].growthOf1000).toBeCloseTo(1016.67, 1)
     })
 
+    it("does not leak pre-window lifetime gain into period investmentGain (regression guard)", async () => {
+      // Original bug (svc-position cache HIT path pre-fix): if the cache was
+      // populated for a longer window, a shorter-window request returned a
+      // per-portfolio series whose series[0] landed mid-window. When the
+      // frontend unioned per-portfolio dates, a portfolio "appearing" at a
+      // mid-window date contributed BOTH its current market value AND its
+      // lifetime netContributions at that moment — leaking (mv - lifetimeContrib),
+      // i.e. the portfolio's pre-window gain, into period investmentGain.
+      // Reported symptom: 3M view showed TWR 1.55% yet investmentGain +$216K.
+      //
+      // Backend fix (PerformanceService.anchorToStartDate) now synthesises an
+      // anchor at the requested startDate for every portfolio. This test pins
+      // the contract from the consumer side: given anchored input where every
+      // series[0].date == window start, period investmentGain reflects only
+      // within-window market change, regardless of how much pre-window
+      // unrealised gain (mv - lifetimeContrib) each portfolio carries in.
+      const { ref } = captureFetcher()
+
+      // P1: existed before window with $20k pre-window unrealised gain locked
+      // in (mv 100k vs lifetime contrib 80k). $10k of further market gain
+      // accrues within the window, no flows.
+      const seriesP1 = [
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 100000,
+          netContributions: 80000,
+          cumulativeReturn: 0,
+          cumulativeDividends: 0,
+        },
+        {
+          date: "2025-12-01",
+          growthOf1000: 1100,
+          marketValue: 110000,
+          netContributions: 80000,
+          cumulativeReturn: 0.1,
+          cumulativeDividends: 0,
+        },
+      ]
+      // P2: synthesised anchor at startDate (no activity yet). Deposit mid-window,
+      // then $2k of real market gain.
+      const seriesP2 = [
+        {
+          date: "2025-01-01",
+          growthOf1000: 1000,
+          marketValue: 0,
+          netContributions: 0,
+          cumulativeReturn: 0,
+          cumulativeDividends: 0,
+        },
+        {
+          date: "2025-06-01",
+          growthOf1000: 1000,
+          marketValue: 20000,
+          netContributions: 20000,
+          cumulativeReturn: 0,
+          cumulativeDividends: 0,
+        },
+        {
+          date: "2025-12-01",
+          growthOf1000: 1100,
+          marketValue: 22000,
+          netContributions: 20000,
+          cumulativeReturn: 0.1,
+          cumulativeDividends: 0,
+        },
+      ]
+
+      global.fetch = jest.fn().mockImplementation((url: string) =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                currency: makeCurrency("USD"),
+                series: url.includes("P1") ? seriesP1 : seriesP2,
+              },
+            }),
+        }),
+      ) as unknown as typeof global.fetch
+
+      renderHook(() =>
+        useAggregatedPerformance(
+          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
+          12,
+          { USD: 1 },
+          "USD",
+          true,
+        ),
+      )
+
+      const series = (await ref.current!()) as Array<{
+        date: string
+        marketValue: number
+        netContributions: number
+        lifetimeContributions: number
+        investmentGain: number
+      }>
+
+      // Baseline t0: only P1 has MV; P2 anchor is zero.
+      expect(series[0].marketValue).toBe(100000)
+      expect(series[0].netContributions).toBe(0)
+      expect(series[0].lifetimeContributions).toBe(80000)
+      expect(series[0].investmentGain).toBe(0)
+
+      // End-of-window: $20k flowed in (P2 deposit); $10k P1 gain + $2k P2 gain.
+      // Period investmentGain = (132k − 100k) − 20k = 12k. NOT 32k (lifetime
+      // leak) and NOT 52k (full mv − period contrib without anchoring).
+      const last = series[series.length - 1]
+      expect(last.marketValue).toBe(132000)
+      expect(last.netContributions).toBe(20000)
+      expect(last.lifetimeContributions).toBe(100000)
+      expect(last.investmentGain).toBe(12000)
+      // Bug repro guard: any leak of P1's pre-window $20k gain would surface
+      // here as investmentGain >= 32000.
+      expect(last.investmentGain).toBeLessThan(32000)
+    })
+
     it("handles portfolio first appearing after window start (no negative skew)", async () => {
-      // P2 starts mid-window. Before its first snapshot, only P1 contributes.
+      // Pre-fix scenario: backend could return P2's series starting mid-window
+      // (no anchor at requested startDate). Post-fix, every portfolio's series
+      // begins at startDate, so this input shape is no longer produced in
+      // production — but the frontend's defensive forward-fill is kept and
+      // pinned here in case of backend regression or third-party data sources.
       const { ref } = captureFetcher()
       const seriesP1 = [
         {

--- a/src/hooks/__tests__/useAggregatedPerformance.test.ts
+++ b/src/hooks/__tests__/useAggregatedPerformance.test.ts
@@ -1,9 +1,11 @@
 import { renderHook } from "@testing-library/react"
-import { useAggregatedPerformance } from "../useAggregatedPerformance"
+import {
+  useAggregatedPerformance,
+  AggregatedDataPoint,
+} from "../useAggregatedPerformance"
 import { Portfolio, Currency } from "types/beancounter"
 import useSwr from "swr"
 
-// Mock SWR so we can control the fetcher execution
 jest.mock("swr")
 const mockUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
 
@@ -41,8 +43,14 @@ const captureFetcher = (): { ref: { current: CapturedFetcher } } => {
 }
 
 describe("useAggregatedPerformance", () => {
+  let originalFetch: typeof global.fetch
+
   beforeEach(() => {
     mockUseSwr.mockReset()
+    originalFetch = global.fetch
+  })
+  afterEach(() => {
+    global.fetch = originalFetch
   })
 
   it("returns empty series when no portfolios", () => {
@@ -53,7 +61,7 @@ describe("useAggregatedPerformance", () => {
     } as ReturnType<typeof useSwr>)
 
     const { result } = renderHook(() =>
-      useAggregatedPerformance([], 12, {}, "USD", true),
+      useAggregatedPerformance([], 12, "USD", true),
     )
 
     expect(mockUseSwr).toHaveBeenCalledWith(
@@ -74,7 +82,7 @@ describe("useAggregatedPerformance", () => {
 
     const portfolios = [makePortfolio("TEST", "USD")]
     const { result } = renderHook(() =>
-      useAggregatedPerformance(portfolios, 12, { USD: 1 }, "USD", false),
+      useAggregatedPerformance(portfolios, 12, "USD", false),
     )
 
     expect(mockUseSwr).toHaveBeenCalledWith(
@@ -83,10 +91,9 @@ describe("useAggregatedPerformance", () => {
       expect.any(Object),
     )
     expect(result.current.series).toEqual([])
-    expect(result.current.isLoading).toBe(false)
   })
 
-  it("passes correct SWR key when enabled", () => {
+  it("passes a stable SWR key including codes, months, displayCurrency", () => {
     mockUseSwr.mockReturnValue({
       data: [],
       isLoading: false,
@@ -94,15 +101,7 @@ describe("useAggregatedPerformance", () => {
     } as unknown as ReturnType<typeof useSwr>)
 
     const portfolios = [makePortfolio("P1", "USD"), makePortfolio("P2", "NZD")]
-    renderHook(() =>
-      useAggregatedPerformance(
-        portfolios,
-        6,
-        { USD: 1, NZD: 0.6 },
-        "USD",
-        true,
-      ),
-    )
+    renderHook(() => useAggregatedPerformance(portfolios, 6, "USD", true))
 
     expect(mockUseSwr).toHaveBeenCalledWith(
       "aggregated-perf:P1,P2:6:USD",
@@ -120,7 +119,7 @@ describe("useAggregatedPerformance", () => {
 
     const portfolios = [makePortfolio("P1", "USD")]
     const { result } = renderHook(() =>
-      useAggregatedPerformance(portfolios, 12, { USD: 1 }, "USD", true),
+      useAggregatedPerformance(portfolios, 12, "USD", true),
     )
 
     expect(result.current.isLoading).toBe(true)
@@ -137,739 +136,112 @@ describe("useAggregatedPerformance", () => {
 
     const portfolios = [makePortfolio("P1", "USD")]
     const { result } = renderHook(() =>
-      useAggregatedPerformance(portfolios, 12, { USD: 1 }, "USD", true),
+      useAggregatedPerformance(portfolios, 12, "USD", true),
     )
 
     expect(result.current.error).toBe(err)
     expect(result.current.series).toEqual([])
   })
 
-  describe("period-relative aggregation", () => {
-    const mockFetchSingle = (
-      series: Array<{
-        date: string
-        growthOf1000: number
-        marketValue: number
-        netContributions: number
-        cumulativeDividends: number
-        cumulativeReturn: number
-      }>,
-      currency = "USD",
-    ): void => {
-      global.fetch = jest.fn().mockImplementation(() =>
-        Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: { currency: makeCurrency(currency), series },
-            }),
+  it("POSTs portfolioCodes, months, displayCurrency to /api/performance/aggregate", async () => {
+    const { ref } = captureFetcher()
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { series: [] } }),
+    })
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    renderHook(() =>
+      useAggregatedPerformance(
+        [makePortfolio("P1", "USD"), makePortfolio("P2", "NZD")],
+        6,
+        "USD",
+        true,
+      ),
+    )
+
+    await ref.current!()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/performance/aggregate",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          portfolioCodes: ["P1", "P2"],
+          months: 6,
+          displayCurrency: "USD",
         }),
-      ) as unknown as typeof global.fetch
-    }
+      }),
+    )
+  })
 
-    let originalFetch: typeof global.fetch
-    beforeEach(() => {
-      originalFetch = global.fetch
-    })
-    afterEach(() => {
-      global.fetch = originalFetch
-    })
+  it("passes the backend series through as-is (regression guard for double-baselining)", async () => {
+    // Backend is the source of truth for period-relative metrics and composite
+    // TWR. Hook must not re-baseline, re-weight, or otherwise mutate the series
+    // — doing so would re-introduce the leak that prompted moving aggregation
+    // server-side (3M view: TWR 1.55% yet investmentGain +$216K).
+    const { ref } = captureFetcher()
+    const backendSeries: AggregatedDataPoint[] = [
+      {
+        date: "2025-01-01",
+        marketValue: 100000,
+        netContributions: 0,
+        lifetimeContributions: 80000,
+        cumulativeDividends: 0,
+        investmentGain: 0,
+        growthOf1000: 1000,
+        cumulativeReturn: 0,
+      },
+      {
+        date: "2025-12-01",
+        marketValue: 132000,
+        netContributions: 20000,
+        lifetimeContributions: 100000,
+        cumulativeDividends: 0,
+        investmentGain: 12000,
+        growthOf1000: 1100,
+        cumulativeReturn: 0.1,
+      },
+    ]
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { series: backendSeries } }),
+    }) as unknown as typeof global.fetch
 
-    it("period netContributions = 0 at first snapshot (lifetime baseline removed)", async () => {
-      const { ref } = captureFetcher()
-      mockFetchSingle([
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 100000,
-          netContributions: 80000, // lifetime contributions before window
-          cumulativeDividends: 0,
-          cumulativeReturn: 0,
-        },
-        {
-          date: "2025-12-01",
-          growthOf1000: 1100,
-          marketValue: 115000,
-          netContributions: 85000, // +5000 deposited during window
-          cumulativeDividends: 500,
-          cumulativeReturn: 0.1,
-        },
-      ])
+    renderHook(() =>
+      useAggregatedPerformance(
+        [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
+        12,
+        "USD",
+        true,
+      ),
+    )
 
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("P1", "USD")],
-          12,
-          { USD: 1 },
-          "USD",
-          true,
-        ),
-      )
+    const result = (await ref.current!()) as AggregatedDataPoint[]
 
-      const result = (await ref.current!()) as Array<{
-        netContributions: number
-        lifetimeContributions: number
-      }>
-      expect(result[0].netContributions).toBe(0)
-      expect(result[1].netContributions).toBe(5000)
-      expect(result[0].lifetimeContributions).toBe(80000)
-      expect(result[1].lifetimeContributions).toBe(85000)
-    })
+    expect(result).toEqual(backendSeries)
+    // Period-relative invariants the backend guarantees, asserted here so a
+    // future hook-side mutation that violates them fails loudly.
+    expect(result[0].netContributions).toBe(0)
+    expect(result[0].investmentGain).toBe(0)
+    expect(result[1].investmentGain).toBe(12000)
+    // Bug repro guard: lifetime leak would push this to >= 32000.
+    expect(result[1].investmentGain).toBeLessThan(32000)
+  })
 
-    it("investmentGain is period MV change minus period contributions, not MV - lifetime contrib", async () => {
-      const { ref } = captureFetcher()
-      mockFetchSingle([
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 100000,
-          netContributions: 80000, // historical contributions
-          cumulativeDividends: 0,
-          cumulativeReturn: 0,
-        },
-        {
-          date: "2025-12-01",
-          growthOf1000: 1100,
-          marketValue: 115000, // +15k MV with +5k deposit -> +10k pure gain
-          netContributions: 85000,
-          cumulativeDividends: 0,
-          cumulativeReturn: 0.1,
-        },
-      ])
+  it("throws when backend responds with non-ok", async () => {
+    const { ref } = captureFetcher()
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof global.fetch
 
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("P1", "USD")],
-          12,
-          { USD: 1 },
-          "USD",
-          true,
-        ),
-      )
+    renderHook(() =>
+      useAggregatedPerformance([makePortfolio("P1", "USD")], 12, "USD", true),
+    )
 
-      const result = (await ref.current!()) as Array<{ investmentGain: number }>
-      // Period gain = (115000 - 100000) - 5000 = 10000 (NOT 115000 - 85000 = 30000)
-      expect(result[1].investmentGain).toBe(10000)
-      // Bug repro guard: must not equal lifetime-style gain
-      expect(result[1].investmentGain).not.toBe(30000)
-    })
-
-    it("cumulativeReturn uses backend TWR, not naive MV/MV0 ratio", async () => {
-      // Backend's growthOf1000 already neutralises cash flows.
-      // MV doubles (100k -> 200k) because of deposit, not investment performance.
-      // TWR = 0%; naive MV/MV0 = 100%.
-      const { ref } = captureFetcher()
-      mockFetchSingle([
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 100000,
-          netContributions: 50000,
-          cumulativeDividends: 0,
-          cumulativeReturn: 0,
-        },
-        {
-          date: "2025-12-01",
-          growthOf1000: 1000, // no investment performance
-          marketValue: 200000, // 100k deposit
-          netContributions: 150000,
-          cumulativeDividends: 0,
-          cumulativeReturn: 0,
-        },
-      ])
-
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("P1", "USD")],
-          12,
-          { USD: 1 },
-          "USD",
-          true,
-        ),
-      )
-
-      const result = (await ref.current!()) as Array<{
-        cumulativeReturn: number
-        growthOf1000: number
-      }>
-      expect(result[1].cumulativeReturn).toBeCloseTo(0, 6)
-      expect(result[1].growthOf1000).toBeCloseTo(1000, 6)
-    })
-
-    it("composite TWR is beginning-AUM weighted across portfolios", async () => {
-      // P1 starts 60k, ends with TWR +20% (growthOf1000 1200)
-      // P2 starts 40k, ends with TWR +5%  (growthOf1000 1050)
-      // weight P1=0.6, P2=0.4
-      // composite growth factor = 0.6*1.20 + 0.4*1.05 = 0.72 + 0.42 = 1.14
-      // composite cumulativeReturn = 0.14 (NOT 0.125 equal-weighted)
-      const { ref } = captureFetcher()
-
-      const seriesP1 = [
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 60000,
-          netContributions: 60000,
-          cumulativeDividends: 0,
-          cumulativeReturn: 0,
-        },
-        {
-          date: "2025-12-01",
-          growthOf1000: 1200,
-          marketValue: 72000,
-          netContributions: 60000,
-          cumulativeDividends: 0,
-          cumulativeReturn: 0.2,
-        },
-      ]
-      const seriesP2 = [
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 40000,
-          netContributions: 40000,
-          cumulativeDividends: 0,
-          cumulativeReturn: 0,
-        },
-        {
-          date: "2025-12-01",
-          growthOf1000: 1050,
-          marketValue: 42000,
-          netContributions: 40000,
-          cumulativeDividends: 0,
-          cumulativeReturn: 0.05,
-        },
-      ]
-
-      global.fetch = jest.fn().mockImplementation((url: string) =>
-        Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: {
-                currency: makeCurrency("USD"),
-                series: url.includes("P1") ? seriesP1 : seriesP2,
-              },
-            }),
-        }),
-      ) as unknown as typeof global.fetch
-
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
-          12,
-          { USD: 1 },
-          "USD",
-          true,
-        ),
-      )
-
-      const result = (await ref.current!()) as Array<{
-        cumulativeReturn: number
-        growthOf1000: number
-        marketValue: number
-      }>
-      expect(result[1].cumulativeReturn).toBeCloseTo(0.14, 5)
-      expect(result[1].growthOf1000).toBeCloseTo(1140, 2)
-      expect(result[1].marketValue).toBe(114000)
-    })
-
-    it("composite TWR weights by display-currency initial MV (FX-aware)", async () => {
-      // P_USD 50k USD @ TWR +10%
-      // P_NZD 100k NZD @ 0.6 = 60k USD initial @ TWR +20%
-      // weight USD = 50/110, NZD = 60/110
-      // composite = 50/110 * 1.10 + 60/110 * 1.20 = 0.55 + 0.7272727... = 1.15454...
-      const { ref } = captureFetcher()
-      global.fetch = jest.fn().mockImplementation((url: string) => {
-        const series = url.includes("US_PORT")
-          ? [
-              {
-                date: "2025-01-01",
-                growthOf1000: 1000,
-                marketValue: 50000,
-                netContributions: 50000,
-                cumulativeDividends: 0,
-                cumulativeReturn: 0,
-              },
-              {
-                date: "2025-12-01",
-                growthOf1000: 1100,
-                marketValue: 55000,
-                netContributions: 50000,
-                cumulativeDividends: 0,
-                cumulativeReturn: 0.1,
-              },
-            ]
-          : [
-              {
-                date: "2025-01-01",
-                growthOf1000: 1000,
-                marketValue: 100000,
-                netContributions: 100000,
-                cumulativeDividends: 0,
-                cumulativeReturn: 0,
-              },
-              {
-                date: "2025-12-01",
-                growthOf1000: 1200,
-                marketValue: 120000,
-                netContributions: 100000,
-                cumulativeDividends: 0,
-                cumulativeReturn: 0.2,
-              },
-            ]
-        const ccy = url.includes("US_PORT") ? "USD" : "NZD"
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: { currency: makeCurrency(ccy), series },
-            }),
-        })
-      }) as unknown as typeof global.fetch
-
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("US_PORT", "USD"), makePortfolio("NZ_PORT", "NZD")],
-          12,
-          { USD: 1, NZD: 0.6 },
-          "USD",
-          true,
-        ),
-      )
-
-      const result = (await ref.current!()) as Array<{
-        cumulativeReturn: number
-        marketValue: number
-      }>
-      // Expected composite return
-      const expected = (50 / 110) * 1.1 + (60 / 110) * 1.2 - 1
-      expect(result[1].cumulativeReturn).toBeCloseTo(expected, 5)
-      // Initial MV in USD = 50000 + 100000*0.6 = 110000
-      expect(result[0].marketValue).toBe(110000)
-      // End MV in USD = 55000 + 120000*0.6 = 127000
-      expect(result[1].marketValue).toBe(127000)
-    })
-
-    it("aggregates same-currency portfolios — period contrib summed, lifetime summed", async () => {
-      const { ref } = captureFetcher()
-      const dates = ["2025-01-01", "2025-02-01"]
-      const makeSeries = (mv: number): object[] =>
-        dates.map((date, i) => ({
-          date,
-          growthOf1000: 1000 + i * 10,
-          marketValue: mv + i * 100,
-          netContributions: mv,
-          cumulativeReturn: (i * 10) / 1000,
-          cumulativeDividends: i * 5,
-        }))
-
-      global.fetch = jest.fn().mockImplementation((url: string) => {
-        const data = url.includes("P1")
-          ? {
-              data: { currency: makeCurrency("USD"), series: makeSeries(5000) },
-            }
-          : {
-              data: { currency: makeCurrency("USD"), series: makeSeries(3000) },
-            }
-        return Promise.resolve({ ok: true, json: () => Promise.resolve(data) })
-      }) as unknown as typeof global.fetch
-
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
-          12,
-          { USD: 1 },
-          "USD",
-          true,
-        ),
-      )
-
-      const series = (await ref.current!()) as Array<{
-        marketValue: number
-        netContributions: number
-        lifetimeContributions: number
-      }>
-
-      expect(series[0].marketValue).toBe(8000)
-      // Period contribution at t0 = 0 (no flows within window)
-      expect(series[0].netContributions).toBe(0)
-      // Lifetime sum = 5000 + 3000 = 8000
-      expect(series[0].lifetimeContributions).toBe(8000)
-      expect(series[1].marketValue).toBe(8200)
-    })
-
-    it("FX-converts MV when aggregating multi-currency portfolios", async () => {
-      const { ref } = captureFetcher()
-      global.fetch = jest.fn().mockImplementation((url: string) => {
-        const mv = url.includes("US_PORT") ? 5000 : 10000
-        const ccy = url.includes("US_PORT") ? "USD" : "NZD"
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: {
-                currency: makeCurrency(ccy),
-                series: [
-                  {
-                    date: "2025-01-01",
-                    growthOf1000: 1000,
-                    marketValue: mv,
-                    netContributions: mv,
-                    cumulativeReturn: 0,
-                    cumulativeDividends: 0,
-                  },
-                ],
-              },
-            }),
-        })
-      }) as unknown as typeof global.fetch
-
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("US_PORT", "USD"), makePortfolio("NZ_PORT", "NZD")],
-          12,
-          { USD: 1, NZD: 0.6 },
-          "USD",
-          true,
-        ),
-      )
-
-      const series = (await ref.current!()) as Array<{ marketValue: number }>
-      expect(series[0].marketValue).toBe(11000)
-    })
-
-    it("forward-fills missing snapshots when portfolios have different date sets", async () => {
-      // Real-world case: P1 cash flow on Feb-15 creates a valuation date that
-      // P2 doesn't have. Without fill, MV at Feb-15 would drop to P2-only,
-      // producing the sawtooth-spike chart artefact.
-      const { ref } = captureFetcher()
-      const seriesP1 = [
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 100000,
-          netContributions: 100000,
-          cumulativeReturn: 0,
-          cumulativeDividends: 0,
-        },
-        // No Feb-15 snapshot for P1
-        {
-          date: "2025-03-01",
-          growthOf1000: 1100,
-          marketValue: 115000,
-          netContributions: 105000,
-          cumulativeReturn: 0.1,
-          cumulativeDividends: 0,
-        },
-      ]
-      const seriesP2 = [
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 50000,
-          netContributions: 50000,
-          cumulativeReturn: 0,
-          cumulativeDividends: 0,
-        },
-        {
-          date: "2025-02-15",
-          growthOf1000: 1050,
-          marketValue: 52500,
-          netContributions: 50000,
-          cumulativeReturn: 0.05,
-          cumulativeDividends: 0,
-        },
-        {
-          date: "2025-03-01",
-          growthOf1000: 1080,
-          marketValue: 54000,
-          netContributions: 50000,
-          cumulativeReturn: 0.08,
-          cumulativeDividends: 0,
-        },
-      ]
-
-      global.fetch = jest.fn().mockImplementation((url: string) =>
-        Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: {
-                currency: makeCurrency("USD"),
-                series: url.includes("P1") ? seriesP1 : seriesP2,
-              },
-            }),
-        }),
-      ) as unknown as typeof global.fetch
-
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
-          12,
-          { USD: 1 },
-          "USD",
-          true,
-        ),
-      )
-
-      const series = (await ref.current!()) as Array<{
-        date: string
-        marketValue: number
-        growthOf1000: number
-        lifetimeContributions: number
-      }>
-
-      // Union dates: Jan-01, Feb-15, Mar-01
-      expect(series.map((s) => s.date)).toEqual([
-        "2025-01-01",
-        "2025-02-15",
-        "2025-03-01",
-      ])
-      // Jan-01: 100k + 50k = 150k
-      expect(series[0].marketValue).toBe(150000)
-      // Feb-15: P1 missing -> forward-fill 100k; P2 = 52500 -> 152500
-      // NOT 52500 (which would be the sawtooth bug)
-      expect(series[1].marketValue).toBe(152500)
-      // Mar-01: real snapshots both = 115000 + 54000 = 169000
-      expect(series[2].marketValue).toBe(169000)
-
-      // Lifetime contributions also forward-fill: Feb-15 = 100k (P1) + 50k (P2) = 150k
-      expect(series[1].lifetimeContributions).toBe(150000)
-
-      // Composite TWR at Feb-15: P1 carried 1.0, P2 1.05, weights 100/150=0.667 & 50/150=0.333
-      // composite = 0.667*1.0 + 0.333*1.05 = 1.01667
-      expect(series[1].growthOf1000).toBeCloseTo(1016.67, 1)
-    })
-
-    it("does not leak pre-window lifetime gain into period investmentGain (regression guard)", async () => {
-      // Original bug (svc-position cache HIT path pre-fix): if the cache was
-      // populated for a longer window, a shorter-window request returned a
-      // per-portfolio series whose series[0] landed mid-window. When the
-      // frontend unioned per-portfolio dates, a portfolio "appearing" at a
-      // mid-window date contributed BOTH its current market value AND its
-      // lifetime netContributions at that moment — leaking (mv - lifetimeContrib),
-      // i.e. the portfolio's pre-window gain, into period investmentGain.
-      // Reported symptom: 3M view showed TWR 1.55% yet investmentGain +$216K.
-      //
-      // Backend fix (PerformanceService.anchorToStartDate) now synthesises an
-      // anchor at the requested startDate for every portfolio. This test pins
-      // the contract from the consumer side: given anchored input where every
-      // series[0].date == window start, period investmentGain reflects only
-      // within-window market change, regardless of how much pre-window
-      // unrealised gain (mv - lifetimeContrib) each portfolio carries in.
-      const { ref } = captureFetcher()
-
-      // P1: existed before window with $20k pre-window unrealised gain locked
-      // in (mv 100k vs lifetime contrib 80k). $10k of further market gain
-      // accrues within the window, no flows.
-      const seriesP1 = [
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 100000,
-          netContributions: 80000,
-          cumulativeReturn: 0,
-          cumulativeDividends: 0,
-        },
-        {
-          date: "2025-12-01",
-          growthOf1000: 1100,
-          marketValue: 110000,
-          netContributions: 80000,
-          cumulativeReturn: 0.1,
-          cumulativeDividends: 0,
-        },
-      ]
-      // P2: synthesised anchor at startDate (no activity yet). Deposit mid-window,
-      // then $2k of real market gain.
-      const seriesP2 = [
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 0,
-          netContributions: 0,
-          cumulativeReturn: 0,
-          cumulativeDividends: 0,
-        },
-        {
-          date: "2025-06-01",
-          growthOf1000: 1000,
-          marketValue: 20000,
-          netContributions: 20000,
-          cumulativeReturn: 0,
-          cumulativeDividends: 0,
-        },
-        {
-          date: "2025-12-01",
-          growthOf1000: 1100,
-          marketValue: 22000,
-          netContributions: 20000,
-          cumulativeReturn: 0.1,
-          cumulativeDividends: 0,
-        },
-      ]
-
-      global.fetch = jest.fn().mockImplementation((url: string) =>
-        Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: {
-                currency: makeCurrency("USD"),
-                series: url.includes("P1") ? seriesP1 : seriesP2,
-              },
-            }),
-        }),
-      ) as unknown as typeof global.fetch
-
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
-          12,
-          { USD: 1 },
-          "USD",
-          true,
-        ),
-      )
-
-      const series = (await ref.current!()) as Array<{
-        date: string
-        marketValue: number
-        netContributions: number
-        lifetimeContributions: number
-        investmentGain: number
-      }>
-
-      // Baseline t0: only P1 has MV; P2 anchor is zero.
-      expect(series[0].marketValue).toBe(100000)
-      expect(series[0].netContributions).toBe(0)
-      expect(series[0].lifetimeContributions).toBe(80000)
-      expect(series[0].investmentGain).toBe(0)
-
-      // End-of-window: $20k flowed in (P2 deposit); $10k P1 gain + $2k P2 gain.
-      // Period investmentGain = (132k − 100k) − 20k = 12k. NOT 32k (lifetime
-      // leak) and NOT 52k (full mv − period contrib without anchoring).
-      const last = series[series.length - 1]
-      expect(last.marketValue).toBe(132000)
-      expect(last.netContributions).toBe(20000)
-      expect(last.lifetimeContributions).toBe(100000)
-      expect(last.investmentGain).toBe(12000)
-      // Bug repro guard: any leak of P1's pre-window $20k gain would surface
-      // here as investmentGain >= 32000.
-      expect(last.investmentGain).toBeLessThan(32000)
-    })
-
-    it("handles portfolio first appearing after window start (no negative skew)", async () => {
-      // Pre-fix scenario: backend could return P2's series starting mid-window
-      // (no anchor at requested startDate). Post-fix, every portfolio's series
-      // begins at startDate, so this input shape is no longer produced in
-      // production — but the frontend's defensive forward-fill is kept and
-      // pinned here in case of backend regression or third-party data sources.
-      const { ref } = captureFetcher()
-      const seriesP1 = [
-        {
-          date: "2025-01-01",
-          growthOf1000: 1000,
-          marketValue: 100000,
-          netContributions: 100000,
-          cumulativeReturn: 0,
-          cumulativeDividends: 0,
-        },
-        {
-          date: "2025-06-01",
-          growthOf1000: 1100,
-          marketValue: 110000,
-          netContributions: 100000,
-          cumulativeReturn: 0.1,
-          cumulativeDividends: 0,
-        },
-      ]
-      const seriesP2 = [
-        {
-          date: "2025-06-01",
-          growthOf1000: 1000,
-          marketValue: 20000,
-          netContributions: 20000,
-          cumulativeReturn: 0,
-          cumulativeDividends: 0,
-        },
-      ]
-
-      global.fetch = jest.fn().mockImplementation((url: string) =>
-        Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: {
-                currency: makeCurrency("USD"),
-                series: url.includes("P1") ? seriesP1 : seriesP2,
-              },
-            }),
-        }),
-      ) as unknown as typeof global.fetch
-
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("P1", "USD"), makePortfolio("P2", "USD")],
-          12,
-          { USD: 1 },
-          "USD",
-          true,
-        ),
-      )
-
-      const series = (await ref.current!()) as Array<{
-        date: string
-        marketValue: number
-      }>
-
-      // Jan-01: only P1 active -> 100k (not 0)
-      expect(series[0].marketValue).toBe(100000)
-      // Jun-01: both -> 110k + 20k = 130k
-      expect(series[1].marketValue).toBe(130000)
-    })
-
-    it("drops failed portfolios silently", async () => {
-      const { ref } = captureFetcher()
-      global.fetch = jest.fn().mockImplementation((url: string) => {
-        if (url.includes("FAIL")) {
-          return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
-        }
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: {
-                currency: makeCurrency("USD"),
-                series: [
-                  {
-                    date: "2025-01-01",
-                    growthOf1000: 1000,
-                    marketValue: 5000,
-                    netContributions: 5000,
-                    cumulativeReturn: 0,
-                    cumulativeDividends: 0,
-                  },
-                ],
-              },
-            }),
-        })
-      }) as unknown as typeof global.fetch
-
-      renderHook(() =>
-        useAggregatedPerformance(
-          [makePortfolio("OK", "USD"), makePortfolio("FAIL", "USD")],
-          12,
-          { USD: 1 },
-          "USD",
-          true,
-        ),
-      )
-
-      const series = (await ref.current!()) as Array<{ marketValue: number }>
-      expect(series).toHaveLength(1)
-      expect(series[0].marketValue).toBe(5000)
-    })
+    await expect(ref.current!()).rejects.toThrow(/500/)
   })
 })

--- a/src/hooks/useAggregatedPerformance.ts
+++ b/src/hooks/useAggregatedPerformance.ts
@@ -1,20 +1,23 @@
 import useSwr from "swr"
-import { Portfolio, PerformanceResponse } from "types/beancounter"
+import { Portfolio } from "types/beancounter"
 
+/**
+ * Aggregated performance shape mirroring the backend
+ * `AggregatedPerformanceDataPoint` contract.
+ *
+ * Composite TWR (`growthOf1000`, `cumulativeReturn`) is chained sub-period
+ * with beginning-of-sub-period AUM weights in display currency. Period
+ * metrics (`netContributions`, `cumulativeDividends`, `investmentGain`) are
+ * baselined from `series[0]` — zero at t=0.
+ */
 export interface AggregatedDataPoint {
   date: string
   marketValue: number
-  /** Period-relative net external cash flows (deposits − withdrawals) WITHIN the requested window. */
   netContributions: number
-  /** Lifetime-cumulative net external cash flows up to this date (for context/tooltip). */
   lifetimeContributions: number
-  /** Period-relative dividends. */
   cumulativeDividends: number
-  /** Period gain: (MV − MV₀) − periodContributions. */
   investmentGain: number
-  /** Composite TWR growth-of-1000, beginning-AUM weighted across portfolios. */
   growthOf1000: number
-  /** Composite TWR as decimal (0.10 = +10%). */
   cumulativeReturn: number
 }
 
@@ -24,167 +27,49 @@ export interface AggregatedPerformance {
   error: Error | undefined
 }
 
-interface PortfolioSnapshot {
-  date: string
-  growthFactor: number // backend growthOf1000 / 1000
-  mv: number // display ccy
-  contrib: number // lifetime, display ccy
-  divs: number // lifetime, display ccy
-}
-
-interface PortfolioSeriesFx {
-  /** FX-converted into display currency. */
-  startMv: number
-  /** Snapshots sorted by date ascending. Used for forward-fill on union dates. */
-  snapshots: PortfolioSnapshot[]
+interface AggregateApiResponse {
+  data: {
+    series: AggregatedDataPoint[]
+  }
 }
 
 /**
- * Fetch performance data for all portfolios in parallel, FX-convert,
- * and aggregate into a single time series.
+ * Fetches a backend-aggregated composite TWR series.
  *
- * Returns period-relative values aligned with GIPS composite TWR conventions:
- * - cumulativeReturn / growthOf1000: beginning-AUM weighted composite TWR (uses
- *   the backend's per-portfolio TWR `growthOf1000`, not a naïve MV ratio).
- * - netContributions: cash flows within the requested window only.
- * - lifetimeContributions: total inception-to-date contributions, for tooltip.
- * - investmentGain: (MV_t − MV_0) − periodContributions.
+ * The backend (`POST /performance/aggregate`) does all the work: pulls each
+ * portfolio's cached TWR, FX-converts to `displayCurrencyCode`, builds the
+ * union of valuation dates, chains sub-period AUM-weighted composite TWR,
+ * and baselines period-relative metrics.
  */
 export function useAggregatedPerformance(
   portfolios: Portfolio[],
   months: number,
-  fxRates: Record<string, number>,
   displayCurrencyCode: string | null,
   enabled: boolean,
 ): AggregatedPerformance {
+  const portfolioCodes = portfolios.map((p) => p.code)
   const key =
-    enabled && portfolios.length > 0 && displayCurrencyCode
-      ? `aggregated-perf:${portfolios.map((p) => p.code).join(",")}:${months}:${displayCurrencyCode}`
+    enabled && portfolioCodes.length > 0 && displayCurrencyCode
+      ? `aggregated-perf:${portfolioCodes.join(",")}:${months}:${displayCurrencyCode}`
       : null
 
   const { data, isLoading, error } = useSwr<AggregatedDataPoint[]>(
     key,
     async () => {
-      const results = await Promise.allSettled(
-        portfolios.map(async (portfolio) => {
-          const res = await fetch(
-            `/api/performance/${portfolio.code}?months=${months}`,
-          )
-          if (!res.ok) throw new Error(`Failed for ${portfolio.code}`)
-          const json: PerformanceResponse = await res.json()
-          return { portfolio, series: json.data?.series || [] }
+      const res = await fetch(`/api/performance/aggregate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          portfolioCodes,
+          months,
+          displayCurrency: displayCurrencyCode,
         }),
-      )
-
-      // Per-portfolio normalised series in display currency
-      const perPortfolio: PortfolioSeriesFx[] = []
-      const allDates = new Set<string>()
-
-      for (const result of results) {
-        if (result.status !== "fulfilled") continue
-        const { portfolio, series } = result.value
-        if (series.length === 0) continue
-        const rate = fxRates[portfolio.currency.code] ?? 1
-
-        const snapshots: PortfolioSnapshot[] = series
-          .map((point) => {
-            allDates.add(point.date)
-            return {
-              date: point.date,
-              growthFactor: point.growthOf1000 / 1000,
-              mv: point.marketValue * rate,
-              contrib: point.netContributions * rate,
-              divs: point.cumulativeDividends * rate,
-            }
-          })
-          .sort((a, b) => a.date.localeCompare(b.date))
-
-        perPortfolio.push({
-          startMv: snapshots[0].mv,
-          snapshots,
-        })
+      })
+      if (!res.ok) {
+        throw new Error(`Aggregate request failed: ${res.status}`)
       }
-
-      if (perPortfolio.length === 0) return []
-
-      const totalStartMv = perPortfolio.reduce((sum, p) => sum + p.startMv, 0)
-      const sortedDates = Array.from(allDates).sort((a, b) =>
-        a.localeCompare(b),
-      )
-
-      // Forward-fill state per portfolio: cursor advances as we walk union dates.
-      // When a portfolio has no snapshot on date d, we carry the last-seen snapshot.
-      // Required because each portfolio's valuation dates differ (cash-flow dates
-      // are portfolio-specific) — without fill, the aggregated MV would zigzag
-      // wildly between $0 and full value as portfolios drop in and out.
-      const cursors: number[] = perPortfolio.map(() => 0)
-
-      const aggregated: AggregatedDataPoint[] = []
-      let baselineMv = 0
-      let baselineContrib = 0
-      let baselineDivs = 0
-
-      for (let i = 0; i < sortedDates.length; i++) {
-        const date = sortedDates[i]
-        let mv = 0
-        let contrib = 0
-        let divs = 0
-        let compositeGrowth = 0
-        let weightSumPresent = 0
-
-        for (let pi = 0; pi < perPortfolio.length; pi++) {
-          const p = perPortfolio[pi]
-          // Advance cursor while next snapshot is on/before this date
-          while (
-            cursors[pi] + 1 < p.snapshots.length &&
-            p.snapshots[cursors[pi] + 1].date <= date
-          ) {
-            cursors[pi]++
-          }
-          const point = p.snapshots[cursors[pi]]
-          // Skip portfolios whose first snapshot is later than this date (they
-          // didn't exist yet within the requested window).
-          if (point.date > date) continue
-
-          mv += point.mv
-          contrib += point.contrib
-          divs += point.divs
-          if (totalStartMv > 0) {
-            const w = p.startMv / totalStartMv
-            compositeGrowth += w * point.growthFactor
-            weightSumPresent += w
-          }
-        }
-
-        // Renormalise composite growth if some portfolios are not yet active
-        const growthFactor =
-          weightSumPresent > 0 ? compositeGrowth / weightSumPresent : 1
-        const growthOf1000 = 1000 * growthFactor
-        const cumulativeReturn = growthFactor - 1
-
-        if (i === 0) {
-          baselineMv = mv
-          baselineContrib = contrib
-          baselineDivs = divs
-        }
-
-        const periodContrib = contrib - baselineContrib
-        const periodDivs = divs - baselineDivs
-        const investmentGain = mv - baselineMv - periodContrib
-
-        aggregated.push({
-          date,
-          marketValue: mv,
-          netContributions: periodContrib,
-          lifetimeContributions: contrib,
-          cumulativeDividends: periodDivs,
-          investmentGain,
-          growthOf1000,
-          cumulativeReturn,
-        })
-      }
-
-      return aggregated
+      const json: AggregateApiResponse = await res.json()
+      return json.data?.series ?? []
     },
     {
       revalidateOnFocus: false,
@@ -194,7 +79,7 @@ export function useAggregatedPerformance(
   )
 
   return {
-    series: data || [],
+    series: data ?? [],
     isLoading,
     error,
   }

--- a/src/lib/utils/api/__tests__/routes/aggregate.route.test.ts
+++ b/src/lib/utils/api/__tests__/routes/aggregate.route.test.ts
@@ -1,4 +1,4 @@
-import aggregateHandler from "../aggregate"
+import aggregateHandler from "@pages/api/performance/aggregate"
 
 jest.mock("@lib/auth0", () => ({
   auth0: {

--- a/src/pages/api/performance/__tests__/aggregate.test.ts
+++ b/src/pages/api/performance/__tests__/aggregate.test.ts
@@ -1,0 +1,119 @@
+import aggregateHandler from "../aggregate"
+
+jest.mock("@lib/auth0", () => ({
+  auth0: {
+    getSession: jest.fn().mockResolvedValue({ user: { sub: "test-user" } }),
+    getAccessToken: jest.fn().mockResolvedValue({ token: "test-token" }),
+  },
+}))
+
+jest.mock("@utils/api/fetchHelper", () => ({
+  requestInit: jest.fn(
+    (token: string, method: string) =>
+      ({
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+      }) as unknown,
+  ),
+}))
+
+jest.mock("@utils/api/responseWriter", () => {
+  const handleResponse = jest
+    .fn()
+    .mockImplementation(
+      (_response: Response, res: { status: jest.Mock; json: jest.Mock }) => {
+        res.status(200).json({ data: { series: [] } })
+      },
+    )
+  return {
+    __esModule: true,
+    default: handleResponse,
+    handleResponse,
+    fetchError: jest.fn(
+      (
+        _req: unknown,
+        res: { status: jest.Mock; json: jest.Mock },
+        error: { message: string },
+      ) => {
+        res.status(500).json({ error: error.message })
+      },
+    ),
+  }
+})
+
+jest.mock("@utils/api/bcConfig", () => ({
+  getPositionsUrl: (path: string): string => `http://positions.test${path}`,
+}))
+
+const mockFetch = jest
+  .fn()
+  .mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
+global.fetch = mockFetch as unknown as typeof fetch
+
+function makeReq(
+  method: string,
+  body?: unknown,
+): {
+  method: string
+  body: unknown
+  query: Record<string, string>
+  headers: Record<string, string>
+} {
+  return { method, body, query: {}, headers: {} }
+}
+
+function makeRes(): {
+  status: jest.Mock
+  end: jest.Mock
+  json: jest.Mock
+  setHeader: jest.Mock
+} {
+  return {
+    status: jest.fn().mockReturnThis(),
+    end: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("/api/performance/aggregate route", () => {
+  it("proxies POST to backend /performance/aggregate", async () => {
+    const req = makeReq("POST", {
+      portfolioCodes: ["P1", "P2"],
+      months: 12,
+      displayCurrency: "USD",
+    })
+    const res = makeRes()
+
+    await aggregateHandler(
+      req as unknown as Parameters<typeof aggregateHandler>[0],
+      res as unknown as Parameters<typeof aggregateHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://positions.test/performance/aggregate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(req.body),
+      }),
+    )
+  })
+
+  it("rejects GET with 405", async () => {
+    const req = makeReq("GET")
+    const res = makeRes()
+
+    await aggregateHandler(
+      req as unknown as Parameters<typeof aggregateHandler>[0],
+      res as unknown as Parameters<typeof aggregateHandler>[1],
+    )
+
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", ["POST"])
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/pages/api/performance/aggregate.ts
+++ b/src/pages/api/performance/aggregate.ts
@@ -1,0 +1,7 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getPositionsUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: () => getPositionsUrl(`/performance/aggregate`),
+  methods: ["POST"],
+})

--- a/src/pages/wealth.tsx
+++ b/src/pages/wealth.tsx
@@ -265,7 +265,6 @@ function WealthDashboard(): React.ReactElement {
           {preferences?.enableTwr && (
             <WealthPerformanceChart
               portfolios={portfolios}
-              fxRates={fxRates}
               displayCurrency={displayCurrency}
               collapsed={collapsedSections.performance}
               onToggle={() => toggleSection("performance")}


### PR DESCRIPTION
Re-targets the stacked work that originally landed on \`fix/perf-cache-anchor\` (the stacked base) instead of main. Brings the consumer-side aggregate flow plus follow-up commits to main in one shot.

Companion to monowai/beancounter#838.

## Includes
- **Regression guard (orig. #676)** — \`useAggregatedPerformance.test.ts\` test asserts the pre-window lifetime gain leak does not surface in the period \`investmentGain\` when the backend returns properly anchored series. Pins the contract from the consumer side.
- **Backend-driven aggregation (orig. #677)** — \`useAggregatedPerformance\` becomes a thin SWR pass-through that POSTs to \`/api/performance/aggregate\`. Removes ~150 lines of client-side FX, forward-fill, union-date stitching, baseline math, and fixed-weight composite TWR. New API route at \`src/pages/api/performance/aggregate.ts\` proxying to svc-position. \`WealthPerformanceChart\` and \`wealth.tsx\` drop the unused \`fxRates\` prop.
- **API route smoke test** — \`src/lib/utils/api/__tests__/routes/aggregate.route.test.ts\`. Located outside \`src/pages/\` because Next.js Pages Router treats every \`.ts\` under \`src/pages/api/\` as a route, including files in \`__tests__/\`, which broke \`yarn build\` in CI.

## Why this re-PR
Original PRs #676 and #677 were stacked; #677 squash landed on \`fix/perf-cache-anchor\` (still on remote), not on main. The route relocation fix and route smoke test were also committed after merge and never PR'd. This PR consolidates and targets main directly.

## Test plan
- [x] \`yarn test\` green (1297/1297)
- [x] \`yarn prettier && yarn lint && yarn typecheck\` green
- [x] \`yarn build\` green locally (was the failure mode in CI before relocation)
- [ ] Manual browser exercise of /wealth tabs after backend #838 deploy

Once merged, stale branches \`fix/perf-cache-anchor\` and \`feat/perf-aggregate-endpoint\` can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized wealth performance calculation by moving aggregation logic to the backend API, reducing client-side computation while maintaining the same user experience.

* **Tests**
  * Added comprehensive test coverage for the new performance aggregation API and updated existing tests to align with the refactored architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/678)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->