### PR TITLE
feat(wealth): XIRR headline alongside TWR

### DIFF
--- a/src/components/features/wealth/WealthPerformanceChart.tsx
+++ b/src/components/features/wealth/WealthPerformanceChart.tsx
@@ -48,7 +48,7 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
   )
   const excludedCount = portfolios.length - liquidPortfolios.length
 
-  const { series, isLoading, error } = useAggregatedPerformance(
+  const { series, xirr, isLoading, error } = useAggregatedPerformance(
     liquidPortfolios,
     months,
     displayCurrency?.code ?? null,
@@ -60,7 +60,7 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
     if (series.length === 0) return null
     const last = series[series.length - 1]
     return {
-      returnPct: last.cumulativeReturn * 100,
+      twrPct: last.cumulativeReturn * 100,
       growthOf1000: last.growthOf1000,
       marketValue: last.marketValue,
       contributed: last.netContributions, // period-only
@@ -69,7 +69,13 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
     }
   }, [series])
 
-  const isPositive = (stats?.returnPct ?? 0) >= 0
+  // XIRR is the headline. >=12M windows are annualised by the solver;
+  // shorter windows return simple ROI (cumulative) per IrrCalculator's
+  // minHoldingDays fallback. Label accordingly so the user can interpret.
+  const xirrPct = xirr != null ? xirr * 100 : null
+  const isAnnualised = months >= 12
+  const headlinePct = xirrPct ?? stats?.twrPct ?? 0
+  const isPositive = headlinePct >= 0
   const fmtCompact = (v: number): string => formatCompact(v, sym)
   const fmtFull = (v: number): string => formatFull(v, sym)
 
@@ -152,22 +158,46 @@ const WealthPerformanceChart: React.FC<WealthPerformanceChartProps> = ({
             <>
               {/* Key metrics row */}
               <div className="grid grid-cols-3 divide-x divide-gray-100 mb-4 py-4 border-y border-gray-100">
-                {/* Aggregate TWR Return */}
-                <div className="px-4">
+                {/* Investment Return — XIRR primary, TWR secondary */}
+                <div
+                  className="px-4"
+                  title={
+                    xirrPct != null
+                      ? "XIRR = money-weighted return on your actual cash flows. " +
+                        "TWR (below) = strategy/market return, ignores when you contributed."
+                      : "TWR cumulative return. XIRR unavailable for this window."
+                  }
+                >
                   <div className="text-[11px] font-medium text-gray-400 uppercase tracking-wider mb-1">
-                    Aggregate TWR
+                    Investment Return
                   </div>
                   <div
                     className={`text-2xl font-mono font-bold tracking-tight ${isPositive ? "text-gain" : "text-loss"}`}
                   >
                     {isPositive ? "+" : ""}
-                    {stats.returnPct.toFixed(2)}%
+                    {headlinePct.toFixed(2)}%
+                    <span className="text-xs font-normal text-gray-500 ml-1">
+                      {xirrPct != null
+                        ? isAnnualised
+                          ? "/ yr"
+                          : "cumulative"
+                        : isAnnualised
+                          ? "TWR / yr"
+                          : "TWR"}
+                    </span>
                   </div>
                   <div className="text-xs text-gray-400 font-mono mt-0.5">
-                    {sym}1,000 &rarr; {sym}
-                    {stats.growthOf1000.toLocaleString(undefined, {
-                      maximumFractionDigits: 0,
-                    })}
+                    {xirrPct != null
+                      ? `TWR ${stats.twrPct >= 0 ? "+" : ""}${stats.twrPct.toFixed(2)}% · ${sym}1,000 → ${sym}${stats.growthOf1000.toLocaleString(
+                          undefined,
+                          { maximumFractionDigits: 0 },
+                        )}`
+                      : `${sym}1,000 → ${sym}${stats.growthOf1000.toLocaleString(
+                          undefined,
+                          {
+                            maximumFractionDigits: 0,
+                          },
+                        )}`}
                   </div>
                 </div>
 

--- a/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
+++ b/src/components/features/wealth/__tests__/WealthPerformanceChart.test.tsx
@@ -75,10 +75,12 @@ const defaultProps = {
   onToggle: jest.fn(),
 }
 
-function setHookReturn(value: AggregatedPerformance): void {
+function setHookReturn(
+  value: Omit<AggregatedPerformance, "xirr"> & { xirr?: number | null },
+): void {
   mockUseAggregatedPerformance.useAggregatedPerformance = jest
     .fn()
-    .mockReturnValue(value)
+    .mockReturnValue({ xirr: null, ...value })
 }
 
 describe("WealthPerformanceChart", () => {

--- a/src/hooks/__tests__/useAggregatedPerformance.test.ts
+++ b/src/hooks/__tests__/useAggregatedPerformance.test.ts
@@ -218,16 +218,56 @@ describe("useAggregatedPerformance", () => {
       ),
     )
 
-    const result = (await ref.current!()) as AggregatedDataPoint[]
+    const result = (await ref.current!()) as {
+      series: AggregatedDataPoint[]
+      xirr: number | null
+    }
 
-    expect(result).toEqual(backendSeries)
+    expect(result.series).toEqual(backendSeries)
+    expect(result.xirr).toBeNull()
     // Period-relative invariants the backend guarantees, asserted here so a
     // future hook-side mutation that violates them fails loudly.
-    expect(result[0].netContributions).toBe(0)
-    expect(result[0].investmentGain).toBe(0)
-    expect(result[1].investmentGain).toBe(12000)
+    expect(result.series[0].netContributions).toBe(0)
+    expect(result.series[0].investmentGain).toBe(0)
+    expect(result.series[1].investmentGain).toBe(12000)
     // Bug repro guard: lifetime leak would push this to >= 32000.
-    expect(result[1].investmentGain).toBeLessThan(32000)
+    expect(result.series[1].investmentGain).toBeLessThan(32000)
+  })
+
+  it("surfaces xirr from backend response", async () => {
+    const { ref } = captureFetcher()
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { series: [], xirr: 0.082 } }),
+    }) as unknown as typeof global.fetch
+
+    renderHook(() =>
+      useAggregatedPerformance([makePortfolio("P1", "USD")], 12, "USD", true),
+    )
+
+    const result = (await ref.current!()) as {
+      series: AggregatedDataPoint[]
+      xirr: number | null
+    }
+    expect(result.xirr).toBe(0.082)
+  })
+
+  it("defaults xirr to null when backend omits the field", async () => {
+    const { ref } = captureFetcher()
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { series: [] } }),
+    }) as unknown as typeof global.fetch
+
+    renderHook(() =>
+      useAggregatedPerformance([makePortfolio("P1", "USD")], 12, "USD", true),
+    )
+
+    const result = (await ref.current!()) as {
+      series: AggregatedDataPoint[]
+      xirr: number | null
+    }
+    expect(result.xirr).toBeNull()
   })
 
   it("throws when backend responds with non-ok", async () => {

--- a/src/hooks/useAggregatedPerformance.ts
+++ b/src/hooks/useAggregatedPerformance.ts
@@ -23,6 +23,14 @@ export interface AggregatedDataPoint {
 
 export interface AggregatedPerformance {
   series: AggregatedDataPoint[]
+  /**
+   * Aggregate money-weighted return (XIRR) for the window, annualised
+   * decimal (0.10 = +10% p.a.). Null when the backend couldn't compute
+   * (insufficient flows / solver failure). For windows shorter than ~1y,
+   * the backend returns simple ROI instead — consumers should label
+   * sub-year values as "cumulative", not "p.a."
+   */
+  xirr: number | null
   isLoading: boolean
   error: Error | undefined
 }
@@ -30,6 +38,7 @@ export interface AggregatedPerformance {
 interface AggregateApiResponse {
   data: {
     series: AggregatedDataPoint[]
+    xirr?: number | null
   }
 }
 
@@ -53,7 +62,10 @@ export function useAggregatedPerformance(
       ? `aggregated-perf:${portfolioCodes.join(",")}:${months}:${displayCurrencyCode}`
       : null
 
-  const { data, isLoading, error } = useSwr<AggregatedDataPoint[]>(
+  const { data, isLoading, error } = useSwr<{
+    series: AggregatedDataPoint[]
+    xirr: number | null
+  }>(
     key,
     async () => {
       const res = await fetch(`/api/performance/aggregate`, {
@@ -69,7 +81,10 @@ export function useAggregatedPerformance(
         throw new Error(`Aggregate request failed: ${res.status}`)
       }
       const json: AggregateApiResponse = await res.json()
-      return json.data?.series ?? []
+      return {
+        series: json.data?.series ?? [],
+        xirr: json.data?.xirr ?? null,
+      }
     },
     {
       revalidateOnFocus: false,
@@ -79,7 +94,8 @@ export function useAggregatedPerformance(
   )
 
   return {
-    series: data ?? [],
+    series: data?.series ?? [],
+    xirr: data?.xirr ?? null,
     isLoading,
     error,
   }


### PR DESCRIPTION
## Summary
Replaces "Aggregate TWR" headline on the Wealth Performance card with **Investment Return (XIRR)**. TWR remains visible as a sub-label.

XIRR is money-weighted: it answers *"what did MY money actually earn given when I added it."* TWR answers *"how did the strategy perform"* — which matters less to a single investor watching their own card than the GIPS-standard fund-manager metric.

Companion: monowai/beancounter#839.

## Display rules
- Headline = XIRR (annualised when window ≥12M; "cumulative" suffix for shorter windows, since the backend's \`IrrCalculator\` falls back to simple ROI under \`minHoldingDays=365\`).
- Sub = \`TWR ±X% · \$1,000 → \$Y\` (cumulative TWR + growth-of-1000).
- Tooltip on the cell explains the XIRR vs TWR distinction in one line.
- When backend can't compute XIRR (sparse flows, solver bails): falls back gracefully to the previous TWR headline.

## Test plan
- [x] \`useAggregatedPerformance.test.ts\` — new tests: surfaces xirr from backend, defaults to null when omitted. Existing regression guard updated for new shape.
- [x] \`WealthPerformanceChart.test.tsx\` helper accepts partial xirr.
- [x] \`yarn test\` (1298/1298) green.
- [x] \`yarn prettier && yarn lint && yarn typecheck\` green.
- [ ] Manual browser exercise after backend #839 deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Investment return metric now prioritizes XIRR (Internal Rate of Return) calculations for enhanced accuracy. Falls back to TWR when XIRR is unavailable.
  * Updated metric display with context-aware labeling, distinguishing between annualized and cumulative return periods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/679)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->