### PR TITLE
fix: preserve dotted public tickers (BRK.B) in holdings display

### DIFF
--- a/src/components/features/holdings/__tests__/AssetNewsButton.test.tsx
+++ b/src/components/features/holdings/__tests__/AssetNewsButton.test.tsx
@@ -58,7 +58,7 @@ describe("AssetNewsButton", () => {
   it("strips owner prefix in aria-label", () => {
     render(
       <AssetNewsButton
-        asset={makeAsset({ code: "userId.MSFT" })}
+        asset={makeAsset({ code: "148_OBRVTziEJUdnLKsSlA.MSFT" })}
         onShow={jest.fn()}
       />,
     )

--- a/src/components/features/holdings/__tests__/QuickSell.test.tsx
+++ b/src/components/features/holdings/__tests__/QuickSell.test.tsx
@@ -31,7 +31,11 @@ const tradedPosition = (
   makePosition({
     asset: makeAsset({
       id: `asset-${code}`,
-      code: `${marketCode}.${code}`,
+      // Real BC asset.code is just the ticker; market.code is separate. Earlier
+      // tests baked `${marketCode}.${code}` together because stripOwnerPrefix
+      // would peel the prefix back off — that misuse relied on a now-fixed bug
+      // that also amputated public dotted tickers like BRK.B.
+      code,
       name: `${code} Company`,
       market: {
         code: marketCode,

--- a/src/components/features/holdings/__tests__/TargetWeightDialog.test.tsx
+++ b/src/components/features/holdings/__tests__/TargetWeightDialog.test.tsx
@@ -11,7 +11,7 @@ const mockPortfolio: Portfolio = makePortfolio({
 })
 
 const mockAsset: Asset = makeAsset({
-  code: "NASDAQ.AAPL",
+  code: "AAPL",
   name: "Apple Inc",
   market: {
     code: "NASDAQ",

--- a/src/lib/utils/assets/__tests__/assetUtils.test.ts
+++ b/src/lib/utils/assets/__tests__/assetUtils.test.ts
@@ -10,8 +10,10 @@ import {
 import { makeAsset, makeCashAsset } from "@test-fixtures/beancounter"
 
 describe("stripOwnerPrefix", () => {
-  it("returns code after last dot", () => {
-    expect(stripOwnerPrefix("userId.WISE")).toBe("WISE")
+  const USER_ID = "148_OBRVTziEJUdnLKsSlA" // realistic 22-char base64 userId
+
+  it("strips a real userId prefix", () => {
+    expect(stripOwnerPrefix(`${USER_ID}.WISE`)).toBe("WISE")
   })
 
   it("returns full code when no dot present", () => {
@@ -22,16 +24,19 @@ describe("stripOwnerPrefix", () => {
     expect(stripOwnerPrefix("")).toBe("")
   })
 
-  it("handles code with multiple dots (returns after last dot)", () => {
-    expect(stripOwnerPrefix("a.b.c")).toBe("c")
+  it("preserves public dotted tickers (BRK.B regression)", () => {
+    // Berkshire Hathaway Class B — must not collapse to "B".
+    expect(stripOwnerPrefix("BRK.B")).toBe("BRK.B")
+    expect(stripOwnerPrefix("RDS.A")).toBe("RDS.A")
   })
 
-  it("handles dot at start", () => {
-    expect(stripOwnerPrefix(".WISE")).toBe("WISE")
+  it("preserves tickers even when multiple dots are present", () => {
+    // Short prefix segments mean none is long enough to be an owner id.
+    expect(stripOwnerPrefix("a.b.c")).toBe("a.b.c")
   })
 
-  it("handles dot at end", () => {
-    expect(stripOwnerPrefix("userId.")).toBe("")
+  it("strips when prefix is long enough to plausibly be an owner id", () => {
+    expect(stripOwnerPrefix(`${USER_ID}.BRK.B`)).toBe("BRK.B")
   })
 })
 
@@ -74,14 +79,21 @@ describe("isNonTradeable", () => {
 })
 
 describe("getDisplayCode", () => {
+  const USER_ID = "148_OBRVTziEJUdnLKsSlA"
+
   it("returns stripped code for asset with owner prefix", () => {
-    const asset = { code: "userId.SCB-SGD" } as any
+    const asset = { code: `${USER_ID}.SCB-SGD` } as any
     expect(getDisplayCode(asset)).toBe("SCB-SGD")
   })
 
   it("returns code as-is for asset without dot", () => {
     const asset = { code: "AAPL" } as any
     expect(getDisplayCode(asset)).toBe("AAPL")
+  })
+
+  it("preserves dotted public tickers (BRK.B regression)", () => {
+    const asset = { code: "BRK.B" } as any
+    expect(getDisplayCode(asset)).toBe("BRK.B")
   })
 
   it("returns empty string for null asset", () => {
@@ -101,13 +113,19 @@ describe("getPositionDisplayName", () => {
   })
 
   it("returns stripped code for non-cash assets", () => {
-    expect(getPositionDisplayName(makeAsset({ code: "userId.AAPL" }))).toBe(
-      "AAPL",
-    )
+    expect(
+      getPositionDisplayName(
+        makeAsset({ code: "148_OBRVTziEJUdnLKsSlA.AAPL" }),
+      ),
+    ).toBe("AAPL")
   })
 
   it("returns code unchanged when no owner prefix", () => {
     expect(getPositionDisplayName(makeAsset({ code: "MSFT" }))).toBe("MSFT")
+  })
+
+  it("preserves dotted public tickers", () => {
+    expect(getPositionDisplayName(makeAsset({ code: "BRK.B" }))).toBe("BRK.B")
   })
 })
 
@@ -121,7 +139,7 @@ describe("buildTradesHref", () => {
 
 describe("buildNewsAsset", () => {
   it("strips owner prefix from ticker, takes market.code, defaults assetName to empty", () => {
-    const asset = makeAsset({ code: "userId.AAPL", name: "" })
+    const asset = makeAsset({ code: "148_OBRVTziEJUdnLKsSlA.AAPL", name: "" })
     expect(buildNewsAsset(asset)).toEqual({
       ticker: "AAPL",
       market: "NASDAQ",
@@ -135,6 +153,15 @@ describe("buildNewsAsset", () => {
       ticker: "AAPL",
       market: "NASDAQ",
       assetName: "Apple Inc.",
+    })
+  })
+
+  it("preserves dotted public tickers (BRK.B regression)", () => {
+    const asset = makeAsset({ code: "BRK.B", name: "Berkshire Hathaway B" })
+    expect(buildNewsAsset(asset)).toEqual({
+      ticker: "BRK.B",
+      market: "NASDAQ",
+      assetName: "Berkshire Hathaway B",
     })
   })
 })

--- a/src/lib/utils/assets/assetUtils.ts
+++ b/src/lib/utils/assets/assetUtils.ts
@@ -46,24 +46,41 @@ export function supportsBalanceSetting(asset: Asset): boolean {
   return isCash(asset) || isAccount(asset)
 }
 
-/**
- * Get the display code for an asset, stripping any owner prefix.
- * Private/custom assets often have codes like "userId.SCB-SGD" - this returns just "SCB-SGD".
- */
-export function getDisplayCode(asset: Asset | null | undefined): string {
-  if (!asset) return ""
-  const code = asset.code || ""
-  const dotIndex = code.lastIndexOf(".")
-  return dotIndex >= 0 ? code.substring(dotIndex + 1) : code
+// Owner-prefix detection. Private-asset codes are stored as `${userId}.${CODE}`
+// where the userId is a base64-encoded UUID (22 chars). Public dotted tickers
+// (BRK.B, RDS.A, JK.M, etc.) have short prefixes (≤5 chars). A length threshold
+// cleanly separates the two without needing the caller to pass marketCode.
+const OWNER_PREFIX_MIN_LENGTH = 12
+
+function dropOwnerPrefix(code: string): string {
+  // Split on the FIRST dot — the owner prefix is the userId, and the asset
+  // code itself may carry further dots (BRK.B, RDS.A). lastIndexOf would
+  // amputate the class indicator from a private dotted asset.
+  const dotIndex = code.indexOf(".")
+  if (dotIndex < 0) return code
+  const prefix = code.substring(0, dotIndex)
+  return prefix.length >= OWNER_PREFIX_MIN_LENGTH
+    ? code.substring(dotIndex + 1)
+    : code
 }
 
 /**
- * Get the display code from a raw code string, stripping any owner prefix.
+ * Get the display code for an asset. Strips the owner prefix from PRIVATE-style
+ * codes (e.g. `${userId}.SCB-SGD` → `SCB-SGD`) while preserving public dotted
+ * tickers (`BRK.B` stays `BRK.B`).
+ */
+export function getDisplayCode(asset: Asset | null | undefined): string {
+  if (!asset) return ""
+  return dropOwnerPrefix(asset.code || "")
+}
+
+/**
+ * Strip the owner prefix from a raw code string. See [getDisplayCode] for
+ * the contract — same heuristic; public dotted tickers are left intact.
  */
 export function stripOwnerPrefix(code: string): string {
   if (!code) return ""
-  const dotIndex = code.lastIndexOf(".")
-  return dotIndex >= 0 ? code.substring(dotIndex + 1) : code
+  return dropOwnerPrefix(code)
 }
 
 /**

--- a/src/lib/utils/trns/cashFormHelpers.test.ts
+++ b/src/lib/utils/trns/cashFormHelpers.test.ts
@@ -45,12 +45,27 @@ describe("cashFormHelpers", () => {
     const currencies: Currency[] = [makeCurrency("USD"), makeCurrency("NZD")]
 
     const accounts: Record<string, Asset> = {
-      a1: makeAsset("uuid-1", "owner.SCB-USD", "SCB USD", "USD"),
-      a2: makeAsset("uuid-2", "owner.KiwiBank", "Kiwi Bank", "NZD"),
+      a1: makeAsset(
+        "uuid-1",
+        "148_OBRVTziEJUdnLKsSlA.SCB-USD",
+        "SCB USD",
+        "USD",
+      ),
+      a2: makeAsset(
+        "uuid-2",
+        "148_OBRVTziEJUdnLKsSlA.KiwiBank",
+        "Kiwi Bank",
+        "NZD",
+      ),
     }
 
     const tradeAccounts: Record<string, Asset> = {
-      t1: makeAsset("uuid-3", "owner.IBKR", "Interactive Brokers", "USD"),
+      t1: makeAsset(
+        "uuid-3",
+        "148_OBRVTziEJUdnLKsSlA.IBKR",
+        "Interactive Brokers",
+        "USD",
+      ),
     }
 
     test("builds currency options with market CASH", () => {
@@ -136,7 +151,12 @@ describe("cashFormHelpers", () => {
     test("falls back to market currency when priceSymbol missing", () => {
       const noSymbol: Record<string, Asset> = {
         x: {
-          ...makeAsset("uuid-x", "owner.Test", "Test Acct", ""),
+          ...makeAsset(
+            "uuid-x",
+            "148_OBRVTziEJUdnLKsSlA.Test",
+            "Test Acct",
+            "",
+          ),
           priceSymbol: undefined,
         },
       }

--- a/src/lib/utils/trns/tradeUtils.test.ts
+++ b/src/lib/utils/trns/tradeUtils.test.ts
@@ -663,7 +663,7 @@ describe("TradeUtils", () => {
     test("returns accountingType currency when available", () => {
       expect(
         getAssetCurrency({
-          code: "owner.SCB-USD",
+          code: "148_OBRVTziEJUdnLKsSlA.SCB-USD",
           accountingType: { currency: { code: "USD" } },
           priceSymbol: "SGD",
           market: { code: "PRIVATE", currency: { code: "SGD" } },
@@ -813,7 +813,7 @@ describe("TradeUtils", () => {
     test("strips owner prefix from private asset code", () => {
       const data: TradeFormData = {
         type: { value: "BUY", label: "Buy" },
-        asset: "userId123.APT",
+        asset: "148_OBRVTziEJUdnLKsSlA.APT",
         market: "PRIVATE",
         tradeDate: "2024-01-15",
         quantity: 1,


### PR DESCRIPTION
## Summary

`stripOwnerPrefix` / `getDisplayCode` peeled the `\${userId}.\${CODE}` private-asset prefix using `lastIndexOf(\".\")` and were applied to **every** asset. A public dotted ticker like `BRK.B` (Berkshire Hathaway class B) collapsed to `B` on holdings cards, rows, news lookups, and trade-import paths.

### Fix

- Split on the **first** dot (the userId boundary) instead of the last one. With `lastIndexOf`, `BRK.B` lost its class indicator; with `indexOf` and the asset code on the right of the split, multi-dot codes like `\${userId}.BRK.B` round-trip cleanly.
- Strip only when the prefix is ≥12 chars — BC userIds are 22-char base64 UUIDs, public ticker prefixes are ≤5 chars (`BRK`, `RDS`, `GOOG`). No caller signature change.
- Internal helper `dropOwnerPrefix` centralises the logic so `stripOwnerPrefix` and `getDisplayCode` stay in lock-step.

### Test updates

- Regression tests pin `BRK.B`, `RDS.A`, and `\${realUserId}.BRK.B` across `stripOwnerPrefix`, `getDisplayCode`, `getPositionDisplayName`, and `buildNewsAsset`.
- Existing tests that used short fake userIds (`owner.`, `userId.`, `userId123.`) updated to use the real 22-char shape (`148_OBRVTziEJUdnLKsSlA.…`), reflecting actual BC data.
- Two test fixtures that synthesised `code: \`\${marketCode}.\${code}\`` and depended on `stripOwnerPrefix` to peel the market portion (a misuse — real BC stores market separately) updated to use bare codes. Comment added so future readers don't re-introduce the anti-pattern.

## Test plan

- [x] `yarn jest` — 1301/1301 pass
- [x] `yarn prettier && yarn lint && yarn typecheck` — clean
- [ ] Manual: load LIV portfolio, confirm `BRK.B` renders as `BRK.B` on Holdings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset code display to properly handle owner prefixes while preserving public tickers with dots (e.g., BRK.B). Assets will now display with correct, user-visible identifiers without internal ID prefixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/680)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->