### PR TITLE
feat(admin): link Service Metrics card to Spring Boot Admin UI

### DIFF
--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -9,6 +9,7 @@ interface AdminCard {
   description: string
   href: string
   icon: string
+  external?: boolean
 }
 
 export default withPageAuthRequired(function AdminPage(): React.ReactElement {
@@ -81,6 +82,15 @@ export default withPageAuthRequired(function AdminPage(): React.ReactElement {
       href: "/admin/tasks",
       icon: "fa-clock",
     },
+    {
+      title: "Service Metrics",
+      description:
+        "Spring Boot Admin: live entity counts, JVM, HTTP, DB pool, health.",
+      href:
+        process.env.NEXT_PUBLIC_SBA_URL ?? "https://kauri.monowai.com:30530",
+      icon: "fa-gauge-high",
+      external: true,
+    },
   ]
 
   return (
@@ -93,12 +103,8 @@ export default withPageAuthRequired(function AdminPage(): React.ReactElement {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {adminCards.map((card) => (
-          <Link
-            key={card.href}
-            href={card.href}
-            className="bg-white rounded-lg border border-gray-200 p-6 hover:border-blue-300 hover:shadow-md transition-all group"
-          >
+        {adminCards.map((card) => {
+          const cardBody = (
             <div className="flex items-start space-x-4">
               <div className="flex-shrink-0 w-12 h-12 bg-blue-50 rounded-lg flex items-center justify-center group-hover:bg-blue-100 transition-colors">
                 <i className={`fas ${card.icon} text-blue-500 text-xl`}></i>
@@ -106,6 +112,12 @@ export default withPageAuthRequired(function AdminPage(): React.ReactElement {
               <div className="flex-1">
                 <h2 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
                   {card.title}
+                  {card.external && (
+                    <i
+                      className="fas fa-external-link-alt text-xs text-gray-400 ml-2"
+                      aria-hidden="true"
+                    />
+                  )}
                 </h2>
                 <p className="text-gray-600 text-sm mt-1">{card.description}</p>
               </div>
@@ -113,8 +125,25 @@ export default withPageAuthRequired(function AdminPage(): React.ReactElement {
                 <i className="fas fa-chevron-right"></i>
               </div>
             </div>
-          </Link>
-        ))}
+          )
+          const cardClass =
+            "bg-white rounded-lg border border-gray-200 p-6 hover:border-blue-300 hover:shadow-md transition-all group"
+          return card.external ? (
+            <a
+              key={card.href}
+              href={card.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cardClass}
+            >
+              {cardBody}
+            </a>
+          ) : (
+            <Link key={card.href} href={card.href} className={cardClass}>
+              {cardBody}
+            </Link>
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- New "Service Metrics" card on `/admin` opens the Spring Boot Admin (bc-admin) dashboard in a new tab.
- URL configurable via `NEXT_PUBLIC_SBA_URL`; default `https://kauri.monowai.com:30530`.
- Adds an `external` flag to the local `AdminCard` interface — external cards render an external-link icon and use `<a target="_blank" rel="noopener noreferrer">` instead of Next's `<Link>`.

## Why
Closes the loop on the SBA rollout (monowai/beancounter PRs #847 + #848 and bc-deploy commit `6bd1082`). Admins land in `/admin`, click "Service Metrics", and see live entity counts + JVM/HTTP/DB pool / health for every BC service.

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn prettier && yarn lint` — clean (eslint + markdownlint)
- [x] `semgrep --config=auto src/pages/admin/index.tsx` — 0 findings (378 rules)
- [ ] Local: `yarn dev`, log in as admin user, verify card appears, click → opens `https://kauri.monowai.com:30530` in new tab.
- [ ] Post-deploy: real users see populated SBA dashboard.

## Risks
- Default URL hardcodes `kauri.monowai.com:30530` — if the bc-admin NodePort changes, override via `NEXT_PUBLIC_SBA_URL`. Documented as the override env var, no surprise behavior.
- No fancy auth gating beyond the existing `useIsAdmin()` check on the hub itself. SBA enforces its own login (currently HTTP basic, OIDC TODO per beancounter PR #848).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Service Metrics card to the admin landing page providing access to external resources
  * External links now open in new browser tabs with enhanced security protocols
  * Implemented visual external-link icon indicator to distinguish external from internal page navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->