### PR TITLE
fix(admin): point Service Metrics link at https://bc-admin.monowai.com

### DIFF
--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -87,7 +87,7 @@ export default withPageAuthRequired(function AdminPage(): React.ReactElement {
       description:
         "Spring Boot Admin: live entity counts, JVM, HTTP, DB pool, health.",
       href:
-        process.env.NEXT_PUBLIC_SBA_URL ?? "https://kauri.monowai.com:30530",
+        process.env.NEXT_PUBLIC_SBA_URL ?? "https://bc-admin.monowai.com",
       icon: "fa-gauge-high",
       external: true,
     },


### PR DESCRIPTION
## Summary
- Default URL for the Service Metrics admin card moves from `https://kauri.monowai.com:30530` (SSL error — NodePort serves plain HTTP) to `https://bc-admin.monowai.com` (fronted by Caddy with the shared Cloudflare origin cert).
- `NEXT_PUBLIC_SBA_URL` env override still wins if set.

## Why
Users hitting the link got `ERR_SSL_PROTOCOL_ERROR` — Tomcat at NodePort 30530 has no TLS. Caddy was added on kauri (`~media/projects/media/volumes/caddy/Caddyfile`) with a `bc-admin.monowai.com` block routing to `host.docker.internal:30530`.

## Pre-merge dependencies
1. DNS `bc-admin.monowai.com → 192.168.50.46` in Pi dnsmasq (LAN/VPN reach).
2. Auth0 callback `https://bc-admin.monowai.com/login/oauth2/code/auth0` added.
3. monowai/beancounter PR #851 merged + deployed — without it, browser still gets HTTP 401 Basic-auth from svc-admin.

## Test plan
- [x] `yarn typecheck`, `yarn lint` — clean
- [ ] Post-deploy + DNS + Auth0 wired: click the card on `/admin`, expect new tab → Auth0 redirect → SBA dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default URL for Spring Boot Admin card access when using the default configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->