### PR TITLE
feat(admin): native metrics + loggers UI

### DIFF
--- a/src/lib/utils/api/bcConfig.ts
+++ b/src/lib/utils/api/bcConfig.ts
@@ -54,6 +54,10 @@ export function getAgentUrl(path: string = ""): string {
   return `${process.env.BC_AGENT}${path}`
 }
 
+export function getAgentActuatorUrl(path: string = ""): string {
+  return `${process.env.BC_AGENT_ACTUATOR || process.env.BC_AGENT}${path}`
+}
+
 export function getTrnTopic(): string {
   return `${process.env.KAFKA_TOPIC_TRN}`
 }

--- a/src/lib/utils/api/requireAdmin.ts
+++ b/src/lib/utils/api/requireAdmin.ts
@@ -1,0 +1,62 @@
+import { auth0 } from "@lib/auth0"
+import { NextApiRequest, NextApiResponse } from "next"
+
+interface AdminGuardResult {
+  ok: boolean
+  token?: string
+}
+
+/**
+ * Server-side admin gate for sensitive API routes. Verifies an Auth0
+ * session exists and the access token carries the
+ * `beancounter:admin` permission (in either the `scope` claim or the
+ * `permissions` array — Auth0 RBAC emits both depending on API
+ * settings). Writes 401 / 403 on the response and returns
+ * `{ ok: false }` when the caller should not proceed.
+ *
+ * The client-side `useIsAdmin` hook hides admin pages from the UI;
+ * this exists so direct calls to `/api/admin/*` are also blocked.
+ */
+export async function requireAdmin(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<AdminGuardResult> {
+  const session = await auth0.getSession(req)
+  if (!session) {
+    res.status(401).json({ error: "Not authenticated" })
+    return { ok: false }
+  }
+
+  const { token } = await auth0.getAccessToken(req, res)
+  if (!token) {
+    res.status(401).json({ error: "Unauthorized" })
+    return { ok: false }
+  }
+
+  const parts = token.split(".")
+  if (parts.length !== 3) {
+    res.status(403).json({ error: "Forbidden" })
+    return { ok: false }
+  }
+
+  let payload: { scope?: string; permissions?: string[] }
+  try {
+    payload = JSON.parse(Buffer.from(parts[1], "base64").toString("utf-8"))
+  } catch {
+    res.status(403).json({ error: "Forbidden" })
+    return { ok: false }
+  }
+
+  const scope = payload.scope ?? ""
+  const permissions = payload.permissions ?? []
+  const isAdmin =
+    scope.split(" ").includes("beancounter:admin") ||
+    permissions.includes("beancounter:admin")
+
+  if (!isAdmin) {
+    res.status(403).json({ error: "Forbidden" })
+    return { ok: false }
+  }
+
+  return { ok: true, token }
+}

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -85,11 +85,16 @@ export default withPageAuthRequired(function AdminPage(): React.ReactElement {
     {
       title: "Service Metrics",
       description:
-        "Spring Boot Admin: live entity counts, JVM, HTTP, DB pool, health.",
-      href:
-        process.env.NEXT_PUBLIC_SBA_URL ?? "https://bc-admin.monowai.com",
+        "Live entity counts from bc-data (assets, market data, transactions, news).",
+      href: "/admin/metrics",
       icon: "fa-gauge-high",
-      external: true,
+    },
+    {
+      title: "Loggers",
+      description:
+        "Browse and tweak log levels live across all backend services.",
+      href: "/admin/loggers",
+      icon: "fa-list-ul",
     },
   ]
 

--- a/src/pages/admin/loggers.tsx
+++ b/src/pages/admin/loggers.tsx
@@ -1,0 +1,211 @@
+import React, { useState, useMemo } from "react"
+import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
+import { rootLoader } from "@components/ui/PageLoader"
+import { useIsAdmin } from "@hooks/useIsAdmin"
+import useSWR, { mutate } from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+
+const SERVICES = [
+  "bc-data",
+  "bc-position",
+  "bc-event",
+  "bc-retire",
+  "bc-rebalance",
+  "bc-agent",
+] as const
+type Service = (typeof SERVICES)[number]
+
+const LEVELS = ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF"] as const
+type Level = (typeof LEVELS)[number]
+
+interface LoggerEntry {
+  configuredLevel: string | null
+  effectiveLevel: string
+}
+
+interface LoggersResponse {
+  levels: string[]
+  loggers: Record<string, LoggerEntry>
+}
+
+function levelBadgeClass(level: string): string {
+  switch (level) {
+    case "TRACE":
+    case "DEBUG":
+      return "bg-blue-100 text-blue-800"
+    case "INFO":
+      return "bg-green-100 text-green-800"
+    case "WARN":
+      return "bg-yellow-100 text-yellow-800"
+    case "ERROR":
+      return "bg-red-100 text-red-800"
+    case "OFF":
+      return "bg-gray-200 text-gray-700"
+    default:
+      return "bg-gray-100 text-gray-700"
+  }
+}
+
+export default withPageAuthRequired(function LoggersPage(): React.ReactElement {
+  const { isAdmin, isLoading } = useIsAdmin()
+  const [service, setService] = useState<Service>("bc-data")
+  const [filter, setFilter] = useState("com.beancounter")
+  const [saving, setSaving] = useState<string | null>(null)
+
+  const swrKey = isAdmin ? `/api/admin/loggers/${service}` : null
+  const {
+    data,
+    error,
+    isLoading: loadingData,
+  } = useSWR<LoggersResponse>(swrKey, simpleFetcher)
+
+  const rows = useMemo(() => {
+    if (!data?.loggers) return []
+    return Object.entries(data.loggers)
+      .filter(([name]) => name.toLowerCase().includes(filter.toLowerCase()))
+      .sort(([a], [b]) => a.localeCompare(b))
+  }, [data, filter])
+
+  async function setLevel(
+    logger: string,
+    configuredLevel: Level | null,
+  ): Promise<void> {
+    setSaving(logger)
+    try {
+      const res = await fetch(`/api/admin/loggers/${service}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ logger, configuredLevel }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      await mutate(swrKey)
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  if (isLoading) return rootLoader("Loading...")
+  if (!isAdmin) {
+    return (
+      <div className="max-w-4xl mx-auto py-12 px-4">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h1 className="text-xl font-semibold text-red-700">Access Denied</h1>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto py-6 px-4">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Loggers</h1>
+        <p className="text-gray-600 mt-1 text-sm">
+          Inspect and adjust log levels live. Changes take effect immediately
+          and persist until the pod restarts.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-4 mb-4">
+        <div>
+          <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">
+            Service
+          </label>
+          <select
+            value={service}
+            onChange={(e) => setService(e.target.value as Service)}
+            className="border border-gray-300 rounded px-3 py-2 text-sm"
+          >
+            {SERVICES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex-1 min-w-[240px]">
+          <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">
+            Filter
+          </label>
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="com.beancounter"
+            className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
+          />
+        </div>
+        <div className="text-sm text-gray-500 self-center">
+          {rows.length} match{rows.length === 1 ? "" : "es"}
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4 text-red-700 text-sm">
+          Failed to load loggers: {error.message}
+        </div>
+      )}
+
+      {loadingData && !data && (
+        <div className="text-gray-500 text-sm">Loading...</div>
+      )}
+
+      {data && (
+        <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="px-4 py-2 text-left font-semibold text-gray-700">
+                  Logger
+                </th>
+                <th className="px-4 py-2 text-left font-semibold text-gray-700 w-24">
+                  Effective
+                </th>
+                <th className="px-4 py-2 text-left font-semibold text-gray-700 w-40">
+                  Set level
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(([name, entry]) => (
+                <tr
+                  key={name}
+                  className="border-b last:border-0 border-gray-100 hover:bg-gray-50"
+                >
+                  <td className="px-4 py-2 text-gray-900 font-mono text-xs">
+                    {name}
+                  </td>
+                  <td className="px-4 py-2">
+                    <span
+                      className={`px-2 py-0.5 rounded text-xs font-medium ${levelBadgeClass(
+                        entry.effectiveLevel,
+                      )}`}
+                    >
+                      {entry.effectiveLevel}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2">
+                    <select
+                      value={entry.configuredLevel ?? ""}
+                      disabled={saving === name}
+                      onChange={(e) => {
+                        const v = e.target.value
+                        setLevel(name, v === "" ? null : (v as Level))
+                      }}
+                      className="border border-gray-300 rounded px-2 py-1 text-xs"
+                    >
+                      <option value="">(inherit)</option>
+                      {LEVELS.map((lvl) => (
+                        <option key={lvl} value={lvl}>
+                          {lvl}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+})

--- a/src/pages/admin/loggers.tsx
+++ b/src/pages/admin/loggers.tsx
@@ -50,7 +50,8 @@ export default withPageAuthRequired(function LoggersPage(): React.ReactElement {
   const { isAdmin, isLoading } = useIsAdmin()
   const [service, setService] = useState<Service>("bc-data")
   const [filter, setFilter] = useState("com.beancounter")
-  const [saving, setSaving] = useState<string | null>(null)
+  const [saving, setSaving] = useState<Set<string>>(new Set())
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   const swrKey = isAdmin ? `/api/admin/loggers/${service}` : null
   const {
@@ -70,17 +71,33 @@ export default withPageAuthRequired(function LoggersPage(): React.ReactElement {
     logger: string,
     configuredLevel: Level | null,
   ): Promise<void> {
-    setSaving(logger)
+    setSaving((prev) => {
+      const next = new Set(prev)
+      next.add(logger)
+      return next
+    })
+    setSaveError(null)
     try {
       const res = await fetch(`/api/admin/loggers/${service}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ logger, configuredLevel }),
       })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      if (!res.ok) {
+        const body = await res.text().catch(() => "")
+        throw new Error(`HTTP ${res.status}${body ? `: ${body}` : ""}`)
+      }
       await mutate(swrKey)
+    } catch (e) {
+      setSaveError(
+        `Failed to set ${logger}: ${e instanceof Error ? e.message : String(e)}`,
+      )
     } finally {
-      setSaving(null)
+      setSaving((prev) => {
+        const next = new Set(prev)
+        next.delete(logger)
+        return next
+      })
     }
   }
 
@@ -144,6 +161,19 @@ export default withPageAuthRequired(function LoggersPage(): React.ReactElement {
         </div>
       )}
 
+      {saveError && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4 text-red-700 text-sm flex justify-between items-center">
+          <span>{saveError}</span>
+          <button
+            onClick={() => setSaveError(null)}
+            className="text-red-500 hover:text-red-700 ml-4"
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
       {loadingData && !data && (
         <div className="text-gray-500 text-sm">Loading...</div>
       )}
@@ -185,7 +215,7 @@ export default withPageAuthRequired(function LoggersPage(): React.ReactElement {
                   <td className="px-4 py-2">
                     <select
                       value={entry.configuredLevel ?? ""}
-                      disabled={saving === name}
+                      disabled={saving.has(name)}
                       onChange={(e) => {
                         const v = e.target.value
                         setLevel(name, v === "" ? null : (v as Level))

--- a/src/pages/admin/metrics.tsx
+++ b/src/pages/admin/metrics.tsx
@@ -1,0 +1,166 @@
+import React from "react"
+import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
+import { rootLoader } from "@components/ui/PageLoader"
+import { useIsAdmin } from "@hooks/useIsAdmin"
+import useSWR from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+
+interface EntityCount {
+  entity: string
+  count: number
+}
+
+interface EntityCountsResponse {
+  service: string
+  counts: EntityCount[]
+  breakdowns: Record<string, EntityCount[]>
+  fetchedAt: string
+}
+
+const BREAKDOWN_LABELS: Record<string, string> = {
+  "asset.count.by_market": "Assets by Market",
+  "marketdata.count.by_market": "Market Data by Market",
+  "transaction.count.by_type": "Transactions by Type",
+  "news.count.by_source": "News by Source",
+}
+
+function formatCount(n: number): string {
+  return n.toLocaleString()
+}
+
+function CountTile({
+  label,
+  value,
+}: {
+  label: string
+  value: number
+}): React.ReactElement {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className="text-xs uppercase tracking-wide text-gray-500">
+        {label}
+      </div>
+      <div className="text-2xl font-semibold text-gray-900 mt-1">
+        {formatCount(value)}
+      </div>
+    </div>
+  )
+}
+
+function BreakdownTable({
+  title,
+  rows,
+}: {
+  title: string
+  rows: EntityCount[]
+}): React.ReactElement | null {
+  if (!rows?.length) return null
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+      <div className="px-4 py-2 bg-gray-50 border-b border-gray-200">
+        <h3 className="font-semibold text-gray-900 text-sm">{title}</h3>
+      </div>
+      <table className="w-full text-sm">
+        <tbody>
+          {rows
+            .filter((r) => r.count > 0)
+            .sort((a, b) => b.count - a.count)
+            .map((r) => (
+              <tr
+                key={r.entity}
+                className="border-b last:border-0 border-gray-100"
+              >
+                <td className="px-4 py-2 text-gray-700">{r.entity}</td>
+                <td className="px-4 py-2 text-right font-mono text-gray-900">
+                  {formatCount(r.count)}
+                </td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default withPageAuthRequired(function MetricsPage(): React.ReactElement {
+  const { isAdmin, isLoading } = useIsAdmin()
+  const {
+    data,
+    error,
+    isLoading: loadingData,
+  } = useSWR<EntityCountsResponse>(
+    isAdmin ? "/api/admin/metrics/entity-counts" : null,
+    simpleFetcher,
+    { refreshInterval: 60_000 },
+  )
+
+  if (isLoading) return rootLoader("Loading...")
+
+  if (!isAdmin) {
+    return (
+      <div className="max-w-4xl mx-auto py-12 px-4">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h1 className="text-xl font-semibold text-red-700">Access Denied</h1>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto py-6 px-4">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Service Metrics</h1>
+        <p className="text-gray-600 mt-1 text-sm">
+          Live entity counts from <code>bc-data</code> Micrometer gauges.
+          {data?.fetchedAt && (
+            <span className="ml-2 text-gray-400">
+              Fetched {new Date(data.fetchedAt).toLocaleTimeString()}
+            </span>
+          )}
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
+          <p className="text-red-700 text-sm">
+            Failed to load metrics: {error.message}
+          </p>
+        </div>
+      )}
+
+      {loadingData && !data && (
+        <div className="text-gray-500 text-sm">Loading metrics...</div>
+      )}
+
+      {data && (
+        <>
+          <h2 className="text-lg font-semibold text-gray-900 mb-3">
+            Entity counts
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
+            {data.counts.map((c) => (
+              <CountTile key={c.entity} label={c.entity} value={c.count} />
+            ))}
+          </div>
+
+          {Object.keys(data.breakdowns).length > 0 && (
+            <>
+              <h2 className="text-lg font-semibold text-gray-900 mb-3">
+                Breakdowns
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {Object.entries(data.breakdowns).map(([key, rows]) => (
+                  <BreakdownTable
+                    key={key}
+                    title={BREAKDOWN_LABELS[key] ?? key}
+                    rows={rows}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  )
+})

--- a/src/pages/api/admin/loggers/[service].ts
+++ b/src/pages/api/admin/loggers/[service].ts
@@ -1,0 +1,102 @@
+import { auth0 } from "@lib/auth0"
+import { fetchError } from "@utils/api/responseWriter"
+import {
+  getDataActuatorUrl,
+  getPositionActuatorUrl,
+  getEventActuatorUrl,
+  getRetireActuatorUrl,
+  getRebalanceActuatorUrl,
+  getAgentActuatorUrl,
+} from "@utils/api/bcConfig"
+import { NextApiRequest, NextApiResponse } from "next"
+
+const ACTUATOR_URLS: Record<string, () => string> = {
+  "bc-data": getDataActuatorUrl,
+  "bc-position": getPositionActuatorUrl,
+  "bc-event": getEventActuatorUrl,
+  "bc-retire": getRetireActuatorUrl,
+  "bc-rebalance": getRebalanceActuatorUrl,
+  "bc-agent": getAgentActuatorUrl,
+}
+
+/**
+ * GET  /api/admin/loggers/{service}              → list loggers
+ * POST /api/admin/loggers/{service}              → set level
+ *      body: { logger: string, configuredLevel: string | null }
+ *
+ * Proxies to {service}/actuator/loggers using the caller's access
+ * token, which jar-auth accepts on /actuator/** with the
+ * `beancounter:admin` scope.
+ */
+export default async function loggersHandler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  try {
+    const session = await auth0.getSession(req)
+    if (!session) {
+      res.status(401).json({ error: "Not authenticated" })
+      return
+    }
+
+    const service = Array.isArray(req.query.service)
+      ? req.query.service[0]
+      : req.query.service
+    if (!service || !ACTUATOR_URLS[service]) {
+      res.status(400).json({ error: "Unknown service" })
+      return
+    }
+
+    const { token } = await auth0.getAccessToken(req, res)
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized" })
+      return
+    }
+
+    const base = ACTUATOR_URLS[service]()
+
+    if (req.method === "GET") {
+      const upstream = await fetch(`${base}/actuator/loggers`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(5000),
+      })
+      const body = await upstream.text()
+      res
+        .status(upstream.status)
+        .setHeader("Content-Type", "application/json")
+        .send(body)
+      return
+    }
+
+    if (req.method === "POST") {
+      const { logger, configuredLevel } = req.body ?? {}
+      if (!logger || typeof logger !== "string") {
+        res.status(400).json({ error: "logger required" })
+        return
+      }
+      const encodedLogger = encodeURIComponent(logger)
+      const upstream = await fetch(
+        `${base}/actuator/loggers/${encodedLogger}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ configuredLevel }),
+          signal: AbortSignal.timeout(5000),
+        },
+      )
+      res.status(upstream.status).end()
+      return
+    }
+
+    res.setHeader("Allow", ["GET", "POST"])
+    res.status(405).end(`Method ${req.method} Not Allowed`)
+  } catch (error: unknown) {
+    fetchError(req, res, error)
+  }
+}

--- a/src/pages/api/admin/loggers/[service].ts
+++ b/src/pages/api/admin/loggers/[service].ts
@@ -1,4 +1,3 @@
-import { auth0 } from "@lib/auth0"
 import { fetchError } from "@utils/api/responseWriter"
 import {
   getDataActuatorUrl,
@@ -8,6 +7,7 @@ import {
   getRebalanceActuatorUrl,
   getAgentActuatorUrl,
 } from "@utils/api/bcConfig"
+import { requireAdmin } from "@utils/api/requireAdmin"
 import { NextApiRequest, NextApiResponse } from "next"
 
 const ACTUATOR_URLS: Record<string, () => string> = {
@@ -18,6 +18,8 @@ const ACTUATOR_URLS: Record<string, () => string> = {
   "bc-rebalance": getRebalanceActuatorUrl,
   "bc-agent": getAgentActuatorUrl,
 }
+
+const VALID_LEVELS = new Set(["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF"])
 
 /**
  * GET  /api/admin/loggers/{service}              → list loggers
@@ -33,12 +35,6 @@ export default async function loggersHandler(
   res: NextApiResponse,
 ): Promise<void> {
   try {
-    const session = await auth0.getSession(req)
-    if (!session) {
-      res.status(401).json({ error: "Not authenticated" })
-      return
-    }
-
     const service = Array.isArray(req.query.service)
       ? req.query.service[0]
       : req.query.service
@@ -47,11 +43,9 @@ export default async function loggersHandler(
       return
     }
 
-    const { token } = await auth0.getAccessToken(req, res)
-    if (!token) {
-      res.status(401).json({ error: "Unauthorized" })
-      return
-    }
+    const guard = await requireAdmin(req, res)
+    if (!guard.ok) return
+    const token = guard.token!
 
     const base = ACTUATOR_URLS[service]()
 
@@ -75,6 +69,16 @@ export default async function loggersHandler(
       const { logger, configuredLevel } = req.body ?? {}
       if (!logger || typeof logger !== "string") {
         res.status(400).json({ error: "logger required" })
+        return
+      }
+      if (
+        configuredLevel !== null &&
+        (typeof configuredLevel !== "string" ||
+          !VALID_LEVELS.has(configuredLevel))
+      ) {
+        res.status(400).json({
+          error: `configuredLevel must be null or one of ${[...VALID_LEVELS].join(", ")}`,
+        })
         return
       }
       const encodedLogger = encodeURIComponent(logger)

--- a/src/pages/api/admin/metrics/entity-counts.ts
+++ b/src/pages/api/admin/metrics/entity-counts.ts
@@ -1,0 +1,129 @@
+import { auth0 } from "@lib/auth0"
+import { fetchError } from "@utils/api/responseWriter"
+import { getDataActuatorUrl } from "@utils/api/bcConfig"
+import { NextApiRequest, NextApiResponse } from "next"
+
+interface MicrometerMeasurement {
+  statistic: string
+  value: number
+}
+
+interface MicrometerMetric {
+  name: string
+  measurements: MicrometerMeasurement[]
+  availableTags?: { tag: string; values: string[] }[]
+}
+
+interface EntityCount {
+  entity: string
+  count: number
+}
+
+interface EntityCountsResponse {
+  service: string
+  counts: EntityCount[]
+  breakdowns: Record<string, EntityCount[]>
+  fetchedAt: string
+}
+
+async function fetchMetric(
+  baseUrl: string,
+  name: string,
+  query: string,
+  token: string,
+): Promise<MicrometerMetric | null> {
+  const url = `${baseUrl}/actuator/metrics/${name}${query}`
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+    signal: AbortSignal.timeout(5000),
+  })
+  if (!response.ok) return null
+  return (await response.json()) as MicrometerMetric
+}
+
+function valueOf(metric: MicrometerMetric | null): number {
+  if (!metric) return 0
+  return metric.measurements.find((m) => m.statistic === "VALUE")?.value ?? 0
+}
+
+/**
+ * GET /api/admin/metrics/entity-counts
+ * Returns svc-data's `beancounter.entity.count` gauge values keyed by entity,
+ * plus tagged breakdown gauges (asset by market, transaction by type, etc).
+ */
+export default async function entityCountsHandler(
+  req: NextApiRequest,
+  res: NextApiResponse<EntityCountsResponse | { error: string }>,
+): Promise<void> {
+  try {
+    const session = await auth0.getSession(req)
+    if (!session) {
+      res.status(401).json({ error: "Not authenticated" })
+      return
+    }
+    if (req.method !== "GET") {
+      res.setHeader("Allow", ["GET"])
+      res.status(405).end(`Method ${req.method} Not Allowed`)
+      return
+    }
+
+    const { token } = await auth0.getAccessToken(req, res)
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized" })
+      return
+    }
+
+    const base = getDataActuatorUrl()
+
+    // First call returns availableTags so we know which entities exist.
+    const root = await fetchMetric(base, "beancounter.entity.count", "", token)
+    const entityTag = root?.availableTags?.find((t) => t.tag === "entity")
+    const entities = entityTag?.values ?? []
+
+    const counts: EntityCount[] = await Promise.all(
+      entities.map(async (entity) => {
+        const m = await fetchMetric(
+          base,
+          "beancounter.entity.count",
+          `?tag=entity:${encodeURIComponent(entity)}`,
+          token,
+        )
+        return { entity, count: valueOf(m) }
+      }),
+    )
+
+    const breakdownMetrics = [
+      { key: "asset.count.by_market", tag: "market" },
+      { key: "marketdata.count.by_market", tag: "market" },
+      { key: "transaction.count.by_type", tag: "type" },
+      { key: "news.count.by_source", tag: "source" },
+    ]
+
+    const breakdowns: Record<string, EntityCount[]> = {}
+    for (const { key, tag } of breakdownMetrics) {
+      const root = await fetchMetric(base, `beancounter.${key}`, "", token)
+      const values = root?.availableTags?.find((t) => t.tag === tag)?.values
+      if (!values) continue
+      breakdowns[key] = await Promise.all(
+        values.map(async (v) => {
+          const m = await fetchMetric(
+            base,
+            `beancounter.${key}`,
+            `?tag=${tag}:${encodeURIComponent(v)}`,
+            token,
+          )
+          return { entity: v, count: valueOf(m) }
+        }),
+      )
+    }
+
+    res.status(200).json({
+      service: "bc-data",
+      counts: counts.sort((a, b) => b.count - a.count),
+      breakdowns,
+      fetchedAt: new Date().toISOString(),
+    })
+  } catch (error: unknown) {
+    fetchError(req, res, error)
+  }
+}

--- a/src/pages/api/admin/metrics/entity-counts.ts
+++ b/src/pages/api/admin/metrics/entity-counts.ts
@@ -1,6 +1,6 @@
-import { auth0 } from "@lib/auth0"
 import { fetchError } from "@utils/api/responseWriter"
 import { getDataActuatorUrl } from "@utils/api/bcConfig"
+import { requireAdmin } from "@utils/api/requireAdmin"
 import { NextApiRequest, NextApiResponse } from "next"
 
 interface MicrometerMeasurement {
@@ -56,28 +56,28 @@ export default async function entityCountsHandler(
   res: NextApiResponse<EntityCountsResponse | { error: string }>,
 ): Promise<void> {
   try {
-    const session = await auth0.getSession(req)
-    if (!session) {
-      res.status(401).json({ error: "Not authenticated" })
-      return
-    }
     if (req.method !== "GET") {
       res.setHeader("Allow", ["GET"])
       res.status(405).end(`Method ${req.method} Not Allowed`)
       return
     }
 
-    const { token } = await auth0.getAccessToken(req, res)
-    if (!token) {
-      res.status(401).json({ error: "Unauthorized" })
-      return
-    }
+    const guard = await requireAdmin(req, res)
+    if (!guard.ok) return
+    const token = guard.token!
 
     const base = getDataActuatorUrl()
 
     // First call returns availableTags so we know which entities exist.
+    // Fail fast if the root call fails — partial data masks auth/actuator outages.
     const root = await fetchMetric(base, "beancounter.entity.count", "", token)
-    const entityTag = root?.availableTags?.find((t) => t.tag === "entity")
+    if (!root) {
+      res
+        .status(502)
+        .json({ error: "Upstream actuator unreachable or unauthorized" })
+      return
+    }
+    const entityTag = root.availableTags?.find((t) => t.tag === "entity")
     const entities = entityTag?.values ?? []
 
     const counts: EntityCount[] = await Promise.all(


### PR DESCRIPTION
## Summary

Replaces the external Spring Boot Admin link on /admin with two in-app pages:

- **/admin/metrics** — bc-data entity counts (asset, transaction, news, market-data, etc.) + tagged breakdowns (assets-by-market, transactions-by-type, news-by-source) rendered as tiles + tables. Auto-refresh every 60s via SWR.
- **/admin/loggers** — service selector + logger list with effective/configured levels and live level setter (POST actuator/loggers). Covers bc-data, bc-position, bc-event, bc-retire, bc-rebalance, bc-agent.

## API

New routes proxy each request through bc-view using the caller's Auth0 access token (requires `beancounter:admin` scope):

- `GET /api/admin/metrics/entity-counts` → bc-data /actuator/metrics + tagged variants
- `GET /api/admin/loggers/{service}` → list
- `POST /api/admin/loggers/{service}` body `{logger, configuredLevel}` → set

No new env vars. Re-uses existing `BC_*_ACTUATOR` config (with `getAgentActuatorUrl()` added).

## Why

User reports SBA's stock UI is functional but "the ui we have in bc-view is way nicer." This keeps the SBA server running as the metric aggregator/scrape backend but renders the data in bc-view's existing admin shell. The bc-admin URL card is dropped; metrics/loggers cards take its place.

## Test plan

- [x] `yarn typecheck && yarn lint && yarn prettier && yarn test` (1301 tests pass)
- [ ] Browse `/admin/metrics` on kauri — entity counts populate from svc-data
- [ ] Browse `/admin/loggers` — switch service, change a level (e.g. `com.beancounter` INFO→DEBUG), confirm by tailing the pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin logger page to inspect and change service logging levels with filtering and per-row save state.
  * Admin metrics page showing live entity counts, breakdowns, timestamps and auto-refresh.
* **Bug Fixes / Improvements**
  * Service Metrics card updated to show live platform entity counts via internal metrics route.
* **Chores**
  * Added server-side admin guard and admin API endpoints powering the new admin pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->