### PR TITLE
fix(holdings): buy indicator contrast on green price chart

### DIFF
--- a/src/components/features/holdings/PriceChartPopup.tsx
+++ b/src/components/features/holdings/PriceChartPopup.tsx
@@ -184,7 +184,7 @@ const ChartTooltip: React.FC<TooltipPayload> = ({
         </div>
       )}
       {typeof point.buyPrice === "number" && (
-        <div className="text-xs text-emerald-600 tabular-nums">
+        <div className="text-xs text-blue-600 tabular-nums">
           Buy {point.buyQty} @ {currencySymbol}
           <FormatValue value={point.buyPrice} />
           {point.buyPriceRaw !== point.buyPrice && (
@@ -419,7 +419,7 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
         <span className="flex items-center gap-1">
           <span
             aria-hidden
-            className="inline-block w-0 h-0 border-l-[5px] border-r-[5px] border-b-[7px] border-l-transparent border-r-transparent border-b-emerald-600"
+            className="inline-block w-0 h-0 border-l-[5px] border-r-[5px] border-b-[7px] border-l-transparent border-r-transparent border-b-blue-600"
           />
           Buy
         </span>
@@ -529,8 +529,8 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
               )}
               <Scatter
                 dataKey="buyPrice"
-                fill="#10B981"
-                shape={<TradeDot color="#10B981" direction="up" />}
+                fill="#2563EB"
+                shape={<TradeDot color="#2563EB" direction="up" />}
                 isAnimationActive={false}
               />
               <Scatter


### PR DESCRIPTION
## Summary
- Buy triangle was emerald-500 (`#10B981`), identical to the chart line/area gradient when the price trend is positive, hiding buy markers on green charts.
- Switched buy color to blue-600 (`#2563EB`) — scatter shape fill, legend swatch, and tooltip text. Sell stays red.

## Test plan
- [x] `yarn jest src/components/features/holdings/__tests__/PriceChartPopup.test.tsx` — 8/8 pass
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] semgrep scan clean
- [ ] Visual check: open a holding's price chart with a positive trend and confirm buy markers are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling for BUY markers in the price chart, changing the color scheme from green to blue across all chart elements including tooltips, legend icons, and data point markers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->