### PR TITLE
fix(holdings): anchor buy/sell markers to nearest trading day

### DIFF
--- a/src/components/features/holdings/PriceChartPopup.tsx
+++ b/src/components/features/holdings/PriceChartPopup.tsx
@@ -262,20 +262,40 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
       string,
       { type: TrnType; price: number; quantity: number }[]
     >()
+    const priceDates = (priceData?.prices ?? []).map((p) => p.priceDate)
+    if (priceDates.length === 0) return map
     const raw = tradesData?.data ?? []
-    for (const trn of raw) {
-      if (trn.trnType !== "BUY" && trn.trnType !== "SELL") continue
-      if (!trn.tradeDate || trn.tradeDate < from || trn.tradeDate > to) continue
-      const list = map.get(trn.tradeDate) ?? []
+    const sortedTrades = raw
+      .filter(
+        (trn): trn is Transaction =>
+          (trn.trnType === "BUY" || trn.trnType === "SELL") &&
+          !!trn.tradeDate &&
+          trn.tradeDate >= from &&
+          trn.tradeDate <= to,
+      )
+      .sort((a, b) => a.tradeDate.localeCompare(b.tradeDate))
+    let cursor = 0
+    for (const trn of sortedTrades) {
+      while (
+        cursor < priceDates.length &&
+        priceDates[cursor] < trn.tradeDate
+      ) {
+        cursor++
+      }
+      const anchor =
+        cursor < priceDates.length
+          ? priceDates[cursor]
+          : priceDates[priceDates.length - 1]
+      const list = map.get(anchor) ?? []
       list.push({
         type: trn.trnType,
         price: Number(trn.price),
         quantity: Number(trn.quantity),
       })
-      map.set(trn.tradeDate, list)
+      map.set(anchor, list)
     }
     return map
-  }, [tradesData, from, to])
+  }, [tradesData, priceData, from, to])
 
   const series: ChartPoint[] = useMemo(() => {
     const raw = priceData?.prices ?? []

--- a/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
@@ -186,6 +186,37 @@ describe("PriceChartPopup", () => {
     expect(screen.getByTestId("scatter-sellPrice")).toBeInTheDocument()
   })
 
+  it("anchors a non-trading-day trade to the next available price date", () => {
+    mockUseSwr.mockImplementation(
+      makeRouter({
+        tradesResult: {
+          data: {
+            data: [
+              {
+                id: "t1",
+                trnType: "BUY",
+                tradeDate: "2026-03-28",
+                quantity: 3,
+                price: 405,
+              },
+            ],
+          },
+          isLoading: false,
+          error: undefined,
+        } as unknown as ReturnType<typeof useSwr>,
+      }) as typeof useSwr,
+    )
+
+    renderPopup()
+
+    const chart = screen.getByTestId("chart")
+    const rows = JSON.parse(
+      chart.getAttribute("data-series") as string,
+    ) as Array<{ priceDate: string; buyPrice: number | null }>
+    const anchored = rows.find((r) => r.buyPrice !== null)
+    expect(anchored?.priceDate).toBe("2026-04-01")
+  })
+
   it("renders backend split-adjusted prices and marks the ex-date", () => {
     // svc-data adjusts pre-split closes server-side and normalises the
     // `split` column so only the canonical ex-date carries a non-1 value.


### PR DESCRIPTION
## Summary
- Chart matched trade dates to price-history dates by exact string equality, so trades on weekends, market holidays, or any day without a price tick produced no visible marker. For DBS/PLD (SGX) and similar holdings, the buy indicator could disappear entirely even when the trade date was clearly within the chart's range.
- Each trade is now anchored to the first `priceDate >= tradeDate` (falling back to the last priceDate if the trade is later than the available history).
- Added a regression test for a non-trading-day trade snapping forward to the next price point.

## Test plan
- [x] `yarn jest src/components/features/holdings/__tests__/PriceChartPopup.test.tsx` — 9/9 pass
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] semgrep scan clean
- [ ] Visual check on kauri: open DBS/PLD price chart in 12m view and confirm the buy marker is now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed price chart display to properly align trades occurring on non-trading days with the next available price date.

* **Tests**
  * Added test coverage for trade date anchoring behavior on price charts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->