### PR TITLE
perf: proxy-denormalize TrnResponse envelope into legacy fat shape

### DIFF
--- a/src/components/features/holdings/PriceChartPopup.tsx
+++ b/src/components/features/holdings/PriceChartPopup.tsx
@@ -276,10 +276,7 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
       .sort((a, b) => a.tradeDate.localeCompare(b.tradeDate))
     let cursor = 0
     for (const trn of sortedTrades) {
-      while (
-        cursor < priceDates.length &&
-        priceDates[cursor] < trn.tradeDate
-      ) {
+      while (cursor < priceDates.length && priceDates[cursor] < trn.tradeDate) {
         cursor++
       }
       const anchor =

--- a/src/lib/utils/api/createApiHandler.ts
+++ b/src/lib/utils/api/createApiHandler.ts
@@ -29,6 +29,13 @@ interface ApiHandlerConfig {
   methods?: HttpMethod[]
   /** Methods that should forward req.body as JSON (default: ["POST", "PATCH", "PUT"]) */
   bodyMethods?: HttpMethod[]
+  /**
+   * Optional transform applied to the JSON response body before it is
+   * forwarded to the browser. Used to denormalise backend envelope
+   * shapes (e.g. `TrnPayload`) into the fat record shape consumed by
+   * existing UI components.
+   */
+  transformJson?: (json: unknown) => unknown
 }
 
 export function createApiHandler(config: ApiHandlerConfig): NextApiHandler {
@@ -61,7 +68,7 @@ export function createApiHandler(config: ApiHandlerConfig): NextApiHandler {
         : requestInit(accessToken, method, req)
 
       const response = await fetch(url, init)
-      await handleResponse(response, res)
+      await handleResponse(response, res, config.transformJson)
     } catch (error: unknown) {
       fetchError(req, res, error)
     }

--- a/src/lib/utils/api/responseWriter.ts
+++ b/src/lib/utils/api/responseWriter.ts
@@ -129,6 +129,7 @@ export function hasError(response: Response): boolean {
 export default async function handleResponse<T>(
   response: Response,
   res: NextApiResponse,
+  transformJson?: (json: unknown) => unknown,
 ): Promise<void> {
   if (hasError(response)) {
     await handleErrors(response)
@@ -137,6 +138,7 @@ export default async function handleResponse<T>(
     res.status(204).end()
   } else {
     const json: T = await response.json()
-    res.status(response.status || 200).json(json)
+    const payload = transformJson ? (transformJson(json) as T) : json
+    res.status(response.status || 200).json(payload)
   }
 }

--- a/src/lib/utils/trns/__tests__/trnsSelectors.test.ts
+++ b/src/lib/utils/trns/__tests__/trnsSelectors.test.ts
@@ -1,52 +1,18 @@
-import type { Asset, Portfolio, TrnPayload } from "types/beancounter"
+import type { TrnPayload } from "types/beancounter"
 import {
   denormalizeTrnPayload,
   transformTrnEnvelopeJson,
 } from "@utils/trns/trnsSelectors"
+import {
+  makeAsset,
+  makeCashAsset,
+  makePortfolio,
+  USD,
+} from "@test-fixtures/beancounter"
 
-const usdAsset: Asset = {
-  id: "USD",
-  code: "USD",
-  name: "US Dollar",
-  market: {
-    code: "CASH",
-    currency: { code: "USD", name: "Dollar", symbol: "$" },
-    timezone: "UTC",
-    multiplier: 1,
-  },
-  priceSymbol: "USD",
-  category: "CASH",
-  assetCategory: { id: "CASH", name: "Cash" },
-  status: "Active",
-  version: "1",
-} as unknown as Asset
-
-const aaplAsset: Asset = {
-  id: "AAPL",
-  code: "AAPL",
-  name: "Apple",
-  market: {
-    code: "NASDAQ",
-    currency: { code: "USD", name: "Dollar", symbol: "$" },
-    timezone: "US/Eastern",
-    multiplier: 1,
-  },
-  priceSymbol: "AAPL",
-  category: "EQUITY",
-  assetCategory: { id: "EQUITY", name: "Equity" },
-  status: "Active",
-  version: "1",
-} as unknown as Asset
-
-const portfolio: Portfolio = {
-  id: "USV",
-  code: "USV",
-  name: "Test",
-  marketValue: 0,
-  irr: 0,
-  currency: { code: "USD", name: "Dollar", symbol: "$" },
-  base: { code: "USD", name: "Dollar", symbol: "$" },
-} as unknown as Portfolio
+const aapl = makeAsset()
+const usdCash = makeCashAsset(USD)
+const portfolio = makePortfolio({ id: "USV", code: "USV" })
 
 const envelope: TrnPayload = {
   trns: [
@@ -55,17 +21,17 @@ const envelope: TrnPayload = {
       callerRef: null,
       trnType: "BUY",
       status: "SETTLED",
-      portfolioId: "USV",
-      assetId: "AAPL",
-      cashAssetId: "USD",
+      portfolioId: portfolio.id,
+      assetId: aapl.id,
+      cashAssetId: usdCash.id,
       tradeDate: "2025-01-15",
       quantity: 10,
       price: 200,
-      tradeCurrencyCode: "USD",
+      tradeCurrencyCode: USD.code,
       tradeAmount: 2000,
       tradeBaseRate: 1,
       tradePortfolioRate: 1,
-      cashCurrencyCode: "USD",
+      cashCurrencyCode: USD.code,
       cashAmount: -2000,
       tradeCashRate: 1,
       fees: 0,
@@ -76,9 +42,9 @@ const envelope: TrnPayload = {
       subAccounts: null,
     },
   ],
-  assets: { AAPL: aaplAsset, USD: usdAsset },
-  portfolios: { USV: portfolio },
-  currencies: { USD: { code: "USD", name: "Dollar", symbol: "$" } },
+  assets: { [aapl.id]: aapl, [usdCash.id]: usdCash },
+  portfolios: { [portfolio.id]: portfolio },
+  currencies: { [USD.code]: USD },
   brokers: {},
 }
 
@@ -86,10 +52,15 @@ describe("trnsSelectors", () => {
   describe("denormalizeTrnPayload", () => {
     it("re-attaches asset and portfolio from envelope maps", () => {
       const [trn] = denormalizeTrnPayload(envelope)
-      expect(trn.asset).toEqual(aaplAsset)
+      expect(trn.asset).toEqual(aapl)
       expect(trn.portfolio).toEqual(portfolio)
-      expect(trn.cashAsset).toEqual(usdAsset)
-      expect(trn.tradeCurrency.code).toBe("USD")
+      expect(trn.cashAsset).toEqual(usdCash)
+      expect(trn.tradeCurrency.code).toBe(USD.code)
+    })
+
+    it("falls back to an empty callerRef when the envelope omits it", () => {
+      const [trn] = denormalizeTrnPayload(envelope)
+      expect(trn.callerRef).toEqual({ provider: "", batch: "", callerId: "" })
     })
 
     it("returns an empty array for missing or empty envelopes", () => {
@@ -105,15 +76,32 @@ describe("trnsSelectors", () => {
         }),
       ).toEqual([])
     })
+
+    it("throws when a required envelope reference is missing", () => {
+      const broken: TrnPayload = {
+        ...envelope,
+        assets: {}, // strip AAPL from the envelope
+      }
+      expect(() => denormalizeTrnPayload(broken)).toThrow(/Invalid TrnPayload refs/)
+    })
+
+    it("throws when an optional id is dangling", () => {
+      const broken: TrnPayload = {
+        ...envelope,
+        brokers: {},
+        trns: [{ ...envelope.trns[0], brokerId: "ghost" }],
+      }
+      expect(() => denormalizeTrnPayload(broken)).toThrow(/brokerId=ghost/)
+    })
   })
 
   describe("transformTrnEnvelopeJson", () => {
     it("rewrites envelope to legacy { data: Transaction[] } shape", () => {
       const out = transformTrnEnvelopeJson({ data: envelope }) as {
-        data: Array<{ id: string; asset: Asset }>
+        data: Array<{ id: string; asset: typeof aapl }>
       }
       expect(out.data).toHaveLength(1)
-      expect(out.data[0].asset.code).toBe("AAPL")
+      expect(out.data[0].asset.code).toBe(aapl.code)
     })
 
     it("passes non-envelope payloads through unchanged", () => {

--- a/src/lib/utils/trns/__tests__/trnsSelectors.test.ts
+++ b/src/lib/utils/trns/__tests__/trnsSelectors.test.ts
@@ -82,7 +82,9 @@ describe("trnsSelectors", () => {
         ...envelope,
         assets: {}, // strip AAPL from the envelope
       }
-      expect(() => denormalizeTrnPayload(broken)).toThrow(/Invalid TrnPayload refs/)
+      expect(() => denormalizeTrnPayload(broken)).toThrow(
+        /Invalid TrnPayload refs/,
+      )
     })
 
     it("throws when an optional id is dangling", () => {

--- a/src/lib/utils/trns/__tests__/trnsSelectors.test.ts
+++ b/src/lib/utils/trns/__tests__/trnsSelectors.test.ts
@@ -1,0 +1,124 @@
+import type { Asset, Portfolio, TrnPayload } from "types/beancounter"
+import {
+  denormalizeTrnPayload,
+  transformTrnEnvelopeJson,
+} from "@utils/trns/trnsSelectors"
+
+const usdAsset: Asset = {
+  id: "USD",
+  code: "USD",
+  name: "US Dollar",
+  market: {
+    code: "CASH",
+    currency: { code: "USD", name: "Dollar", symbol: "$" },
+    timezone: "UTC",
+    multiplier: 1,
+  },
+  priceSymbol: "USD",
+  category: "CASH",
+  assetCategory: { id: "CASH", name: "Cash" },
+  status: "Active",
+  version: "1",
+} as unknown as Asset
+
+const aaplAsset: Asset = {
+  id: "AAPL",
+  code: "AAPL",
+  name: "Apple",
+  market: {
+    code: "NASDAQ",
+    currency: { code: "USD", name: "Dollar", symbol: "$" },
+    timezone: "US/Eastern",
+    multiplier: 1,
+  },
+  priceSymbol: "AAPL",
+  category: "EQUITY",
+  assetCategory: { id: "EQUITY", name: "Equity" },
+  status: "Active",
+  version: "1",
+} as unknown as Asset
+
+const portfolio: Portfolio = {
+  id: "USV",
+  code: "USV",
+  name: "Test",
+  marketValue: 0,
+  irr: 0,
+  currency: { code: "USD", name: "Dollar", symbol: "$" },
+  base: { code: "USD", name: "Dollar", symbol: "$" },
+} as unknown as Portfolio
+
+const envelope: TrnPayload = {
+  trns: [
+    {
+      id: "t1",
+      callerRef: null,
+      trnType: "BUY",
+      status: "SETTLED",
+      portfolioId: "USV",
+      assetId: "AAPL",
+      cashAssetId: "USD",
+      tradeDate: "2025-01-15",
+      quantity: 10,
+      price: 200,
+      tradeCurrencyCode: "USD",
+      tradeAmount: 2000,
+      tradeBaseRate: 1,
+      tradePortfolioRate: 1,
+      cashCurrencyCode: "USD",
+      cashAmount: -2000,
+      tradeCashRate: 1,
+      fees: 0,
+      tax: 0,
+      comments: null,
+      brokerId: null,
+      modelId: null,
+      subAccounts: null,
+    },
+  ],
+  assets: { AAPL: aaplAsset, USD: usdAsset },
+  portfolios: { USV: portfolio },
+  currencies: { USD: { code: "USD", name: "Dollar", symbol: "$" } },
+  brokers: {},
+}
+
+describe("trnsSelectors", () => {
+  describe("denormalizeTrnPayload", () => {
+    it("re-attaches asset and portfolio from envelope maps", () => {
+      const [trn] = denormalizeTrnPayload(envelope)
+      expect(trn.asset).toEqual(aaplAsset)
+      expect(trn.portfolio).toEqual(portfolio)
+      expect(trn.cashAsset).toEqual(usdAsset)
+      expect(trn.tradeCurrency.code).toBe("USD")
+    })
+
+    it("returns an empty array for missing or empty envelopes", () => {
+      expect(denormalizeTrnPayload(null)).toEqual([])
+      expect(denormalizeTrnPayload(undefined)).toEqual([])
+      expect(
+        denormalizeTrnPayload({
+          trns: [],
+          assets: {},
+          portfolios: {},
+          currencies: {},
+          brokers: {},
+        }),
+      ).toEqual([])
+    })
+  })
+
+  describe("transformTrnEnvelopeJson", () => {
+    it("rewrites envelope to legacy { data: Transaction[] } shape", () => {
+      const out = transformTrnEnvelopeJson({ data: envelope }) as {
+        data: Array<{ id: string; asset: Asset }>
+      }
+      expect(out.data).toHaveLength(1)
+      expect(out.data[0].asset.code).toBe("AAPL")
+    })
+
+    it("passes non-envelope payloads through unchanged", () => {
+      const deleteResponse = { data: ["t1"] }
+      expect(transformTrnEnvelopeJson(deleteResponse)).toBe(deleteResponse)
+    })
+  })
+})

--- a/src/lib/utils/trns/trnsSelectors.ts
+++ b/src/lib/utils/trns/trnsSelectors.ts
@@ -1,0 +1,114 @@
+import type {
+  Asset,
+  Broker,
+  Currency,
+  Portfolio,
+  Transaction,
+  TrnDto,
+  TrnPayload,
+  TrnResponse,
+} from "types/beancounter"
+
+/**
+ * Re-hydrates a normalised [[TrnPayload]] envelope back into the fat
+ * [[Transaction]] shape that existing components consume. Asset,
+ * Portfolio, Currency, and Broker lookups come from the envelope maps.
+ *
+ * Returns an empty array when the envelope or its trns list is missing
+ * so callers can keep their existing `.map`/`.length` access patterns
+ * without an extra null guard.
+ */
+export function denormalizeTrnPayload(
+  payload: TrnPayload | null | undefined,
+): Transaction[] {
+  if (!payload?.trns?.length) return []
+  const { trns, assets, portfolios, currencies, brokers } = payload
+  return trns.map((dto) =>
+    denormalizeTrn(dto, assets, portfolios, currencies, brokers),
+  )
+}
+
+/**
+ * Unwrap the outer `{ data: TrnPayload }` envelope and denormalize in one
+ * step. Convenient at fetch boundaries:
+ *
+ * ```ts
+ * const trns = denormalizeTrnResponse(await res.json())
+ * ```
+ */
+export function denormalizeTrnResponse(
+  response: TrnResponse | null | undefined,
+): Transaction[] {
+  return denormalizeTrnPayload(response?.data)
+}
+
+/**
+ * Server-side proxy transform: takes the backend `{ data: TrnPayload }`
+ * envelope and returns the legacy `{ data: Transaction[] }` shape that
+ * existing browser-side components consume. Used by API route handlers
+ * to keep UI code untouched while the inter-service hop ships the
+ * normalised envelope.
+ *
+ * Defensive: a route that handles multiple methods may also serve
+ * non-TrnResponse payloads (e.g. DELETE returns `{ data: string[] }`).
+ * The transform inspects the shape and only rewrites when it sees an
+ * actual TrnPayload (object with a `trns` array).
+ */
+export function transformTrnEnvelopeJson(json: unknown): unknown {
+  if (
+    json !== null &&
+    typeof json === "object" &&
+    "data" in (json as Record<string, unknown>)
+  ) {
+    const data = (json as { data: unknown }).data
+    if (
+      data !== null &&
+      typeof data === "object" &&
+      Array.isArray((data as { trns?: unknown }).trns)
+    ) {
+      return { data: denormalizeTrnPayload(data as TrnPayload) }
+    }
+  }
+  return json
+}
+
+function denormalizeTrn(
+  dto: TrnDto,
+  assets: Record<string, Asset>,
+  portfolios: Record<string, Portfolio>,
+  currencies: Record<string, Currency>,
+  brokers: Record<string, Broker>,
+): Transaction {
+  const asset = assets[dto.assetId]
+  const portfolio = portfolios[dto.portfolioId]
+  const tradeCurrency = currencies[dto.tradeCurrencyCode]
+  const cashAsset = dto.cashAssetId ? assets[dto.cashAssetId] : undefined
+  const broker = dto.brokerId ? brokers[dto.brokerId] : undefined
+
+  return {
+    id: dto.id,
+    callerRef: dto.callerRef!,
+    trnType: dto.trnType,
+    status: dto.status,
+    portfolio,
+    asset,
+    cashAsset,
+    tradeDate: dto.tradeDate,
+    quantity: dto.quantity,
+    price: dto.price ?? 0,
+    tradeCurrency,
+    tradeAmount: dto.tradeAmount,
+    tradeBaseRate: dto.tradeBaseRate,
+    tradePortfolioRate: dto.tradePortfolioRate,
+    cashCurrency: dto.cashCurrencyCode ?? "",
+    cashAmount: dto.cashAmount,
+    tradeCashRate: dto.tradeCashRate,
+    fees: dto.fees,
+    tax: dto.tax,
+    comments: dto.comments ?? "",
+    broker,
+    brokerId: dto.brokerId ?? undefined,
+    modelId: dto.modelId ?? undefined,
+    subAccounts: dto.subAccounts ?? undefined,
+  }
+}

--- a/src/lib/utils/trns/trnsSelectors.ts
+++ b/src/lib/utils/trns/trnsSelectors.ts
@@ -82,12 +82,22 @@ function denormalizeTrn(
   const asset = assets[dto.assetId]
   const portfolio = portfolios[dto.portfolioId]
   const tradeCurrency = currencies[dto.tradeCurrencyCode]
-  const cashAsset = dto.cashAssetId ? assets[dto.cashAssetId] : undefined
-  const broker = dto.brokerId ? brokers[dto.brokerId] : undefined
+  if (!asset || !portfolio || !tradeCurrency) {
+    throw new Error(
+      `Invalid TrnPayload refs for trn ${dto.id} ` +
+        `(assetId=${dto.assetId}, portfolioId=${dto.portfolioId}, ` +
+        `tradeCurrencyCode=${dto.tradeCurrencyCode})`,
+    )
+  }
+  const cashAsset = dto.cashAssetId ? lookup(assets, dto.cashAssetId, dto.id, "cashAssetId") : undefined
+  const cashCurrency = dto.cashCurrencyCode
+    ? lookup(currencies, dto.cashCurrencyCode, dto.id, "cashCurrencyCode")
+    : undefined
+  const broker = dto.brokerId ? lookup(brokers, dto.brokerId, dto.id, "brokerId") : undefined
 
   return {
     id: dto.id,
-    callerRef: dto.callerRef!,
+    callerRef: dto.callerRef ?? { provider: "", batch: "", callerId: "" },
     trnType: dto.trnType,
     status: dto.status,
     portfolio,
@@ -100,7 +110,7 @@ function denormalizeTrn(
     tradeAmount: dto.tradeAmount,
     tradeBaseRate: dto.tradeBaseRate,
     tradePortfolioRate: dto.tradePortfolioRate,
-    cashCurrency: dto.cashCurrencyCode ?? "",
+    cashCurrency: cashCurrency?.code ?? "",
     cashAmount: dto.cashAmount,
     tradeCashRate: dto.tradeCashRate,
     fees: dto.fees,
@@ -111,4 +121,17 @@ function denormalizeTrn(
     modelId: dto.modelId ?? undefined,
     subAccounts: dto.subAccounts ?? undefined,
   }
+}
+
+function lookup<T>(
+  map: Record<string, T>,
+  id: string,
+  trnId: string,
+  field: string,
+): T {
+  const value = map[id]
+  if (!value) {
+    throw new Error(`TrnPayload missing ${field}=${id} for trn ${trnId}`)
+  }
+  return value
 }

--- a/src/lib/utils/trns/trnsSelectors.ts
+++ b/src/lib/utils/trns/trnsSelectors.ts
@@ -89,11 +89,15 @@ function denormalizeTrn(
         `tradeCurrencyCode=${dto.tradeCurrencyCode})`,
     )
   }
-  const cashAsset = dto.cashAssetId ? lookup(assets, dto.cashAssetId, dto.id, "cashAssetId") : undefined
+  const cashAsset = dto.cashAssetId
+    ? lookup(assets, dto.cashAssetId, dto.id, "cashAssetId")
+    : undefined
   const cashCurrency = dto.cashCurrencyCode
     ? lookup(currencies, dto.cashCurrencyCode, dto.id, "cashCurrencyCode")
     : undefined
-  const broker = dto.brokerId ? lookup(brokers, dto.brokerId, dto.id, "brokerId") : undefined
+  const broker = dto.brokerId
+    ? lookup(brokers, dto.brokerId, dto.id, "brokerId")
+    : undefined
 
   return {
     id: dto.id,

--- a/src/pages/api/trns/[trnId].ts
+++ b/src/pages/api/trns/[trnId].ts
@@ -1,5 +1,6 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export default createApiHandler({
   url: (req) => {
@@ -10,4 +11,5 @@ export default createApiHandler({
     return getDataUrl(`/trns/${trnId}`)
   },
   methods: ["GET", "PATCH", "DELETE"],
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/api/trns/index.ts
+++ b/src/pages/api/trns/index.ts
@@ -1,9 +1,11 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export const baseUrl = getDataUrl("/trns")
 
 export default createApiHandler({
   url: baseUrl,
   methods: ["POST"],
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/api/trns/investments/monthly/transactions.ts
+++ b/src/pages/api/trns/investments/monthly/transactions.ts
@@ -1,5 +1,6 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export default createApiHandler({
   url: (req) => {
@@ -11,4 +12,5 @@ export default createApiHandler({
       `/trns/investments/monthly/transactions${qs ? `?${qs}` : ""}`,
     )
   },
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/api/trns/move.ts
+++ b/src/pages/api/trns/move.ts
@@ -1,9 +1,11 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export const baseUrl = getDataUrl("/trns/move")
 
 export default createApiHandler({
   url: baseUrl,
   methods: ["POST"],
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/api/trns/patch/[portfolioId]/[trnId].ts
+++ b/src/pages/api/trns/patch/[portfolioId]/[trnId].ts
@@ -1,5 +1,6 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export default createApiHandler({
   url: (req) => {
@@ -7,4 +8,5 @@ export default createApiHandler({
     return getDataUrl(`/trns/${portfolioId}/${trnId}`)
   },
   methods: ["PATCH"],
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/api/trns/portfolio/[portfolioId]/cash-ladder/[cashAssetId].ts
+++ b/src/pages/api/trns/portfolio/[portfolioId]/cash-ladder/[cashAssetId].ts
@@ -1,9 +1,11 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export default createApiHandler({
   url: (req) => {
     const { portfolioId, cashAssetId } = req.query
     return getDataUrl(`/trns/${portfolioId}/cash-ladder/${cashAssetId}`)
   },
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/api/trns/portfolio/[portfolioId]/status/[status].ts
+++ b/src/pages/api/trns/portfolio/[portfolioId]/status/[status].ts
@@ -1,5 +1,6 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export default createApiHandler({
   url: (req) => {
@@ -8,4 +9,5 @@ export default createApiHandler({
     if (tradeDate) url += `?tradeDate=${tradeDate}`
     return url
   },
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/api/trns/proposed/index.ts
+++ b/src/pages/api/trns/proposed/index.ts
@@ -1,5 +1,6 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 const ALLOWED_SCOPES = new Set(["OWNED", "MANAGED", "ALL"])
 
@@ -14,4 +15,5 @@ export default createApiHandler({
     const scope = resolveScope(req.query.scope)
     return getDataUrl(`/trns/proposed?scope=${scope}`)
   },
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/api/trns/settled.ts
+++ b/src/pages/api/trns/settled.ts
@@ -1,9 +1,11 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export default createApiHandler({
   url: (req) => {
     const tradeDate = req.query.tradeDate as string
     return getDataUrl(`/trns/settled?tradeDate=${tradeDate}`)
   },
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/api/trns/trades/[...trades].ts
+++ b/src/pages/api/trns/trades/[...trades].ts
@@ -3,6 +3,7 @@ import {
   sanitizePathParam,
 } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export default createApiHandler({
   url: (req) => {
@@ -15,4 +16,5 @@ export default createApiHandler({
     return getDataUrl(`/trns/${portfolioId}/asset/${assetId}/trades`)
   },
   methods: ["GET", "DELETE"],
+  transformJson: transformTrnEnvelopeJson,
 })

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -347,6 +347,58 @@ export interface Transaction {
   subAccounts?: Record<string, number>
 }
 
+/**
+ * Wire-format Trn record matching the backend `TrnDto`. Asset, Portfolio,
+ * Currency, and Broker are referenced by id/code; the actual objects live
+ * in the parent [[TrnPayload]] maps. Re-hydrate via
+ * `denormalizeTrnPayload` when components need the fat [[Transaction]].
+ */
+export interface TrnDto {
+  id: string
+  callerRef: CallerRef | null
+  trnType: TrnType
+  status: TrnStatus
+  portfolioId: string
+  assetId: string
+  cashAssetId: string | null
+  tradeDate: string
+  quantity: number
+  price: number | null
+  tradeCurrencyCode: string
+  tradeAmount: number
+  tradeBaseRate: number
+  tradePortfolioRate: number
+  cashCurrencyCode: string | null
+  cashAmount: number
+  tradeCashRate: number
+  fees: number
+  tax: number
+  comments: string | null
+  brokerId: string | null
+  modelId: string | null
+  subAccounts: Record<string, number> | null
+}
+
+/**
+ * Normalised envelope returned by every `/api/trns/...` endpoint.
+ * De-duplicates Asset / Portfolio / Currency / Broker references across
+ * many trns in a single response.
+ */
+export interface TrnPayload {
+  trns: TrnDto[]
+  assets: Record<string, Asset>
+  portfolios: Record<string, Portfolio>
+  currencies: Record<string, Currency>
+  brokers: Record<string, Broker>
+}
+
+/**
+ * Top-level response envelope from backend trn endpoints.
+ */
+export interface TrnResponse {
+  data: TrnPayload
+}
+
 interface Registration {
   id: string
   email: string


### PR DESCRIPTION
## Summary

Companion PR for monowai/beancounter#862 (TrnResponse wire-format normalization).

The backend now ships `TrnResponse` as a normalised envelope (`{ data: TrnPayload }`) with de-duplicated `assets` / `portfolios` / `currencies` / `brokers` maps and `TrnDto` records carrying id refs. This PR keeps the inter-service hop saving (bc-data → bc-view server) **without touching any UI component**, by denormalizing back to the legacy `{ data: Transaction[] }` shape at the bc-view proxy layer.

## Approach

- Adds `TrnDto`, `TrnPayload`, `TrnResponse` types in \`types/beancounter.d.ts\`.
- New \`src/lib/utils/trns/trnsSelectors.ts\`:
  - \`denormalizeTrnPayload(payload)\` re-attaches asset/portfolio from envelope maps.
  - \`transformTrnEnvelopeJson(json)\` for server-side proxy use; defensive against non-envelope payloads (DELETE returns \`{ data: string[] }\`, etc.) — passes them through untouched.
- Extends \`createApiHandler\` with an optional \`transformJson\` hook; \`handleResponse\` applies it before forwarding to the browser.
- Wires \`transformTrnEnvelopeJson\` into all 10 trn-returning API routes (settled, proposed, portfolio/status, cash-ladder, [trnId], index POST, patch, move, trades GET, investments/monthly/transactions). Browser still sees the legacy shape — zero component-level change.

## Bandwidth notes

- **Inter-service hop (bc-data → bc-view server):** ~45% saving on trn-heavy payloads per the kauri baseline. Won.
- **Browser hop:** unchanged in this PR (re-bloated at the proxy). Once UI components migrate to the envelope directly (follow-up), browser will also see the saving. Caddy gzip at the public edge covers most of the gap in the meantime.

## Test plan

- [x] \`yarn test\` 1306/1306 green locally.
- [x] \`yarn typecheck\` clean.
- [x] \`yarn lint && yarn prettier\` clean.
- [x] Unit tests for \`denormalizeTrnPayload\` + \`transformTrnEnvelopeJson\` (legacy shape rewrite + pass-through on DELETE-style payloads).
- [ ] After backend PRs land: smoke-test \`/trns/proposed\`, \`/trns/cash-ladder\`, \`/portfolios/<id>/trades\`, \`/wealth\` against kauri.

⚠ **Merge after monowai/beancounter#862** (so the proxy actually sees the envelope shape it's denormalizing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction API responses are now consistently transformed and denormalized across endpoints for more reliable client-side transaction data.

* **Refactor**
  * Minor optimizations to transaction processing and display logic to improve consistency and robustness.

* **Tests**
  * Added comprehensive tests covering transaction denormalization and response transformations to reduce regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->