### PR TITLE
fix(portfolios+holdings): mobile checkbox + managed-portfolio performance chart

### DIFF
--- a/src/components/features/portfolios/PortfoliosList.tsx
+++ b/src/components/features/portfolios/PortfoliosList.tsx
@@ -410,23 +410,31 @@ const PortfoliosList: React.FC<PortfoliosListProps> = ({
             >
               {/* Dedicated checkbox tap zone — outside the navigate region.
                   Wide enough to clear the 44px iOS HIG minimum so users
-                  can toggle without accidentally opening the portfolio. */}
-              <label
+                  can toggle without accidentally opening the portfolio.
+                  Uses `button` not `label` — a label wrapping a checkbox
+                  re-dispatches click to the input, firing the handler
+                  twice (toggle then toggle = no-op). The inner checkbox
+                  is purely visual (aria-hidden, no handlers). */}
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={effectiveSelected.has(portfolio.code)}
+                aria-label={`Select ${portfolio.code}`}
                 className="flex items-center justify-center px-4 py-4 cursor-pointer select-none"
                 onClick={(e) => {
                   e.stopPropagation()
                   togglePortfolioSelection(portfolio.code)
                 }}
-                aria-label={`Select ${portfolio.code}`}
               >
                 <input
                   type="checkbox"
                   checked={effectiveSelected.has(portfolio.code)}
                   readOnly
                   tabIndex={-1}
+                  aria-hidden="true"
                   className="w-5 h-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500 pointer-events-none"
                 />
-              </label>
+              </button>
               <div
                 className="flex-1 p-4 pl-0 cursor-pointer"
                 onClick={() => router.push(`/holdings/${portfolio.code}`)}

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -598,7 +598,7 @@ function HoldingsPage(): React.ReactElement {
             onViewModeChange={setViewMode}
           />
           <PerformanceChart
-            portfolioCode={holdingResults.portfolio.code}
+            portfolioCode={holdingResults.portfolio.id}
             currencySymbol={holdingResults.portfolio.currency.symbol}
           />
         </div>


### PR DESCRIPTION
## Summary

Two fixes on the same branch.

### 1. Mobile checkbox double-fire (Portfolios)

#690 shipped a `<label onClick>...<input/>...</label>` for the mobile checkbox tap zone. Browsers re-dispatch click to the wrapped input as part of label-input semantics; that click bubbles back to the label, *then* the label's own click fires for the direct tap. Handler runs twice, toggle cancels itself → checkbox completely inert.

Switched to `<button type="button" role="checkbox" aria-checked>`. Buttons have no synthetic click delegation to inner inputs, so the handler fires exactly once. Inner `<input>` is now purely visual (`aria-hidden`, `pointer-events-none`, `readOnly`). Tap target unchanged (>= 44px iOS HIG minimum).

### 2. Managed-portfolio performance chart 404 (Holdings)

Holdings page for a managed/shared portfolio (e.g. LIV from a manager account) showed `Failed to load performance data` with `404 Portfolio not found: LIV`. The page itself loads via the `?byId=1` route -> svc-position holdings `find(id)` + `canView`, which works for both owner and manager. But the embedded PerformanceChart was being fed `portfolio.code` -> svc-position `/{code}/performance` -> owner-scoped `findByCodeAndOwner` -> 404.

Passing `portfolio.id` instead. Pairs with beancounter PR #872 which makes the performance endpoints resolve by-id first then fall back to by-code.

## Test plan

- [x] `yarn typecheck` -- green.
- [x] `yarn lint` -- green.
- [x] `yarn test` -- 111 suites / 1309 tests green.
- [x] Semgrep clean.
- [ ] Manual mobile (Portfolios): tap card checkbox -> must toggle selection, NOT navigate. Tap card body -> must navigate.
- [ ] Manual managed portfolio (Holdings): view /holdings for a shared portfolio after backend PR #872 deploys; PerformanceChart loads without 404.

Follow-up to #690.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Redesigned the mobile portfolio selection control to a dedicated tap target with explicit ARIA roles and states for better keyboard and screen reader support.
* **Bug Fixes**
  * Fixed chart view to reference the correct portfolio identifier so holdings charts display the intended portfolio.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->