### PR TITLE
fix(holdings): enable price chart on aggregated cards and table

### DIFF
--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 import {
   TableSkeletonLoader,
   SummarySkeletonLoader,
@@ -12,7 +12,8 @@ import { useHoldingState } from "@lib/holdings/holdingState"
 import { useHoldingsView } from "@lib/holdings/useHoldingsView"
 import HoldingsHeader from "@components/features/holdings/HoldingsHeader"
 import HoldingMenu from "@components/features/holdings/HoldingMenu"
-import Rows from "@components/features/holdings/Rows"
+import Rows, { PriceChartData } from "@components/features/holdings/Rows"
+import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
 import SubTotal from "@components/features/holdings/SubTotal"
 import Header from "@components/features/holdings/Header"
 import GrandTotal from "@components/features/holdings/GrandTotal"
@@ -248,6 +249,16 @@ function AggregatedHoldingsPage(): React.ReactElement {
   // State for copy functionality
   const [columns, setColumns] = useState<string[]>([])
   const [copyModalOpen, setCopyModalOpen] = useState(false)
+  const [priceChartData, setPriceChartData] = useState<
+    PriceChartData | undefined
+  >(undefined)
+
+  const handlePriceChart = useCallback((data: PriceChartData) => {
+    setPriceChartData(data)
+  }, [])
+  const handlePriceChartClose = useCallback(() => {
+    setPriceChartData(undefined)
+  }, [])
 
   // Determine the subtitle based on selected portfolios
   const subtitle = useMemo(() => {
@@ -432,6 +443,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
                             holdingGroup={holdings.holdingGroups[groupKey]}
                             valueIn={holdingState.valueIn.value}
                             onColumnsChange={setColumns}
+                            onPriceChart={handlePriceChart}
                           />
                           <SubTotal
                             groupBy={groupKey}
@@ -463,6 +475,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
               valueIn={holdingState.valueIn.value}
               groupBy={holdingState.groupBy.value}
               isMixedCurrencies={holdingResults.isMixedCurrencies}
+              onPriceChart={handlePriceChart}
             />
           </div>
         ) : viewMode === "heatmap" ? (
@@ -524,6 +537,13 @@ function AggregatedHoldingsPage(): React.ReactElement {
           modalOpen={copyModalOpen}
           onClose={() => setCopyModalOpen(false)}
         />
+        {priceChartData && (
+          <PriceChartPopup
+            asset={priceChartData.asset}
+            currencySymbol={priceChartData.currencySymbol}
+            onClose={handlePriceChartClose}
+          />
+        )}
         {reviewPopup}
       </div>
     </>


### PR DESCRIPTION
## Summary
- Aggregated holdings page rendered `CardView` + `Rows` without `onPriceChart`, so the price cell was plain text instead of a button — tapping it did nothing
- Wire the same handler used by `/holdings/[code]` into `aggregated.tsx` and mount `PriceChartPopup`
- `portfolioId` omitted (aggregated spans portfolios); `PriceChartPopup` already skips trade markers in that path

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `CardView.test.tsx` — 8/8 pass
- [ ] Open `/holdings/aggregated` on mobile, tap GOOG price in cards view → chart popup opens, no buy/sell markers
- [ ] Same on table view (desktop)
- [ ] Single-portfolio `/holdings/[code]` still shows markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an on-demand price chart popup to the aggregated holdings page, enabling users to view detailed price information directly from the holdings interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->