### PR TITLE
feat(holdings): tap quantity in aggregated view to see contributing portfolios

### DIFF
--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -27,7 +27,10 @@ import { getGroupComparator } from "@lib/categoryMapping"
 import { useRouter } from "next/router"
 import AssetNewsButton from "@components/features/holdings/AssetNewsButton"
 import { useNewsAsset } from "@components/features/holdings/useNewsAsset"
-import { PriceChartData } from "@components/features/holdings/Rows"
+import {
+  PortfolioBreakdownData,
+  PriceChartData,
+} from "@components/features/holdings/Rows"
 import {
   ActionsMenu,
   CashActionsMenu,
@@ -50,6 +53,7 @@ interface SharedActionHandlers {
   onCashTransfer?: (data: CashTransferData) => void
   onCashTransaction?: (assetCode: string) => void
   onPriceChart?: (data: PriceChartData) => void
+  onPortfolioBreakdown?: (data: PortfolioBreakdownData) => void
 }
 
 interface CardViewProps extends SharedActionHandlers {
@@ -98,6 +102,8 @@ interface PositionFooterProps {
   currencySymbol: string
   onPriceClick?: (e: React.MouseEvent) => void
   priceAriaLabel?: string
+  onQuantityClick?: (e: React.MouseEvent) => void
+  quantityAriaLabel?: string
 }
 
 const PositionFooter: React.FC<PositionFooterProps> = ({
@@ -108,6 +114,8 @@ const PositionFooter: React.FC<PositionFooterProps> = ({
   currencySymbol,
   onPriceClick,
   priceAriaLabel,
+  onQuantityClick,
+  quantityAriaLabel,
 }) => {
   const priceText = (
     <>
@@ -127,12 +135,22 @@ const PositionFooter: React.FC<PositionFooterProps> = ({
   ) : (
     priceText
   )
+  const quantityText = <PrivateQuantity value={quantity} precision={precision} />
+  const quantityValue = onQuantityClick ? (
+    <button
+      type="button"
+      aria-label={quantityAriaLabel}
+      className="cursor-pointer hover:text-wealth-700 hover:underline underline-offset-2 decoration-dotted"
+      onClick={onQuantityClick}
+    >
+      {quantityText}
+    </button>
+  ) : (
+    quantityText
+  )
   return (
     <div className="mt-3 pt-3 border-t border-gray-100 grid grid-cols-3 gap-2 text-sm">
-      <PositionMetric
-        label="Quantity"
-        value={<PrivateQuantity value={quantity} precision={precision} />}
-      />
+      <PositionMetric label="Quantity" value={quantityValue} />
       <PositionMetric label="Price" align="center" value={priceValue} />
       <PositionMetric
         label="Weight"
@@ -256,10 +274,12 @@ const PositionCard: React.FC<PositionCardProps> = ({
   onCashTransfer,
   onCashTransaction,
   onPriceChart,
+  onPortfolioBreakdown,
 }) => {
   const router = useRouter()
   const { popup, showNews } = useNewsAsset()
-  const { asset, moneyValues, quantityValues, dateValues } = position
+  const { asset, moneyValues, quantityValues, dateValues, portfolioBreakdown } =
+    position
   const values = moneyValues[valueIn]
 
   const positionCurrency =
@@ -404,6 +424,20 @@ const PositionCard: React.FC<PositionCardProps> = ({
                 })
               }
             : undefined
+          const isBreakdownable =
+            !!onPortfolioBreakdown &&
+            !!portfolioBreakdown &&
+            portfolioBreakdown.length > 1
+          const handleQuantityClick = isBreakdownable
+            ? (e: React.MouseEvent) => {
+                e.preventDefault()
+                e.stopPropagation()
+                onPortfolioBreakdown!({
+                  asset,
+                  breakdown: portfolioBreakdown!,
+                })
+              }
+            : undefined
           return (
             <PositionFooter
               quantity={quantityValues.total}
@@ -415,6 +449,12 @@ const PositionCard: React.FC<PositionCardProps> = ({
               priceAriaLabel={
                 isChartable
                   ? `Show price chart for ${stripOwnerPrefix(asset.code)}`
+                  : undefined
+              }
+              onQuantityClick={handleQuantityClick}
+              quantityAriaLabel={
+                isBreakdownable
+                  ? `Show portfolios holding ${stripOwnerPrefix(asset.code)}`
                   : undefined
               }
             />
@@ -469,6 +509,7 @@ const CardView: React.FC<CardViewProps> = ({
   onCashTransfer,
   onCashTransaction,
   onPriceChart,
+  onPortfolioBreakdown,
 }) => {
   // Group positions by holdingGroups, sorted by group comparator
   const groupedPositions = useMemo((): GroupedPositions[] => {
@@ -697,6 +738,7 @@ const CardView: React.FC<CardViewProps> = ({
                     onCashTransfer={onCashTransfer}
                     onCashTransaction={onCashTransaction}
                     onPriceChart={onPriceChart}
+                    onPortfolioBreakdown={onPortfolioBreakdown}
                   />
                 ))}
               </div>

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -6,7 +6,9 @@ import {
   Holdings,
   MovePositionData,
   Portfolio,
+  PortfolioBreakdownData,
   Position,
+  PriceChartData,
   QuickSellData,
   SetBalanceData,
   SetCashBalanceData,
@@ -27,10 +29,6 @@ import { getGroupComparator } from "@lib/categoryMapping"
 import { useRouter } from "next/router"
 import AssetNewsButton from "@components/features/holdings/AssetNewsButton"
 import { useNewsAsset } from "@components/features/holdings/useNewsAsset"
-import {
-  PortfolioBreakdownData,
-  PriceChartData,
-} from "@components/features/holdings/Rows"
 import {
   ActionsMenu,
   CashActionsMenu,

--- a/src/components/features/holdings/PortfolioBreakdownPopup.tsx
+++ b/src/components/features/holdings/PortfolioBreakdownPopup.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import { useRouter } from "next/router"
+import { Asset, PortfolioBreakdown } from "types/beancounter"
+import Dialog from "@components/ui/Dialog"
+import { PrivateQuantity } from "@components/ui/MoneyUtils"
+import { stripOwnerPrefix } from "@lib/assets/assetUtils"
+
+interface PortfolioBreakdownPopupProps {
+  asset: Asset
+  breakdown: PortfolioBreakdown[]
+  onClose: () => void
+}
+
+const PortfolioBreakdownPopup: React.FC<PortfolioBreakdownPopupProps> = ({
+  asset,
+  breakdown,
+  onClose,
+}) => {
+  const router = useRouter()
+
+  const handleSelect = (portfolioCode: string): void => {
+    onClose()
+    router.push(`/holdings/${portfolioCode}`)
+  }
+
+  const sorted = [...breakdown].sort((a, b) => b.quantity - a.quantity)
+
+  return (
+    <Dialog
+      title={`Held by — ${stripOwnerPrefix(asset.code)}`}
+      onClose={onClose}
+      maxWidth="md"
+      scrollable
+    >
+      <ul className="divide-y divide-gray-100">
+        {sorted.map((row) => (
+          <li key={row.portfolioId}>
+            <button
+              type="button"
+              className="w-full flex items-center justify-between gap-3 px-2 py-3 text-left rounded-md hover:bg-slate-50 focus:bg-slate-100 focus:outline-none"
+              onClick={() => handleSelect(row.portfolioCode)}
+              aria-label={`Open ${row.portfolioCode} holdings`}
+            >
+              <span className="min-w-0">
+                <span className="block font-semibold text-gray-900">
+                  {row.portfolioCode}
+                </span>
+                <span className="block text-sm text-gray-500 truncate">
+                  {row.portfolioName}
+                </span>
+              </span>
+              <span className="font-medium text-gray-900 tabular-nums shrink-0">
+                <PrivateQuantity value={row.quantity} />
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </Dialog>
+  )
+}
+
+export default PortfolioBreakdownPopup

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -11,6 +11,7 @@ import {
   CostAdjustData,
   MovePositionData,
   Asset,
+  PortfolioBreakdown,
 } from "types/beancounter"
 import {
   FormatValue,
@@ -48,6 +49,11 @@ export interface PriceChartData {
   portfolioId: string
 }
 
+export interface PortfolioBreakdownData {
+  asset: Asset
+  breakdown: PortfolioBreakdown[]
+}
+
 interface RowsProps extends HoldingValues {
   onColumnsChange: (columns: string[]) => void
   onTrade?: (data: QuickSellData) => void
@@ -65,6 +71,7 @@ interface RowsProps extends HoldingValues {
   onRecordIncome?: (data: QuickSellData) => void
   onRecordExpense?: (data: QuickSellData) => void
   onPriceChart?: (data: PriceChartData) => void
+  onPortfolioBreakdown?: (data: PortfolioBreakdownData) => void
 }
 
 // Helper function to truncate text with ellipsis
@@ -94,6 +101,7 @@ export default function Rows({
   onRecordIncome,
   onRecordExpense,
   onPriceChart,
+  onPortfolioBreakdown,
 }: RowsProps): React.ReactElement {
   const router = useRouter()
   const { popup: newsPopup, showNews } = useNewsAsset()
@@ -147,7 +155,17 @@ export default function Rows({
   return (
     <tbody>
       {holdingGroup.positions.map(
-        ({ asset, moneyValues, quantityValues, dateValues, held }, index) => (
+        (
+          {
+            asset,
+            moneyValues,
+            quantityValues,
+            dateValues,
+            held,
+            portfolioBreakdown,
+          },
+          index,
+        ) => (
           <tr
             key={`${groupBy}-${valueIn}-${index}`}
             className={`holding-row text-sm cursor-pointer border-l-2 border-l-transparent ${
@@ -338,29 +356,57 @@ export default function Rows({
             </td>
 
             <td className={getCellClasses(3)}>
-              {isCashRelated(asset) ||
-              hideValue(moneyValues[valueIn].priceData) ? (
-                " "
-              ) : held && Object.keys(held).length > 1 ? (
-                <span className="relative group cursor-help">
+              {(() => {
+                if (
+                  isCashRelated(asset) ||
+                  hideValue(moneyValues[valueIn].priceData)
+                ) {
+                  return " "
+                }
+                const quantity = (
                   <PrivateQuantity
                     value={quantityValues.total}
                     precision={quantityValues.precision}
                   />
-                  <span className="absolute right-0 transform -translate-y-full mb-1 bg-slate-800 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none whitespace-nowrap z-50 shadow-lg">
-                    {Object.entries(held).map(([broker, qty]) => (
-                      <div key={broker}>
-                        {broker}: {qty.toLocaleString()}
-                      </div>
-                    ))}
-                  </span>
-                </span>
-              ) : (
-                <PrivateQuantity
-                  value={quantityValues.total}
-                  precision={quantityValues.precision}
-                />
-              )}
+                )
+                const isBreakdownable =
+                  !!onPortfolioBreakdown &&
+                  !!portfolioBreakdown &&
+                  portfolioBreakdown.length > 1
+                if (isBreakdownable) {
+                  return (
+                    <button
+                      type="button"
+                      aria-label={`Show portfolios holding ${stripOwnerPrefix(asset.code)}`}
+                      className="cursor-pointer hover:text-wealth-700 hover:underline underline-offset-2 decoration-dotted"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onPortfolioBreakdown!({
+                          asset,
+                          breakdown: portfolioBreakdown!,
+                        })
+                      }}
+                    >
+                      {quantity}
+                    </button>
+                  )
+                }
+                if (held && Object.keys(held).length > 1) {
+                  return (
+                    <span className="relative group cursor-help">
+                      {quantity}
+                      <span className="absolute right-0 transform -translate-y-full mb-1 bg-slate-800 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none whitespace-nowrap z-50 shadow-lg">
+                        {Object.entries(held).map(([broker, qty]) => (
+                          <div key={broker}>
+                            {broker}: {qty.toLocaleString()}
+                          </div>
+                        ))}
+                      </span>
+                    </span>
+                  )
+                }
+                return quantity
+              })()}
             </td>
             <td className={getCellClasses(4)}>
               <span className="relative group">

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -10,8 +10,8 @@ import {
   CashTransferData,
   CostAdjustData,
   MovePositionData,
-  Asset,
-  PortfolioBreakdown,
+  PortfolioBreakdownData,
+  PriceChartData,
 } from "types/beancounter"
 import {
   FormatValue,
@@ -42,17 +42,6 @@ import {
 } from "./ActionsMenus"
 
 export type { CorporateActionsData, SectorWeightingsData }
-
-export interface PriceChartData {
-  asset: Asset
-  currencySymbol: string
-  portfolioId: string
-}
-
-export interface PortfolioBreakdownData {
-  asset: Asset
-  breakdown: PortfolioBreakdown[]
-}
 
 interface RowsProps extends HoldingValues {
   onColumnsChange: (columns: string[]) => void

--- a/src/components/features/holdings/__tests__/CardView.test.tsx
+++ b/src/components/features/holdings/__tests__/CardView.test.tsx
@@ -151,6 +151,137 @@ describe("CardView footer (Quantity / Price / Weight)", () => {
     })
   })
 
+  describe("portfolio breakdown click", () => {
+    it("renders quantity as a button and invokes onPortfolioBreakdown when breakdown has multiple entries", () => {
+      const onPortfolioBreakdown = jest.fn()
+      const portfolio = makePortfolio()
+      const asset = makeAsset({
+        assetCategory: { id: "EQUITY", name: "Equity" },
+      })
+      const position = makePosition({
+        asset,
+        moneyValues: { weight: 0.25 },
+        price: 150,
+        quantityValues: { total: 100 },
+        overrides: {
+          portfolioBreakdown: [
+            {
+              portfolioId: "p1",
+              portfolioCode: "MAIN",
+              portfolioName: "Main Account",
+              quantity: 60,
+            },
+            {
+              portfolioId: "p2",
+              portfolioCode: "ISA",
+              portfolioName: "ISA",
+              quantity: 40,
+            },
+          ],
+        },
+      })
+      const holdings = makeHoldings({
+        portfolio,
+        holdingGroups: { Equity: makeHoldingGroup({ positions: [position] }) },
+      })
+      render(
+        <CardView
+          holdings={holdings}
+          portfolio={portfolio}
+          valueIn={ValueIn.PORTFOLIO}
+          onPortfolioBreakdown={onPortfolioBreakdown}
+        />,
+      )
+
+      const button = screen.getByRole("button", {
+        name: /Show portfolios holding AAPL/i,
+      })
+      fireEvent.click(button)
+      expect(onPortfolioBreakdown).toHaveBeenCalledWith(
+        expect.objectContaining({
+          asset: expect.objectContaining({ code: "AAPL" }),
+          breakdown: expect.arrayContaining([
+            expect.objectContaining({ portfolioCode: "MAIN" }),
+            expect.objectContaining({ portfolioCode: "ISA" }),
+          ]),
+        }),
+      )
+    })
+
+    it("does not render a quantity button when breakdown has only one entry", () => {
+      const portfolio = makePortfolio()
+      const position = makePosition({
+        moneyValues: { weight: 0.25 },
+        price: 150,
+        quantityValues: { total: 100 },
+        overrides: {
+          portfolioBreakdown: [
+            {
+              portfolioId: "p1",
+              portfolioCode: "MAIN",
+              portfolioName: "Main Account",
+              quantity: 100,
+            },
+          ],
+        },
+      })
+      const holdings = makeHoldings({
+        portfolio,
+        holdingGroups: { Equity: makeHoldingGroup({ positions: [position] }) },
+      })
+      render(
+        <CardView
+          holdings={holdings}
+          portfolio={portfolio}
+          valueIn={ValueIn.PORTFOLIO}
+          onPortfolioBreakdown={jest.fn()}
+        />,
+      )
+      expect(
+        screen.queryByRole("button", { name: /Show portfolios holding/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it("does not render a quantity button when handler is omitted", () => {
+      const portfolio = makePortfolio()
+      const position = makePosition({
+        moneyValues: { weight: 0.25 },
+        price: 150,
+        quantityValues: { total: 100 },
+        overrides: {
+          portfolioBreakdown: [
+            {
+              portfolioId: "p1",
+              portfolioCode: "MAIN",
+              portfolioName: "Main",
+              quantity: 60,
+            },
+            {
+              portfolioId: "p2",
+              portfolioCode: "ISA",
+              portfolioName: "ISA",
+              quantity: 40,
+            },
+          ],
+        },
+      })
+      const holdings = makeHoldings({
+        portfolio,
+        holdingGroups: { Equity: makeHoldingGroup({ positions: [position] }) },
+      })
+      render(
+        <CardView
+          holdings={holdings}
+          portfolio={portfolio}
+          valueIn={ValueIn.PORTFOLIO}
+        />,
+      )
+      expect(
+        screen.queryByRole("button", { name: /Show portfolios holding/i }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
   describe("actions menu parity with table view", () => {
     it("invokes onQuickSell with the same payload as the row menu", () => {
       const onQuickSell = jest.fn()

--- a/src/components/features/holdings/__tests__/PortfolioBreakdownPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PortfolioBreakdownPopup.test.tsx
@@ -2,8 +2,11 @@ import React from "react"
 import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import PortfolioBreakdownPopup from "../PortfolioBreakdownPopup"
-import { Asset, PortfolioBreakdown } from "types/beancounter"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
+import {
+  makeAsset,
+  makePortfolioBreakdown,
+} from "@test-fixtures/beancounter"
 
 jest.mock("@hooks/usePrivacyMode")
 const mockedUsePrivacyMode = usePrivacyMode as jest.MockedFunction<
@@ -15,31 +18,21 @@ jest.mock("next/router", () => ({
   useRouter: () => ({ push }),
 }))
 
-const asset: Asset = {
-  id: "asset-aapl",
-  code: "AAPL",
-  name: "Apple Inc",
-  assetCategory: { id: "EQUITY", name: "Equity" },
-  market: {
-    code: "NASDAQ",
-    name: "NASDAQ",
-    currency: { code: "USD", name: "US Dollar", symbol: "$" },
-  },
-}
+const asset = makeAsset({ code: "AAPL", name: "Apple Inc" })
 
-const breakdown: PortfolioBreakdown[] = [
-  {
+const breakdown = [
+  makePortfolioBreakdown({
     portfolioId: "p1",
     portfolioCode: "MAIN",
     portfolioName: "Main Account",
     quantity: 60,
-  },
-  {
+  }),
+  makePortfolioBreakdown({
     portfolioId: "p2",
     portfolioCode: "ISA",
     portfolioName: "Stocks ISA",
     quantity: 40,
-  },
+  }),
 ]
 
 describe("PortfolioBreakdownPopup", () => {

--- a/src/components/features/holdings/__tests__/PortfolioBreakdownPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PortfolioBreakdownPopup.test.tsx
@@ -1,0 +1,100 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import PortfolioBreakdownPopup from "../PortfolioBreakdownPopup"
+import { Asset, PortfolioBreakdown } from "types/beancounter"
+import { usePrivacyMode } from "@hooks/usePrivacyMode"
+
+jest.mock("@hooks/usePrivacyMode")
+const mockedUsePrivacyMode = usePrivacyMode as jest.MockedFunction<
+  typeof usePrivacyMode
+>
+
+const push = jest.fn()
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push }),
+}))
+
+const asset: Asset = {
+  id: "asset-aapl",
+  code: "AAPL",
+  name: "Apple Inc",
+  assetCategory: { id: "EQUITY", name: "Equity" },
+  market: {
+    code: "NASDAQ",
+    name: "NASDAQ",
+    currency: { code: "USD", name: "US Dollar", symbol: "$" },
+  },
+}
+
+const breakdown: PortfolioBreakdown[] = [
+  {
+    portfolioId: "p1",
+    portfolioCode: "MAIN",
+    portfolioName: "Main Account",
+    quantity: 60,
+  },
+  {
+    portfolioId: "p2",
+    portfolioCode: "ISA",
+    portfolioName: "Stocks ISA",
+    quantity: 40,
+  },
+]
+
+describe("PortfolioBreakdownPopup", () => {
+  beforeEach(() => {
+    push.mockReset()
+    mockedUsePrivacyMode.mockReturnValue({
+      hideValues: false,
+      toggleHideValues: jest.fn(),
+    })
+  })
+
+  it("lists each portfolio with code, name, and quantity", () => {
+    render(
+      <PortfolioBreakdownPopup
+        asset={asset}
+        breakdown={breakdown}
+        onClose={jest.fn()}
+      />,
+    )
+    expect(screen.getByText("MAIN")).toBeInTheDocument()
+    expect(screen.getByText("Main Account")).toBeInTheDocument()
+    expect(screen.getByText("ISA")).toBeInTheDocument()
+    expect(screen.getByText("Stocks ISA")).toBeInTheDocument()
+    expect(screen.getByText("60")).toBeInTheDocument()
+    expect(screen.getByText("40")).toBeInTheDocument()
+  })
+
+  it("sorts rows by quantity descending", () => {
+    render(
+      <PortfolioBreakdownPopup
+        asset={asset}
+        breakdown={[breakdown[1], breakdown[0]]}
+        onClose={jest.fn()}
+      />,
+    )
+    const buttons = screen.getAllByRole("button", {
+      name: /Open .* holdings/i,
+    })
+    expect(buttons[0]).toHaveTextContent("MAIN")
+    expect(buttons[1]).toHaveTextContent("ISA")
+  })
+
+  it("navigates to /holdings/{code} and closes when a row is clicked", () => {
+    const onClose = jest.fn()
+    render(
+      <PortfolioBreakdownPopup
+        asset={asset}
+        breakdown={breakdown}
+        onClose={onClose}
+      />,
+    )
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open MAIN holdings/i }),
+    )
+    expect(onClose).toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith("/holdings/MAIN")
+  })
+})

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -30,9 +30,9 @@ import HoldingMenu from "@components/features/holdings/HoldingMenu"
 import HoldingsHeader from "@components/features/holdings/HoldingsHeader"
 import Rows, {
   CorporateActionsData,
-  PriceChartData,
   SectorWeightingsData,
 } from "@components/features/holdings/Rows"
+import { PriceChartData } from "types/beancounter"
 import SectorWeightingsPopup from "@components/features/holdings/SectorWeightingsPopup"
 import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
 import SubTotal from "@components/features/holdings/SubTotal"

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -12,8 +12,12 @@ import { useHoldingState } from "@lib/holdings/holdingState"
 import { useHoldingsView } from "@lib/holdings/useHoldingsView"
 import HoldingsHeader from "@components/features/holdings/HoldingsHeader"
 import HoldingMenu from "@components/features/holdings/HoldingMenu"
-import Rows, { PriceChartData } from "@components/features/holdings/Rows"
+import Rows, {
+  PortfolioBreakdownData,
+  PriceChartData,
+} from "@components/features/holdings/Rows"
 import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
+import PortfolioBreakdownPopup from "@components/features/holdings/PortfolioBreakdownPopup"
 import SubTotal from "@components/features/holdings/SubTotal"
 import Header from "@components/features/holdings/Header"
 import GrandTotal from "@components/features/holdings/GrandTotal"
@@ -252,12 +256,24 @@ function AggregatedHoldingsPage(): React.ReactElement {
   const [priceChartData, setPriceChartData] = useState<
     PriceChartData | undefined
   >(undefined)
+  const [portfolioBreakdownData, setPortfolioBreakdownData] = useState<
+    PortfolioBreakdownData | undefined
+  >(undefined)
 
   const handlePriceChart = useCallback((data: PriceChartData) => {
     setPriceChartData(data)
   }, [])
   const handlePriceChartClose = useCallback(() => {
     setPriceChartData(undefined)
+  }, [])
+  const handlePortfolioBreakdown = useCallback(
+    (data: PortfolioBreakdownData) => {
+      setPortfolioBreakdownData(data)
+    },
+    [],
+  )
+  const handlePortfolioBreakdownClose = useCallback(() => {
+    setPortfolioBreakdownData(undefined)
   }, [])
 
   // Determine the subtitle based on selected portfolios
@@ -444,6 +460,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
                             valueIn={holdingState.valueIn.value}
                             onColumnsChange={setColumns}
                             onPriceChart={handlePriceChart}
+                            onPortfolioBreakdown={handlePortfolioBreakdown}
                           />
                           <SubTotal
                             groupBy={groupKey}
@@ -476,6 +493,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
               groupBy={holdingState.groupBy.value}
               isMixedCurrencies={holdingResults.isMixedCurrencies}
               onPriceChart={handlePriceChart}
+              onPortfolioBreakdown={handlePortfolioBreakdown}
             />
           </div>
         ) : viewMode === "heatmap" ? (
@@ -542,6 +560,13 @@ function AggregatedHoldingsPage(): React.ReactElement {
             asset={priceChartData.asset}
             currencySymbol={priceChartData.currencySymbol}
             onClose={handlePriceChartClose}
+          />
+        )}
+        {portfolioBreakdownData && (
+          <PortfolioBreakdownPopup
+            asset={portfolioBreakdownData.asset}
+            breakdown={portfolioBreakdownData.breakdown}
+            onClose={handlePortfolioBreakdownClose}
           />
         )}
         {reviewPopup}

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -12,12 +12,13 @@ import { useHoldingState } from "@lib/holdings/holdingState"
 import { useHoldingsView } from "@lib/holdings/useHoldingsView"
 import HoldingsHeader from "@components/features/holdings/HoldingsHeader"
 import HoldingMenu from "@components/features/holdings/HoldingMenu"
-import Rows, {
-  PortfolioBreakdownData,
-  PriceChartData,
-} from "@components/features/holdings/Rows"
+import Rows from "@components/features/holdings/Rows"
 import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
 import PortfolioBreakdownPopup from "@components/features/holdings/PortfolioBreakdownPopup"
+import {
+  PortfolioBreakdownData,
+  PriceChartData,
+} from "types/beancounter"
 import SubTotal from "@components/features/holdings/SubTotal"
 import Header from "@components/features/holdings/Header"
 import GrandTotal from "@components/features/holdings/GrandTotal"

--- a/src/test-fixtures/beancounter.ts
+++ b/src/test-fixtures/beancounter.ts
@@ -16,6 +16,7 @@ import {
   HoldingGroup,
   MoneyValues,
   Portfolio,
+  PortfolioBreakdown,
   Position,
   QuantityValues,
 } from "types/beancounter"
@@ -204,6 +205,18 @@ export function makePortfolio(overrides: Partial<Portfolio> = {}): Portfolio {
     irr: 0.1,
     ...overrides,
   } as Portfolio
+}
+
+export function makePortfolioBreakdown(
+  overrides: Partial<PortfolioBreakdown> = {},
+): PortfolioBreakdown {
+  return {
+    portfolioId: "p-1",
+    portfolioCode: "TEST",
+    portfolioName: "Test Portfolio",
+    quantity: 100,
+    ...overrides,
+  }
 }
 
 export interface MakeHoldingsOptions {

--- a/src/test-fixtures/beancounter.ts
+++ b/src/test-fixtures/beancounter.ts
@@ -118,7 +118,7 @@ export interface MakePositionOptions {
   /** Build the same MoneyValues for these buckets (default: ["PORTFOLIO"]) */
   buckets?: ValueIn[]
   quantityValues?: Partial<QuantityValues>
-  overrides?: Partial<Position>
+  overrides?: Record<string, unknown>
 }
 
 export function makePosition(options: MakePositionOptions = {}): Position {

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -166,6 +166,13 @@ export interface QuantityValues {
   precision: number
 }
 
+export interface PortfolioBreakdown {
+  portfolioId: string
+  portfolioCode: string
+  portfolioName: string
+  quantity: number
+}
+
 export interface Position {
   [index: string]: ValueIn
 
@@ -177,6 +184,7 @@ export interface Position {
   roi: number
   held?: Record<string, number> // Broker name -> quantity held
   subAccounts?: Record<string, number>
+  portfolioBreakdown?: PortfolioBreakdown[]
 }
 
 export interface DateValues {

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -173,6 +173,17 @@ export interface PortfolioBreakdown {
   quantity: number
 }
 
+export interface PortfolioBreakdownData {
+  asset: Asset
+  breakdown: PortfolioBreakdown[]
+}
+
+export interface PriceChartData {
+  asset: Asset
+  currencySymbol: string
+  portfolioId: string
+}
+
 export interface Position {
   [index: string]: ValueIn
 


### PR DESCRIPTION
## Summary
- On the aggregated holdings page, positions held in more than one portfolio render Quantity as a button
- Tapping it opens `PortfolioBreakdownPopup` listing each contributing portfolio (code, name, quantity, sorted desc by quantity)
- Selecting a row navigates to `/holdings/{code}` (same target as the portfolios page link)
- Wired in both Rows (table view) and CardView (card/mobile view); popup mounted from `aggregated.tsx` alongside `PriceChartPopup`

Requires svc-position `Position.portfolioBreakdown` from beancounter#873. When the field is empty (single-portfolio responses or pre-deploy backend), the quantity renders as plain text — no behaviour change for non-aggregated views.

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn test` — 1315/1315 pass (new: 3 popup tests, 3 CardView breakdown tests)
- [ ] Manual: hit `/holdings/aggregated` with multiple portfolios; verify Quantity button only appears when asset spans ≥2 portfolios; verify nav lands on chosen portfolio's holdings
- [ ] Manual: hit single-portfolio `/holdings/[code]`; verify Quantity remains plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click position quantities to open a portfolio breakdown showing per-portfolio quantities for an asset
  * From the breakdown dialog, navigate directly to a selected portfolio's holdings
  * Only shown for non-cash positions with multiple portfolio holdings

* **Tests**
  * Added tests covering quantity click behavior and the breakdown dialog rendering and navigation

* **Chores**
  * Added portfolio breakdown types and test fixtures to support the feature

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->