### PR TITLE
fix(holdings): always show quantity popup in aggregated view

### DIFF
--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -425,7 +425,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
           const isBreakdownable =
             !!onPortfolioBreakdown &&
             !!portfolioBreakdown &&
-            portfolioBreakdown.length > 1
+            portfolioBreakdown.length > 0
           const handleQuantityClick = isBreakdownable
             ? (e: React.MouseEvent) => {
                 e.preventDefault()

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -361,7 +361,7 @@ export default function Rows({
                 const isBreakdownable =
                   !!onPortfolioBreakdown &&
                   !!portfolioBreakdown &&
-                  portfolioBreakdown.length > 1
+                  portfolioBreakdown.length > 0
                 if (isBreakdownable) {
                   return (
                     <button

--- a/src/components/features/holdings/__tests__/CardView.test.tsx
+++ b/src/components/features/holdings/__tests__/CardView.test.tsx
@@ -208,7 +208,8 @@ describe("CardView footer (Quantity / Price / Weight)", () => {
       )
     })
 
-    it("does not render a quantity button when breakdown has only one entry", () => {
+    it("renders a quantity button even when breakdown has a single entry", () => {
+      const onPortfolioBreakdown = jest.fn()
       const portfolio = makePortfolio()
       const position = makePosition({
         moneyValues: { weight: 0.25 },
@@ -224,6 +225,38 @@ describe("CardView footer (Quantity / Price / Weight)", () => {
             },
           ],
         },
+      })
+      const holdings = makeHoldings({
+        portfolio,
+        holdingGroups: { Equity: makeHoldingGroup({ positions: [position] }) },
+      })
+      render(
+        <CardView
+          holdings={holdings}
+          portfolio={portfolio}
+          valueIn={ValueIn.PORTFOLIO}
+          onPortfolioBreakdown={onPortfolioBreakdown}
+        />,
+      )
+      const button = screen.getByRole("button", {
+        name: /Show portfolios holding AAPL/i,
+      })
+      fireEvent.click(button)
+      expect(onPortfolioBreakdown).toHaveBeenCalledWith(
+        expect.objectContaining({
+          breakdown: expect.arrayContaining([
+            expect.objectContaining({ portfolioCode: "MAIN" }),
+          ]),
+        }),
+      )
+    })
+
+    it("does not render a quantity button when breakdown is missing", () => {
+      const portfolio = makePortfolio()
+      const position = makePosition({
+        moneyValues: { weight: 0.25 },
+        price: 150,
+        quantityValues: { total: 100 },
       })
       const holdings = makeHoldings({
         portfolio,


### PR DESCRIPTION
## Summary
- Drops the `breakdown.length > 1` gate on the Quantity button in `Rows.tsx` and `CardView.tsx`
- Popup now opens for any aggregated position with a `portfolioBreakdown`, even single-portfolio ones
- Single-portfolio rows still link to that portfolio — useful as a one-tap shortcut to the holding's source
- Removes the inconsistency where some cards reacted and others didn't (e.g. GOOG vs BRK.B)
- Single-portfolio `/holdings/[code]` view is unchanged: it doesn't wire `onPortfolioBreakdown`, so quantity stays plain text there

## Test plan
- [x] `yarn typecheck` clean, `yarn lint` clean
- [x] `CardView.test.tsx` — 12/12 (replaced "no button for single entry" with "shows button for single entry")
- [ ] Manual: tap GOOG (single portfolio) → popup with one row that opens `/holdings/USV`
- [ ] Manual: tap BRK.B (two portfolios) → popup with both rows, each navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Portfolio breakdown is now accessible for positions with a single portfolio entry, improving visibility when reviewing your holdings across accounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->