### PR TITLE
feat(holdings): admin can repair an asset's split history from the chart

### DIFF
--- a/src/components/features/holdings/PriceChartPopup.tsx
+++ b/src/components/features/holdings/PriceChartPopup.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo, useState } from "react"
-import useSwr from "swr"
+import React, { useCallback, useMemo, useState } from "react"
+import useSwr, { mutate } from "swr"
+import { useIsAdmin } from "@hooks/useIsAdmin"
 import {
   ComposedChart,
   Area,
@@ -233,6 +234,12 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
 }) => {
   const [months, setMonths] = useState(DEFAULT_MONTHS)
   const [smaWindow, setSmaWindow] = useState(DEFAULT_SMA)
+  const { isAdmin } = useIsAdmin()
+  const [repairState, setRepairState] = useState<{
+    busy: boolean
+    message: string | null
+    error: boolean
+  }>({ busy: false, message: null, error: false })
 
   const { from, to } = useMemo(() => {
     const today = new Date()
@@ -248,6 +255,46 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
     error: priceError,
     isLoading: pricesLoading,
   } = useSwr<PriceHistoryResponse>(priceUrl, simpleFetcher(priceUrl))
+
+  const handleRepairSplits = useCallback(async () => {
+    setRepairState({ busy: true, message: null, error: false })
+    try {
+      const response = await fetch(`/api/prices/${asset.id}/repair-splits`, {
+        method: "POST",
+      })
+      if (!response.ok) {
+        const detail =
+          response.status === 403
+            ? "Admin scope required"
+            : `HTTP ${response.status}`
+        setRepairState({
+          busy: false,
+          message: `Repair failed: ${detail}`,
+          error: true,
+        })
+        return
+      }
+      const body = (await response.json()) as {
+        stamped: number
+        alreadyStamped: number
+        missingRows: number
+      }
+      setRepairState({
+        busy: false,
+        message: `Repaired: ${body.stamped} stamped, ${body.alreadyStamped} already, ${body.missingRows} missing`,
+        error: false,
+      })
+      // Force a chart refresh against the now-stamped data.
+      await mutate(priceUrl)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Unknown error"
+      setRepairState({
+        busy: false,
+        message: `Repair failed: ${message}`,
+        error: true,
+      })
+    }
+  }, [asset.id, priceUrl])
 
   const tradesUrl = portfolioId
     ? `/api/trns/trades/${portfolioId}/${asset.id}`
@@ -371,12 +418,36 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
       maxWidth="3xl"
       scrollable
       footer={
-        <button
-          className="bg-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-400 transition-colors"
-          onClick={onClose}
-        >
-          {"Close"}
-        </button>
+        <div className="flex items-center gap-3 w-full justify-between">
+          <div className="flex items-center gap-3">
+            {isAdmin && (
+              <button
+                className="bg-amber-100 text-amber-800 border border-amber-300 px-3 py-2 rounded hover:bg-amber-200 disabled:opacity-50 transition-colors text-sm"
+                onClick={handleRepairSplits}
+                disabled={repairState.busy}
+                title="Stamp split factors on this asset's price history (admin only)"
+              >
+                {repairState.busy ? "Repairing…" : "Repair splits"}
+              </button>
+            )}
+            {repairState.message && (
+              <span
+                className={`text-xs ${
+                  repairState.error ? "text-red-600" : "text-emerald-700"
+                }`}
+                role="status"
+              >
+                {repairState.message}
+              </span>
+            )}
+          </div>
+          <button
+            className="bg-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-400 transition-colors"
+            onClick={onClose}
+          >
+            {"Close"}
+          </button>
+        </div>
       }
     >
       <div className="flex items-center justify-between mb-3 gap-3 flex-wrap">

--- a/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
@@ -8,8 +8,15 @@ import { makeAsset } from "@test-fixtures/beancounter"
 jest.mock("swr", () => ({
   __esModule: true,
   default: jest.fn(),
+  mutate: jest.fn(),
 }))
 const mockUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
+
+const mockUseIsAdmin = jest.fn(() => ({ isAdmin: false, isLoading: false }))
+jest.mock("@hooks/useIsAdmin", () => ({
+  __esModule: true,
+  useIsAdmin: () => mockUseIsAdmin(),
+}))
 
 jest.mock("recharts", () => ({
   ComposedChart: ({
@@ -98,6 +105,7 @@ function renderPopup(
 describe("PriceChartPopup", () => {
   beforeEach(() => {
     mockUseSwr.mockReset()
+    mockUseIsAdmin.mockReturnValue({ isAdmin: false, isLoading: false })
   })
 
   it("renders the chart with the asset name and close price", () => {
@@ -293,5 +301,71 @@ describe("PriceChartPopup", () => {
     renderPopup()
 
     expect(screen.getByText("Failed to load price history")).toBeInTheDocument()
+  })
+
+  describe("Repair splits admin action", () => {
+    it("hides the Repair splits button from non-admin users", () => {
+      mockUseSwr.mockImplementation(makeRouter({}) as typeof useSwr)
+      // default mock: isAdmin = false
+      renderPopup()
+      expect(
+        screen.queryByRole("button", { name: "Repair splits" }),
+      ).not.toBeInTheDocument()
+    })
+
+    it("posts to the repair endpoint and surfaces the response when admin clicks", async () => {
+      mockUseIsAdmin.mockReturnValue({ isAdmin: true, isLoading: false })
+      mockUseSwr.mockImplementation(makeRouter({}) as typeof useSwr)
+
+      const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            stamped: 2,
+            alreadyStamped: 0,
+            missingRows: 1,
+          }),
+      } as Response)
+
+      renderPopup()
+
+      const button = screen.getByRole("button", { name: "Repair splits" })
+      fireEvent.click(button)
+
+      // Endpoint hit with the correct asset id and POST method.
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `/api/prices/${asset.id}/repair-splits`,
+        { method: "POST" },
+      )
+
+      // Response counters surface to the user.
+      expect(
+        await screen.findByText("Repaired: 2 stamped, 0 already, 1 missing"),
+      ).toBeInTheDocument()
+
+      fetchSpy.mockRestore()
+    })
+
+    it("surfaces a forbidden error if the server rejects the admin gate", async () => {
+      mockUseIsAdmin.mockReturnValue({ isAdmin: true, isLoading: false })
+      mockUseSwr.mockImplementation(makeRouter({}) as typeof useSwr)
+
+      const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({}),
+      } as Response)
+
+      renderPopup()
+
+      fireEvent.click(screen.getByRole("button", { name: "Repair splits" }))
+
+      expect(
+        await screen.findByText("Repair failed: Admin scope required"),
+      ).toBeInTheDocument()
+
+      fetchSpy.mockRestore()
+    })
   })
 })

--- a/src/pages/api/prices/[assetId]/repair-splits.ts
+++ b/src/pages/api/prices/[assetId]/repair-splits.ts
@@ -1,0 +1,18 @@
+import {
+  createApiHandler,
+  sanitizePathParam,
+} from "@utils/api/createApiHandler"
+import { getDataUrl } from "@utils/api/bcConfig"
+
+/**
+ * Forwards the user's bearer token to bc-data's
+ * `POST /prices/{assetId}/repair-splits`. The server-side gate on bc-data
+ * requires admin scope; non-admin tokens get 403 from the bc-data side.
+ */
+export default createApiHandler({
+  url: (req) => {
+    const assetId = sanitizePathParam(req.query.assetId, "assetId")
+    return getDataUrl(`/prices/${assetId}/repair-splits`)
+  },
+  methods: ["POST"],
+})


### PR DESCRIPTION
## Summary
Adds an admin-gated **Repair splits** button to the price chart popup. Clicking it triggers `bc-data` to walk an asset's corporate-event splits and stamp the `split` column on each ex-date `MarketData` row — `SplitAdjuster` then rebases historical OHLC on every subsequent read.

Companion to beancounter PR #879 which enforces admin scope server-side.

## Changes
- New `src/pages/api/prices/[assetId]/repair-splits.ts` — thin handler forwarding the bearer to `bc-data` `POST /prices/{assetId}/repair-splits`.
- `PriceChartPopup` shows the button only when `useIsAdmin()` reports admin. Response counters or 403 errors surface inline next to it; chart re-fetches on success via `mutate(priceUrl)`.

## Test plan
- [x] `PriceChartPopup.test.tsx`:
  - hides the button from non-admins
  - admin click hits `/api/prices/{id}/repair-splits` POST and renders `Repaired: N stamped, …`
  - 403 from bc-data surfaces `Repair failed: Admin scope required`
- [x] `yarn test PriceChartPopup` 12/12 green
- [x] `yarn lint && yarn typecheck && yarn prettier` clean
- [ ] After both PRs merge: visual click-test on kauri for a known-split asset (e.g. SCHG 4:1 on 2024-10-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only "Repair splits" action in the price chart interface. Admins can now trigger a repair operation with real-time status feedback, displaying success messages with operation details or error messages if the repair fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->