### PR TITLE
ci: gate docker build to main + workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,12 @@ on:
   push:
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      build_image:
+        description: "Build and publish docker image"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -128,7 +134,9 @@ jobs:
     name: Build Docker (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: [test, build]
-    if: github.event_name == 'push'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.build_image)
     permissions:
       contents: read
       packages: write
@@ -190,7 +198,9 @@ jobs:
     name: Create Multi-arch Manifest
     runs-on: ubuntu-latest
     needs: docker
-    if: github.event_name == 'push'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.build_image)
     permissions:
       contents: read
       packages: write
@@ -203,6 +213,8 @@ jobs:
           password: ${{ secrets.GH_TOKEN }}
 
       - name: Create and push manifest
+        env:
+          GITHUB_REF: ${{ github.ref }}
         run: |
           IMAGE="${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_ORG }}/${{ env.IMAGE_NAME }}"
 
@@ -212,18 +224,24 @@ jobs:
             ${IMAGE}:${{ github.run_number }}-linux-arm64
           docker manifest push ${IMAGE}:${{ github.run_number }}
 
-          # Create manifest for latest tag
-          docker manifest create ${IMAGE}:latest \
-            ${IMAGE}:${{ github.run_number }}-linux-amd64 \
-            ${IMAGE}:${{ github.run_number }}-linux-arm64
-          docker manifest push ${IMAGE}:latest
+          # Only tag :latest from main so branch builds don't clobber the deployed tag
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            docker manifest create ${IMAGE}:latest \
+              ${IMAGE}:${{ github.run_number }}-linux-amd64 \
+              ${IMAGE}:${{ github.run_number }}-linux-arm64
+            docker manifest push ${IMAGE}:latest
+          fi
 
       - name: Output image tags
+        env:
+          GITHUB_REF: ${{ github.ref }}
         run: |
           echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Multi-arch Images (amd64 + arm64):**" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_ORG }}/${{ env.IMAGE_NAME }}:${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
-          echo "${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_ORG }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            echo "${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_ORG }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          fi
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ env:
   CONTAINER_REGISTRY: ghcr.io
   CONTAINER_ORG: monowai
   IMAGE_NAME: bc-view
+  # Force JS actions still pinned to Node 20 onto Node 24 — Node 20 is
+  # being removed from GHA runners. See:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Docker + multi-arch manifest jobs only run on `push` to main or manual `workflow_dispatch` with `build_image=true`
- `:latest` tag now only emitted from main, so a manual branch build can't clobber the deployed tag
- Feature branches and PRs still run `test` + `build` (typecheck, lint, jest, `yarn build`) — the safety gate stays intact; only the costly docker stage is skipped

## Why
- Previous gate `if: github.event_name == 'push'` fired docker on every branch push, burning ARM runner minutes and GHA cache pool on throwaway commits
- `:latest` was overwritten from any branch that happened to push last, risking kauri pulling a non-main image
- Renovate's gating check (`test` job) is unchanged, so automerge behaviour is preserved

## Test plan
- [ ] PR build: `test` and `build` run; `docker` and `docker-manifest` skip
- [ ] Merge to main: full pipeline including docker + `:latest` retag
- [ ] Manual `workflow_dispatch` with `build_image=true` from this branch: docker runs but `:latest` is NOT pushed
- [ ] Manual `workflow_dispatch` with `build_image=false`: docker skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual CI trigger with an option to publish Docker images on demand.
  * CI now always creates and publishes versioned image manifests (run-number based).

* **Bug Fixes**
  * Fixed behavior so the `latest` image tag is only created and reported for main branch runs, preventing branch builds from overwriting it.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->