### PR TITLE
ci: bump GHA actions to Node 24 + drop test-results upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,6 @@ env:
   CONTAINER_REGISTRY: ghcr.io
   CONTAINER_ORG: monowai
   IMAGE_NAME: bc-view
-  # Force JS actions still pinned to Node 20 onto Node 24 — Node 20 is
-  # being removed from GHA runners. See:
-  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   test:
@@ -36,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "yarn"
@@ -48,7 +44,7 @@ jobs:
         run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 8
 
       - name: Restore Jest cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .jest-cache
           key: jest-cache-${{ hashFiles('yarn.lock') }}
@@ -79,25 +75,15 @@ jobs:
             echo "⚠️  No Codacy token set, skipping coverage upload"
           fi
 
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: |
-            coverage/
-            junit.xml
-          retention-days: 7
-
   build:
     name: Build Application
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "yarn"
@@ -110,7 +96,7 @@ jobs:
       # past the repo cache budget. .next/cache is designed to restore stale —
       # Next handles incremental compilation from there.
       - name: Restore Next.js build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .next/cache
           key: nextjs-cache-${{ hashFiles('yarn.lock', 'next.config.js') }}
@@ -124,7 +110,7 @@ jobs:
         run: yarn build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-output
           path: |
@@ -153,10 +139,10 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-output
 


### PR DESCRIPTION
## Summary
Follow-up to #696. That PR squash-merged before three follow-on commits landed; this PR re-applies them on top of main.

## Changes
- Action major bumps (all native Node 24):
  - `actions/checkout@v4` → `@v5`
  - `actions/setup-node@v4` → `@v5`
  - `actions/cache@v4` → `@v5`
  - `actions/upload-artifact@v4` → `@v6` (v5 was advertised as Node 24 but still ran on Node 20 — see upstream v6 release notes)
  - `actions/download-artifact@v4` → `@v7` (v5 and v6 still ran on Node 20)
- Drop the **Upload test results** step (coverage + junit.xml). Coverage isn't consumed downstream — the Codacy upload step is gated `if: false`. Cuts Actions artifact storage.
- Drop `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` — redundant now every action is on a Node 24 major.

## Why drop FORCE rather than keep it as defence-in-depth
If a future Renovate bump reintroduces a Node 20-pinned action, we want GHA to surface the deprecation warning explicitly so it gets fixed, not silently shimmed.

## Test plan
- [ ] PR build: no Node 20 deprecation warning in any job summary
- [ ] No `test-results` artifact uploaded
- [ ] `build-output` artifact still uploaded (docker job input)
- [ ] After merge: kauri deploy unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow dependencies and configuration to maintain compatibility with the latest tooling standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->