### PR TITLE
fix: clear manualAssets via empty map

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -505,7 +505,7 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
         onClick={onClose}
       ></div>
       <div
-        className="bg-white rounded-lg shadow-lg w-full max-w-md mx-4 p-4 sm:p-6 z-50 max-h-[90vh] overflow-y-auto"
+        className="bg-white rounded-lg shadow-lg w-full max-w-md sm:max-w-2xl lg:max-w-4xl mx-4 p-4 sm:p-6 z-50 max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <header className="flex justify-between items-center border-b pb-2 mb-4">

--- a/src/components/features/assets/CompositeAssetEditor.tsx
+++ b/src/components/features/assets/CompositeAssetEditor.tsx
@@ -308,7 +308,7 @@ export default function CompositeAssetEditor({
                           )
                         }
                         placeholder="0"
-                        className="w-full text-right border-gray-300 rounded px-2 py-1 border focus:ring-indigo-500 focus:border-indigo-500"
+                        className="w-full min-w-[6rem] text-right border-gray-300 rounded px-2 py-1.5 border focus:ring-indigo-500 focus:border-indigo-500"
                       />
                     </td>
                     <td className="px-3 py-2">
@@ -332,7 +332,7 @@ export default function CompositeAssetEditor({
                           )
                         }
                         placeholder="--"
-                        className="w-full text-right border-gray-300 rounded px-2 py-1 border focus:ring-indigo-500 focus:border-indigo-500"
+                        className="w-full min-w-[4.5rem] text-right border-gray-300 rounded px-2 py-1.5 border focus:ring-indigo-500 focus:border-indigo-500"
                       />
                     </td>
                     <td className="px-3 py-2">
@@ -356,7 +356,7 @@ export default function CompositeAssetEditor({
                           )
                         }
                         placeholder="--"
-                        className="w-full text-right border-gray-300 rounded px-2 py-1 border focus:ring-indigo-500 focus:border-indigo-500"
+                        className="w-full min-w-[4.5rem] text-right border-gray-300 rounded px-2 py-1.5 border focus:ring-indigo-500 focus:border-indigo-500"
                       />
                     </td>
                     <td className="px-3 py-2 text-center">

--- a/src/components/features/holdings/ActionsMenus.tsx
+++ b/src/components/features/holdings/ActionsMenus.tsx
@@ -155,6 +155,7 @@ export interface ActionsMenuProps {
   onMovePosition?: (data: MovePositionData) => void
   onRecordIncome?: (data: QuickSellData) => void
   onRecordExpense?: (data: QuickSellData) => void
+  onEditAsset?: (asset: Asset) => void
 }
 
 export const ActionsMenu: React.FC<ActionsMenuProps> = ({
@@ -178,10 +179,12 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
   onMovePosition,
   onRecordIncome,
   onRecordExpense,
+  onEditAsset,
 }) => {
   const { isOpen, buttonRef, menuRef, menuPos, toggle, close } =
     useDropdownMenu()
   const assetCode = stripOwnerPrefix(asset.code)
+  const isPrivateAsset = asset.market?.code === "PRIVATE"
 
   const tradePayload = (): QuickSellData => ({
     asset: assetCode,
@@ -328,6 +331,13 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
                       type: "EXPENSE",
                     }),
                   )}
+                />
+              )}
+              {onEditAsset && isPrivateAsset && (
+                <MenuItem
+                  iconClass="fas fa-pen-to-square text-slate-500 w-4"
+                  label="Edit Asset"
+                  onClick={handle(() => onEditAsset(asset))}
                 />
               )}
             </div>

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react"
 import {
+  Asset,
   CashTransferData,
   CostAdjustData,
   Currency,
@@ -52,6 +53,7 @@ interface SharedActionHandlers {
   onCashTransaction?: (assetCode: string) => void
   onPriceChart?: (data: PriceChartData) => void
   onPortfolioBreakdown?: (data: PortfolioBreakdownData) => void
+  onEditAsset?: (asset: Asset) => void
 }
 
 interface CardViewProps extends SharedActionHandlers {
@@ -273,6 +275,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
   onCashTransaction,
   onPriceChart,
   onPortfolioBreakdown,
+  onEditAsset,
 }) => {
   const router = useRouter()
   const { popup, showNews } = useNewsAsset()
@@ -316,7 +319,8 @@ const PositionCard: React.FC<PositionCardProps> = ({
           isConstantPrice(asset)) ||
         (!!onSectorWeightings && asset.assetCategory?.id === "ETF"))) ||
     (asset.assetCategory?.id === "RE" &&
-      (!!onRecordIncome || !!onRecordExpense))
+      (!!onRecordIncome || !!onRecordExpense)) ||
+    (!!onEditAsset && asset.market?.code === "PRIVATE")
 
   const hasCashActions =
     supportsBalanceSetting(asset) &&
@@ -352,6 +356,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
             onMovePosition={isCashRelated(asset) ? undefined : onMovePosition}
             onRecordIncome={onRecordIncome}
             onRecordExpense={onRecordExpense}
+            onEditAsset={onEditAsset}
           />
         )}
         {hasCashActions && (
@@ -508,6 +513,7 @@ const CardView: React.FC<CardViewProps> = ({
   onCashTransaction,
   onPriceChart,
   onPortfolioBreakdown,
+  onEditAsset,
 }) => {
   // Group positions by holdingGroups, sorted by group comparator
   const groupedPositions = useMemo((): GroupedPositions[] => {
@@ -737,6 +743,7 @@ const CardView: React.FC<CardViewProps> = ({
                     onCashTransaction={onCashTransaction}
                     onPriceChart={onPriceChart}
                     onPortfolioBreakdown={onPortfolioBreakdown}
+                    onEditAsset={onEditAsset}
                   />
                 ))}
               </div>

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from "react"
 import {
+  Asset,
   HoldingValues,
   PriceData,
   QuickSellData,
@@ -61,7 +62,7 @@ interface RowsProps extends HoldingValues {
   onRecordExpense?: (data: QuickSellData) => void
   onPriceChart?: (data: PriceChartData) => void
   onPortfolioBreakdown?: (data: PortfolioBreakdownData) => void
-  onEditAsset?: (asset: import("types/beancounter").Asset) => void
+  onEditAsset?: (asset: Asset) => void
 }
 
 // Helper function to truncate text with ellipsis

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -61,6 +61,7 @@ interface RowsProps extends HoldingValues {
   onRecordExpense?: (data: QuickSellData) => void
   onPriceChart?: (data: PriceChartData) => void
   onPortfolioBreakdown?: (data: PortfolioBreakdownData) => void
+  onEditAsset?: (asset: import("types/beancounter").Asset) => void
 }
 
 // Helper function to truncate text with ellipsis
@@ -91,6 +92,7 @@ export default function Rows({
   onRecordExpense,
   onPriceChart,
   onPortfolioBreakdown,
+  onEditAsset,
 }: RowsProps): React.ReactElement {
   const router = useRouter()
   const { popup: newsPopup, showNews } = useNewsAsset()
@@ -203,7 +205,8 @@ export default function Rows({
                       asset.market?.code === "PRIVATE" &&
                       isConstantPrice(asset)))) ||
                 (asset.assetCategory?.id === "RE" &&
-                  (onRecordIncome || onRecordExpense)) ? (
+                  (onRecordIncome || onRecordExpense)) ||
+                (onEditAsset && asset.market?.code === "PRIVATE") ? (
                   <div className="flex items-center">
                     <ActionsMenu
                       asset={asset}
@@ -237,6 +240,7 @@ export default function Rows({
                       }
                       onRecordIncome={onRecordIncome}
                       onRecordExpense={onRecordExpense}
+                      onEditAsset={onEditAsset}
                     />
                   </div>
                 ) : null}

--- a/src/components/features/holdings/__tests__/CardView.test.tsx
+++ b/src/components/features/holdings/__tests__/CardView.test.tsx
@@ -353,6 +353,77 @@ describe("CardView footer (Quantity / Price / Weight)", () => {
       })
     })
 
+    it("invokes onEditAsset for PRIVATE/POLICY assets", () => {
+      const onEditAsset = jest.fn()
+      const portfolio = makePortfolio()
+      const asset = makeAsset({
+        id: "policy-1",
+        code: "CPF",
+        name: "CPF Composite",
+        assetCategory: { id: "POLICY", name: "Retirement Fund" },
+        market: {
+          code: "PRIVATE",
+          name: "Private",
+          currency: { code: "SGD", symbol: "S$", name: "Singapore Dollar" },
+        },
+      })
+      const position = makePosition({
+        asset,
+        moneyValues: { weight: 0.25, marketValue: 100000 },
+        quantityValues: { total: 1 },
+      })
+      const holdings = makeHoldings({
+        portfolio,
+        holdingGroups: { Policy: makeHoldingGroup({ positions: [position] }) },
+      })
+      render(
+        <CardView
+          holdings={holdings}
+          portfolio={portfolio}
+          valueIn={ValueIn.PORTFOLIO}
+          onEditAsset={onEditAsset}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole("button", { name: /Actions CPF/i }))
+      fireEvent.click(screen.getByRole("button", { name: "Edit Asset" }))
+
+      expect(onEditAsset).toHaveBeenCalledWith(asset)
+    })
+
+    it("hides Edit Asset for public-market holdings", () => {
+      const onEditAsset = jest.fn()
+      const onQuickSell = jest.fn()
+      const portfolio = makePortfolio()
+      const asset = makeAsset({
+        assetCategory: { id: "EQUITY", name: "Equity" },
+      })
+      const position = makePosition({
+        asset,
+        moneyValues: { weight: 0.25 },
+        price: 150,
+        quantityValues: { total: 100 },
+      })
+      const holdings = makeHoldings({
+        portfolio,
+        holdingGroups: { Equity: makeHoldingGroup({ positions: [position] }) },
+      })
+      render(
+        <CardView
+          holdings={holdings}
+          portfolio={portfolio}
+          valueIn={ValueIn.PORTFOLIO}
+          onEditAsset={onEditAsset}
+          onQuickSell={onQuickSell}
+        />,
+      )
+
+      fireEvent.click(screen.getByRole("button", { name: /Actions AAPL/i }))
+      expect(
+        screen.queryByRole("button", { name: "Edit Asset" }),
+      ).not.toBeInTheDocument()
+    })
+
     it("invokes onSetCashBalance for cash positions via CashActionsMenu", () => {
       const onSetCashBalance = jest.fn()
       const portfolio = makePortfolio()

--- a/src/components/features/independence/WizardContainer.tsx
+++ b/src/components/features/independence/WizardContainer.tsx
@@ -181,18 +181,17 @@ export default function WizardContainer({
         0,
       )
 
-      // Filter out zero-value manual assets before sending
-      const nonZeroManualAssets = formData.manualAssets
+      // Filter out zero-value manual assets before sending. An empty object
+      // is sent explicitly (not null) so the backend distinguishes "user
+      // cleared all categories" from "field omitted" and wipes the stored
+      // value — see PlanService.updatePlan PATCH semantics.
+      const manualAssets = formData.manualAssets
         ? Object.fromEntries(
             Object.entries(formData.manualAssets).filter(
               ([, value]) => value > 0,
             ),
           )
-        : null
-      const manualAssets =
-        nonZeroManualAssets && Object.keys(nonZeroManualAssets).length > 0
-          ? nonZeroManualAssets
-          : null
+        : {}
 
       // Backend stores decimals (0.07 for 7%), so convert from percentage
       // yearOfBirth and lifeExpectancy are now user-level settings, not plan-level

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -17,12 +17,23 @@ import {
 } from "@components/ui/SkeletonLoader"
 import { useRouter } from "next/router"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
-import useSwr from "swr"
+import useSwr, { mutate as globalMutate } from "swr"
 import {
+  ccyKey,
+  categoriesKey,
   holdingByIdKey,
   holdingKey,
   simpleFetcher,
 } from "@utils/api/fetchHelper"
+import EditAccountDialog from "@components/features/accounts/EditAccountDialog"
+import {
+  USER_ASSET_CATEGORIES,
+  type CategoryOption,
+  type SectorInfo,
+  type SectorOption,
+} from "@components/features/accounts/accountTypes"
+import { currencyOptions } from "@lib/currency"
+import { AssetCategory } from "types/beancounter"
 import { errorOut } from "@components/errors/ErrorOut"
 import { useHoldingState } from "@lib/holdings/holdingState"
 import { useHoldingsView } from "@lib/holdings/useHoldingsView"
@@ -124,6 +135,7 @@ function HoldingsPage(): React.ReactElement {
   const [cashTransactionAsset, setCashTransactionAsset] = useState<
     string | undefined
   >(undefined)
+  const [editAsset, setEditAsset] = useState<Asset | undefined>(undefined)
 
   // Share dialog state
   const [showShareDialog, setShowShareDialog] = useState(false)
@@ -137,6 +149,81 @@ function HoldingsPage(): React.ReactElement {
   const { data: portfoliosData } = useSwr(
     "/api/portfolios",
     simpleFetcher("/api/portfolios"),
+  )
+
+  // Edit-asset dialog needs the same reference data as the accounts page
+  const { data: ccyData } = useSwr(ccyKey, simpleFetcher(ccyKey))
+  const { data: categoriesData } = useSwr(
+    categoriesKey,
+    simpleFetcher(categoriesKey),
+  )
+  const { data: sectorsData } = useSwr<{ data: SectorInfo[] }>(
+    "/api/classifications/sectors",
+    simpleFetcher("/api/classifications/sectors"),
+  )
+  const ccyOptions = ccyData?.data ? currencyOptions(ccyData.data) : []
+  const categoryOptions: CategoryOption[] = categoriesData?.data
+    ? categoriesData.data
+        .filter((cat: AssetCategory) => USER_ASSET_CATEGORIES.includes(cat.id))
+        .map((cat: AssetCategory) => ({ value: cat.id, label: cat.name }))
+    : []
+  const sectorOptions: SectorOption[] = sectorsData?.data
+    ? sectorsData.data.map((sector: SectorInfo) => ({
+        value: sector.name,
+        label: sector.name,
+      }))
+    : []
+
+  const handleEditAsset = useCallback((asset: Asset) => {
+    setEditAsset(asset)
+  }, [])
+
+  const handleEditAssetClose = useCallback(() => {
+    setEditAsset(undefined)
+  }, [])
+
+  const handleEditAssetSave = useCallback(
+    async (
+      assetId: string,
+      code: string,
+      name: string,
+      currency: string,
+      category: string,
+      sector?: string,
+      expectedReturnRate?: number,
+    ): Promise<void> => {
+      const response = await fetch(`/api/assets/${assetId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          market: "PRIVATE",
+          code,
+          name,
+          currency,
+          category,
+          expectedReturnRate,
+        }),
+      })
+      if (!response.ok) {
+        throw new Error("Failed to update asset")
+      }
+      if (sector) {
+        try {
+          await fetch(`/api/classifications/${assetId}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ sector }),
+          })
+        } catch (err) {
+          console.error("Failed to update sector classification:", err)
+        }
+      }
+      // Refresh holdings (this page) and the assets list (accounts page cache)
+      await mutate()
+      globalMutate("/api/assets")
+      setEditAsset(undefined)
+    },
+    [mutate],
   )
 
   // Handle quick sell from position row
@@ -518,6 +605,7 @@ function HoldingsPage(): React.ReactElement {
                           onMovePosition={handleMovePosition}
                           onRecordIncome={handleRecordIncome}
                           onRecordExpense={handleRecordExpense}
+                          onEditAsset={handleEditAsset}
                         />
                         <SubTotal
                           groupBy={groupKey}
@@ -561,6 +649,7 @@ function HoldingsPage(): React.ReactElement {
             onCashTransfer={handleCashTransfer}
             onCashTransaction={handleCashTransaction}
             onPriceChart={handlePriceChart}
+            onEditAsset={handleEditAsset}
           />
         </div>
       ) : viewMode === "heatmap" ? (
@@ -749,6 +838,16 @@ function HoldingsPage(): React.ReactElement {
           preSelectedPortfolioId={holdingResults.portfolio.id}
           onClose={() => setShowShareDialog(false)}
           onSuccess={() => setShowShareDialog(false)}
+        />
+      )}
+      {editAsset && (
+        <EditAccountDialog
+          asset={editAsset}
+          currencies={ccyOptions}
+          categories={categoryOptions}
+          sectors={sectorOptions}
+          onClose={handleEditAssetClose}
+          onSave={handleEditAssetSave}
         />
       )}
     </div>

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -25,13 +25,17 @@ import {
   holdingKey,
   simpleFetcher,
 } from "@utils/api/fetchHelper"
-import EditAccountDialog from "@components/features/accounts/EditAccountDialog"
+import dynamic from "next/dynamic"
 import {
   USER_ASSET_CATEGORIES,
   type CategoryOption,
   type SectorInfo,
   type SectorOption,
 } from "@components/features/accounts/accountTypes"
+const EditAccountDialog = dynamic(
+  () => import("@components/features/accounts/EditAccountDialog"),
+  { ssr: false },
+)
 import { currencyOptions } from "@lib/currency"
 import { AssetCategory } from "types/beancounter"
 import { errorOut } from "@components/errors/ErrorOut"
@@ -151,14 +155,20 @@ function HoldingsPage(): React.ReactElement {
     simpleFetcher("/api/portfolios"),
   )
 
-  // Edit-asset dialog needs the same reference data as the accounts page
-  const { data: ccyData } = useSwr(ccyKey, simpleFetcher(ccyKey))
+  // Edit-asset dialog needs the same reference data as the accounts page.
+  // Lazy-fetch — only after the user opens the dialog. Holdings is a hot
+  // path; editing is incidental, so we skip the three round-trips on the
+  // common case.
+  const { data: ccyData } = useSwr(
+    editAsset ? ccyKey : null,
+    simpleFetcher(ccyKey),
+  )
   const { data: categoriesData } = useSwr(
-    categoriesKey,
+    editAsset ? categoriesKey : null,
     simpleFetcher(categoriesKey),
   )
   const { data: sectorsData } = useSwr<{ data: SectorInfo[] }>(
-    "/api/classifications/sectors",
+    editAsset ? "/api/classifications/sectors" : null,
     simpleFetcher("/api/classifications/sectors"),
   )
   const ccyOptions = ccyData?.data ? currencyOptions(ccyData.data) : []
@@ -220,7 +230,7 @@ function HoldingsPage(): React.ReactElement {
       }
       // Refresh holdings (this page) and the assets list (accounts page cache)
       await mutate()
-      globalMutate("/api/assets")
+      await globalMutate("/api/assets")
       setEditAsset(undefined)
     },
     [mutate],


### PR DESCRIPTION
## Summary
- Wizard now sends `{}` instead of `null` when all manualAssets categories are zeroed
- Pairs with svc-retire PR that treats empty map as explicit clear

## Why
With the prior `null` payload, the backend fell back to the existing row and stale entries (e.g. a removed RE account) reappeared on refresh.

## Test plan
- [x] `yarn lint && yarn typecheck && yarn test` green
- [ ] Manual: zero RE in independence wizard → save → refresh; RE should not return