### PR TITLE
feat(asset): contribution frequency dropdown on pension edit

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -30,6 +30,7 @@ interface AssetConfigState {
   payoutAge: string
   monthlyPayoutAmount: string
   monthlyContribution: string
+  contributionFrequency: "MONTHLY" | "ANNUAL"
   lumpSum: boolean
   expectedReturnRate: string
   // Composite policy support
@@ -64,6 +65,7 @@ const defaultConfigState: AssetConfigState = {
   payoutAge: "",
   monthlyPayoutAmount: "0",
   monthlyContribution: "0",
+  contributionFrequency: "MONTHLY",
   lumpSum: false,
   expectedReturnRate: "",
   policyType: undefined,
@@ -295,6 +297,10 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
               monthlyContribution: String(
                 Math.round((data.data.monthlyContribution || 0) * 100) / 100,
               ),
+              contributionFrequency:
+                data.data.contributionFrequency === "ANNUAL"
+                  ? "ANNUAL"
+                  : "MONTHLY",
               lumpSum: data.data.lumpSum || false,
               // Round to 1 decimal place for percentage display (e.g., 3.0%, 5.5%)
               expectedReturnRate: data.data.expectedReturnRate
@@ -457,6 +463,7 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
             payoutAge: config.payoutAge ? parseInt(config.payoutAge) : null,
             monthlyPayoutAmount: parseFloat(config.monthlyPayoutAmount) || 0,
             monthlyContribution: parseFloat(config.monthlyContribution) || 0,
+            contributionFrequency: config.contributionFrequency,
             lumpSum: config.lumpSum,
             expectedReturnRate: config.expectedReturnRate
               ? parseFloat(config.expectedReturnRate) / 100
@@ -749,24 +756,45 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                     </div>
 
                     <div className="grid grid-cols-2 gap-4">
-                      {/* Monthly Contribution */}
+                      {/* Contribution */}
                       <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">
-                          {"Monthly Contribution"}
+                          {"Contribution"}
                         </label>
-                        <MathInput
-                          value={config.monthlyContribution}
-                          onChange={(val) =>
-                            setConfig({
-                              ...config,
-                              monthlyContribution: String(val),
-                            })
-                          }
-                          placeholder="e.g. 500, 1k"
-                          className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-indigo-500 focus:border-indigo-500"
-                        />
+                        <div className="flex gap-2">
+                          <MathInput
+                            value={config.monthlyContribution}
+                            onChange={(val) =>
+                              setConfig({
+                                ...config,
+                                monthlyContribution: String(val),
+                              })
+                            }
+                            placeholder="e.g. 500, 1k"
+                            className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-indigo-500 focus:border-indigo-500"
+                          />
+                          <select
+                            aria-label="Contribution frequency"
+                            value={config.contributionFrequency}
+                            onChange={(e) =>
+                              setConfig({
+                                ...config,
+                                contributionFrequency:
+                                  e.target.value === "ANNUAL"
+                                    ? "ANNUAL"
+                                    : "MONTHLY",
+                              })
+                            }
+                            className="border-gray-300 rounded-md shadow-sm px-2 py-2 border focus:ring-indigo-500 focus:border-indigo-500"
+                          >
+                            <option value="MONTHLY">Monthly</option>
+                            <option value="ANNUAL">Annual</option>
+                          </select>
+                        </div>
                         <p className="text-xs text-gray-500 mt-1">
-                          {"Your regular contributions"}
+                          {config.contributionFrequency === "ANNUAL"
+                            ? "Total contribution per year (e.g. CPF top-up, SRS)"
+                            : "Regular monthly contribution (e.g. SuperFund)"}
                         </p>
                       </div>
 

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -770,6 +770,7 @@ export interface PrivateAssetConfig {
   monthlyPayoutAmount?: number
   lumpSum?: boolean
   monthlyContribution?: number
+  contributionFrequency?: "MONTHLY" | "ANNUAL"
   isPension: boolean
   // Composite policy support
   policyType?: PolicyType
@@ -805,6 +806,7 @@ export interface PrivateAssetConfigRequest {
   monthlyPayoutAmount?: number
   lumpSum?: boolean
   monthlyContribution?: number
+  contributionFrequency?: "MONTHLY" | "ANNUAL"
   isPension?: boolean
   // Composite policy support
   policyType?: PolicyType


### PR DESCRIPTION
## Summary
Adds a Monthly/Annual frequency selector next to the contribution amount on the Edit Asset dialog (POLICY/pension assets). Matches the backend field shipped in beancounter#887 + svc-retire#25 so the Independence projection knows how to annualise the per-scenario contribution amount (MONTHLY × 12, ANNUAL × 1).

## Why
CPF top-ups are typically annual; SuperFund / private pensions are typically monthly. Capturing the frequency on the asset gives a single source of truth — the Work Scenario stores the per-period amount, the asset says how to roll it forward.

## Test plan
- [x] `yarn typecheck && yarn lint && yarn test` green (1321 tests)
- [ ] Manual: open Edit Asset on a CPF or pension policy, toggle Annual, save, reopen — confirm persists
- [ ] Manual: verify helper text changes between "Total contribution per year" (Annual) and "Regular monthly contribution" (Monthly)
- [ ] Manual: confirm round-trip with backend (POST `/api/assets/config/<id>` with `contributionFrequency: "ANNUAL"` shows up on reload)

## Followups (next slice)
- Work Scenario form: per-asset contribution amount list (loops user's pension assets, lets them set the amount the scenario contributes)
- Projection wiring for CPF: bypass salary-based ratio when scenario provides annual CPF contribution (svc-retire CpfLifeService)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contribution frequency configuration for retirement projections. Users can now select between monthly and annual contribution options in the Income & Planning section, with adjusted guidance text based on their selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->