### PR TITLE
feat(scenarios): per-asset pension contribution editor

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -358,7 +358,13 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
         return
       }
 
-      const monthlyContribution = parseFloat(config.monthlyContribution) || 0
+      const contributionAmount = parseFloat(config.monthlyContribution) || 0
+      // Projection endpoint takes monthly. For ANNUAL-frequency assets the
+      // user enters a per-year figure, so divide by 12 before sending.
+      const monthlyContribution =
+        config.contributionFrequency === "ANNUAL"
+          ? contributionAmount / 12
+          : contributionAmount
       const currentAge = parseInt(config.currentAge) || 0
       const payoutAge = parseInt(config.payoutAge) || 0
       const expectedReturn = (parseFloat(config.expectedReturnRate) || 0) / 100
@@ -407,6 +413,7 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
     config.payoutAge,
     config.currentAge,
     config.monthlyContribution,
+    config.contributionFrequency,
     config.expectedReturnRate,
   ])
 
@@ -912,7 +919,7 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                         ) : (
                           <p className="text-green-600 text-xs">
                             {parseFloat(config.monthlyContribution || "0") <= 0
-                              ? "Enter monthly contribution to see projected payout."
+                              ? `Enter ${config.contributionFrequency === "ANNUAL" ? "annual" : "monthly"} contribution to see projected payout.`
                               : "Calculating projection..."}
                           </p>
                         )}

--- a/src/components/features/independence/scenarios/ScenarioContributions.tsx
+++ b/src/components/features/independence/scenarios/ScenarioContributions.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useMemo, useState, useCallback } from "react"
+import useSWR from "swr"
+import { PlanContribution } from "types/independence"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+
+/**
+ * Per-asset pension contribution editor for a Work Scenario.
+ *
+ * Lists the user's pension/policy assets and lets them set how much this
+ * scenario contributes per asset. The backend (svc-retire) annualises the
+ * stored monthlyAmount using the asset's contributionFrequency
+ * (MONTHLY × 12, ANNUAL × 1) when feeding the Independence projection,
+ * so the input label adapts to whichever cadence the asset is configured
+ * for — entering "8000" against an ANNUAL-frequency asset means $8,000
+ * per year, not per month.
+ */
+
+interface PensionAsset {
+  assetId: string
+  assetName: string
+  contributionFrequency: "MONTHLY" | "ANNUAL"
+  policyType?: string
+}
+
+interface PrivateAssetConfig {
+  assetId: string
+  isPension?: boolean
+  policyType?: string
+  contributionFrequency?: "MONTHLY" | "ANNUAL"
+}
+
+interface PrivateAssetConfigsResponse {
+  data: PrivateAssetConfig[]
+  assetNames?: Record<string, string>
+}
+
+interface ScenarioContributionsProps {
+  scenarioId: string
+  currency: string
+}
+
+export default function ScenarioContributions({
+  scenarioId,
+  currency,
+}: ScenarioContributionsProps): React.ReactElement | null {
+  const configsKey = "/api/assets/config"
+  const contributionsKey = `/api/independence/work-scenarios/${scenarioId}/contributions`
+
+  const { data: configsResp } = useSWR<PrivateAssetConfigsResponse>(
+    configsKey,
+    simpleFetcher,
+  )
+  const { data: contribsResp, mutate: refreshContribs } = useSWR<{
+    data: PlanContribution[]
+  }>(contributionsKey, simpleFetcher)
+
+  const pensionAssets: PensionAsset[] = (configsResp?.data || [])
+    .filter((c) => c.isPension)
+    .map((c) => ({
+      assetId: c.assetId,
+      assetName: configsResp?.assetNames?.[c.assetId] || c.assetId,
+      contributionFrequency: c.contributionFrequency || "MONTHLY",
+      policyType: c.policyType,
+    }))
+
+  const contribsByAssetId = useMemo(() => {
+    const map: Record<string, PlanContribution> = {}
+    for (const c of contribsResp?.data || []) {
+      map[c.assetId] = c
+    }
+    return map
+  }, [contribsResp])
+
+  // Local edits keyed by assetId. String to preserve typing UX.
+  const [edits, setEdits] = useState<Record<string, string>>({})
+  const [savingAssetId, setSavingAssetId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Seed edits from server when contributions land. Key the effect on a
+  // stringified snapshot so identical SWR refreshes don't reset local
+  // edits the user is mid-typing — and don't cause an infinite render
+  // loop when the SWR cache returns a fresh object on every poll.
+  const contribsSignature = (contribsResp?.data || [])
+    .map((c) => `${c.assetId}=${c.monthlyAmount}`)
+    .sort()
+    .join("|")
+  useEffect(() => {
+    if (!contribsResp?.data) return
+    const seed: Record<string, string> = {}
+    for (const c of contribsResp.data) {
+      seed[c.assetId] = String(c.monthlyAmount)
+    }
+    setEdits(seed)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contribsSignature])
+
+  const saveOne = useCallback(
+    async (asset: PensionAsset) => {
+      const raw = edits[asset.assetId] ?? ""
+      const amount = parseFloat(raw) || 0
+      const existing = contribsByAssetId[asset.assetId]
+      // If the user clears the input and no contribution existed, do nothing.
+      if (amount === 0 && !existing) return
+      setSavingAssetId(asset.assetId)
+      setError(null)
+      try {
+        const res = await fetch(
+          `/api/independence/work-scenarios/${scenarioId}/contributions`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              assetId: asset.assetId,
+              assetName: asset.assetName,
+              monthlyAmount: amount,
+              currency,
+              contributionType: "PENSION",
+            }),
+          },
+        )
+        if (!res.ok) throw new Error(`Save failed: ${res.status}`)
+        await refreshContribs()
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : "Save failed")
+      } finally {
+        setSavingAssetId(null)
+      }
+    },
+    [edits, contribsByAssetId, scenarioId, currency, refreshContribs],
+  )
+
+  if (!configsResp) return null
+  if (pensionAssets.length === 0) {
+    return (
+      <p className="text-sm text-gray-500">
+        No pension or policy assets configured. Mark an asset as a pension in
+        Edit Asset to allocate contributions here.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {error && (
+        <div
+          role="alert"
+          className="text-sm text-red-600 border border-red-200 bg-red-50 rounded px-2 py-1"
+        >
+          {error}
+        </div>
+      )}
+      <ul className="divide-y divide-gray-200">
+        {pensionAssets.map((asset) => {
+          const value = edits[asset.assetId] ?? ""
+          const isSaving = savingAssetId === asset.assetId
+          const frequencyLabel =
+            asset.contributionFrequency === "ANNUAL" ? "per year" : "per month"
+          return (
+            <li
+              key={asset.assetId}
+              className="py-2 flex items-center gap-3"
+            >
+              <span className="flex-1 text-sm text-gray-700">
+                {asset.assetName}
+                {asset.policyType && (
+                  <span className="ml-2 text-xs text-gray-400">
+                    {asset.policyType}
+                  </span>
+                )}
+              </span>
+              <input
+                type="number"
+                min={0}
+                step="any"
+                value={value}
+                aria-label={`Contribution for ${asset.assetName}`}
+                onChange={(e) =>
+                  setEdits((prev) => ({
+                    ...prev,
+                    [asset.assetId]: e.target.value,
+                  }))
+                }
+                onBlur={() => saveOne(asset)}
+                disabled={isSaving}
+                className="w-32 border border-gray-300 rounded px-2 py-1 text-sm focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+              />
+              <span className="text-xs text-gray-500 w-20">
+                {currency} {frequencyLabel}
+              </span>
+            </li>
+          )
+        })}
+      </ul>
+      <p className="text-xs text-gray-400">
+        Contributions are saved when you leave the field. Frequency comes from
+        the asset itself (Edit Asset → Contribution).
+      </p>
+    </div>
+  )
+}

--- a/src/components/features/independence/scenarios/ScenarioEditor.tsx
+++ b/src/components/features/independence/scenarios/ScenarioEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react"
 import { WorkScenario, WorkScenarioRequest } from "types/independence"
 import Dialog from "@components/ui/Dialog"
+import ScenarioContributions from "@components/features/independence/scenarios/ScenarioContributions"
 
 interface ScenarioEditorProps {
   scenario?: WorkScenario | null
@@ -221,6 +222,18 @@ export default function ScenarioEditor({
             />
           </div>
         </div>
+
+        {isEditing && scenario && (
+          <div className="border-t border-gray-200 pt-4">
+            <h4 className="text-sm font-semibold text-gray-700 mb-2">
+              Pension contributions
+            </h4>
+            <ScenarioContributions
+              scenarioId={scenario.id}
+              currency={form.currency || "NZD"}
+            />
+          </div>
+        )}
 
         <div className="bg-gradient-to-r from-independence-50 to-independence-100 rounded-lg p-3 border border-independence-100">
           <div className="flex justify-between items-center">

--- a/src/components/features/independence/scenarios/__tests__/ScenarioContributions.test.tsx
+++ b/src/components/features/independence/scenarios/__tests__/ScenarioContributions.test.tsx
@@ -1,0 +1,88 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import ScenarioContributions from "../ScenarioContributions"
+
+// SWR is mocked per-key so we can simulate the asset-configs + contributions
+// fetches independently. Without per-key control, the same data goes to both
+// hooks and the contribution-seed effect overwrites our edits.
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string) => {
+    if (key === "/api/assets/config") {
+      return {
+        data: {
+          data: [
+            {
+              assetId: "cpf-1",
+              isPension: true,
+              contributionFrequency: "ANNUAL",
+              policyType: "CPF",
+            },
+            {
+              assetId: "kiwi-1",
+              isPension: true,
+              contributionFrequency: "MONTHLY",
+            },
+            { assetId: "re-1", isPension: false }, // filtered out
+          ],
+          assetNames: {
+            "cpf-1": "My CPF",
+            "kiwi-1": "Kiwi Saver",
+            "re-1": "House",
+          },
+        },
+        error: undefined,
+        isLoading: false,
+        mutate: jest.fn(),
+      }
+    }
+    return {
+      data: { data: [] },
+      error: undefined,
+      isLoading: false,
+      mutate: jest.fn(),
+    }
+  },
+}))
+
+describe("ScenarioContributions", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+    ) as jest.Mock
+  })
+
+  afterEach(() => jest.restoreAllMocks())
+
+  it("lists only pension assets", () => {
+    render(<ScenarioContributions scenarioId="s1" currency="SGD" />)
+    expect(screen.getByText("My CPF")).toBeInTheDocument()
+    expect(screen.getByText("Kiwi Saver")).toBeInTheDocument()
+    expect(screen.queryByText("House")).not.toBeInTheDocument()
+  })
+
+  it("renders ANNUAL / MONTHLY frequency labels from asset config", () => {
+    render(<ScenarioContributions scenarioId="s1" currency="SGD" />)
+    expect(screen.getByText(/SGD per year/i)).toBeInTheDocument()
+    expect(screen.getByText(/SGD per month/i)).toBeInTheDocument()
+  })
+
+  it("posts to the scenario contributions endpoint on blur", async () => {
+    render(<ScenarioContributions scenarioId="s1" currency="SGD" />)
+
+    const input = screen.getByLabelText("Contribution for My CPF")
+    fireEvent.change(input, { target: { value: "8000" } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/independence/work-scenarios/s1/contributions",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"monthlyAmount":8000'),
+        }),
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- New \`ScenarioContributions\` component renders inside the existing \`ScenarioEditor\` when editing a Work Scenario
- Lists the user's pension / policy assets, lets each scenario record a contribution amount per asset
- Reads each asset's \`contributionFrequency\` to label the row \`per month\` / \`per year\` so the unit is unambiguous
- Saves on blur to \`POST /api/independence/work-scenarios/:id/contributions\`; clearing to zero on a row that didn't exist is a no-op
- Folds in CodeRabbit's nitpick from #700: lump-sum projection in EditAccountDialog was treating ANNUAL contributions as monthly (12x over-count). Now divides by 12 when frequency is ANNUAL, dep array tracks contributionFrequency, empty-state copy adapts.

## Why
Backend (svc-data #887, svc-retire #25/#26) already plumbs the scenario-override path: the projection uses the scenario contribution annualised by asset frequency, falling back to the asset-level default if no scenario row exists. The UI to actually enter those scenario amounts has been missing — this fills the gap so the override has data to consume.

## Test plan
- [x] 3 new unit tests for ScenarioContributions (filter, frequency labels, save on blur)
- [x] \`yarn lint && yarn typecheck && yarn test\` green (1324 tests)
- [ ] Manual: open Edit Scenario on an existing scenario, enter amount against a pension asset, blur, reload — value persists
- [ ] Manual: confirm ANNUAL-frequency asset shows \"SGD per year\" and stores \`monthlyAmount\` as the annual figure (backend annualisation handles the math)
- [ ] Manual: verify lump-sum projection on Edit Asset reflects the right cadence — set ANNUAL + 8000, payout should ~ 8000 × yearsToMaturity, not 12 × that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contribution projections now adjust for frequency: annual contributions are converted to monthly equivalents before calculation
  * New interface for editing per-asset pension contributions within work scenarios
  * Contribution input labels dynamically display frequency-based messaging (annual vs. monthly) based on asset configuration

* **Tests**
  * Added comprehensive test coverage for per-asset contribution editing and validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->