### PR TITLE
feat(scenarios): salary-based CPF tooltip + per-asset projection modal

### DIFF
--- a/src/components/features/independence/scenarios/PensionProjectionModal.tsx
+++ b/src/components/features/independence/scenarios/PensionProjectionModal.tsx
@@ -79,11 +79,20 @@ export default function PensionProjectionModal({
       (asset.cpfLifePlan ? `&cpfLifePlan=${asset.cpfLifePlan}` : "")
     : null
 
+  // Scenario override wins for the non-CPF projection too: the user-entered
+  // amount in this scenario edit should drive the table, not the stale asset
+  // default. Convert the annual override back to a monthly figure (the
+  // endpoint takes monthlyContribution); fall through to asset default when
+  // the user has cleared the row.
+  const policyMonthly =
+    scenarioAnnualOverride && scenarioAnnualOverride > 0
+      ? scenarioAnnualOverride / 12
+      : (asset.monthlyContribution ?? 0)
   const policyKey = !isCpf
     ? `/api/independence/cpf/policy-balance-series?currentAge=${currentAge}` +
       `&payoutAge=${payoutAge}` +
       `&startingBalance=${subBalanceFor("BALANCE") || 0}` +
-      `&monthlyContribution=${asset.monthlyContribution ?? 0}` +
+      `&monthlyContribution=${policyMonthly}` +
       `&expectedReturnRate=${asset.expectedReturnRate ?? 0}`
     : null
 

--- a/src/components/features/independence/scenarios/PensionProjectionModal.tsx
+++ b/src/components/features/independence/scenarios/PensionProjectionModal.tsx
@@ -1,0 +1,179 @@
+import React from "react"
+import useSWR from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+import Dialog from "@components/ui/Dialog"
+
+/**
+ * Per-asset balance-projection modal opened from a ScenarioContributions
+ * row. Shows a year-by-year table of how the asset's balance is expected
+ * to evolve until payout age, plus a banner reminding the user that the
+ * starting balance is the figure they entered when the asset was created
+ * — there's currently no in-app way to refresh it, so the projection
+ * starts from whatever was true at that point in time.
+ */
+
+interface CpfYearlyBalance {
+  age: number
+  oa: number
+  sa: number
+  ma: number
+  ra: number
+  annualContribution: number
+}
+
+interface PolicyYearlyBalance {
+  age: number
+  balance: number
+  annualContribution: number
+}
+
+export interface PensionProjectionAsset {
+  assetId: string
+  assetName: string
+  policyType?: string
+  cpfLifePlan?: string
+  payoutAge?: number
+  expectedReturnRate?: number
+  monthlyContribution?: number
+  /** Snapshot date for the starting balance — used in the stale-balance banner. */
+  updatedDate?: string
+  /** CPF only: starting OA / SA / MA / RA balances. */
+  subAccounts?: { code: string; balance: number }[]
+}
+
+interface Props {
+  asset: PensionProjectionAsset
+  currency: string
+  currentAge: number
+  /** Scenario-resolved figures (may differ from asset.monthlyContribution). */
+  scenarioMonthlySalary?: number
+  scenarioAnnualOverride?: number
+  onClose: () => void
+}
+
+export default function PensionProjectionModal({
+  asset,
+  currency,
+  currentAge,
+  scenarioMonthlySalary,
+  scenarioAnnualOverride,
+  onClose,
+}: Props): React.ReactElement {
+  const isCpf = asset.policyType === "CPF"
+  const payoutAge = asset.payoutAge ?? 65
+
+  const subBalanceFor = (code: string): number =>
+    asset.subAccounts?.find((s) => s.code === code)?.balance ?? 0
+
+  const cpfKey = isCpf
+    ? `/api/independence/cpf/balance-series?currentAge=${currentAge}` +
+      `&payoutAge=${payoutAge}` +
+      `&oa=${subBalanceFor("OA")}&sa=${subBalanceFor("SA")}` +
+      `&ma=${subBalanceFor("MA")}&ra=${subBalanceFor("RA")}` +
+      (scenarioMonthlySalary
+        ? `&monthlySalary=${scenarioMonthlySalary}`
+        : "") +
+      (scenarioAnnualOverride
+        ? `&annualContributionOverride=${scenarioAnnualOverride}`
+        : "") +
+      (asset.cpfLifePlan ? `&cpfLifePlan=${asset.cpfLifePlan}` : "")
+    : null
+
+  const policyKey = !isCpf
+    ? `/api/independence/cpf/policy-balance-series?currentAge=${currentAge}` +
+      `&payoutAge=${payoutAge}` +
+      `&startingBalance=${subBalanceFor("BALANCE") || 0}` +
+      `&monthlyContribution=${asset.monthlyContribution ?? 0}` +
+      `&expectedReturnRate=${asset.expectedReturnRate ?? 0}`
+    : null
+
+  const { data: cpfData } = useSWR<{ data: CpfYearlyBalance[] } | CpfYearlyBalance[]>(
+    cpfKey,
+    simpleFetcher,
+  )
+  const { data: policyData } = useSWR<
+    { data: PolicyYearlyBalance[] } | PolicyYearlyBalance[]
+  >(policyKey, simpleFetcher)
+
+  // Endpoints return arrays directly, but SWR-via-proxy may wrap in { data }.
+  const cpfSeries: CpfYearlyBalance[] = Array.isArray(cpfData)
+    ? cpfData
+    : (cpfData?.data ?? [])
+  const policySeries: PolicyYearlyBalance[] = Array.isArray(policyData)
+    ? policyData
+    : (policyData?.data ?? [])
+
+  const fmt = (n: number): string =>
+    `${currency} ${Math.round(n).toLocaleString()}`
+
+  return (
+    <Dialog
+      title={`Projection · ${asset.assetName}`}
+      onClose={onClose}
+      maxWidth="lg"
+      scrollable
+      footer={<Dialog.CancelButton onClick={onClose} label="Close" />}
+    >
+      <div
+        role="alert"
+        className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded p-2 mb-3"
+      >
+        Starting balance is the figure you entered when the asset was last
+        edited
+        {asset.updatedDate ? ` (${asset.updatedDate})` : ""}. There&rsquo;s
+        currently no in-app way to refresh it, so the projection grows from
+        that snapshot — actual balances may already be higher.
+      </div>
+
+      {isCpf ? (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-gray-500 border-b">
+              <th className="py-1">Age</th>
+              <th className="py-1 text-right">OA</th>
+              <th className="py-1 text-right">SA</th>
+              <th className="py-1 text-right">MA</th>
+              <th className="py-1 text-right">RA</th>
+              <th className="py-1 text-right">Contribution</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cpfSeries.map((row) => (
+              <tr key={row.age} className="border-b last:border-b-0">
+                <td className="py-1">{row.age}</td>
+                <td className="py-1 text-right">{fmt(row.oa)}</td>
+                <td className="py-1 text-right">{fmt(row.sa)}</td>
+                <td className="py-1 text-right">{fmt(row.ma)}</td>
+                <td className="py-1 text-right">{fmt(row.ra)}</td>
+                <td className="py-1 text-right text-gray-500">
+                  {row.annualContribution > 0 ? fmt(row.annualContribution) : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-gray-500 border-b">
+              <th className="py-1">Age</th>
+              <th className="py-1 text-right">Balance</th>
+              <th className="py-1 text-right">Contribution</th>
+            </tr>
+          </thead>
+          <tbody>
+            {policySeries.map((row) => (
+              <tr key={row.age} className="border-b last:border-b-0">
+                <td className="py-1">{row.age}</td>
+                <td className="py-1 text-right">{fmt(row.balance)}</td>
+                <td className="py-1 text-right text-gray-500">
+                  {row.annualContribution > 0 ? fmt(row.annualContribution) : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Dialog>
+  )
+}

--- a/src/components/features/independence/scenarios/ScenarioContributions.tsx
+++ b/src/components/features/independence/scenarios/ScenarioContributions.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState, useCallback } from "react"
 import useSWR from "swr"
 import { PlanContribution } from "types/independence"
 import { simpleFetcher } from "@utils/api/fetchHelper"
+import PensionProjectionModal from "@components/features/independence/scenarios/PensionProjectionModal"
 
 /**
  * Per-asset pension contribution editor for a Work Scenario.
@@ -20,6 +21,13 @@ interface PensionAsset {
   assetName: string
   contributionFrequency: "MONTHLY" | "ANNUAL"
   policyType?: string
+  payoutAge?: number
+  updatedDate?: string
+  subAccounts?: { code: string; balance: number }[]
+  monthlyPayoutAmount?: number
+  expectedReturnRate?: number
+  monthlyContribution?: number
+  cpfLifePlan?: string
 }
 
 interface PrivateAssetConfig {
@@ -27,6 +35,13 @@ interface PrivateAssetConfig {
   isPension?: boolean
   policyType?: string
   contributionFrequency?: "MONTHLY" | "ANNUAL"
+  payoutAge?: number
+  updatedDate?: string
+  subAccounts?: { code: string; balance: number }[]
+  monthlyPayoutAmount?: number
+  expectedReturnRate?: number
+  monthlyContribution?: number
+  cpfLifePlan?: string
 }
 
 interface PrivateAssetConfigsResponse {
@@ -97,7 +112,18 @@ export default function ScenarioContributions({
       assetName: configsResp?.assetNames?.[c.assetId] || c.assetId,
       contributionFrequency: c.contributionFrequency || "MONTHLY",
       policyType: c.policyType,
+      payoutAge: c.payoutAge,
+      updatedDate: c.updatedDate,
+      subAccounts: c.subAccounts,
+      monthlyPayoutAmount: c.monthlyPayoutAmount,
+      expectedReturnRate: c.expectedReturnRate,
+      monthlyContribution: c.monthlyContribution,
+      cpfLifePlan: c.cpfLifePlan,
     }))
+
+  const [projectionAsset, setProjectionAsset] = useState<PensionAsset | null>(
+    null,
+  )
 
   const contribsByAssetId = useMemo(() => {
     const map: Record<string, PlanContribution> = {}
@@ -232,6 +258,21 @@ export default function ScenarioContributions({
               <span className="text-xs text-gray-500 w-20">
                 {currency} {frequencyLabel}
               </span>
+              <button
+                type="button"
+                onClick={() => setProjectionAsset(asset)}
+                disabled={!asset.payoutAge || !currentAge}
+                title={
+                  !asset.payoutAge
+                    ? "Set a payout age on the asset to view projection"
+                    : !currentAge
+                      ? "Set year of birth on your plan to view projection"
+                      : "Year-by-year balance projection until payout"
+                }
+                className="text-xs text-independence-600 hover:text-independence-800 disabled:text-gray-300 disabled:cursor-not-allowed underline"
+              >
+                Projection
+              </button>
             </li>
           )
         })}
@@ -240,6 +281,19 @@ export default function ScenarioContributions({
         Contributions are saved when you leave the field. Frequency comes from
         the asset itself (Edit Asset → Contribution).
       </p>
+      {projectionAsset && currentAge && (
+        <PensionProjectionModal
+          asset={projectionAsset}
+          currency={currency}
+          currentAge={currentAge}
+          scenarioMonthlySalary={monthlySalary}
+          scenarioAnnualOverride={
+            (parseFloat(edits[projectionAsset.assetId] || "0") || 0) *
+            (projectionAsset.contributionFrequency === "ANNUAL" ? 1 : 12)
+          }
+          onClose={() => setProjectionAsset(null)}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/features/independence/scenarios/ScenarioContributions.tsx
+++ b/src/components/features/independence/scenarios/ScenarioContributions.tsx
@@ -37,14 +37,50 @@ interface PrivateAssetConfigsResponse {
 interface ScenarioContributionsProps {
   scenarioId: string
   currency: string
+  /**
+   * The scenario's monthly working income. When >0 AND we know the user's
+   * age, the row for any CPF asset shows a tooltip with the salary-derived
+   * contribution figure the projection WOULD have applied — so the user
+   * can see what they're overriding (employer + employee combined).
+   */
+  monthlySalary?: number
+  currentAge?: number
+}
+
+interface CpfPreviewResponse {
+  data: {
+    annualContribution: number
+    monthlyContribution: number
+    annualOa: number
+    annualSa: number
+    annualMa: number
+    employeeRate: number
+    employerRate: number
+    cappedSalary: number
+    wageCeiling: number
+  }
 }
 
 export default function ScenarioContributions({
   scenarioId,
   currency,
+  monthlySalary,
+  currentAge,
 }: ScenarioContributionsProps): React.ReactElement | null {
   const configsKey = "/api/assets/config"
   const contributionsKey = `/api/independence/work-scenarios/${scenarioId}/contributions`
+  // Skip the preview fetch if we don't have both salary and age — there's
+  // nothing useful to show. Reuse one preview for all CPF rows; salary
+  // is at the scenario level, so the figure is the same for each asset.
+  const previewKey =
+    monthlySalary && monthlySalary > 0 && currentAge && currentAge > 0
+      ? `/api/independence/cpf/contribution-preview?monthlySalary=${monthlySalary}&age=${currentAge}`
+      : null
+  const { data: previewResp } = useSWR<CpfPreviewResponse>(
+    previewKey,
+    simpleFetcher,
+  )
+  const salaryAnnual = previewResp?.data?.annualContribution
 
   const { data: configsResp } = useSWR<PrivateAssetConfigsResponse>(
     configsKey,
@@ -165,6 +201,15 @@ export default function ScenarioContributions({
                 {asset.policyType && (
                   <span className="ml-2 text-xs text-gray-400">
                     {asset.policyType}
+                  </span>
+                )}
+                {asset.policyType === "CPF" && salaryAnnual != null && (
+                  <span
+                    className="ml-2 text-xs text-gray-500 cursor-help"
+                    title={`Your salary-based CPF contribution would be ${currency} ${salaryAnnual.toLocaleString()}/yr (employer + employee combined at the age-${currentAge} band). Entering an amount here overrides that figure for the projection.`}
+                  >
+                    {" "}ⓘ salary-based: {currency}{" "}
+                    {Math.round(salaryAnnual).toLocaleString()}/yr
                   </span>
                 )}
               </span>

--- a/src/components/features/independence/scenarios/ScenarioEditor.tsx
+++ b/src/components/features/independence/scenarios/ScenarioEditor.tsx
@@ -37,6 +37,26 @@ export default function ScenarioEditor({
   const [form, setForm] = useState<WorkScenarioRequest>(DEFAULT_FORM)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Used by ScenarioContributions to compute the salary-derived CPF
+  // contribution tooltip; the projection picks an age band based on it.
+  const [currentAge, setCurrentAge] = useState<number | undefined>(undefined)
+
+  useEffect(() => {
+    if (!isEditing) return undefined
+    let cancelled = false
+    fetch("/api/independence/plans")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body) => {
+        if (cancelled) return
+        const plan = body?.data?.[0]
+        if (!plan?.yearOfBirth) return
+        setCurrentAge(new Date().getFullYear() - plan.yearOfBirth)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [isEditing])
 
   useEffect(() => {
     if (scenario) {
@@ -231,6 +251,8 @@ export default function ScenarioEditor({
             <ScenarioContributions
               scenarioId={scenario.id}
               currency={form.currency || "NZD"}
+              monthlySalary={form.workingIncomeMonthly}
+              currentAge={currentAge}
             />
           </div>
         )}

--- a/src/components/features/independence/scenarios/__tests__/ScenarioContributions.test.tsx
+++ b/src/components/features/independence/scenarios/__tests__/ScenarioContributions.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
-import ScenarioContributions from "../ScenarioContributions"
+import ScenarioContributions from "@components/features/independence/scenarios/ScenarioContributions"
 
 // SWR is mocked per-key so we can simulate the asset-configs + contributions
 // fetches independently. Without per-key control, the same data goes to both

--- a/src/pages/api/independence/cpf/balance-series.ts
+++ b/src/pages/api/independence/cpf/balance-series.ts
@@ -1,11 +1,23 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getRetireUrl } from "@utils/api/bcConfig"
 
+// Next.js query values can be string[] — fold each entry to a scalar string
+// before handing the dict to URLSearchParams, otherwise array params get
+// stringified as "v1,v2" which svc-retire won't parse as a BigDecimal.
+function scalarQuery(
+  query: Record<string, string | string[] | undefined>,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(query)) {
+    if (v == null) continue
+    out[k] = Array.isArray(v) ? (v[0] ?? "") : v
+  }
+  return out
+}
+
 export default createApiHandler({
   url: (req) => {
-    const qs = new URLSearchParams(
-      req.query as Record<string, string>,
-    ).toString()
+    const qs = new URLSearchParams(scalarQuery(req.query)).toString()
     return getRetireUrl(`/cpf/balance-series?${qs}`)
   },
   methods: ["GET"],

--- a/src/pages/api/independence/cpf/balance-series.ts
+++ b/src/pages/api/independence/cpf/balance-series.ts
@@ -1,0 +1,12 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getRetireUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: (req) => {
+    const qs = new URLSearchParams(
+      req.query as Record<string, string>,
+    ).toString()
+    return getRetireUrl(`/cpf/balance-series?${qs}`)
+  },
+  methods: ["GET"],
+})

--- a/src/pages/api/independence/cpf/contribution-preview.ts
+++ b/src/pages/api/independence/cpf/contribution-preview.ts
@@ -1,0 +1,13 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getRetireUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: (req) => {
+    const monthlySalary = req.query.monthlySalary as string
+    const age = req.query.age as string
+    return getRetireUrl(
+      `/cpf/contribution-preview?monthlySalary=${encodeURIComponent(monthlySalary)}&age=${encodeURIComponent(age)}`,
+    )
+  },
+  methods: ["GET"],
+})

--- a/src/pages/api/independence/cpf/contribution-preview.ts
+++ b/src/pages/api/independence/cpf/contribution-preview.ts
@@ -1,10 +1,20 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getRetireUrl } from "@utils/api/bcConfig"
 
+// Next.js req.query values are string | string[] | undefined. Forwarding the
+// raw value to encodeURIComponent collapses arrays to "v1,v2" and undefined
+// to "undefined" — neither is what svc-retire wants. Pick the first element
+// of arrays, treat undefined as the empty string, so the upstream gets
+// canonical scalar query params.
+function asScalar(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value[0] ?? ""
+  return value ?? ""
+}
+
 export default createApiHandler({
   url: (req) => {
-    const monthlySalary = req.query.monthlySalary as string
-    const age = req.query.age as string
+    const monthlySalary = asScalar(req.query.monthlySalary)
+    const age = asScalar(req.query.age)
     return getRetireUrl(
       `/cpf/contribution-preview?monthlySalary=${encodeURIComponent(monthlySalary)}&age=${encodeURIComponent(age)}`,
     )

--- a/src/pages/api/independence/cpf/policy-balance-series.ts
+++ b/src/pages/api/independence/cpf/policy-balance-series.ts
@@ -1,11 +1,20 @@
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getRetireUrl } from "@utils/api/bcConfig"
 
+function scalarQuery(
+  query: Record<string, string | string[] | undefined>,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(query)) {
+    if (v == null) continue
+    out[k] = Array.isArray(v) ? (v[0] ?? "") : v
+  }
+  return out
+}
+
 export default createApiHandler({
   url: (req) => {
-    const qs = new URLSearchParams(
-      req.query as Record<string, string>,
-    ).toString()
+    const qs = new URLSearchParams(scalarQuery(req.query)).toString()
     return getRetireUrl(`/cpf/policy-balance-series?${qs}`)
   },
   methods: ["GET"],

--- a/src/pages/api/independence/cpf/policy-balance-series.ts
+++ b/src/pages/api/independence/cpf/policy-balance-series.ts
@@ -1,0 +1,12 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getRetireUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: (req) => {
+    const qs = new URLSearchParams(
+      req.query as Record<string, string>,
+    ).toString()
+    return getRetireUrl(`/cpf/policy-balance-series?${qs}`)
+  },
+  methods: ["GET"],
+})


### PR DESCRIPTION
## Summary
Two follow-on UX improvements to the per-asset contribution editor shipped in #701:

- **Salary-based CPF tooltip** next to each CPF row in the Work Scenario contribution editor: shows the salary-derived figure the projection WOULD have used (employer + employee combined at the age-N band), so the user understands what their override is replacing.
- **Per-asset projection modal**: every pension / CPF row gets a `Projection` link that opens a year-by-year balance table until the asset's payout age. CPF shows OA/SA/MA/RA per year; non-CPF shows a single balance + annual contribution per year. Amber caveat banner reminds the user the starting balance is the snapshot from when the asset was last edited — there's no in-app refresh path yet.
- Companion svc-retire PR: monowai/svc-retire#27 — adds `/cpf/contribution-preview`, `/cpf/balance-series`, `/cpf/policy-balance-series`, the scenario annual-contribution override path.
- Bonus: folds in the CodeRabbit nit from #700 (test using `@components/*` alias instead of relative import).

## Test plan
- [x] `yarn typecheck && yarn lint && yarn test` green
- [ ] Manual: open Edit Scenario; hover a CPF row — tooltip shows salary-based figure with employer/employee explanation
- [ ] Manual: click Projection on a CPF row — modal opens with year-by-year OA/SA/MA/RA + amber stale-balance caveat
- [ ] Manual: same for a non-CPF lump-sum policy — modal shows balance + contribution per year
- [ ] Manual: with no payout age set on the asset, Projection link is disabled with explanatory tooltip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pension projection modal displaying year-by-year balance and contribution forecasts for pension assets.
  * Added CPF contribution preview tooltips in the scenario editor based on salary information.
  * Added projection buttons for individual pension assets to view detailed projections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->