### PR TITLE
fix(independence): pension data sourced from user settings + surfaced per asset

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -175,40 +175,35 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
     fetchCountryTaxRates()
   }, [])
 
-  // Fetch user's independence plan for age data (used for POLICY projections)
+  // Fetch user's age + retirement horizon for POLICY projection. yearOfBirth
+  // and lifeExpectancy live in /api/independence/settings now (user-level),
+  // not on the plan — earlier this read plan.yearOfBirth which is always
+  // undefined post-migration, so the "Create an Independence Plan" message
+  // showed even when both a plan and a yearOfBirth were already set.
   useEffect(() => {
     async function fetchPlanData(): Promise<void> {
-      // Only fetch for POLICY assets
       const categoryId = asset.assetCategory?.id
       if (categoryId !== "POLICY") return
-
       try {
-        const response = await fetch("/api/independence/plans")
-        if (response.ok) {
-          const data = await response.json()
-          const plans = data.data || []
-          if (plans.length > 0) {
-            // Use the first plan's data
-            const plan = plans[0]
-            const currentYear = new Date().getFullYear()
-            const currentAge = plan.yearOfBirth
-              ? currentYear - plan.yearOfBirth
-              : null
-            const lifeExpectancy = plan.lifeExpectancy || 90
-            const retirementAge = plan.planningHorizonYears
-              ? lifeExpectancy - plan.planningHorizonYears
-              : 65
-
-            if (currentAge) {
-              setPlanData({ currentAge, retirementAge })
-              // Also set currentAge in config for projection calculation
-              setConfig((prev) => ({
-                ...prev,
-                currentAge: String(currentAge),
-              }))
-            }
-          }
-        }
+        const [settingsRes, plansRes] = await Promise.all([
+          fetch("/api/independence/settings"),
+          fetch("/api/independence/plans"),
+        ])
+        const settings = settingsRes.ok
+          ? (await settingsRes.json())?.data
+          : null
+        const firstPlan = plansRes.ok
+          ? ((await plansRes.json())?.data || [])[0]
+          : null
+        if (!settings?.yearOfBirth) return
+        const currentAge =
+          new Date().getFullYear() - Number(settings.yearOfBirth)
+        const lifeExpectancy = settings.lifeExpectancy || 90
+        const retirementAge = firstPlan?.planningHorizonYears
+          ? lifeExpectancy - firstPlan.planningHorizonYears
+          : 65
+        setPlanData({ currentAge, retirementAge })
+        setConfig((prev) => ({ ...prev, currentAge: String(currentAge) }))
       } catch (err) {
         console.error("Failed to fetch plan data:", err)
       }

--- a/src/components/features/independence/__tests__/IncomeSourcesStep.test.tsx
+++ b/src/components/features/independence/__tests__/IncomeSourcesStep.test.tsx
@@ -146,6 +146,7 @@ describe("IncomeSourcesStep", () => {
         configs: [
           {
             id: "pension-1",
+            assetId: "pension-1",
             isPension: true,
             isPrimaryResidence: false,
             monthlyRentalIncome: 0,
@@ -167,15 +168,15 @@ describe("IncomeSourcesStep", () => {
       // Pension input should not be rendered
       expect(screen.queryByLabelText(/pension/i)).not.toBeInTheDocument()
 
-      // Info box should be shown with header
+      // Info box should be shown with header. Body now lists each pension
+      // asset rather than a 'configured from N assets' summary string, so
+      // assert the new header copy + that the asset id surfaces in a row.
       expect(
-        screen.getByRole("heading", { name: /pension income/i }),
+        screen.getByRole("heading", {
+          name: /income from private retirement plans/i,
+        }),
       ).toBeInTheDocument()
-      expect(
-        screen.getByText(
-          /pension income is calculated from your 1 configured pension asset\./i,
-        ),
-      ).toBeInTheDocument()
+      expect(screen.getByText(/pension-1/)).toBeInTheDocument()
     })
 
     it("shows correct pluralization for multiple pension assets", () => {
@@ -183,6 +184,7 @@ describe("IncomeSourcesStep", () => {
         configs: [
           {
             id: "pension-1",
+            assetId: "pension-1",
             isPension: true,
             isPrimaryResidence: false,
             monthlyRentalIncome: 0,
@@ -191,6 +193,7 @@ describe("IncomeSourcesStep", () => {
           },
           {
             id: "pension-2",
+            assetId: "pension-2",
             isPension: true,
             isPrimaryResidence: false,
             monthlyRentalIncome: 0,
@@ -209,11 +212,9 @@ describe("IncomeSourcesStep", () => {
         </TestWrapper>,
       )
 
-      expect(
-        screen.getByText(
-          /pension income is calculated from your 2 configured pension assets\./i,
-        ),
-      ).toBeInTheDocument()
+      // List renders one row per pension asset; assert both ids show up.
+      expect(screen.getByText(/pension-1/)).toBeInTheDocument()
+      expect(screen.getByText(/pension-2/)).toBeInTheDocument()
     })
   })
 })

--- a/src/components/features/independence/steps/AssetsStep.tsx
+++ b/src/components/features/independence/steps/AssetsStep.tsx
@@ -13,6 +13,7 @@ import { wizardMessages } from "@lib/independence/messages"
 import CompositeAssetEditor from "@components/features/assets/CompositeAssetEditor"
 import { buildCashRow } from "@lib/trns/tradeUtils"
 import { postData } from "@components/ui/DropZone"
+import ExistingRetirementAccounts from "@components/features/independence/steps/ExistingRetirementAccounts"
 import Spinner from "@components/ui/Spinner"
 import { getAssetCurrency } from "@lib/assets/assetUtils"
 
@@ -1046,6 +1047,13 @@ export default function AssetsStep({
             </div>
           </div>
         )}
+
+        {/* Existing Retirement Accounts callout — surfaces pension assets the
+            user already has so the page doesn't look like only the portfolio
+            currency block exists when there are CPF / SingLife / SRS rows
+            already configured behind the scenes. Click-through is via
+            Accounts → Edit, intentionally kept light here. */}
+        <ExistingRetirementAccounts />
 
         {/* Add Retirement Account Button and Form */}
         <div className="border-t border-gray-200 pt-4 mt-4">

--- a/src/components/features/independence/steps/ExistingRetirementAccounts.tsx
+++ b/src/components/features/independence/steps/ExistingRetirementAccounts.tsx
@@ -1,0 +1,54 @@
+import React from "react"
+import { usePrivateAssetConfigs } from "@utils/assets/usePrivateAssetConfigs"
+
+/**
+ * Light read-only summary of the user's existing pension / policy assets,
+ * rendered on the Wealth (AssetsStep) page so it doesn't look like the
+ * portfolio currency block + 'Add Retirement Account' CTA are the whole
+ * picture when there are CPF / SingLife / SRS rows already configured.
+ *
+ * Anything actionable lives on the Accounts page Edit Asset dialog — this
+ * is just a 'these exist' callout with the same data IncomeSourcesStep
+ * uses to compute payouts later in the wizard.
+ */
+export default function ExistingRetirementAccounts(): React.ReactElement | null {
+  const { configs, assetNames } = usePrivateAssetConfigs()
+  const pensionAssets = (configs || []).filter((c) => c.isPension)
+  if (pensionAssets.length === 0) return null
+
+  return (
+    <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4 mt-4">
+      <div className="flex items-center mb-2">
+        <i className="fas fa-piggy-bank text-indigo-600 mr-2"></i>
+        <h3 className="text-sm font-semibold text-indigo-800">
+          Your retirement accounts ({pensionAssets.length})
+        </h3>
+      </div>
+      <ul className="space-y-1">
+        {pensionAssets.map((c) => (
+          <li
+            key={c.assetId}
+            className="flex justify-between text-sm text-indigo-700"
+          >
+            <span>
+              {assetNames?.[c.assetId] || c.assetId}
+              {c.policyType ? (
+                <span className="ml-2 text-xs text-indigo-500">
+                  {c.policyType}
+                </span>
+              ) : null}
+            </span>
+            <span className="text-xs text-indigo-500">
+              {c.payoutAge ? `payout age ${c.payoutAge}` : "no payout age"}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className="text-xs text-indigo-600 mt-2">
+        <i className="fas fa-info-circle mr-1"></i>
+        Edit each one on the Accounts page — projected income shows on the
+        Monthly Income step.
+      </p>
+    </div>
+  )
+}

--- a/src/components/features/independence/steps/IncomeSourcesStep.tsx
+++ b/src/components/features/independence/steps/IncomeSourcesStep.tsx
@@ -1,8 +1,33 @@
 import React from "react"
+import useSWR from "swr"
 import { Control, Controller, FieldErrors, useWatch } from "react-hook-form"
 import { WizardFormData } from "types/independence"
 import { StepHeader, CurrencyInputWithPeriod, SummaryBox } from "../form"
 import { usePrivateAssetConfigs } from "@utils/assets/usePrivateAssetConfigs"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+
+/**
+ * Future value of an ordinary annuity:
+ *   FV = startingBalance × (1+r)^n + PMT × ((1+r)^n − 1) / r
+ * matches PensionIncomeService.calculatePolicyFutureValue (interest before
+ * contribution per month), so the inline lump-sum estimate here agrees with
+ * the projection-detail modal and the projection itself.
+ */
+function projectLumpSum(
+  startingBalance: number,
+  monthlyContribution: number,
+  annualReturnRate: number,
+  yearsToMaturity: number,
+): number {
+  if (yearsToMaturity <= 0) return startingBalance
+  const r = annualReturnRate / 12
+  const n = yearsToMaturity * 12
+  const growth = Math.pow(1 + r, n)
+  const startFv = startingBalance * growth
+  const pmtFv =
+    r > 0 ? monthlyContribution * ((growth - 1) / r) : monthlyContribution * n
+  return startFv + pmtFv
+}
 
 interface IncomeSourcesStepProps {
   control: Control<WizardFormData>
@@ -22,6 +47,15 @@ export default function IncomeSourcesStep({
     useWatch({ control, name: "otherIncomeMonthly" }) || 0
 
   const { configs } = usePrivateAssetConfigs()
+  // yearOfBirth lives in user-level settings (not the plan) — fetch it so we
+  // can derive currentAge for the inline lump-sum projections. Endpoint is
+  // tiny + SWR-cached; falls back to no-projection text if unavailable.
+  const { data: settingsResp } = useSWR<{
+    data?: { yearOfBirth?: number; lifeExpectancy?: number }
+  }>("/api/independence/settings", simpleFetcher)
+  const currentAge = settingsResp?.data?.yearOfBirth
+    ? new Date().getFullYear() - Number(settingsResp.data.yearOfBirth)
+    : null
 
   // Filter pension assets (isPension = true), excluding composites
   const pensionAssets = React.useMemo(() => {
@@ -76,17 +110,59 @@ export default function IncomeSourcesStep({
             <div className="flex items-center mb-2">
               <i className="fas fa-piggy-bank text-blue-600 mr-2"></i>
               <h3 className="text-sm font-semibold text-blue-800">
-                Pension Income
+                Income from private Retirement plans
               </h3>
             </div>
-            <p className="text-sm text-blue-700">
-              Pension income is calculated from your {pensionAssets.length}{" "}
-              configured pension asset
-              {pensionAssets.length > 1 ? "s" : ""}.
-            </p>
+            <ul className="space-y-1 mt-2">
+              {pensionAssets.map((c) => {
+                const payoutAge = c.payoutAge
+                const yearsToMaturity =
+                  payoutAge && currentAge ? payoutAge - currentAge : null
+                const startingBalance =
+                  (c.subAccounts?.reduce(
+                    (sum, sa) => sum + (sa.balance || 0),
+                    0,
+                  ) || 0) > 0
+                    ? (c.subAccounts?.reduce(
+                        (sum, sa) => sum + (sa.balance || 0),
+                        0,
+                      ) ?? 0)
+                    : 0
+                const projectedLumpSum =
+                  c.lumpSum && yearsToMaturity && yearsToMaturity > 0
+                    ? projectLumpSum(
+                        startingBalance,
+                        c.monthlyContribution || 0,
+                        c.expectedReturnRate || 0,
+                        yearsToMaturity,
+                      )
+                    : null
+                return (
+                  <li
+                    key={c.assetId}
+                    className="flex justify-between text-sm text-blue-700"
+                  >
+                    <span>
+                      {c.assetId}
+                      {payoutAge ? ` — payout at age ${payoutAge}` : ""}
+                    </span>
+                    <span className="font-medium">
+                      {c.monthlyPayoutAmount && c.monthlyPayoutAmount > 0
+                        ? `$${Math.round(c.monthlyPayoutAmount).toLocaleString()}/mo annuity`
+                        : projectedLumpSum != null
+                          ? `~$${Math.round(projectedLumpSum).toLocaleString()} lump sum`
+                          : c.lumpSum
+                            ? "Lump sum (set age to project)"
+                            : "Configured"}
+                    </span>
+                  </li>
+                )
+              })}
+            </ul>
             <p className="text-xs text-blue-600 mt-2">
               <i className="fas fa-info-circle mr-1"></i>
-              Configure in Accounts with &apos;Is Pension&apos; enabled.
+              Read-only — figures come from your asset config + Profile age.
+              Edit in Accounts to change.
             </p>
           </div>
         )}

--- a/src/components/features/independence/steps/IncomeSourcesStep.tsx
+++ b/src/components/features/independence/steps/IncomeSourcesStep.tsx
@@ -52,7 +52,10 @@ export default function IncomeSourcesStep({
   // tiny + SWR-cached; falls back to no-projection text if unavailable.
   const { data: settingsResp } = useSWR<{
     data?: { yearOfBirth?: number; lifeExpectancy?: number }
-  }>("/api/independence/settings", simpleFetcher)
+  }>(
+    "/api/independence/settings",
+    simpleFetcher("/api/independence/settings"),
+  )
   const currentAge = settingsResp?.data?.yearOfBirth
     ? new Date().getFullYear() - Number(settingsResp.data.yearOfBirth)
     : null
@@ -128,11 +131,19 @@ export default function IncomeSourcesStep({
                         0,
                       ) ?? 0)
                     : 0
+                // contributionFrequency=ANNUAL stores the raw annual figure
+                // in monthlyContribution (legacy column name). Divide by 12
+                // here so the inline FV matches the projection backend,
+                // which annualises the same way.
+                const monthlyForProjection =
+                  c.contributionFrequency === "ANNUAL"
+                    ? (c.monthlyContribution || 0) / 12
+                    : c.monthlyContribution || 0
                 const projectedLumpSum =
                   c.lumpSum && yearsToMaturity && yearsToMaturity > 0
                     ? projectLumpSum(
                         startingBalance,
-                        c.monthlyContribution || 0,
+                        monthlyForProjection,
                         c.expectedReturnRate || 0,
                         yearsToMaturity,
                       )


### PR DESCRIPTION
## Summary
Three connected gaps that left pension assets invisible inside the Independence wizard. All three traced back to wizard code still reading \`plan.yearOfBirth\` after the field migrated to user-level \`/api/independence/settings\`.

- **EditAccountDialog**: \"Create an Independence Plan...\" appeared even when both a plan and a yearOfBirth were configured. Root cause: \`fetchPlanData\` read \`plan.yearOfBirth\` (always undefined post-migration). Now reads from settings; plan only used for \`planningHorizonYears\`.
- **IncomeSourcesStep** (Monthly Income): non-composite pensions collapsed into \"calculated from N assets\" — no actual figure. Now enumerates each row with monthlyPayoutAmount (annuity) or an inline ordinary-annuity FV (lump sum). Read-only.
- **AssetsStep** (Wealth): only listed portfolios + an Add Retirement Account CTA. New \`<ExistingRetirementAccounts />\` callout above the CTA enumerates existing pension assets so it doesn't look like nothing's there when CPF / SingLife / SRS rows are already configured.

## Test plan
- [x] Existing tests updated (mocks added \`assetId\` to match real shape)
- [x] \`yarn typecheck && yarn lint && yarn test\` green
- [ ] Manual as Ruby: open Edit Asset on a POLICY → dialog no longer shows \"Create an Independence Plan\" (yearOfBirth set on Profile)
- [ ] Manual: Independence wizard → Wealth step shows the existing pension assets callout
- [ ] Manual: Monthly Income step lists each pension row with annuity or lump-sum projection

## Related
- depends on the deferred follow-up: in-app \"refresh balance\" for stale pension snapshots (separate ticket)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a callout section displaying existing retirement accounts with payout age and policy type details
  * Enhanced pension income view to show configured account details, monthly payouts, and projected lump-sum values based on current age

* **Improvements**
  * Improved retirement-age calculations by retrieving age data from profile settings for more accurate projections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->