### PR TITLE
fix(independence): unwrap profile settings + read Asset profile from svc-data + CPF Life Plan nudge

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -7,6 +7,8 @@ import CompositeAssetEditor from "@components/features/assets/CompositeAssetEdit
 import { CategoryOption, SectorOption } from "./accountTypes"
 import Alert from "@components/ui/Alert"
 import Spinner from "@components/ui/Spinner"
+import { useUserPreferences } from "@contexts/UserPreferencesContext"
+import { currentAgeFromSettings } from "@lib/independence/age"
 
 // Private Asset Config state interface
 interface AssetConfigState {
@@ -175,41 +177,41 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
     fetchCountryTaxRates()
   }, [])
 
-  // Fetch user's age + retirement horizon for POLICY projection. yearOfBirth
-  // and lifeExpectancy live in /api/independence/settings now (user-level),
-  // not on the plan — earlier this read plan.yearOfBirth which is always
-  // undefined post-migration, so the "Create an Independence Plan" message
-  // showed even when both a plan and a yearOfBirth were already set.
+  // Resolve POLICY projection inputs from the user's profile demographics
+  // mirrored onto svc-data's UserPreferences — keeps the Asset screen
+  // self-contained inside svc-data (no runtime svc-retire dependency for
+  // computing age). svc-retire still owns writes via the Profile modal;
+  // a successful settings PATCH there mirrors here.
+  const { preferences } = useUserPreferences()
   useEffect(() => {
-    async function fetchPlanData(): Promise<void> {
-      const categoryId = asset.assetCategory?.id
-      if (categoryId !== "POLICY") return
+    const categoryId = asset.assetCategory?.id
+    if (categoryId !== "POLICY") return undefined
+    const age = currentAgeFromSettings(preferences)
+    if (age === undefined) return undefined
+    let cancelled = false
+    async function deriveRetirementAge(): Promise<number> {
       try {
-        const [settingsRes, plansRes] = await Promise.all([
-          fetch("/api/independence/settings"),
-          fetch("/api/independence/plans"),
-        ])
-        const settings = settingsRes.ok
-          ? (await settingsRes.json())?.data
-          : null
-        const firstPlan = plansRes.ok
-          ? ((await plansRes.json())?.data || [])[0]
-          : null
-        if (!settings?.yearOfBirth) return
-        const currentAge =
-          new Date().getFullYear() - Number(settings.yearOfBirth)
-        const lifeExpectancy = settings.lifeExpectancy || 90
-        const retirementAge = firstPlan?.planningHorizonYears
+        const res = await fetch("/api/independence/plans")
+        if (!res.ok) return 65
+        const body = await res.json()
+        const firstPlan = (body?.data || [])[0]
+        const lifeExpectancy = preferences?.lifeExpectancy || 90
+        return firstPlan?.planningHorizonYears
           ? lifeExpectancy - firstPlan.planningHorizonYears
           : 65
-        setPlanData({ currentAge, retirementAge })
-        setConfig((prev) => ({ ...prev, currentAge: String(currentAge) }))
-      } catch (err) {
-        console.error("Failed to fetch plan data:", err)
+      } catch {
+        return 65
       }
     }
-    fetchPlanData()
-  }, [asset.assetCategory?.id])
+    deriveRetirementAge().then((retirementAge) => {
+      if (cancelled) return
+      setPlanData({ currentAge: age, retirementAge })
+      setConfig((prev) => ({ ...prev, currentAge: String(age) }))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [asset.assetCategory?.id, preferences])
 
   // Fetch current sector classification on mount
   useEffect(() => {

--- a/src/components/features/assets/CompositeAssetEditor.tsx
+++ b/src/components/features/assets/CompositeAssetEditor.tsx
@@ -224,13 +224,27 @@ export default function CompositeAssetEditor({
                       </option>
                     ))}
                   </select>
-                  {cpfLifePlan && (
+                  {cpfLifePlan ? (
                     <p className="text-xs text-blue-600 mt-1">
                       {
                         CPF_LIFE_PLAN_OPTIONS.find(
                           (o) => o.value === cpfLifePlan,
                         )?.description
                       }
+                    </p>
+                  ) : (
+                    // Surface the silent enrichment skip: svc-retire's
+                    // enrichCpfConfigs only computes monthlyPayoutAmount
+                    // when cpfLifePlan is set, so an unset plan reports
+                    // zero pension income in projections without any
+                    // visible cue. Amber inline; not a save block.
+                    <p
+                      role="alert"
+                      className="text-xs text-amber-700 mt-1 bg-amber-50 border border-amber-200 rounded px-2 py-1"
+                    >
+                      <i className="fas fa-triangle-exclamation mr-1"></i>
+                      CPF LIFE Plan required for projected payout — pick
+                      one or pension income stays zero.
                     </p>
                   )}
                 </div>

--- a/src/components/features/independence/scenarios/ScenarioEditor.tsx
+++ b/src/components/features/independence/scenarios/ScenarioEditor.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useCallback } from "react"
 import { WorkScenario, WorkScenarioRequest } from "types/independence"
 import Dialog from "@components/ui/Dialog"
 import ScenarioContributions from "@components/features/independence/scenarios/ScenarioContributions"
+import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
+import { currentAgeFromSettings } from "@lib/independence/age"
 
 interface ScenarioEditorProps {
   scenario?: WorkScenario | null
@@ -37,26 +39,11 @@ export default function ScenarioEditor({
   const [form, setForm] = useState<WorkScenarioRequest>(DEFAULT_FORM)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  // Used by ScenarioContributions to compute the salary-derived CPF
-  // contribution tooltip; the projection picks an age band based on it.
-  const [currentAge, setCurrentAge] = useState<number | undefined>(undefined)
-
-  useEffect(() => {
-    if (!isEditing) return undefined
-    let cancelled = false
-    fetch("/api/independence/plans")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((body) => {
-        if (cancelled) return
-        const plan = body?.data?.[0]
-        if (!plan?.yearOfBirth) return
-        setCurrentAge(new Date().getFullYear() - plan.yearOfBirth)
-      })
-      .catch(() => {})
-    return () => {
-      cancelled = true
-    }
-  }, [isEditing])
+  // yearOfBirth lives in user-level Independence settings (svc-retire) now,
+  // not on the plan — the prior fetch of /api/independence/plans[0].yearOfBirth
+  // was always undefined post-migration and the salary tooltip never fired.
+  const { settings: independenceSettings } = useIndependenceSettings()
+  const currentAge = currentAgeFromSettings(independenceSettings)
 
   useEffect(() => {
     if (scenario) {

--- a/src/components/features/independence/steps/IncomeSourcesStep.tsx
+++ b/src/components/features/independence/steps/IncomeSourcesStep.tsx
@@ -1,10 +1,10 @@
 import React from "react"
-import useSWR from "swr"
 import { Control, Controller, FieldErrors, useWatch } from "react-hook-form"
 import { WizardFormData } from "types/independence"
 import { StepHeader, CurrencyInputWithPeriod, SummaryBox } from "../form"
 import { usePrivateAssetConfigs } from "@utils/assets/usePrivateAssetConfigs"
-import { simpleFetcher } from "@utils/api/fetchHelper"
+import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
+import { currentAgeFromSettings } from "@lib/independence/age"
 
 /**
  * Future value of an ordinary annuity:
@@ -47,18 +47,12 @@ export default function IncomeSourcesStep({
     useWatch({ control, name: "otherIncomeMonthly" }) || 0
 
   const { configs } = usePrivateAssetConfigs()
-  // yearOfBirth lives in user-level settings (not the plan) — fetch it so we
-  // can derive currentAge for the inline lump-sum projections. Endpoint is
-  // tiny + SWR-cached; falls back to no-projection text if unavailable.
-  const { data: settingsResp } = useSWR<{
-    data?: { yearOfBirth?: number; lifeExpectancy?: number }
-  }>(
-    "/api/independence/settings",
-    simpleFetcher("/api/independence/settings"),
-  )
-  const currentAge = settingsResp?.data?.yearOfBirth
-    ? new Date().getFullYear() - Number(settingsResp.data.yearOfBirth)
-    : null
+  // yearOfBirth lives in user-level UserIndependenceSettings (svc-retire),
+  // not the plan. useIndependenceSettings returns the unwrapped entity —
+  // an earlier inline SWR fetch tried to unwrap a `.data` envelope that
+  // doesn't exist and silently kept currentAge null.
+  const { settings: independenceSettings } = useIndependenceSettings()
+  const currentAge = currentAgeFromSettings(independenceSettings) ?? null
 
   // Filter pension assets (isPension = true), excluding composites
   const pensionAssets = React.useMemo(() => {

--- a/src/lib/utils/independence/age.ts
+++ b/src/lib/utils/independence/age.ts
@@ -1,0 +1,32 @@
+/**
+ * Compute the user's current age in whole years from any object carrying
+ * the standard demographic shape (yearOfBirth + optional monthOfBirth).
+ * Returns undefined when yearOfBirth is missing so callers can branch on
+ * "no profile yet" vs "have a profile".
+ *
+ * Accepts both `UserIndependenceSettings` (svc-retire) and `UserPreferences`
+ * (svc-data) since profile demographics now live on both — UserPreferences
+ * is the denormalised read copy that screens scoped to svc-data (Edit Asset,
+ * holdings) can read without a runtime call to svc-retire. Same year-
+ * rollover rule applies regardless of source: subtract one if we haven't
+ * passed the birth month yet.
+ */
+export interface ProfileDemographics {
+  yearOfBirth?: number
+  monthOfBirth?: number
+}
+
+export function currentAgeFromSettings(
+  settings: ProfileDemographics | undefined | null,
+): number | undefined {
+  const yob = settings?.yearOfBirth
+  if (!yob) return undefined
+  const now = new Date()
+  let age = now.getFullYear() - Number(yob)
+  const monthOfBirth = settings?.monthOfBirth
+  // Months stored 1-based; getMonth() is 0-based.
+  if (monthOfBirth && now.getMonth() + 1 < Number(monthOfBirth)) {
+    age -= 1
+  }
+  return age
+}

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -462,6 +462,12 @@ export interface UserPreferences {
   hideValues?: boolean // Privacy mode - hide monetary values and quantities
   defaultMarket?: string // Default market for asset search (e.g., "US", "NZX")
   milestoneMode?: "ACTIVE" | "SILENT" | "OFF" // Milestone notification mode
+  // Profile demographics mirrored from svc-retire's UserIndependenceSettings
+  // so screens scoped to svc-data (Edit Asset, holdings) can resolve current
+  // age without a runtime call to svc-retire.
+  yearOfBirth?: number
+  monthOfBirth?: number
+  lifeExpectancy?: number
 }
 
 export interface UserPreferencesRequest {
@@ -476,6 +482,9 @@ export interface UserPreferencesRequest {
   hideValues?: boolean
   defaultMarket?: string
   milestoneMode?: "ACTIVE" | "SILENT" | "OFF"
+  yearOfBirth?: number
+  monthOfBirth?: number
+  lifeExpectancy?: number
 }
 
 export interface RegistrationResponse {


### PR DESCRIPTION
## Summary
Bundle of three fixes that together unblock projection rendering on the Asset screen + Income tab for users who set their Profile correctly.

| Symptom on kauri | Root cause | Fix |
|---|---|---|
| Edit Asset / Income & Planning shows "Create an Independence Plan" with one configured | \`(await res.json())?.data\` unwrap on /api/independence/settings that doesn't return a \`.data\` envelope | Read profile from \`useUserPreferences()\` (svc-data) — Asset screen no longer depends on svc-retire at runtime |
| Income step's lump-sum projection silently shows nothing | Same .data unwrap on a sibling inline SWR call | Switch to the shared \`useIndependenceSettings()\` hook |
| ScenarioEditor's CPF salary tooltip never fires | Reads \`plan.yearOfBirth\` (gone post-migration) | Same hook |
| Pension projection = 0 with no UI cue when CPF asset has no LIFE Plan | \`enrichCpfConfigs\` silently skips enrichment | Amber inline warning on the CPF Life Plan dropdown in CompositeAssetEditor; not a save block |

New \`currentAgeFromSettings\` util in \`@lib/independence/age\` applies one year-rollover rule (subtract one if we haven't passed the birth month yet) — accepts either UserIndependenceSettings (svc-retire) or UserPreferences (svc-data) so the three callers agree.

## Companion PRs
- monowai/beancounter#890 — jar-common UserPreferences fields + svc-data Flyway migration so \`useUserPreferences()\` actually has yearOfBirth populated.
- monowai/svc-retire#28 — mirrors writes to svc-data /me on settings PATCH so the read copy stays in sync.

This PR is safe to merge before the backend PRs deploy: \`useUserPreferences()\` simply returns undefined yearOfBirth until the columns + mirror exist, which keeps current behaviour (no projection panel). Once #890 + #28 deploy, projections populate as soon as Ruby re-saves Profile.

## Test plan
- [x] \`yarn typecheck && yarn lint && yarn test\` green (1324 tests)
- [ ] Manual after all three PRs deploy: Ruby's Edit Asset → Income & Planning shows the projection panel, no "Create…" message
- [ ] Manual: an unset CPF asset shows the amber warning under the dropdown; picking STANDARD + save makes it disappear and projection populates
- [ ] Manual: Independence Plan → Income tab Total Monthly Income > 0; Pension series in chart > 0