### PR TITLE
feat(asset): Projections tab on Edit Asset (POLICY)

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -9,6 +9,7 @@ import Alert from "@components/ui/Alert"
 import Spinner from "@components/ui/Spinner"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import { currentAgeFromSettings } from "@lib/independence/age"
+import PensionProjectionPanel from "@components/features/independence/scenarios/PensionProjectionPanel"
 
 // Private Asset Config state interface
 interface AssetConfigState {
@@ -85,7 +86,7 @@ const COUNTRY_OPTIONS = [
   { code: "US", name: "United States" },
 ]
 
-type EditTab = "details" | "income"
+type EditTab = "details" | "income" | "projections"
 
 interface EditAccountDialogProps {
   asset: Asset
@@ -152,6 +153,10 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
 
   // Show income/planning tab for RE and POLICY categories
   const showIncomeTab = category === "RE" || category === "POLICY"
+  // Projections tab — only for POLICY assets. CPF gets the year-by-year
+  // OA/SA/MA/RA table; non-CPF lump-sum policies get the balance-vs-age
+  // table. RE has its own projection elsewhere.
+  const showProjectionsTab = category === "POLICY"
 
   // Fetch country tax rates on mount
   useEffect(() => {
@@ -553,6 +558,18 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
               >
                 {"Income & Planning"}
               </button>
+              {showProjectionsTab && (
+                <button
+                  onClick={() => setActiveTab("projections")}
+                  className={`py-2 px-1 border-b-2 text-sm font-medium ${
+                    activeTab === "projections"
+                      ? "border-indigo-500 text-indigo-600"
+                      : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                  }`}
+                >
+                  {"Projections"}
+                </button>
+              )}
             </nav>
           </div>
         )}
@@ -1301,6 +1318,37 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                   </p>
                 </div>
               </>
+            )}
+          </div>
+        )}
+
+        {/* Projections Tab (POLICY only) */}
+        {activeTab === "projections" && showProjectionsTab && (
+          <div className="space-y-3">
+            {planData?.currentAge && config.payoutAge ? (
+              <PensionProjectionPanel
+                policyType={config.policyType}
+                cpfLifePlan={config.cpfLifePlan}
+                payoutAge={parseInt(config.payoutAge) || undefined}
+                expectedReturnRate={
+                  parseFloat(config.expectedReturnRate) / 100 || undefined
+                }
+                monthlyContribution={
+                  parseFloat(config.monthlyContribution) || undefined
+                }
+                subAccounts={config.subAccounts.map((s) => ({
+                  code: s.code,
+                  balance: s.balance,
+                }))}
+                currency={currency}
+                currentAge={planData.currentAge}
+              />
+            ) : (
+              <p className="text-sm text-gray-500">
+                {
+                  "Set Payout Age + ensure your Profile yearOfBirth is set to view projections."
+                }
+              </p>
             )}
           </div>
         )}

--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -1333,9 +1333,17 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                 expectedReturnRate={
                   parseFloat(config.expectedReturnRate) / 100 || undefined
                 }
-                monthlyContribution={
-                  parseFloat(config.monthlyContribution) || undefined
-                }
+                monthlyContribution={(() => {
+                  // ANNUAL-frequency assets store the per-year figure; the
+                  // projection endpoint takes monthly, so divide by 12.
+                  // Matches the same conversion in the lump-sum projection
+                  // fetch in this dialog.
+                  const raw = parseFloat(config.monthlyContribution) || 0
+                  if (!raw) return undefined
+                  return config.contributionFrequency === "ANNUAL"
+                    ? raw / 12
+                    : raw
+                })()}
                 subAccounts={config.subAccounts.map((s) => ({
                   code: s.code,
                   balance: s.balance,

--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -850,95 +850,8 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                       </div>
                     </div>
 
-                    {/* Projection for lump sum */}
-                    {config.lumpSum && config.payoutAge && (
-                      <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-sm space-y-3">
-                        <div className="flex items-center justify-between">
-                          <label className="text-green-700 font-medium">
-                            <i className="fas fa-calculator mr-2"></i>
-                            {"Projected Payout at Independence"}
-                          </label>
-                          {planData && (
-                            <span className="text-green-600 text-xs">
-                              Based on your plan (age {planData.currentAge})
-                            </span>
-                          )}
-                        </div>
-                        {!planData ? (
-                          <p className="text-green-600 text-xs">
-                            <i className="fas fa-info-circle mr-1"></i>
-                            {
-                              "Create an Independence Plan to see projected payout based on your age."
-                            }
-                          </p>
-                        ) : projectionLoading ? (
-                          <div className="flex items-center justify-center py-2">
-                            <Spinner className="mr-2 text-green-600" />
-                            <span className="text-green-600 text-sm">
-                              {"Loading..."}
-                            </span>
-                          </div>
-                        ) : lumpSumProjection ? (
-                          <div className="space-y-2">
-                            <div className="flex justify-between items-center">
-                              <span className="text-green-700">
-                                {`At age ${config.payoutAge}:`}
-                              </span>
-                              <span className="text-green-800 font-bold text-lg">
-                                $
-                                {lumpSumProjection.projectedPayout.toLocaleString(
-                                  undefined,
-                                  {
-                                    minimumFractionDigits: 0,
-                                    maximumFractionDigits: 0,
-                                  },
-                                )}
-                              </span>
-                            </div>
-                            <div className="text-xs text-green-600 space-y-1">
-                              <div className="flex justify-between">
-                                <span>{"Years to maturity:"}</span>
-                                <span>{lumpSumProjection.yearsToMaturity}</span>
-                              </div>
-                              <div className="flex justify-between">
-                                <span>{"Total contributions:"}</span>
-                                <span>
-                                  $
-                                  {lumpSumProjection.totalContributions.toLocaleString(
-                                    undefined,
-                                    {
-                                      minimumFractionDigits: 0,
-                                      maximumFractionDigits: 0,
-                                    },
-                                  )}
-                                </span>
-                              </div>
-                              {lumpSumProjection.interestEarned > 0 && (
-                                <div className="flex justify-between">
-                                  <span>{"Interest earned:"}</span>
-                                  <span>
-                                    $
-                                    {lumpSumProjection.interestEarned.toLocaleString(
-                                      undefined,
-                                      {
-                                        minimumFractionDigits: 0,
-                                        maximumFractionDigits: 0,
-                                      },
-                                    )}
-                                  </span>
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        ) : (
-                          <p className="text-green-600 text-xs">
-                            {parseFloat(config.monthlyContribution || "0") <= 0
-                              ? `Enter ${config.contributionFrequency === "ANNUAL" ? "annual" : "monthly"} contribution to see projected payout.`
-                              : "Calculating projection..."}
-                          </p>
-                        )}
-                      </div>
-                    )}
+                    {/* Lump-sum summary moved to Projections tab — see
+                        showProjectionsTab block below. */}
                   </>
                 )}
 
@@ -1324,7 +1237,96 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
 
         {/* Projections Tab (POLICY only) */}
         {activeTab === "projections" && showProjectionsTab && (
-          <div className="space-y-3">
+          <div className="space-y-4">
+            {/* Lump-sum summary card — shown when the policy pays out as a
+                lump (vs. monthly annuity like CPF Life). Mirrors backend
+                /api/projection/lump-sum already fetched above. */}
+            {config.lumpSum && config.payoutAge && (
+              <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-sm space-y-3">
+                <div className="flex items-center justify-between">
+                  <label className="text-green-700 font-medium">
+                    <i className="fas fa-calculator mr-2"></i>
+                    {"Projected Payout at Independence"}
+                  </label>
+                  {planData && (
+                    <span className="text-green-600 text-xs">
+                      Based on your profile (age {planData.currentAge})
+                    </span>
+                  )}
+                </div>
+                {!planData ? (
+                  <p className="text-green-600 text-xs">
+                    <i className="fas fa-info-circle mr-1"></i>
+                    {"Set yearOfBirth in your Profile to see projected payout."}
+                  </p>
+                ) : projectionLoading ? (
+                  <div className="flex items-center justify-center py-2">
+                    <Spinner className="mr-2 text-green-600" />
+                    <span className="text-green-600 text-sm">
+                      {"Loading..."}
+                    </span>
+                  </div>
+                ) : lumpSumProjection ? (
+                  <div className="space-y-2">
+                    <div className="flex justify-between items-center">
+                      <span className="text-green-700">
+                        {`At age ${config.payoutAge}:`}
+                      </span>
+                      <span className="text-green-800 font-bold text-lg">
+                        $
+                        {lumpSumProjection.projectedPayout.toLocaleString(
+                          undefined,
+                          {
+                            minimumFractionDigits: 0,
+                            maximumFractionDigits: 0,
+                          },
+                        )}
+                      </span>
+                    </div>
+                    <div className="text-xs text-green-600 space-y-1">
+                      <div className="flex justify-between">
+                        <span>{"Years to maturity:"}</span>
+                        <span>{lumpSumProjection.yearsToMaturity}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>{"Total contributions:"}</span>
+                        <span>
+                          $
+                          {lumpSumProjection.totalContributions.toLocaleString(
+                            undefined,
+                            {
+                              minimumFractionDigits: 0,
+                              maximumFractionDigits: 0,
+                            },
+                          )}
+                        </span>
+                      </div>
+                      {lumpSumProjection.interestEarned > 0 && (
+                        <div className="flex justify-between">
+                          <span>{"Interest earned:"}</span>
+                          <span>
+                            $
+                            {lumpSumProjection.interestEarned.toLocaleString(
+                              undefined,
+                              {
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 0,
+                              },
+                            )}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-green-600 text-xs">
+                    {parseFloat(config.monthlyContribution || "0") <= 0
+                      ? `Enter ${config.contributionFrequency === "ANNUAL" ? "annual" : "monthly"} contribution to see projected payout.`
+                      : "Calculating projection..."}
+                  </p>
+                )}
+              </div>
+            )}
             {planData?.currentAge && config.payoutAge ? (
               <PensionProjectionPanel
                 policyType={config.policyType}

--- a/src/components/features/assets/CompositeAssetEditor.tsx
+++ b/src/components/features/assets/CompositeAssetEditor.tsx
@@ -243,8 +243,8 @@ export default function CompositeAssetEditor({
                       className="text-xs text-amber-700 mt-1 bg-amber-50 border border-amber-200 rounded px-2 py-1"
                     >
                       <i className="fas fa-triangle-exclamation mr-1"></i>
-                      CPF LIFE Plan required for projected payout — pick
-                      one or pension income stays zero.
+                      CPF LIFE Plan required for projected payout — pick one or
+                      pension income stays zero.
                     </p>
                   )}
                 </div>

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -135,7 +135,9 @@ const PositionFooter: React.FC<PositionFooterProps> = ({
   ) : (
     priceText
   )
-  const quantityText = <PrivateQuantity value={quantity} precision={precision} />
+  const quantityText = (
+    <PrivateQuantity value={quantity} precision={precision} />
+  )
   const quantityValue = onQuantityClick ? (
     <button
       type="button"

--- a/src/components/features/holdings/__tests__/PortfolioBreakdownPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PortfolioBreakdownPopup.test.tsx
@@ -3,10 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import PortfolioBreakdownPopup from "../PortfolioBreakdownPopup"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
-import {
-  makeAsset,
-  makePortfolioBreakdown,
-} from "@test-fixtures/beancounter"
+import { makeAsset, makePortfolioBreakdown } from "@test-fixtures/beancounter"
 
 jest.mock("@hooks/usePrivacyMode")
 const mockedUsePrivacyMode = usePrivacyMode as jest.MockedFunction<
@@ -84,9 +81,7 @@ describe("PortfolioBreakdownPopup", () => {
         onClose={onClose}
       />,
     )
-    fireEvent.click(
-      screen.getByRole("button", { name: /Open MAIN holdings/i }),
-    )
+    fireEvent.click(screen.getByRole("button", { name: /Open MAIN holdings/i }))
     expect(onClose).toHaveBeenCalled()
     expect(push).toHaveBeenCalledWith("/holdings/MAIN")
   })

--- a/src/components/features/independence/scenarios/PensionProjectionModal.tsx
+++ b/src/components/features/independence/scenarios/PensionProjectionModal.tsx
@@ -1,31 +1,12 @@
 import React from "react"
-import useSWR from "swr"
-import { simpleFetcher } from "@utils/api/fetchHelper"
 import Dialog from "@components/ui/Dialog"
+import PensionProjectionPanel from "@components/features/independence/scenarios/PensionProjectionPanel"
 
 /**
  * Per-asset balance-projection modal opened from a ScenarioContributions
- * row. Shows a year-by-year table of how the asset's balance is expected
- * to evolve until payout age, plus a banner reminding the user that the
- * starting balance is the figure they entered when the asset was created
- * — there's currently no in-app way to refresh it, so the projection
- * starts from whatever was true at that point in time.
+ * row. Thin Dialog wrapper around PensionProjectionPanel — the panel
+ * is also reused inline as a tab in EditAccountDialog.
  */
-
-interface CpfYearlyBalance {
-  age: number
-  oa: number
-  sa: number
-  ma: number
-  ra: number
-  annualContribution: number
-}
-
-interface PolicyYearlyBalance {
-  age: number
-  balance: number
-  annualContribution: number
-}
 
 export interface PensionProjectionAsset {
   assetId: string
@@ -59,62 +40,6 @@ export default function PensionProjectionModal({
   scenarioAnnualOverride,
   onClose,
 }: Props): React.ReactElement {
-  const isCpf = asset.policyType === "CPF"
-  const payoutAge = asset.payoutAge ?? 65
-
-  const subBalanceFor = (code: string): number =>
-    asset.subAccounts?.find((s) => s.code === code)?.balance ?? 0
-
-  const cpfKey = isCpf
-    ? `/api/independence/cpf/balance-series?currentAge=${currentAge}` +
-      `&payoutAge=${payoutAge}` +
-      `&oa=${subBalanceFor("OA")}&sa=${subBalanceFor("SA")}` +
-      `&ma=${subBalanceFor("MA")}&ra=${subBalanceFor("RA")}` +
-      (scenarioMonthlySalary
-        ? `&monthlySalary=${scenarioMonthlySalary}`
-        : "") +
-      (scenarioAnnualOverride
-        ? `&annualContributionOverride=${scenarioAnnualOverride}`
-        : "") +
-      (asset.cpfLifePlan ? `&cpfLifePlan=${asset.cpfLifePlan}` : "")
-    : null
-
-  // Scenario override wins for the non-CPF projection too: the user-entered
-  // amount in this scenario edit should drive the table, not the stale asset
-  // default. Convert the annual override back to a monthly figure (the
-  // endpoint takes monthlyContribution); fall through to asset default when
-  // the user has cleared the row.
-  const policyMonthly =
-    scenarioAnnualOverride && scenarioAnnualOverride > 0
-      ? scenarioAnnualOverride / 12
-      : (asset.monthlyContribution ?? 0)
-  const policyKey = !isCpf
-    ? `/api/independence/cpf/policy-balance-series?currentAge=${currentAge}` +
-      `&payoutAge=${payoutAge}` +
-      `&startingBalance=${subBalanceFor("BALANCE") || 0}` +
-      `&monthlyContribution=${policyMonthly}` +
-      `&expectedReturnRate=${asset.expectedReturnRate ?? 0}`
-    : null
-
-  const { data: cpfData } = useSWR<{ data: CpfYearlyBalance[] } | CpfYearlyBalance[]>(
-    cpfKey,
-    simpleFetcher,
-  )
-  const { data: policyData } = useSWR<
-    { data: PolicyYearlyBalance[] } | PolicyYearlyBalance[]
-  >(policyKey, simpleFetcher)
-
-  // Endpoints return arrays directly, but SWR-via-proxy may wrap in { data }.
-  const cpfSeries: CpfYearlyBalance[] = Array.isArray(cpfData)
-    ? cpfData
-    : (cpfData?.data ?? [])
-  const policySeries: PolicyYearlyBalance[] = Array.isArray(policyData)
-    ? policyData
-    : (policyData?.data ?? [])
-
-  const fmt = (n: number): string =>
-    `${currency} ${Math.round(n).toLocaleString()}`
-
   return (
     <Dialog
       title={`Projection · ${asset.assetName}`}
@@ -123,66 +48,19 @@ export default function PensionProjectionModal({
       scrollable
       footer={<Dialog.CancelButton onClick={onClose} label="Close" />}
     >
-      <div
-        role="alert"
-        className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded p-2 mb-3"
-      >
-        Starting balance is the figure you entered when the asset was last
-        edited
-        {asset.updatedDate ? ` (${asset.updatedDate})` : ""}. There&rsquo;s
-        currently no in-app way to refresh it, so the projection grows from
-        that snapshot — actual balances may already be higher.
-      </div>
-
-      {isCpf ? (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-left text-gray-500 border-b">
-              <th className="py-1">Age</th>
-              <th className="py-1 text-right">OA</th>
-              <th className="py-1 text-right">SA</th>
-              <th className="py-1 text-right">MA</th>
-              <th className="py-1 text-right">RA</th>
-              <th className="py-1 text-right">Contribution</th>
-            </tr>
-          </thead>
-          <tbody>
-            {cpfSeries.map((row) => (
-              <tr key={row.age} className="border-b last:border-b-0">
-                <td className="py-1">{row.age}</td>
-                <td className="py-1 text-right">{fmt(row.oa)}</td>
-                <td className="py-1 text-right">{fmt(row.sa)}</td>
-                <td className="py-1 text-right">{fmt(row.ma)}</td>
-                <td className="py-1 text-right">{fmt(row.ra)}</td>
-                <td className="py-1 text-right text-gray-500">
-                  {row.annualContribution > 0 ? fmt(row.annualContribution) : "—"}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-left text-gray-500 border-b">
-              <th className="py-1">Age</th>
-              <th className="py-1 text-right">Balance</th>
-              <th className="py-1 text-right">Contribution</th>
-            </tr>
-          </thead>
-          <tbody>
-            {policySeries.map((row) => (
-              <tr key={row.age} className="border-b last:border-b-0">
-                <td className="py-1">{row.age}</td>
-                <td className="py-1 text-right">{fmt(row.balance)}</td>
-                <td className="py-1 text-right text-gray-500">
-                  {row.annualContribution > 0 ? fmt(row.annualContribution) : "—"}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <PensionProjectionPanel
+        policyType={asset.policyType}
+        cpfLifePlan={asset.cpfLifePlan}
+        payoutAge={asset.payoutAge}
+        expectedReturnRate={asset.expectedReturnRate}
+        monthlyContribution={asset.monthlyContribution}
+        updatedDate={asset.updatedDate}
+        subAccounts={asset.subAccounts}
+        currency={currency}
+        currentAge={currentAge}
+        scenarioMonthlySalary={scenarioMonthlySalary}
+        scenarioAnnualOverride={scenarioAnnualOverride}
+      />
     </Dialog>
   )
 }

--- a/src/components/features/independence/scenarios/PensionProjectionPanel.tsx
+++ b/src/components/features/independence/scenarios/PensionProjectionPanel.tsx
@@ -1,0 +1,171 @@
+import React from "react"
+import useSWR from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+
+/**
+ * Year-by-year balance projection body for a pension asset. Extracted
+ * from PensionProjectionModal so the same view can render inline as a
+ * tab in EditAccountDialog as well as inside the scenario modal.
+ */
+
+interface CpfYearlyBalance {
+  age: number
+  oa: number
+  sa: number
+  ma: number
+  ra: number
+  annualContribution: number
+}
+
+interface PolicyYearlyBalance {
+  age: number
+  balance: number
+  annualContribution: number
+}
+
+export interface PensionProjectionPanelProps {
+  policyType?: string
+  cpfLifePlan?: string
+  payoutAge?: number
+  expectedReturnRate?: number
+  monthlyContribution?: number
+  /** Snapshot date for the starting balance — used in the stale-balance banner. */
+  updatedDate?: string
+  /** CPF only: starting OA / SA / MA / RA balances. */
+  subAccounts?: { code: string; balance: number }[]
+  currency: string
+  currentAge: number
+  scenarioMonthlySalary?: number
+  scenarioAnnualOverride?: number
+}
+
+export default function PensionProjectionPanel({
+  policyType,
+  cpfLifePlan,
+  payoutAge: payoutAgeProp,
+  expectedReturnRate,
+  monthlyContribution,
+  updatedDate,
+  subAccounts,
+  currency,
+  currentAge,
+  scenarioMonthlySalary,
+  scenarioAnnualOverride,
+}: PensionProjectionPanelProps): React.ReactElement {
+  const isCpf = policyType === "CPF"
+  const payoutAge = payoutAgeProp ?? 65
+
+  const subBalanceFor = (code: string): number =>
+    subAccounts?.find((s) => s.code === code)?.balance ?? 0
+
+  const cpfKey = isCpf
+    ? `/api/independence/cpf/balance-series?currentAge=${currentAge}` +
+      `&payoutAge=${payoutAge}` +
+      `&oa=${subBalanceFor("OA")}&sa=${subBalanceFor("SA")}` +
+      `&ma=${subBalanceFor("MA")}&ra=${subBalanceFor("RA")}` +
+      (scenarioMonthlySalary ? `&monthlySalary=${scenarioMonthlySalary}` : "") +
+      (scenarioAnnualOverride
+        ? `&annualContributionOverride=${scenarioAnnualOverride}`
+        : "") +
+      (cpfLifePlan ? `&cpfLifePlan=${cpfLifePlan}` : "")
+    : null
+
+  const policyMonthly =
+    scenarioAnnualOverride && scenarioAnnualOverride > 0
+      ? scenarioAnnualOverride / 12
+      : (monthlyContribution ?? 0)
+  const policyKey = !isCpf
+    ? `/api/independence/cpf/policy-balance-series?currentAge=${currentAge}` +
+      `&payoutAge=${payoutAge}` +
+      `&startingBalance=${subBalanceFor("BALANCE") || 0}` +
+      `&monthlyContribution=${policyMonthly}` +
+      `&expectedReturnRate=${expectedReturnRate ?? 0}`
+    : null
+
+  const { data: cpfData } = useSWR<
+    { data: CpfYearlyBalance[] } | CpfYearlyBalance[]
+  >(cpfKey, simpleFetcher)
+  const { data: policyData } = useSWR<
+    { data: PolicyYearlyBalance[] } | PolicyYearlyBalance[]
+  >(policyKey, simpleFetcher)
+
+  // Endpoints return arrays directly, but SWR-via-proxy may wrap in { data }.
+  const cpfSeries: CpfYearlyBalance[] = Array.isArray(cpfData)
+    ? cpfData
+    : (cpfData?.data ?? [])
+  const policySeries: PolicyYearlyBalance[] = Array.isArray(policyData)
+    ? policyData
+    : (policyData?.data ?? [])
+
+  const fmt = (n: number): string =>
+    `${currency} ${Math.round(n).toLocaleString()}`
+
+  return (
+    <div>
+      <div
+        role="alert"
+        className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded p-2 mb-3"
+      >
+        Starting balance is the figure you entered when the asset was last
+        edited
+        {updatedDate ? ` (${updatedDate})` : ""}. There&rsquo;s currently no
+        in-app way to refresh it, so the projection grows from that snapshot —
+        actual balances may already be higher.
+      </div>
+
+      {isCpf ? (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-gray-500 border-b">
+              <th className="py-1">Age</th>
+              <th className="py-1 text-right">OA</th>
+              <th className="py-1 text-right">SA</th>
+              <th className="py-1 text-right">MA</th>
+              <th className="py-1 text-right">RA</th>
+              <th className="py-1 text-right">Contribution</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cpfSeries.map((row) => (
+              <tr key={row.age} className="border-b last:border-b-0">
+                <td className="py-1">{row.age}</td>
+                <td className="py-1 text-right">{fmt(row.oa)}</td>
+                <td className="py-1 text-right">{fmt(row.sa)}</td>
+                <td className="py-1 text-right">{fmt(row.ma)}</td>
+                <td className="py-1 text-right">{fmt(row.ra)}</td>
+                <td className="py-1 text-right text-gray-500">
+                  {row.annualContribution > 0
+                    ? fmt(row.annualContribution)
+                    : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-gray-500 border-b">
+              <th className="py-1">Age</th>
+              <th className="py-1 text-right">Balance</th>
+              <th className="py-1 text-right">Contribution</th>
+            </tr>
+          </thead>
+          <tbody>
+            {policySeries.map((row) => (
+              <tr key={row.age} className="border-b last:border-b-0">
+                <td className="py-1">{row.age}</td>
+                <td className="py-1 text-right">{fmt(row.balance)}</td>
+                <td className="py-1 text-right text-gray-500">
+                  {row.annualContribution > 0
+                    ? fmt(row.annualContribution)
+                    : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/independence/scenarios/PensionProjectionPanel.tsx
+++ b/src/components/features/independence/scenarios/PensionProjectionPanel.tsx
@@ -63,15 +63,23 @@ export default function PensionProjectionPanel({
       `&payoutAge=${payoutAge}` +
       `&oa=${subBalanceFor("OA")}&sa=${subBalanceFor("SA")}` +
       `&ma=${subBalanceFor("MA")}&ra=${subBalanceFor("RA")}` +
-      (scenarioMonthlySalary ? `&monthlySalary=${scenarioMonthlySalary}` : "") +
-      (scenarioAnnualOverride
+      // Use `!== undefined` so an explicit 0 (e.g. "no salary this phase",
+      // "clear the override") is forwarded instead of falling through to
+      // the salary-derived default — the truthy check loses that signal.
+      (scenarioMonthlySalary !== undefined
+        ? `&monthlySalary=${scenarioMonthlySalary}`
+        : "") +
+      (scenarioAnnualOverride !== undefined
         ? `&annualContributionOverride=${scenarioAnnualOverride}`
         : "") +
       (cpfLifePlan ? `&cpfLifePlan=${cpfLifePlan}` : "")
     : null
 
+  // Same semantics as the query-string above: an explicit 0 override means
+  // "this phase contributes nothing" — only fall through to the asset
+  // default when the override isn't supplied at all.
   const policyMonthly =
-    scenarioAnnualOverride && scenarioAnnualOverride > 0
+    scenarioAnnualOverride !== undefined
       ? scenarioAnnualOverride / 12
       : (monthlyContribution ?? 0)
   const policyKey = !isCpf

--- a/src/components/features/independence/scenarios/ScenarioContributions.tsx
+++ b/src/components/features/independence/scenarios/ScenarioContributions.tsx
@@ -218,10 +218,7 @@ export default function ScenarioContributions({
           const frequencyLabel =
             asset.contributionFrequency === "ANNUAL" ? "per year" : "per month"
           return (
-            <li
-              key={asset.assetId}
-              className="py-2 flex items-center gap-3"
-            >
+            <li key={asset.assetId} className="py-2 flex items-center gap-3">
               <span className="flex-1 text-sm text-gray-700">
                 {asset.assetName}
                 {asset.policyType && (
@@ -234,7 +231,8 @@ export default function ScenarioContributions({
                     className="ml-2 text-xs text-gray-500 cursor-help"
                     title={`Your salary-based CPF contribution would be ${currency} ${salaryAnnual.toLocaleString()}/yr (employer + employee combined at the age-${currentAge} band). Entering an amount here overrides that figure for the projection.`}
                   >
-                    {" "}ⓘ salary-based: {currency}{" "}
+                    {" "}
+                    ⓘ salary-based: {currency}{" "}
                     {Math.round(salaryAnnual).toLocaleString()}/yr
                   </span>
                 )}

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -15,10 +15,7 @@ import HoldingMenu from "@components/features/holdings/HoldingMenu"
 import Rows from "@components/features/holdings/Rows"
 import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
 import PortfolioBreakdownPopup from "@components/features/holdings/PortfolioBreakdownPopup"
-import {
-  PortfolioBreakdownData,
-  PriceChartData,
-} from "types/beancounter"
+import { PortfolioBreakdownData, PriceChartData } from "types/beancounter"
 import SubTotal from "@components/features/holdings/SubTotal"
 import Header from "@components/features/holdings/Header"
 import GrandTotal from "@components/features/holdings/GrandTotal"


### PR DESCRIPTION
## Summary
- New **Projections** tab on EditAccountDialog for POLICY assets (CPF Life or non-CPF lump-sum).
- Extracts the year-by-year balance table from `PensionProjectionModal` into a reusable `PensionProjectionPanel`; the modal now wraps the panel in a Dialog so behaviour from the Scenario editor is unchanged.
- CPF rows show OA / SA / MA / RA balances per age + annual contribution; non-CPF rows show balance + contribution.

## Context
First slice of the wider ask. Still TODO:
- Plan view (Projections) showing income from POLICY assets
- Plan-edit Income tab showing projected payouts from POLICY assets

Those land in follow-up PRs.

## Test plan
- [x] `yarn typecheck && yarn lint && yarn test` green (113 suites / 1324 tests)
- [ ] Manual on kauri: Ruby's SG Life shows the non-CPF table; her CPF POLICY shows the OA/SA/MA/RA table
- [ ] Banner copy ("Starting balance is the figure you entered…") shows in both flavours

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a POLICY-only "Projections" tab showing lump-sum summary or year-by-year pension forecasts (CPF/non-CPF columns) and prompting for payout age/profile if missing; previous lump-sum view moved out of Income & Planning.

* **Refactor**
  * Reworked projection modal to reuse a new projection panel component.

* **Style**
  * Clarified CPF LIFE Settings warning wording.

* **Tests**
  * Minor test import/formatting cleanups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->