### PR TITLE
fix(asset): projection card move + ANNUAL/zero handling + simpleFetcher

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -144,6 +144,7 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
     yearsToMaturity: number
   } | null>(null)
   const [projectionLoading, setProjectionLoading] = useState(false)
+  const [projectionError, setProjectionError] = useState<string | null>(null)
 
   // User's plan data for age-based calculations
   const [planData, setPlanData] = useState<{
@@ -377,10 +378,12 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
         payoutAge <= currentAge
       ) {
         setLumpSumProjection(null)
+        setProjectionError(null)
         return
       }
 
       setProjectionLoading(true)
+      setProjectionError(null)
       try {
         const response = await fetch("/api/projection/lump-sum", {
           method: "POST",
@@ -395,13 +398,16 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
 
         if (response.ok) {
           const data = await response.json()
-          setLumpSumProjection(data.data)
+          setLumpSumProjection(data.data ?? null)
+          setProjectionError(data.data ? null : "Projection returned no data")
         } else {
           setLumpSumProjection(null)
+          setProjectionError(`Backend ${response.status}: ${response.statusText}`)
         }
       } catch (err) {
         console.error("Failed to fetch lump sum projection:", err)
         setLumpSumProjection(null)
+        setProjectionError(err instanceof Error ? err.message : String(err))
       } finally {
         setProjectionLoading(false)
       }
@@ -556,7 +562,7 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                     : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
                 }`}
               >
-                {"Income & Planning"}
+                {category === "RE" ? "Income" : "Planning"}
               </button>
               {showProjectionsTab && (
                 <button
@@ -1318,11 +1324,16 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                       )}
                     </div>
                   </div>
+                ) : projectionError ? (
+                  <p className="text-red-600 text-xs">
+                    <i className="fas fa-exclamation-triangle mr-1"></i>
+                    {`Projection failed: ${projectionError}. Adjust the contribution or return rate and the projection will retry.`}
+                  </p>
                 ) : (
                   <p className="text-green-600 text-xs">
                     {parseFloat(config.monthlyContribution || "0") <= 0
-                      ? `Enter ${config.contributionFrequency === "ANNUAL" ? "annual" : "monthly"} contribution to see projected payout.`
-                      : "Calculating projection..."}
+                      ? `Enter ${config.contributionFrequency === "ANNUAL" ? "annual" : "monthly"} contribution on the Planning tab to see projected payout.`
+                      : "Adjusting projection inputs on the Planning tab will refresh this view automatically."}
                   </p>
                 )}
               </div>

--- a/src/components/features/independence/scenarios/PensionProjectionPanel.tsx
+++ b/src/components/features/independence/scenarios/PensionProjectionPanel.tsx
@@ -92,10 +92,10 @@ export default function PensionProjectionPanel({
 
   const { data: cpfData } = useSWR<
     { data: CpfYearlyBalance[] } | CpfYearlyBalance[]
-  >(cpfKey, simpleFetcher)
+  >(cpfKey, cpfKey ? simpleFetcher(cpfKey) : null)
   const { data: policyData } = useSWR<
     { data: PolicyYearlyBalance[] } | PolicyYearlyBalance[]
-  >(policyKey, simpleFetcher)
+  >(policyKey, policyKey ? simpleFetcher(policyKey) : null)
 
   // Endpoints return arrays directly, but SWR-via-proxy may wrap in { data }.
   const cpfSeries: CpfYearlyBalance[] = Array.isArray(cpfData)


### PR DESCRIPTION
## Summary
Four small fixes that landed on \`feat/edit-asset-cpf-projections-tab\` after PR #705 was squash-merged — picking them up cleanly here on top of current main.

- **Lump-sum projection card** moved from Income & Planning → Projections tab. Income & Planning is inputs-only now.
- **ANNUAL contribution** now divided by 12 before feeding the projection (was 12x-inflating). CodeRabbit nit from #705.
- **Explicit zero** preserved for \`scenarioMonthlySalary\` / \`scenarioAnnualOverride\` via \`!== undefined\` so users can clear an override without falling back to the asset default. CodeRabbit nit from #705.
- **simpleFetcher invocation** — \`simpleFetcher(key)\` returns the fetcher SWR calls. Bare \`simpleFetcher\` made SWR resolve to the function itself; empty CPF table with only the header row was the visible symptom.
- **Tab label** — "Income" for RE, "Planning" for POLICY (was the conflated "Income & Planning").
- **Projection error state** — surface backend HTTP status / exception instead of leaving the card stuck on "Calculating projection…".

## Test plan
- [x] \`yarn test && yarn lint && yarn typecheck\` green (113 suites / 1324 tests)
- [ ] Manual: Ruby's SG Life Projections tab shows the projection card + populated balance table after a contribution change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Lump-sum policy projection fetch failures now display with explicit error messages and clear guidance for resolution  
  * Users receive actionable feedback and can retry projections by adjusting contribution or return rates
  * Account tab labels are now dynamic and context-aware, showing "Income" for real estate asset accounts and "Planning" for other account types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->