### PR TITLE
fix(asset): seed POLICY projection from asset's current holding

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -152,6 +152,14 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
     retirementAge: number
   } | null>(null)
 
+  // Current asset balance summed across all portfolios holding this asset
+  // — used as the starting point for non-CPF POLICY projections. CPF assets
+  // carry their starting balances on private_asset_sub_account (OA/SA/MA/RA)
+  // and don't need this.
+  const [assetCurrentBalance, setAssetCurrentBalance] = useState<number | null>(
+    null,
+  )
+
   // Show income/planning tab for RE and POLICY categories
   const showIncomeTab = category === "RE" || category === "POLICY"
   // Projections tab — only for POLICY assets. CPF gets the year-by-year
@@ -218,6 +226,34 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
       cancelled = true
     }
   }, [asset.assetCategory?.id, preferences])
+
+  // Fetch the asset's current balance across all portfolios so the
+  // Projections tab can seed the non-CPF policy projection. The balance
+  // lives on positions/transactions (not on private_asset_sub_account)
+  // for non-CPF policies, so the projection panel can't reach it via
+  // config.subAccounts.
+  useEffect(() => {
+    if (asset.assetCategory?.id !== "POLICY") return undefined
+    let cancelled = false
+    async function fetchBalance(): Promise<void> {
+      try {
+        const res = await fetch(
+          `/api/assets/${asset.id}/positions?date=today`,
+        )
+        if (!res.ok) return
+        const body = await res.json()
+        const positions: { balance?: number }[] = body?.data || []
+        const total = positions.reduce((sum, p) => sum + (p.balance || 0), 0)
+        if (!cancelled) setAssetCurrentBalance(total)
+      } catch {
+        // Best-effort; projection still works, just starts from 0.
+      }
+    }
+    fetchBalance()
+    return () => {
+      cancelled = true
+    }
+  }, [asset.id, asset.assetCategory?.id])
 
   // Fetch current sector classification on mount
   useEffect(() => {
@@ -1357,10 +1393,19 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                     ? raw / 12
                     : raw
                 })()}
-                subAccounts={config.subAccounts.map((s) => ({
-                  code: s.code,
-                  balance: s.balance,
-                }))}
+                subAccounts={[
+                  ...config.subAccounts.map((s) => ({
+                    code: s.code,
+                    balance: s.balance,
+                  })),
+                  // Non-CPF policies don't have OA/SA/MA/RA — surface the
+                  // asset's current holding as the "BALANCE" sub-account
+                  // the projection panel reads for startingBalance.
+                  ...(config.policyType !== "CPF" &&
+                  assetCurrentBalance !== null
+                    ? [{ code: "BALANCE", balance: assetCurrentBalance }]
+                    : []),
+                ]}
                 currency={currency}
                 currentAge={planData.currentAge}
               />


### PR DESCRIPTION
## Symptom
Ruby's SG Life Projections tab grew the balance series from SGD 0 even though she has SGD 32,088 set via the Set Balance flow. Each row was just last-year + contribution + 3.3% interest on a zero start.

## Root cause
Non-CPF policies (SG Life, generic insurance) carry their starting balance on a position/DEPOSIT trn — NOT on \`private_asset_sub_account\`. \`PensionProjectionPanel\` reads \`subBalanceFor("BALANCE")\` for the \`startingBalance\` query param, but \`config.subAccounts\` was always empty for SG Life-type assets, so the panel sent \`startingBalance=0\` to svc-retire.

## Fix
EditAccountDialog now hits \`/api/assets/<id>/positions?date=today\` (the same endpoint \`SetBalanceDialog\` already uses), sums positions[].balance, and injects it as a synthetic \`{ code: "BALANCE" }\` sub-account when the asset isn't CPF.

CPF assets continue to source OA/SA/MA/RA balances from \`config.subAccounts\` and ignore this synthetic entry (the projection panel only reads "BALANCE" on the non-CPF branch).

## Test plan
- [x] \`yarn typecheck && yarn lint && yarn test\` green
- [ ] Manual on kauri: Ruby's SG Life Projections tab now starts at SGD 32,088 and grows by SGD 4,000/yr + interest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved projection calculations for policy-type assets by automatically fetching and incorporating current balance data as the starting foundation for financial projections.
  * Enhanced the handling of sub-account balances in projection scenarios to better support multiple asset categories and types.
  * Better integration of asset balance information ensures more consistent projection calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->