### PR TITLE
chore(renovate): require status checks before auto-merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,5 +79,7 @@
   "commitMessageExtra": "to {{newVersion}}",
   "prTitle": "{{commitMessagePrefix}} {{commitMessageAction}} {{commitMessageTopic}} {{commitMessageExtra}}",
   "prBodyTemplate": "This PR updates {{depName}} from `{{currentVersion}}` to `{{newVersion}}`.\n\n{{#if hasReleaseNotes}}**Release Notes:**\n{{{releaseNotes}}}{{/if}}\n\n{{#if hasChangelog}}**Changelog:**\n{{{changelog}}}{{/if}}\n\n---\n*This PR was generated automatically by Renovate Bot.*",
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "ignoreTests": false,
+  "automergeStrategy": "squash"
 }


### PR DESCRIPTION
## Summary
- `ignoreTests: false` (explicit) — Renovate must wait on CI status before auto-merging any PR
- `automergeStrategy: "squash"` — keep main history clean
- Pairs with new branch protection ruleset on `main` requiring `Run Tests` + `Build Application` checks

## Why
Without both layers (Renovate `ignoreTests: false` + branch protection's required status checks), Renovate's aggressive `automerge: true` for patches could land a broken upgrade without waiting for CI. Belt + braces.

## Test plan
- [ ] Manually trigger Renovate (`workflow_dispatch` on `Renovate` workflow) and confirm a generated PR does not auto-merge until `Run Tests` + `Build Application` are green
- [ ] If a build fails on a Renovate PR, confirm it stays open instead of auto-merging
- [ ] Confirm direct pushes to `main` are now blocked (expected — matches existing policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation configuration to ensure tests are validated during updates and standardize the automated merge approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->