### PR TITLE
feat(holdings): show actions on mobile portrait

### DIFF
--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -50,12 +50,14 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   return (
     <div className="relative" ref={dropdownRef}>
       <button
-        className={`mobile-portrait:hidden w-full sm:w-auto ${colorClass} text-white px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center justify-center gap-1.5 ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+        className={`w-auto ${colorClass} text-white px-2.5 sm:px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center justify-center gap-1 sm:gap-1.5 ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
         onClick={() => !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
+        aria-label={label}
+        title={label}
       >
         <i className={`fas ${icon} text-[10px]`}></i>
-        <span>{label}</span>
+        <span className="hidden sm:inline">{label}</span>
         <i
           className={`fas fa-chevron-down text-[8px] transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
         ></i>
@@ -491,12 +493,15 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
           </button>
         )}
 
-        {/* Right side: secondary action buttons - hidden on mobile portrait */}
-        <div className="mobile-portrait:hidden flex items-center gap-2 flex-shrink-0">
+        {/* Right side: secondary action buttons. Labels collapse to icons on
+            mobile portrait so the row stays inside the viewport. */}
+        <div className="flex items-center gap-1.5 sm:gap-2 flex-shrink-0 flex-wrap justify-end">
           {onShare && (
             <button
-              className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300"
+              className="px-2.5 sm:px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1 sm:gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300"
               onClick={onShare}
+              aria-label="Share"
+              title="Share"
             >
               <i className="fas fa-share-alt text-[10px] text-blue-500"></i>
               <span className="hidden sm:inline">Share</span>
@@ -504,8 +509,10 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
           )}
           {!emptyHoldings && (
             <button
-              className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300"
+              className="px-2.5 sm:px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 flex items-center gap-1 sm:gap-1.5 shadow-sm bg-white hover:bg-slate-50 text-slate-700 ring-1 ring-slate-200/80 hover:ring-slate-300"
               onClick={handleCopyClick}
+              aria-label="Copy Holdings"
+              title="Copy Holdings"
             >
               <i className="fas fa-copy text-[10px] text-blue-500"></i>
               <span className="hidden sm:inline">Copy Holdings</span>

--- a/src/components/features/holdings/__tests__/HoldingActions.test.tsx
+++ b/src/components/features/holdings/__tests__/HoldingActions.test.tsx
@@ -162,47 +162,54 @@ describe("HoldingActions Mobile Portrait Tests (TDD)", () => {
       setupMatchMedia(375, 667)
     })
 
-    it("should have mobile-portrait:hidden class on actions container", () => {
+    // Mobile-portrait parity: Copy / Trade / Rebalance / Share must all render
+    // and must NOT sit inside a `mobile-portrait:hidden` ancestor. Labels may
+    // collapse to icon-only via `hidden sm:inline`, but the actions stay
+    // reachable. Locate by aria-label since the visible text label is
+    // CSS-hidden in this viewport.
+    it.each([
+      ["Copy Holdings"],
+      ["Trade"],
+      ["Rebalance"],
+    ])(
+      "renders %s reachable on mobile portrait (no hidden ancestor)",
+      (label) => {
+        render(
+          <HoldingActions
+            holdingResults={mockHoldingResults}
+            columns={mockColumns}
+            valueIn={mockValueIn}
+            onShare={() => {}}
+          />,
+        )
+
+        const button = screen.getByLabelText(label)
+        expect(button).toBeInTheDocument()
+        let node: HTMLElement | null = button
+        while (node) {
+          expect(node).not.toHaveClass("mobile-portrait:hidden")
+          node = node.parentElement
+        }
+      },
+    )
+
+    it("renders Share reachable on mobile portrait when onShare provided", () => {
       render(
         <HoldingActions
           holdingResults={mockHoldingResults}
           columns={mockColumns}
           valueIn={mockValueIn}
+          onShare={() => {}}
         />,
       )
 
-      // The parent container has mobile-portrait:hidden class
-      const copyButton = screen.getByText("Copy Holdings")
-      const container = copyButton.closest(".mobile-portrait\\:hidden")
-      expect(container).toBeInTheDocument()
-    })
-
-    it("should have mobile-portrait:hidden class on Trade dropdown button", () => {
-      render(
-        <HoldingActions
-          holdingResults={mockHoldingResults}
-          columns={mockColumns}
-          valueIn={mockValueIn}
-        />,
-      )
-
-      const tradeButton = screen.getByText("Trade")
-      const button = tradeButton.closest("button")
-      expect(button).toHaveClass("mobile-portrait:hidden")
-    })
-
-    it("should have mobile-portrait:hidden class on Rebalance dropdown button", () => {
-      render(
-        <HoldingActions
-          holdingResults={mockHoldingResults}
-          columns={mockColumns}
-          valueIn={mockValueIn}
-        />,
-      )
-
-      const rebalanceButton = screen.getByText("Rebalance")
-      const button = rebalanceButton.closest("button")
-      expect(button).toHaveClass("mobile-portrait:hidden")
+      const shareButton = screen.getByLabelText("Share")
+      expect(shareButton).toBeInTheDocument()
+      let node: HTMLElement | null = shareButton
+      while (node) {
+        expect(node).not.toHaveClass("mobile-portrait:hidden")
+        node = node.parentElement
+      }
     })
 
     it("should keep the AI Summary button visible (not in a mobile-portrait:hidden ancestor)", () => {
@@ -227,50 +234,8 @@ describe("HoldingActions Mobile Portrait Tests (TDD)", () => {
     })
   })
 
-  describe("Mobile Landscape Mode (width > height, width < 640px)", () => {
-    beforeEach(() => {
-      // Mock mobile landscape viewport (e.g., iPhone landscape: 667x375)
-      Object.defineProperty(window, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: 667,
-      })
-      Object.defineProperty(window, "innerHeight", {
-        writable: true,
-        configurable: true,
-        value: 375,
-      })
-      setupMatchMedia(667, 375)
-    })
-
-    it("should still have mobile-portrait:hidden class but not be in portrait mode", () => {
-      render(
-        <HoldingActions
-          holdingResults={mockHoldingResults}
-          columns={mockColumns}
-          valueIn={mockValueIn}
-        />,
-      )
-
-      // The parent container has mobile-portrait:hidden class
-      const copyButton = screen.getByText("Copy Holdings")
-      const container = copyButton.closest(".mobile-portrait\\:hidden")
-      expect(container).toBeInTheDocument()
-
-      // Trade and Rebalance buttons have mobile-portrait:hidden class
-      const tradeButton = screen.getByText("Trade")
-      const tradeButtonElement = tradeButton.closest("button")
-      expect(tradeButtonElement).toHaveClass("mobile-portrait:hidden")
-
-      const rebalanceButton = screen.getByText("Rebalance")
-      const rebalanceButtonElement = rebalanceButton.closest("button")
-      expect(rebalanceButtonElement).toHaveClass("mobile-portrait:hidden")
-    })
-  })
-
   describe("Desktop/Tablet Mode (width >= 640px)", () => {
     beforeEach(() => {
-      // Mock desktop viewport
       Object.defineProperty(window, "innerWidth", {
         writable: true,
         configurable: true,
@@ -284,7 +249,7 @@ describe("HoldingActions Mobile Portrait Tests (TDD)", () => {
       setupMatchMedia(1024, 768)
     })
 
-    it("should have mobile-portrait:hidden class but not be in mobile portrait mode", () => {
+    it("renders Copy / Trade / Rebalance on desktop", () => {
       render(
         <HoldingActions
           holdingResults={mockHoldingResults}
@@ -293,19 +258,9 @@ describe("HoldingActions Mobile Portrait Tests (TDD)", () => {
         />,
       )
 
-      // The parent container has mobile-portrait:hidden class
-      const copyButton = screen.getByText("Copy Holdings")
-      const container = copyButton.closest(".mobile-portrait\\:hidden")
-      expect(container).toBeInTheDocument()
-
-      // Trade and Rebalance buttons have mobile-portrait:hidden class
-      const tradeButton = screen.getByText("Trade")
-      const tradeButtonElement = tradeButton.closest("button")
-      expect(tradeButtonElement).toHaveClass("mobile-portrait:hidden")
-
-      const rebalanceButton = screen.getByText("Rebalance")
-      const rebalanceButtonElement = rebalanceButton.closest("button")
-      expect(rebalanceButtonElement).toHaveClass("mobile-portrait:hidden")
+      expect(screen.getByLabelText("Copy Holdings")).toBeInTheDocument()
+      expect(screen.getByLabelText("Trade")).toBeInTheDocument()
+      expect(screen.getByLabelText("Rebalance")).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -389,26 +389,30 @@ function AggregatedHoldingsPage(): React.ReactElement {
             </button>
           )}
 
-          {/* Action buttons - hidden on mobile portrait */}
-          <div className="mobile-portrait:hidden flex items-center space-x-2 shrink-0">
+          {/* Action buttons. Labels collapse to icons on mobile portrait so
+              the row stays inside the viewport. */}
+          <div className="flex items-center gap-1.5 sm:gap-2 shrink-0 flex-wrap justify-end">
             <button
-              className="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1.5 rounded-lg text-sm font-medium transition-colors duration-200 flex items-center justify-center"
+              className="bg-blue-500 hover:bg-blue-600 text-white px-2.5 sm:px-3 py-1.5 rounded-lg text-sm font-medium transition-colors duration-200 flex items-center justify-center"
               onClick={() => setCopyModalOpen(true)}
+              aria-label="Copy Data"
+              title="Copy Data"
             >
-              <i className="fas fa-copy mr-2"></i>
+              <i className="fas fa-copy sm:mr-2"></i>
               <span className="hidden sm:inline">Copy Data</span>
-              <span className="sm:hidden">Copy</span>
             </button>
             <button
-              className="bg-indigo-500 hover:bg-indigo-600 text-white px-3 py-1.5 rounded-lg text-sm font-medium transition-colors duration-200 flex items-center justify-center"
+              className="bg-indigo-500 hover:bg-indigo-600 text-white px-2.5 sm:px-3 py-1.5 rounded-lg text-sm font-medium transition-colors duration-200 flex items-center justify-center"
               onClick={() => {
                 const portfolioParams = codes
                   ? `?portfolios=${encodeURIComponent(codes)}`
                   : ""
                 router.push(`/rebalance/wizard${portfolioParams}`)
               }}
+              aria-label="Rebalance"
+              title="Rebalance"
             >
-              <i className="fas fa-balance-scale mr-2"></i>
+              <i className="fas fa-balance-scale sm:mr-2"></i>
               <span className="hidden sm:inline">Rebalance</span>
             </button>
           </div>


### PR DESCRIPTION
## Summary

- Copy Holdings, Trade, Rebalance, Share were hidden on mobile portrait via `mobile-portrait:hidden`. Now visible with labels collapsed to icon-only (`hidden sm:inline`) so the row fits.
- Same treatment for aggregated holdings page (Copy Data, Rebalance).
- Icon-only buttons get `aria-label` + `title` for accessibility.
- Wrapper gains `flex-wrap justify-end` so actions stack inside narrow viewports if needed.
- Tests rewritten: assert each action reachable on 375×667 without `mobile-portrait:hidden` ancestor.

## Test plan

- [x] `yarn test` — 1324/1324 pass (pre-commit hook)
- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] semgrep scan — 0 findings
- [ ] Verify on real iPhone portrait (375px): tap Copy Holdings → modal opens; tap Trade dropdown; tap Rebalance dropdown
- [ ] Verify on landscape (667px+): full labels show, layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile responsiveness for action buttons—labels now collapse to icons on smaller screens while remaining accessible.
  * Enhanced accessibility with improved button labeling for screen readers.

* **Bug Fixes**
  * Action buttons now remain visible and usable on mobile portrait mode, addressing previous layout constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->