### PR TITLE
fix(holdings): dedupe ⋮ on cash accounts

### DIFF
--- a/src/components/features/holdings/ActionsMenus.tsx
+++ b/src/components/features/holdings/ActionsMenus.tsx
@@ -352,18 +352,26 @@ export interface CashActionsMenuProps {
   asset: Asset
   portfolio: { id: string; code: string }
   marketValue: number
+  tradeCurrency?: { code: string; symbol: string; name: string }
   onSetCashBalance?: (data: SetCashBalanceData) => void
   onCashTransfer?: (data: CashTransferData) => void
   onCashTransaction?: (assetCode: string) => void
+  onRecordIncome?: (data: QuickSellData) => void
+  onRecordExpense?: (data: QuickSellData) => void
+  onEditAsset?: (asset: Asset) => void
 }
 
 export const CashActionsMenu: React.FC<CashActionsMenuProps> = ({
   asset,
   portfolio,
   marketValue,
+  tradeCurrency,
   onSetCashBalance,
   onCashTransfer,
   onCashTransaction,
+  onRecordIncome,
+  onRecordExpense,
+  onEditAsset,
 }) => {
   const { isOpen, buttonRef, menuRef, menuPos, toggle, close } =
     useDropdownMenu()
@@ -441,6 +449,53 @@ export const CashActionsMenu: React.FC<CashActionsMenuProps> = ({
                   iconClass="fas fa-dollar-sign text-green-500 w-4"
                   label="Cash Transaction"
                   onClick={handle(() => onCashTransaction(assetCode))}
+                />
+              )}
+              {onRecordIncome && (
+                <MenuItem
+                  iconClass="fas fa-arrow-down text-green-500 w-4"
+                  label="Record Income"
+                  onClick={handle(() =>
+                    onRecordIncome({
+                      asset: assetCode,
+                      assetId: asset.id,
+                      currency:
+                        (tradeCurrency?.code ??
+                          getAssetCurrency(asset)) ||
+                        asset.code,
+                      market: asset.market.code,
+                      quantity: 0,
+                      price: 0,
+                      type: "INCOME",
+                    }),
+                  )}
+                />
+              )}
+              {onRecordExpense && (
+                <MenuItem
+                  iconClass="fas fa-arrow-up text-red-500 w-4"
+                  label="Record Expense"
+                  onClick={handle(() =>
+                    onRecordExpense({
+                      asset: assetCode,
+                      assetId: asset.id,
+                      currency:
+                        (tradeCurrency?.code ??
+                          getAssetCurrency(asset)) ||
+                        asset.code,
+                      market: asset.market.code,
+                      quantity: 0,
+                      price: 0,
+                      type: "EXPENSE",
+                    }),
+                  )}
+                />
+              )}
+              {onEditAsset && asset.market?.code === "PRIVATE" && (
+                <MenuItem
+                  iconClass="fas fa-pen-to-square text-slate-500 w-4"
+                  label="Edit Asset"
+                  onClick={handle(() => onEditAsset(asset))}
                 />
               )}
             </div>

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -307,26 +307,31 @@ const PositionCard: React.FC<PositionCardProps> = ({
   const cashLadderHref = `/trns/cash-ladder/${portfolio.id}/${asset.id}`
 
   const hasActions =
-    (!isCashRelated(asset) &&
-      (!!onTrade ||
-        !!onQuickSell ||
-        !!onCorporateActions ||
-        !!onCostAdjust ||
-        !!onMovePosition ||
-        !!onRecordIncome ||
-        !!onRecordExpense ||
-        (!!onSetPrice && asset.market?.code === "PRIVATE") ||
-        (!!onSetBalance &&
-          asset.market?.code === "PRIVATE" &&
-          isConstantPrice(asset)) ||
-        (!!onSectorWeightings && asset.assetCategory?.id === "ETF"))) ||
-    (asset.assetCategory?.id === "RE" &&
-      (!!onRecordIncome || !!onRecordExpense)) ||
-    (!!onEditAsset && asset.market?.code === "PRIVATE")
+    !isCashRelated(asset) &&
+    ((!!onTrade ||
+      !!onQuickSell ||
+      !!onCorporateActions ||
+      !!onCostAdjust ||
+      !!onMovePosition ||
+      !!onRecordIncome ||
+      !!onRecordExpense ||
+      (!!onSetPrice && asset.market?.code === "PRIVATE") ||
+      (!!onSetBalance &&
+        asset.market?.code === "PRIVATE" &&
+        isConstantPrice(asset)) ||
+      (!!onSectorWeightings && asset.assetCategory?.id === "ETF")) ||
+      (asset.assetCategory?.id === "RE" &&
+        (!!onRecordIncome || !!onRecordExpense)) ||
+      (!!onEditAsset && asset.market?.code === "PRIVATE"))
 
   const hasCashActions =
     supportsBalanceSetting(asset) &&
-    (!!onSetCashBalance || !!onCashTransfer || !!onCashTransaction)
+    (!!onSetCashBalance ||
+      !!onCashTransfer ||
+      !!onCashTransaction ||
+      !!onRecordIncome ||
+      !!onRecordExpense ||
+      (!!onEditAsset && asset.market?.code === "PRIVATE"))
 
   const tradeMoney = moneyValues["TRADE"]
   const tradeCurrency = tradeMoney?.currency || portfolio.currency
@@ -366,6 +371,10 @@ const PositionCard: React.FC<PositionCardProps> = ({
             asset={asset}
             portfolio={portfolio}
             marketValue={tradeMoney?.marketValue || 0}
+            tradeCurrency={tradeCurrency}
+            onRecordIncome={onRecordIncome}
+            onRecordExpense={onRecordExpense}
+            onEditAsset={onEditAsset}
             onSetCashBalance={onSetCashBalance}
             onCashTransfer={onCashTransfer}
             onCashTransaction={onCashTransaction}

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -175,20 +175,20 @@ export default function Rows({
                     </div>
                   )}
                 </div>
-                {(!isCashRelated(asset) &&
-                  (onTrade ||
-                    onQuickSell ||
-                    onCorporateActions ||
-                    onCostAdjust ||
-                    onRecordIncome ||
-                    onRecordExpense ||
-                    (onSetPrice && asset.market?.code === "PRIVATE") ||
-                    (onSetBalance &&
-                      asset.market?.code === "PRIVATE" &&
-                      isConstantPrice(asset)))) ||
-                (asset.assetCategory?.id === "RE" &&
-                  (onRecordIncome || onRecordExpense)) ||
-                (onEditAsset && asset.market?.code === "PRIVATE") ? (
+                {!isCashRelated(asset) &&
+                ((onTrade ||
+                  onQuickSell ||
+                  onCorporateActions ||
+                  onCostAdjust ||
+                  onRecordIncome ||
+                  onRecordExpense ||
+                  (onSetPrice && asset.market?.code === "PRIVATE") ||
+                  (onSetBalance &&
+                    asset.market?.code === "PRIVATE" &&
+                    isConstantPrice(asset))) ||
+                  (asset.assetCategory?.id === "RE" &&
+                    (onRecordIncome || onRecordExpense)) ||
+                  (onEditAsset && asset.market?.code === "PRIVATE")) ? (
                   <div className="flex items-center">
                     <ActionsMenu
                       asset={asset}
@@ -227,15 +227,26 @@ export default function Rows({
                   </div>
                 ) : null}
                 {supportsBalanceSetting(asset) &&
-                  (onSetCashBalance || onCashTransfer || onCashTransaction) && (
+                  (onSetCashBalance ||
+                    onCashTransfer ||
+                    onCashTransaction ||
+                    onRecordIncome ||
+                    onRecordExpense ||
+                    (onEditAsset && asset.market?.code === "PRIVATE")) && (
                     <div className="flex items-center">
                       <CashActionsMenu
                         asset={asset}
                         portfolio={portfolio}
                         marketValue={moneyValues["TRADE"].marketValue}
+                        tradeCurrency={
+                          moneyValues["TRADE"]?.currency || portfolio.currency
+                        }
                         onSetCashBalance={onSetCashBalance}
                         onCashTransfer={onCashTransfer}
                         onCashTransaction={onCashTransaction}
+                        onRecordIncome={onRecordIncome}
+                        onRecordExpense={onRecordExpense}
+                        onEditAsset={onEditAsset}
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Summary

Cash accounts at PRIVATE market with `onEditAsset` wired were rendering **two** ⋮ menus side-by-side on the same row/card:

1. **ActionsMenu** — Set Balance (private+constant branch) / Record Income / Record Expense / Edit Asset
2. **CashActionsMenu** — Set Balance / Transfer Cash / Cash Transaction

Both menus contained a "Set Balance" item but they routed to different handlers (`onSetBalance` vs `onSetCashBalance`) — confusing and ambiguous.

Fix:
- Suppress `ActionsMenu` entirely for cash-related assets (`isCash || isAccount`).
- Fold `Record Income`, `Record Expense`, `Edit Asset` (PRIVATE only) items into `CashActionsMenu`.
- `ActionsMenu`'s duplicate "Set Balance" dropped — `CashActionsMenu`'s cash-specific one (via `onSetCashBalance`) is the canonical action.

Non-cash assets at PRIVATE market with `onEditAsset` still get `ActionsMenu` — unchanged behaviour.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn test` 14/14 (ActionsMenu/Rows/CardView matched) + full suite 1324/1324 (pre-commit)
- [x] semgrep 0 findings
- [ ] Visual: open a portfolio with a CASH/ACCOUNT holding at PRIVATE market → confirm single ⋮ on the row + on the card with Set Balance / Transfer Cash / Cash Transaction / Record Income / Record Expense / Edit Asset
- [ ] Visual: equity holding still shows full ActionsMenu (Trade / Quick Sell / Corp Actions / …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cash holdings now support recording income and expense transactions directly from the actions menu, enabling faster transaction entry without navigating away.
  * Private-market assets can now be edited directly through expanded action menu options.
  * Enhanced menu organization provides streamlined workflows for comprehensive asset management and operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->