### PR TITLE
chore(e2e): playwright backend health-check setup project

### DIFF
--- a/e2e/health-check.setup.ts
+++ b/e2e/health-check.setup.ts
@@ -1,0 +1,72 @@
+import { test as setup, expect } from "@playwright/test"
+
+interface ServiceCheck {
+  name: string
+  url: string
+  required: boolean
+}
+
+const services: ServiceCheck[] = [
+  {
+    name: "bc-data",
+    url: process.env.BC_DATA_ACTUATOR || "http://localhost:9511",
+    required: true,
+  },
+  {
+    name: "bc-position",
+    url: process.env.BC_POSITION_ACTUATOR || "http://localhost:9501",
+    required: true,
+  },
+  {
+    name: "bc-event",
+    url: process.env.BC_EVENT_ACTUATOR || "http://localhost:9521",
+    required: true,
+  },
+  {
+    name: "bc-retire",
+    url: process.env.BC_RETIRE_ACTUATOR || "http://localhost:9541",
+    required: true,
+  },
+  {
+    name: "bc-rebalance",
+    url: process.env.BC_REBALANCE_ACTUATOR || "http://localhost:9551",
+    required: process.env.E2E_SKIP_REBALANCE_CHECK !== "true",
+  },
+]
+
+setup("backends are up", async ({ request }) => {
+  const failures: string[] = []
+  const warnings: string[] = []
+
+  for (const svc of services) {
+    const healthUrl = `${svc.url}/actuator/health`
+    try {
+      const res = await request.get(healthUrl, { timeout: 5000 })
+      if (!res.ok()) {
+        const msg = `${svc.name} ${healthUrl} -> ${res.status()}`
+        if (svc.required) failures.push(msg)
+        else warnings.push(msg)
+        continue
+      }
+      const body = (await res.json()) as { status?: string }
+      if (body.status !== "UP") {
+        const msg = `${svc.name} ${healthUrl} status=${body.status}`
+        if (svc.required) failures.push(msg)
+        else warnings.push(msg)
+      }
+    } catch (err) {
+      const msg = `${svc.name} ${healthUrl} unreachable: ${(err as Error).message}`
+      if (svc.required) failures.push(msg)
+      else warnings.push(msg)
+    }
+  }
+
+  for (const w of warnings) {
+    console.warn(`[health-check] WARN ${w}`)
+  }
+
+  expect(
+    failures,
+    `Required backend services not healthy:\n  - ${failures.join("\n  - ")}\nStart them via ./gradlew bootRun in the relevant repo, or set E2E_SKIP_REBALANCE_CHECK=true to skip svc-rebalance.`,
+  ).toHaveLength(0)
+})

--- a/e2e/tests/trade/auto-settle-cash.spec.ts
+++ b/e2e/tests/trade/auto-settle-cash.spec.ts
@@ -472,9 +472,9 @@ test.describe("Auto-settle cash to linked funding portfolio", () => {
       await expect(reactSelectInput).toBeAttached({ timeout: 5000 })
 
       // Placeholder text confirms the default "use account default" state.
-      await expect(
-        page.locator("text=Use account default (none)"),
-      ).toBeVisible({ timeout: 5000 })
+      await expect(page.locator("text=Use account default (none)")).toBeVisible(
+        { timeout: 5000 },
+      )
 
       // master reference kept only to document the intended link target;
       // actual persistence is covered by tests 1 and 2 via API round-trip.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,11 +30,18 @@ export default defineConfig({
   },
 
   projects: [
-    // Auth setup - runs first to establish session
+    // Health check - verify backends are up before anything else
+    {
+      name: "health-check",
+      testMatch: /health-check\.setup\.ts/,
+      testDir: "./e2e",
+    },
+    // Auth setup - runs after health-check to establish session
     {
       name: "auth-setup",
       testMatch: /auth\.setup\.ts/,
       testDir: "./e2e",
+      dependencies: ["health-check"],
     },
     // Desktop Chrome
     {


### PR DESCRIPTION
## Summary
- Adds `e2e/health-check.setup.ts`, a Playwright setup project that probes `/actuator/health` on bc-data, bc-position, bc-event, bc-retire (required) and bc-rebalance (optional, downgraded to a warning; suppress with `E2E_SKIP_REBALANCE_CHECK=true`).
- Wires it as a project in `playwright.config.ts` that `auth-setup` depends on, so the suite fails fast on a missing backend with the offending service in the message instead of producing opaque timeouts mid-suite.
- Reflows one `expect(...).toBeVisible(...)` call in `auto-settle-cash.spec.ts` to match Prettier.

## Test plan
- [x] `yarn lint` — clean.
- [ ] `BC_*_ACTUATOR` overrides honoured when set; otherwise localhost defaults used.
- [ ] Suite fails immediately if e.g. bc-data is down; passes the existing trade tests when backends are up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automatic health checks for required backend services before running end-to-end tests. Test execution proceeds only if all critical services are confirmed available.
  * Improved test infrastructure reliability by establishing proper dependencies between service health verification and authentication setup procedures.

* **Style**
  * Reformatted test assertions for improved consistency and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->