### PR TITLE
fix(portfolios): toast on save + SWR cache invalidation

### DIFF
--- a/src/pages/portfolios/[id].tsx
+++ b/src/pages/portfolios/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react"
+import React, { useState, useMemo, useEffect } from "react"
 import { Controller, SubmitHandler, useForm } from "react-hook-form"
 import {
   Currency,
@@ -18,14 +18,23 @@ import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import Link from "next/link"
 import { rootLoader } from "@components/ui/PageLoader"
 import { errorOut } from "@components/errors/ErrorOut"
-import useSwr from "swr"
+import useSwr, { useSWRConfig } from "swr"
 import { currencyOptions, toCurrency, toCurrencyOption } from "@lib/currency"
 import ReactSelect from "react-select"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { validateInput } from "@components/errors/validator"
 import { portfolioInputSchema } from "@lib/portfolio/schema"
 import TrnDropZone from "@components/ui/DropZone"
+import Alert from "@components/ui/Alert"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
+
+const SAVE_FEEDBACK_MS = 2500
+
+type SaveState =
+  | { kind: "idle" }
+  | { kind: "saving" }
+  | { kind: "success" }
+  | { kind: "error"; message: string }
 
 export default withPageAuthRequired(function Manage(): React.ReactElement {
   function toPortfolioRequest(portfolio: PortfolioInput): PortfolioRequest {
@@ -45,33 +54,60 @@ export default withPageAuthRequired(function Manage(): React.ReactElement {
     }
   }
 
+  const router = useRouter()
+  const { preferences } = useUserPreferences()
+  const { mutate: globalMutate } = useSWRConfig()
+  const [purgeTrn, setPurgeTrn] = useState(false)
+  const [saveState, setSaveState] = useState<SaveState>({ kind: "idle" })
+
   const handleSubmit: SubmitHandler<PortfolioInput> = (portfolioInput) => {
+    setSaveState({ kind: "saving" })
     validateInput(portfolioInputSchema, portfolioInput)
-      .then(() => {
+      .then(async () => {
         const post = router.query.id === "__NEW__"
-        fetch(key, {
+        const response = await fetch(key, {
           method: post ? "POST" : "PATCH",
           headers: { "Content-Type": "application/json" },
           body: post
             ? JSON.stringify(toPortfolioRequests(portfolioInput))
             : JSON.stringify(toPortfolioRequest(portfolioInput)),
         })
-          .then((response) => response.json())
-          .then((data) => {
-            const route = post
-              ? `/portfolios/${data.data[0].id}`
-              : `/portfolios/${data.data.id}`
-            router.push(route).then(() => {})
-          })
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}))
+          const message =
+            body?.message || body?.error || `Save failed (${response.status})`
+          setSaveState({ kind: "error", message })
+          return
+        }
+        const body = await response.json()
+        const savedId = post ? body.data[0].id : body.data.id
+        // Invalidate caches so the list and the just-saved portfolio
+        // both refetch with the new values (incl. cashPortfolioId,
+        // marketValue, valuedAt).
+        await Promise.all([
+          globalMutate(portfoliosKey),
+          globalMutate(portfolioKey(savedId)),
+        ])
+        if (post) {
+          await router.push(`/portfolios/${savedId}`)
+        } else {
+          setSaveState({ kind: "success" })
+        }
       })
       .catch((e) => {
         console.error(`Some error ${e.message}`)
+        setSaveState({ kind: "error", message: e.message ?? "Save failed" })
       })
   }
 
-  const router = useRouter()
-  const { preferences } = useUserPreferences()
-  const [purgeTrn, setPurgeTrn] = useState(false)
+  useEffect(() => {
+    if (saveState.kind !== "success") return undefined
+    const timer = setTimeout(
+      () => setSaveState({ kind: "idle" }),
+      SAVE_FEEDBACK_MS,
+    )
+    return () => clearTimeout(timer)
+  }, [saveState.kind])
   const {
     formState: { errors },
     control,
@@ -141,6 +177,16 @@ export default withPageAuthRequired(function Manage(): React.ReactElement {
   return (
     <div className="container mx-auto p-4">
       <form className="max-w-lg mx-auto bg-white p-6 rounded shadow-md">
+        {saveState.kind === "success" && (
+          <Alert variant="success" className="mb-4">
+            {"Portfolio saved."}
+          </Alert>
+        )}
+        {saveState.kind === "error" && (
+          <Alert variant="error" className="mb-4">
+            {saveState.message}
+          </Alert>
+        )}
         <label className="block text-gray-700 text-sm font-bold mb-2">
           {"Code"}
         </label>
@@ -269,13 +315,14 @@ export default withPageAuthRequired(function Manage(): React.ReactElement {
           <button
             type="submit"
             value="submit"
-            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            disabled={saveState.kind === "saving"}
+            className="bg-blue-500 hover:bg-blue-700 disabled:bg-blue-300 disabled:cursor-not-allowed text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
             onClick={(e) => {
               e.preventDefault()
               handleSubmit(getValues() as PortfolioInput)
             }}
           >
-            {"Submit"}
+            {saveState.kind === "saving" ? "Saving…" : "Submit"}
           </button>
           <button
             className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"

--- a/src/pages/portfolios/[id].tsx
+++ b/src/pages/portfolios/[id].tsx
@@ -60,44 +60,56 @@ export default withPageAuthRequired(function Manage(): React.ReactElement {
   const [purgeTrn, setPurgeTrn] = useState(false)
   const [saveState, setSaveState] = useState<SaveState>({ kind: "idle" })
 
-  const handleSubmit: SubmitHandler<PortfolioInput> = (portfolioInput) => {
+  const handleSubmit: SubmitHandler<PortfolioInput> = async (portfolioInput) => {
     setSaveState({ kind: "saving" })
-    validateInput<PortfolioInput>(portfolioInputSchema, portfolioInput)
-      .then(async (validated) => {
-        const post = router.query.id === "__NEW__"
-        const response = await fetch(key, {
-          method: post ? "POST" : "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: post
-            ? JSON.stringify(toPortfolioRequests(validated))
-            : JSON.stringify(toPortfolioRequest(validated)),
-        })
-        if (!response.ok) {
-          const body = await response.json().catch(() => ({}))
-          const message =
-            body?.message || body?.error || `Save failed (${response.status})`
-          setSaveState({ kind: "error", message })
-          return
-        }
-        const body = await response.json()
-        const savedId = post ? body.data[0].id : body.data.id
-        // Invalidate caches so the list and the just-saved portfolio
-        // both refetch with the new values (incl. cashPortfolioId,
-        // marketValue, valuedAt).
-        await Promise.all([
-          globalMutate(portfoliosKey),
-          globalMutate(portfolioKey(savedId)),
-        ])
-        if (post) {
-          await router.push(`/portfolios/${savedId}`)
-        } else {
-          setSaveState({ kind: "success" })
-        }
+    try {
+      const validated = await validateInput<PortfolioInput>(
+        portfolioInputSchema,
+        portfolioInput,
+      )
+      const post = router.query.id === "__NEW__"
+      const response = await fetch(key, {
+        method: post ? "POST" : "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          post
+            ? toPortfolioRequests(validated)
+            : toPortfolioRequest(validated),
+        ),
       })
-      .catch((e) => {
-        console.error(`Some error ${e.message}`)
-        setSaveState({ kind: "error", message: e.message ?? "Save failed" })
-      })
+      if (!response.ok) {
+        const errBody = await response.json().catch(() => ({}))
+        throw new Error(
+          errBody?.message ||
+            errBody?.error ||
+            `Save failed (${response.status})`,
+        )
+      }
+      const body = await response.json()
+      const saved: Portfolio = post ? body.data[0] : body.data
+      // Prime the detail cache directly from the response (svc-data
+      // returns the canonical saved Portfolio), and revalidate the list
+      // since row ordering / aggregates may have shifted. Note that
+      // valuation fields are eventually-consistent: bc-position will
+      // republish marketValue/irr via the bc-pos-mv stream shortly.
+      await Promise.all([
+        globalMutate(
+          portfolioKey(saved.id),
+          { data: saved },
+          { revalidate: false },
+        ),
+        globalMutate(portfoliosKey),
+      ])
+      if (post) {
+        await router.push(`/portfolios/${saved.id}`)
+      } else {
+        setSaveState({ kind: "success" })
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Save failed"
+      console.error(`Portfolio save failed: ${message}`)
+      setSaveState({ kind: "error", message })
+    }
   }
 
   useEffect(() => {

--- a/src/pages/portfolios/[id].tsx
+++ b/src/pages/portfolios/[id].tsx
@@ -62,15 +62,15 @@ export default withPageAuthRequired(function Manage(): React.ReactElement {
 
   const handleSubmit: SubmitHandler<PortfolioInput> = (portfolioInput) => {
     setSaveState({ kind: "saving" })
-    validateInput(portfolioInputSchema, portfolioInput)
-      .then(async () => {
+    validateInput<PortfolioInput>(portfolioInputSchema, portfolioInput)
+      .then(async (validated) => {
         const post = router.query.id === "__NEW__"
         const response = await fetch(key, {
           method: post ? "POST" : "PATCH",
           headers: { "Content-Type": "application/json" },
           body: post
-            ? JSON.stringify(toPortfolioRequests(portfolioInput))
-            : JSON.stringify(toPortfolioRequest(portfolioInput)),
+            ? JSON.stringify(toPortfolioRequests(validated))
+            : JSON.stringify(toPortfolioRequest(validated)),
         })
         if (!response.ok) {
           const body = await response.json().catch(() => ({}))

--- a/src/pages/portfolios/[id].tsx
+++ b/src/pages/portfolios/[id].tsx
@@ -22,7 +22,6 @@ import useSwr, { useSWRConfig } from "swr"
 import { currencyOptions, toCurrency, toCurrencyOption } from "@lib/currency"
 import ReactSelect from "react-select"
 import { yupResolver } from "@hookform/resolvers/yup"
-import { validateInput } from "@components/errors/validator"
 import { portfolioInputSchema } from "@lib/portfolio/schema"
 import TrnDropZone from "@components/ui/DropZone"
 import Alert from "@components/ui/Alert"
@@ -60,13 +59,12 @@ export default withPageAuthRequired(function Manage(): React.ReactElement {
   const [purgeTrn, setPurgeTrn] = useState(false)
   const [saveState, setSaveState] = useState<SaveState>({ kind: "idle" })
 
-  const handleSubmit: SubmitHandler<PortfolioInput> = async (portfolioInput) => {
+  // RHF's handleSubmit runs the yup resolver and only calls onSubmit
+  // with the already-validated, cast value (schema transforms like
+  // `.trim()` applied), so no second validateInput pass is needed.
+  const onSubmit: SubmitHandler<PortfolioInput> = async (validated) => {
     setSaveState({ kind: "saving" })
     try {
-      const validated = await validateInput<PortfolioInput>(
-        portfolioInputSchema,
-        portfolioInput,
-      )
       const post = router.query.id === "__NEW__"
       const response = await fetch(key, {
         method: post ? "POST" : "PATCH",
@@ -124,7 +122,7 @@ export default withPageAuthRequired(function Manage(): React.ReactElement {
     formState: { errors },
     control,
     register,
-    getValues,
+    handleSubmit,
   } = useForm<PortfolioInput>({
     resolver: yupResolver(portfolioInputSchema),
     mode: "onChange",
@@ -188,7 +186,10 @@ export default withPageAuthRequired(function Manage(): React.ReactElement {
   const cashPortfoliosLoading = portfoliosResponse.isLoading
   return (
     <div className="container mx-auto p-4">
-      <form className="max-w-lg mx-auto bg-white p-6 rounded shadow-md">
+      <form
+        className="max-w-lg mx-auto bg-white p-6 rounded shadow-md"
+        onSubmit={handleSubmit(onSubmit)}
+      >
         {saveState.kind === "success" && (
           <Alert variant="success" className="mb-4">
             {"Portfolio saved."}
@@ -326,20 +327,15 @@ export default withPageAuthRequired(function Manage(): React.ReactElement {
         <div className="flex items-center justify-between mt-4">
           <button
             type="submit"
-            value="submit"
             disabled={saveState.kind === "saving"}
             className="bg-blue-500 hover:bg-blue-700 disabled:bg-blue-300 disabled:cursor-not-allowed text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-            onClick={(e) => {
-              e.preventDefault()
-              handleSubmit(getValues() as PortfolioInput)
-            }}
           >
             {saveState.kind === "saving" ? "Saving…" : "Submit"}
           </button>
           <button
+            type="button"
             className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-            onClick={(e) => {
-              e.preventDefault()
+            onClick={() => {
               router.push("/portfolios").then()
             }}
           >


### PR DESCRIPTION
## Summary
- Invalidate `portfoliosKey` and `portfolioKey(savedId)` via `useSWRConfig().mutate` after a PATCH/POST so the portfolios list and the just-saved detail view both refetch. Without this the list kept showing pre-save values (most visibly the cash funding portfolio and market value) until SWR's revalidate-on-focus kicked in.
- Adds Submit/Success/Error UI states so the user gets immediate feedback:
  - "Saving…" disables the button while the request is in flight.
  - Green Alert "Portfolio saved." renders for 2.5s after a successful PATCH (POST still redirects to the new portfolio's edit page).
  - Red Alert surfaces the server's error message on a failed save and stays until the next attempt.

Pairs with beancounter PR #899 which stops PATCH from zeroing the portfolio's valuation; once that is deployed the refreshed cache will reflect the preserved values immediately.

## Test plan
- [x] `yarn lint && yarn typecheck && yarn test` — clean.
- [ ] Manual: edit a portfolio, set Cash Funding Portfolio, click Submit. Banner appears, button disabled briefly, list reflects the new funding portfolio without a page refresh.
- [ ] Manual: trigger a save error (e.g. duplicate code) and confirm the red banner shows the server message and persists until next submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portfolio save operations show real-time status: Saving, Success, Error.
  * Success and error alerts appear above the form to surface server messages.
  * Submit button disables and displays "Saving..." while requests run.
  * Newly created portfolios redirect to their detail page after creation.
  * Successful updates remain on the page and show a transient success state that resets automatically.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->