### PR TITLE
fix(e2e): use bc-rebalance in health-check failure message

### DIFF
--- a/e2e/health-check.setup.ts
+++ b/e2e/health-check.setup.ts
@@ -67,6 +67,6 @@ setup("backends are up", async ({ request }) => {
 
   expect(
     failures,
-    `Required backend services not healthy:\n  - ${failures.join("\n  - ")}\nStart them via ./gradlew bootRun in the relevant repo, or set E2E_SKIP_REBALANCE_CHECK=true to skip svc-rebalance.`,
+    `Required backend services not healthy:\n  - ${failures.join("\n  - ")}\nStart them via ./gradlew bootRun in the relevant repo, or set E2E_SKIP_REBALANCE_CHECK=true to skip bc-rebalance.`,
   ).toHaveLength(0)
 })


### PR DESCRIPTION
## Summary
- The `services` array in `e2e/health-check.setup.ts` registers the rebalance backend as `bc-rebalance`, but the failure-message help text on the final `expect` said `svc-rebalance`. Anyone hitting the assertion would be told to skip a service name that doesn't exist anywhere else in the file.
- Renames the dangling `svc-rebalance` to `bc-rebalance` so the suggested `E2E_SKIP_REBALANCE_CHECK=true` escape hatch points at the same name as the service registration.

Surfaced by CodeRabbit during a follow-up review on #720.

## Test plan
- [x] `yarn lint` — clean.
- [ ] Manually trigger the assertion (e.g. point `BC_REBALANCE_ACTUATOR` at a closed port without `E2E_SKIP_REBALANCE_CHECK=true`); the failure message now reads `bc-rebalance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)