### PR TITLE
fix(security): prototype pollution in holdings/weights API

### DIFF
--- a/src/pages/api/holdings/weights.ts
+++ b/src/pages/api/holdings/weights.ts
@@ -71,8 +71,11 @@ export default async function holdingsWeights(
       codes.push(code)
     }
 
-    // Fetch holdings for each portfolio
-    const assetValues: Record<
+    // Fetch holdings for each portfolio.
+    // Use a Map (not a Record) so attacker-controlled assetId values like
+    // "__proto__" / "constructor" can't pollute Object.prototype via
+    // bracket access (CWE-1321).
+    const assetValues = new Map<
       string,
       {
         assetId: string
@@ -82,7 +85,7 @@ export default async function holdingsWeights(
         price?: number
         priceCurrency?: string
       }
-    > = {}
+    >()
     let totalValue = 0
     let currency = "USD"
 
@@ -141,12 +144,13 @@ export default async function holdingsWeights(
         const priceCurrency =
           tradeMoneyValues?.currency?.code || asset.market?.currency?.code
 
-        if (assetValues[assetId]) {
-          assetValues[assetId].value += value
+        const existing = assetValues.get(assetId)
+        if (existing) {
+          existing.value += value
           // Keep the most recent price if already exists
-          if (price && !assetValues[assetId].price) {
-            assetValues[assetId].price = price
-            assetValues[assetId].priceCurrency = priceCurrency
+          if (price && !existing.price) {
+            existing.price = price
+            existing.priceCurrency = priceCurrency
           }
         } else {
           // Build asset code: omit "US:" prefix for US market (default)
@@ -155,21 +159,21 @@ export default async function holdingsWeights(
           const fullCode =
             marketCode && marketCode !== "US" ? `${marketCode}:${code}` : code
 
-          assetValues[assetId] = {
+          assetValues.set(assetId, {
             assetId,
             assetCode: fullCode,
             assetName: asset.name || asset.code || assetId,
             value,
             price,
             priceCurrency,
-          }
+          })
         }
         totalValue += value
       }
     }
 
     // Calculate weights as decimals (0.0 - 1.0)
-    const weights: HoldingWeight[] = Object.values(assetValues)
+    const weights: HoldingWeight[] = Array.from(assetValues.values())
       .map((asset) => ({
         assetId: asset.assetId,
         assetCode: asset.assetCode,


### PR DESCRIPTION
## Summary

Closes three Snyk SAST findings in `src/pages/api/holdings/weights.ts` (`05acf7be`, `e4513c39`, `a166d2f7` — Prototype Pollution / CWE-1321):

- The accumulator `assetValues` was a plain-object `Record<string, …>`. The key (`assetId`) came from `position.asset.id` — upstream JSON, not validated server-side.
- An attacker controlling the upstream response could send `__proto__` / `constructor` as the asset id and pollute `Object.prototype`, with downstream RCE / logic-bypass risk for any code that later relies on prototype keys.

Fix: swap `Record<string, …>` for `Map<string, …>`. `Map` keys are scoped to the instance and don't traverse the prototype chain, so the entire class of bug disappears. Lookups switch to `.get` / `.set`; the iteration in the weight-calculation step swaps `Object.values()` for `Array.from(assetValues.values())`.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (full 1350-test suite, all green)
- [x] Local semgrep scan on modified file: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security and stability of holdings weight calculations to prevent potential data integrity issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->