### PR TITLE
fix(security): guard API route query params against array values

### DIFF
--- a/src/pages/api/assets/resolve.ts
+++ b/src/pages/api/assets/resolve.ts
@@ -1,9 +1,19 @@
-import { createApiHandler } from "@utils/api/createApiHandler"
+import {
+  createApiHandler,
+  sanitizePathParam,
+} from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
 
 export default createApiHandler({
   url: (req) => {
-    let { market, code } = req.query as { market?: string; code: string }
+    // Snyk Improper Type Validation (09c4ea12 / af2dcbf3 — CWE-1287):
+    // Next.js types req.query values as `string | string[] | undefined`.
+    // Calling .includes()/.split() on a string[] would crash the route.
+    // sanitizePathParam normalises to string and rejects traversal chars.
+    let code = sanitizePathParam(req.query.code, "code")
+    let market = req.query.market
+      ? sanitizePathParam(req.query.market, "market")
+      : undefined
     if (code.includes(":")) {
       const parts = code.split(":")
       market = parts[0]

--- a/src/pages/api/tax-rates/[countryCode].ts
+++ b/src/pages/api/tax-rates/[countryCode].ts
@@ -1,9 +1,18 @@
-import { createApiHandler } from "@utils/api/createApiHandler"
+import {
+  createApiHandler,
+  sanitizePathParam,
+} from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
 
 export default createApiHandler({
   url: (req) => {
-    const countryCode = (req.query.countryCode as string).toUpperCase()
+    // Snyk Improper Type Validation (d9a2ccad — CWE-1287): req.query
+    // values are `string | string[] | undefined`; .toUpperCase() on an
+    // array would throw. sanitizePathParam normalises and validates.
+    const countryCode = sanitizePathParam(
+      req.query.countryCode,
+      "countryCode",
+    ).toUpperCase()
     return getDataUrl(`/tax-rates/${countryCode}`)
   },
   methods: ["GET", "DELETE"],


### PR DESCRIPTION
## Summary

Closes two of the five Snyk **Improper Type Validation** findings (CWE-1287) in `bc-view` API routes:

| Snyk ID | Route | Issue |
|---|---|---|
| `09c4ea12-a070-4d43-907c-7153fb1b4bec` | `src/pages/api/assets/resolve.ts:7` | `code.includes(\":\")` on unchecked cast crashes when caller sends `?code[]=foo&code[]=bar` (array). |
| `af2dcbf3-18f0-431f-b33e-686e1dbdc7c8` | `src/pages/api/assets/resolve.ts:8` | Same root cause — `code.split(\":\")` on array. |
| `d9a2ccad-cb88-41ab-9407-24913aa4bdcc` | `src/pages/api/tax-rates/[countryCode].ts:6` | `.toUpperCase()` on `(req.query.countryCode as string)` — same shape. |

Both routes now funnel through the existing `sanitizePathParam` helper in `src/lib/utils/api/createApiHandler.ts`. It normalises array inputs to their first element and rejects path-traversal characters (`/`, `\\`, `..`, `\\0`). Behaviour for well-formed callers is unchanged; malformed callers now get a 400 from `BcApiError` instead of a 500 / crashed handler.

## Deferred

Three other findings in the same Snyk category are intentionally **not** in this PR:

- `f7b914d4` — `src/pages/api/holdings/weights.ts:56` (`.split` on `portfolioIds`). The same file already lives on PR #722's branch (prototype-pollution fix); folding the .split guard in there avoids a merge conflict.
- `9ec74019` — `src/pages/api/prices/[...price].ts:10` (`.map`). Next.js catch-all segments (`[...slug]`) always return `string[]` by spec, so `.map` is type-safe. Snyk's flow analysis doesn't model catch-all routing. False positive.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (1350 tests pass)
- [x] Local semgrep on modified files — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened request parameter validation across asset and tax rate endpoints to enhance API reliability and prevent edge-case errors.
  * Improved handling of various input types to ensure consistent, stable performance of critical backend services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->