### PR TITLE
fix(holdings): strip #asset-<id> hash after first scroll

### DIFF
--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo } from "react"
+import React, { useState, useCallback, useEffect } from "react"
 import {
   QuickSellData,
   WeightClickData,
@@ -108,14 +108,28 @@ function HoldingsPage(): React.ReactElement {
   } = useHoldingsView(data?.data)
 
   // Deep-link from asset lookup: `/holdings/<code>#asset-<id>` jumps to
-  // the specific holding. Summary view doesn't render rows, so flip to
-  // table when a target is set.
-  const targetAssetId = useMemo<string | undefined>(() => {
-    const hashIdx = router.asPath.indexOf("#")
-    if (hashIdx < 0) return undefined
-    const m = router.asPath.slice(hashIdx).match(/^#asset-(.+)$/)
+  // the specific holding. The hash is captured into state once on mount
+  // (asset lookup is a different route, so this page always mounts
+  // fresh on navigation in) and then stripped from the URL so that
+  // back/forward navigation within the session doesn't keep re-firing
+  // the scroll. A fresh load (bookmark, asset-lookup click) still works.
+  // Summary view doesn't render rows, so flip to table when a target
+  // is set.
+  const [targetAssetId] = useState<string | undefined>(() => {
+    if (typeof window === "undefined") return undefined
+    const m = window.location.hash.match(/^#asset-(.+)$/)
     return m ? decodeURIComponent(m[1]) : undefined
-  }, [router.asPath])
+  })
+  useEffect(() => {
+    if (!targetAssetId) return
+    if (typeof window === "undefined") return
+    if (!window.location.hash) return
+    router.replace(window.location.pathname + window.location.search, undefined, {
+      shallow: true,
+    })
+    // Run once after the hash is captured; router stays stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     if (targetAssetId && viewMode === "summary") setViewMode("table")


### PR DESCRIPTION
## Summary

Follow-up to #724. The deep-link hash was persisting in the URL, so navigating away (e.g. to /trns) and back via the browser back button kept re-firing the scroll/highlight on every return. Now the hash is captured into state on mount and immediately replaced out of the URL (shallow), so back/forward within the session no longer re-triggers.

- Fresh loads (bookmark, asset-lookup click) still work — the page always mounts fresh on navigation in from /assets/lookup, so the lazy useState init runs and picks up the hash.
- `router.replace(...,  { shallow: true })` keeps SWR caches intact.

## Test plan

- [ ] Asset lookup → click portfolio → holdings scrolls + highlights; URL no longer contains `#asset-…` after the scroll lands.
- [ ] Navigate to /trns → browser back → no second scroll/highlight.
- [ ] Reload the bookmarked `/holdings/<code>#asset-<id>` → scroll/highlight runs again on the fresh load.
- [ ] `yarn typecheck && yarn lint && yarn test` clean (1350/1350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep-linking to specific assets on the holdings page.
  * Fixed navigation behavior to prevent unintended scrolling when using browser back/forward buttons within the holdings page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->