### PR TITLE
fix(asset-search): show spinner from first keystroke through results

### DIFF
--- a/src/components/features/assets/AssetSearch.tsx
+++ b/src/components/features/assets/AssetSearch.tsx
@@ -95,6 +95,12 @@ export default function AssetSearch({
   const [internalValue, setInternalValue] = useState<AssetOption | null>(null)
   const lastSelectedRef = useRef<AssetOption | null>(null)
   const displayValue = isControlled ? value : internalValue
+  // Explicit search-in-flight flag. AsyncSelect only flips its internal
+  // isLoading while the loadOptions promise is pending, so the 300ms debounce
+  // + backend round-trip (up to ~3s with the per-provider coroutine cap)
+  // would otherwise show no spinner. Drive isLoading from this so the user
+  // sees feedback the moment they type.
+  const [isSearching, setIsSearching] = useState(false)
 
   const isSpecificMarket = market !== undefined && market !== ""
 
@@ -128,12 +134,14 @@ export default function AssetSearch({
       )
 
       if (!parsed.validMarket || parsed.keyword.length < 2) {
+        setIsSearching(false)
         callback(
           fallbackOptions && fallbackOptions.length > 0 ? fallbackOptions : [],
         )
         return
       }
 
+      setIsSearching(true)
       debounceRef.current = setTimeout(async () => {
         try {
           const results = await doFetch(parsed.keyword, parsed.market)
@@ -144,6 +152,8 @@ export default function AssetSearch({
           callback(options)
         } catch {
           callback([])
+        } finally {
+          setIsSearching(false)
         }
       }, 300)
     },
@@ -207,6 +217,9 @@ export default function AssetSearch({
     placeholder: placeholder || "Search for asset...",
     noOptionsMessage,
     loadingMessage: () => "Searching...",
+    // Drive the spinner from our own flag so it shows from the first keystroke
+    // through the debounce window, not just while the fetch promise is alive.
+    isLoading: isSearching,
     onChange: handleChange,
     isClearable,
     inputValue: inputText,
@@ -269,6 +282,14 @@ export default function AssetSearch({
       loadingMessage: (base: Record<string, unknown>) => ({
         ...base,
         color: "#6b7280",
+      }),
+      loadingIndicator: (base: Record<string, unknown>) => ({
+        ...base,
+        // Default DotLoader uses currentColor which inherits the muted control
+        // text — invisible against the white input. Brand-blue makes it stand
+        // out so users know a search is in flight.
+        color: "#2563eb",
+        fontSize: "8px",
       }),
     },
   }


### PR DESCRIPTION
## Summary
- AsyncSelect only flips its internal `isLoading` while `loadOptions` is alive. The 300ms debounce + the backend's per-provider 3s coroutine cap (for header fan-out) left users with no feedback while the keystroke was in flight.
- Now: explicit `isSearching` flag flips on at the first valid keystroke, clears in the load callback's `finally`. `isLoading={isSearching}` is forwarded to AsyncSelect so the spinner shows across the full debounce + fetch window.
- `loadingIndicator` is styled brand-blue (`#2563eb`). Default DotLoader inherits muted control text and was effectively invisible on the white input.

## Test plan
- [ ] Type "TSM" in the header search — spinner appears on first keystroke, persists until results land.
- [ ] Short input (< 2 chars) → no spinner.
- [ ] Slow backend (header fan-out hitting EODHD) — spinner stays visible across the wait.
- [ ] Form-mode AssetSearch (e.g. portfolio edit) still loads with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading indicator visibility in asset search—now displays promptly when typing and uses a more visible brand color for better user feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->