### PR TITLE
fix(accounts): default isPension=true for POLICY assets

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -374,10 +374,15 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
               currentAge: "",
             })
           } else if (categoryId === "POLICY") {
-            // Set default isPension for POLICY category even if no config exists
+            // POLICY assets (CPF, SingLife, state pension, life policies) are
+            // pension-class by default — they all deliver scheduled income to
+            // the Independence plan. Defaulting false used to drop them out
+            // of svc-retire's PensionIncomeService filter, so a fully
+            // configured CPF or lump-sum policy showed $0 income. Defensive
+            // mirror of the backend widening in svc-retire PR #35.
             setConfig((prev) => ({
               ...prev,
-              isPension: false,
+              isPension: true,
             }))
           }
         }


### PR DESCRIPTION
## Summary
- POLICY assets (CPF, SingLife, state pension, life policies) all deliver scheduled income to the Independence plan, so `isPension` should default `true` when creating a new POLICY-category asset via `EditAccountDialog`.
- The previous default (`false` at `EditAccountDialog.tsx:380`) silently dropped fully-configured assets out of svc-retire's `PensionIncomeService.getPensionConfigs` filter, leaving Income Breakdown showing $0 from pension sources even when CPF + sub-accounts + STANDARD plan, or a lump-sum life policy with payoutAge + monthly contribution, were configured.
- Defensive mirror of the backend widening in svc-retire PR #35 (read path); this PR fixes the write path so new rows don't recreate the trap.
- Existing affected production rows get repaired by a separate one-shot DB backfill.

## Test plan
- `yarn lint` green
- `yarn typecheck` green
- `yarn test` — 1350 / 1350 pass
- `yarn prettier` clean
- semgrep scan on changed file — no findings