### PR TITLE
fix(independence): hide Retirement Fund slice; rename Defined Contribution

### DIFF
--- a/src/components/features/independence/DetailsTabContent.tsx
+++ b/src/components/features/independence/DetailsTabContent.tsx
@@ -160,10 +160,10 @@ export default function DetailsTabContent({
           {planInputs?.definedContribution != null &&
             planInputs.definedContribution > 0 && (
               <div className="flex justify-between">
-                <InfoTooltip text="Mandatory defined contribution (e.g., CPF) deducted from your investment allocation. This is invested for you by the government scheme.">
+                <InfoTooltip text="CPF employee contribution deducted from your investable income while you're still working. Stops at retirement age.">
                   <span className="text-gray-500">
                     <i className="fas fa-building text-xs mr-1"></i>
-                    Defined Contribution
+                    CPF Employee Deduction
                   </span>
                 </InfoTooltip>
                 <span

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -195,20 +195,28 @@ function PlanView(): React.ReactElement {
 
   // Transform holdings into category slices (or use manual assets if no holdings)
   const categorySlices = useMemo(() => {
-    // If user has manual assets and no portfolio holdings, use manual assets
-    if (usingManualAssets) {
-      const parsed = parseManualAssets(plan?.manualAssets)
-      if (parsed) {
-        return manualAssetsToSlices(parsed)
+    const raw = (() => {
+      // If user has manual assets and no portfolio holdings, use manual assets
+      if (usingManualAssets) {
+        const parsed = parseManualAssets(plan?.manualAssets)
+        if (parsed) {
+          return manualAssetsToSlices(parsed)
+        }
       }
-    }
-    // Otherwise use portfolio holdings
-    if (!holdingsData) return []
-    return transformToAllocationSlices(
-      holdingsData,
-      "category",
-      ValueIn.PORTFOLIO,
-    )
+      // Otherwise use portfolio holdings
+      if (!holdingsData) return []
+      return transformToAllocationSlices(
+        holdingsData,
+        "category",
+        ValueIn.PORTFOLIO,
+      )
+    })()
+    // Retirement Fund holdings (CPF, SingLife etc.) already feed the
+    // projection as income streams via svc-retire's PensionIncomeService —
+    // showing them in Assets by Category invites the user to toggle them
+    // spendable, which would double-count against the CPF LIFE annuity +
+    // policy maturity already in the Income column.
+    return raw.filter((s) => s.key !== "Retirement Fund")
   }, [holdingsData, usingManualAssets, plan?.manualAssets])
 
   // Auto-select all portfolios when data first loads


### PR DESCRIPTION
## Summary
Two UX corrections on the Independence plan view.

### 1. Retirement Fund — read-only display, no checkbox
Retirement Fund holdings (CPF balances, policy accumulated premium) already feed the projection as scheduled income streams via svc-retire's `PensionIncomeService` — CPF LIFE annuity from age 65, policy maturity lump sum at `payoutAge`. A toggle here invites the user to mark the balance spendable, which double-counts against the Income column.

Approach: keep the row visible (so the user still sees the balance and Total Assets stays meaningful) but render it read-only with a "Pays as income" badge. New `INCOME_STREAM_CATEGORIES = ["Retirement Fund"]` constant feeds:
- a third info-only render section in `AssetsTabContent` (sits between the spendable toggle list and the Property non-spendable row)
- the `effectiveSpendableCategories` filter so it never enters the spendable pool sent to the projection backend

### 2. Relabel "Defined Contribution" → "CPF Employee Deduction"
The negative figure is the CPF employee contribution rate × capped salary (`AllocationResolver.calculateCpfEmployeeDeduction`), deducted from investable income while still working. Tooltip now spells that out and makes explicit it stops at retirement.

## Test plan
- `yarn lint` green
- `yarn typecheck` green
- `yarn test` — 1350 / 1350 pass
- semgrep scan on changed files — no findings