### PR TITLE
fix(independence): show Retirement Fund as read-only Pays as income row

### DIFF
--- a/src/components/features/independence/AssetsTabContent.tsx
+++ b/src/components/features/independence/AssetsTabContent.tsx
@@ -4,6 +4,7 @@ import { AllocationSlice } from "@lib/allocation/aggregateHoldings"
 import { HIDDEN_VALUE, PensionProjection } from "@lib/independence/planHelpers"
 import {
   DEFAULT_NON_SPENDABLE_CATEGORIES,
+  INCOME_STREAM_CATEGORIES,
   FiMetrics,
 } from "@components/features/independence"
 import Spinner from "@components/ui/Spinner"
@@ -150,7 +151,8 @@ export default function AssetsTabContent({
               {categorySlices
                 .filter(
                   (slice) =>
-                    !DEFAULT_NON_SPENDABLE_CATEGORIES.includes(slice.key),
+                    !DEFAULT_NON_SPENDABLE_CATEGORIES.includes(slice.key) &&
+                    !INCOME_STREAM_CATEGORIES.includes(slice.key),
                 )
                 .map((slice) => {
                   const isSpendable = spendableCategories.includes(slice.key)
@@ -200,6 +202,43 @@ export default function AssetsTabContent({
                     </div>
                   )
                 })}
+
+              {/* Income-stream categories (CPF, policy assets) — show
+                  read-only because their balance is already projected as
+                  scheduled income (CPF LIFE annuity, policy maturity).
+                  A toggle here would invite double-counting against the
+                  Income column. */}
+              {categorySlices
+                .filter((slice) =>
+                  INCOME_STREAM_CATEGORIES.includes(slice.key),
+                )
+                .map((slice) => (
+                  <div
+                    key={slice.key}
+                    className="p-3 rounded-lg border border-purple-200 bg-purple-50"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className="w-3 h-3 rounded-full"
+                          style={{ backgroundColor: slice.color }}
+                        />
+                        <span className="text-gray-700">{slice.label}</span>
+                        <span
+                          className="text-xs text-purple-700 bg-purple-100 px-2 py-0.5 rounded"
+                          title="Balance pays out as a scheduled income stream (CPF LIFE annuity, policy maturity) — already counted in the Income column."
+                        >
+                          Pays as income
+                        </span>
+                      </div>
+                      <span className="font-medium text-gray-500">
+                        {hideValues
+                          ? HIDDEN_VALUE
+                          : `${effectiveCurrency}${Math.round(slice.value * effectiveFxRate).toLocaleString()}`}
+                      </span>
+                    </div>
+                  </div>
+                ))}
 
               {/* Show non-spendable (Property) separately */}
               {categorySlices

--- a/src/components/features/independence/index.ts
+++ b/src/components/features/independence/index.ts
@@ -6,6 +6,7 @@ export {
   useAssetBreakdown,
   calculateAssetBreakdown,
   DEFAULT_NON_SPENDABLE_CATEGORIES,
+  INCOME_STREAM_CATEGORIES,
   type AssetBreakdown,
 } from "./useAssetBreakdown"
 

--- a/src/components/features/independence/types.ts
+++ b/src/components/features/independence/types.ts
@@ -1,8 +1,11 @@
 import { RetirementProjection } from "types/independence"
-import { DEFAULT_NON_SPENDABLE_CATEGORIES } from "./useAssetBreakdown"
+import {
+  DEFAULT_NON_SPENDABLE_CATEGORIES,
+  INCOME_STREAM_CATEGORIES,
+} from "./useAssetBreakdown"
 
 // Re-export for backwards compatibility
-export { DEFAULT_NON_SPENDABLE_CATEGORIES }
+export { DEFAULT_NON_SPENDABLE_CATEGORIES, INCOME_STREAM_CATEGORIES }
 
 // What-if adjustments for scenario planning
 export interface WhatIfAdjustments {

--- a/src/components/features/independence/useAssetBreakdown.ts
+++ b/src/components/features/independence/useAssetBreakdown.ts
@@ -4,6 +4,15 @@ import { HoldingContract, ValueInOption } from "types/beancounter"
 /** Default non-spendable categories (property typically can't be easily liquidated) */
 export const DEFAULT_NON_SPENDABLE_CATEGORIES = ["Property", "Real Estate"]
 
+/**
+ * Categories whose balance feeds the Independence projection as a
+ * scheduled income stream (CPF LIFE annuity, policy maturity) rather
+ * than as drawable principal. Excluded from both spendable + non-
+ * spendable pools so the value isn't double-counted against the
+ * income column.
+ */
+export const INCOME_STREAM_CATEGORIES = ["Retirement Fund"]
+
 export interface AssetBreakdown {
   /** Liquid/spendable assets (everything except property) */
   liquidAssets: number

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -12,6 +12,7 @@ import {
   TabId,
   TABS,
   DEFAULT_NON_SPENDABLE_CATEGORIES,
+  INCOME_STREAM_CATEGORIES,
   DEFAULT_WHAT_IF_ADJUSTMENTS,
   hasScenarioChanges,
   useUnifiedProjection,
@@ -228,7 +229,10 @@ function PlanView(): React.ReactElement {
     }
   }, [portfolios])
 
-  // Initialize spendable categories (all except property by default)
+  // Initialize spendable categories. Default = everything that is not
+  // property-style non-spendable AND not an income-stream category whose
+  // balance is already projected as a future income stream (CPF LIFE
+  // annuity, policy maturity).
   useEffect(() => {
     if (
       categorySlices.length > 0 &&
@@ -237,7 +241,9 @@ function PlanView(): React.ReactElement {
     ) {
       const allCategories = categorySlices.map((s) => s.key)
       const spendable = allCategories.filter(
-        (cat) => !DEFAULT_NON_SPENDABLE_CATEGORIES.includes(cat),
+        (cat) =>
+          !DEFAULT_NON_SPENDABLE_CATEGORIES.includes(cat) &&
+          !INCOME_STREAM_CATEGORIES.includes(cat),
       )
       setSpendableCategories(spendable)
       hasCategoriesInitialized.current = true
@@ -257,10 +263,16 @@ function PlanView(): React.ReactElement {
     if (spendableCategories.length > 0) {
       return spendableCategories
     }
-    // Before initialization, use default: all categories except non-spendable ones
+    // Before initialization, use default: everything except property-style
+    // non-spendable AND income-stream categories (those flow to the
+    // projection as scheduled income, not drawable principal).
     return categorySlices
       .map((s) => s.key)
-      .filter((cat) => !DEFAULT_NON_SPENDABLE_CATEGORIES.includes(cat))
+      .filter(
+        (cat) =>
+          !DEFAULT_NON_SPENDABLE_CATEGORIES.includes(cat) &&
+          !INCOME_STREAM_CATEGORIES.includes(cat),
+      )
   }, [spendableCategories, categorySlices])
 
   // Calculate liquid (spendable) assets - only selected categories (for local display)


### PR DESCRIPTION
## Summary
Follow-up to #729 which hid the Retirement Fund row entirely from Assets by Category. Hiding worked as a double-count guard but lost visibility — the ~$300k pension pot (CPF + policy balances) disappeared, and Total Assets understated.

Restore the row but render it read-only with a "Pays as income" badge, sitting between the spendable toggle list and the existing Property non-spendable row. Cannot be toggled spendable, so still safe against double-counting against the projection's Income column (CPF LIFE annuity + policy maturity).

Mechanics:
- New `INCOME_STREAM_CATEGORIES = ["Retirement Fund"]` constant in `useAssetBreakdown.ts`, re-exported via the feature index.
- `AssetsTabContent` renders any slice in that list inside a third read-only section (purple badge, no checkbox).
- `[id].tsx` excludes income-stream categories from the default + effective spendable filters so the projection backend never sees the balance in the spendable pool.

## Test plan
- `yarn lint` green
- `yarn typecheck` green
- `yarn test` — 1350 / 1350 pass
- semgrep scan on changed files — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Income-stream categories (e.g., CPF LIFE annuity, policy maturity) now display separately in the Assets tab with a "Pays as income" indicator and distinct styling, preventing double-counting in income projections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->