### PR TITLE
refactor(labels): rename "Retirement Fund" -> "Policies"

### DIFF
--- a/e2e/tests/onboarding/cpf-onboarding.spec.ts
+++ b/e2e/tests/onboarding/cpf-onboarding.spec.ts
@@ -289,7 +289,7 @@ test.describe("CPF Onboarding Flow", () => {
 
       // Default card view groups by Asset Class; the first group is expanded
       // by default, so the CPF asset card should be visible without a toggle.
-      await expect(newPage.getByText("Retirement Fund").first()).toBeVisible()
+      await expect(newPage.getByText("Policies").first()).toBeVisible()
 
       // Verify the CPF asset name appears
       await expect(newPage.getByText("Central Provident Fund")).toBeVisible({

--- a/src/components/features/accounts/AssetTable.tsx
+++ b/src/components/features/accounts/AssetTable.tsx
@@ -3,12 +3,12 @@ import { Asset } from "types/beancounter"
 import { stripOwnerPrefix, getAssetCurrency } from "@lib/assets/assetUtils"
 
 const CATEGORY_LABELS: Record<string, string> = {
-  PENSION: "Retirement Fund",
+  PENSION: "Policies",
   ACCOUNT: "Bank Account",
   TRADE: "Trade Account",
   RE: "Real Estate",
   "MUTUAL FUND": "Mutual Fund",
-  POLICY: "Retirement Fund",
+  POLICY: "Policies",
 }
 
 interface AssetTableProps {

--- a/src/components/features/accounts/CategoryCard.tsx
+++ b/src/components/features/accounts/CategoryCard.tsx
@@ -25,7 +25,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
       "Unlisted mutual funds and unit trusts. Set prices manually as these don't have market data feeds.",
     POLICY:
       "Defined contribution scheme or Investment Linked Insurance that contains sub-accounts.",
-    PENSION: "Retirement Fund",
+    PENSION: "Policies",
   }
   const description = CATEGORY_DESCRIPTIONS[categoryId] || ""
 

--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -749,7 +749,7 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                   <>
                     <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-sm text-blue-700 mb-4">
                       <i className="fas fa-info-circle mr-2"></i>
-                      {"Configure your retirement fund for projections."}
+                      {"Configure your policy for projections."}
                     </div>
 
                     {/* Payout Type */}

--- a/src/components/features/accounts/SetPriceDialog.tsx
+++ b/src/components/features/accounts/SetPriceDialog.tsx
@@ -4,12 +4,12 @@ import { stripOwnerPrefix, getAssetCurrency } from "@lib/assets/assetUtils"
 import { useDialogSubmit } from "@hooks/useDialogSubmit"
 
 const CATEGORY_LABELS: Record<string, string> = {
-  PENSION: "Retirement Fund",
+  PENSION: "Policies",
   ACCOUNT: "Bank Account",
   TRADE: "Trade Account",
   RE: "Real Estate",
   "MUTUAL FUND": "Mutual Fund",
-  POLICY: "Retirement Fund",
+  POLICY: "Policies",
 }
 import Dialog from "@components/ui/Dialog"
 import Alert from "@components/ui/Alert"

--- a/src/components/features/holdings/CostAdjustDialog.tsx
+++ b/src/components/features/holdings/CostAdjustDialog.tsx
@@ -2,12 +2,12 @@ import React, { useState, useMemo } from "react"
 import { Asset, Currency } from "types/beancounter"
 
 const CATEGORY_LABELS: Record<string, string> = {
-  PENSION: "Retirement Fund",
+  PENSION: "Policies",
   ACCOUNT: "Bank Account",
   TRADE: "Trade Account",
   RE: "Real Estate",
   "MUTUAL FUND": "Mutual Fund",
-  POLICY: "Retirement Fund",
+  POLICY: "Policies",
 }
 import MathInput from "@components/ui/MathInput"
 import DateInput from "@components/ui/DateInput"

--- a/src/components/features/holdings/SetBalanceDialog.tsx
+++ b/src/components/features/holdings/SetBalanceDialog.tsx
@@ -7,12 +7,12 @@ import {
 } from "types/beancounter"
 
 const CATEGORY_LABELS: Record<string, string> = {
-  PENSION: "Retirement Fund",
+  PENSION: "Policies",
   ACCOUNT: "Bank Account",
   TRADE: "Trade Account",
   RE: "Real Estate",
   "MUTUAL FUND": "Mutual Fund",
-  POLICY: "Retirement Fund",
+  POLICY: "Policies",
 }
 import useSwr from "swr"
 import { portfoliosKey, simpleFetcher } from "@utils/api/fetchHelper"

--- a/src/components/features/holdings/SetPriceDialog.tsx
+++ b/src/components/features/holdings/SetPriceDialog.tsx
@@ -7,12 +7,12 @@ import { stripOwnerPrefix, getAssetCurrency } from "@lib/assets/assetUtils"
 import { useDialogSubmit } from "@hooks/useDialogSubmit"
 
 const CATEGORY_LABELS: Record<string, string> = {
-  PENSION: "Retirement Fund",
+  PENSION: "Policies",
   ACCOUNT: "Bank Account",
   TRADE: "Trade Account",
   RE: "Real Estate",
   "MUTUAL FUND": "Mutual Fund",
-  POLICY: "Retirement Fund",
+  POLICY: "Policies",
 }
 
 interface SetPriceDialogProps {

--- a/src/components/features/holdings/__tests__/CardView.test.tsx
+++ b/src/components/features/holdings/__tests__/CardView.test.tsx
@@ -360,7 +360,7 @@ describe("CardView footer (Quantity / Price / Weight)", () => {
         id: "policy-1",
         code: "CPF",
         name: "CPF Composite",
-        assetCategory: { id: "POLICY", name: "Retirement Fund" },
+        assetCategory: { id: "POLICY", name: "Policies" },
         market: {
           code: "PRIVATE",
           name: "Private",

--- a/src/components/features/independence/useAssetBreakdown.ts
+++ b/src/components/features/independence/useAssetBreakdown.ts
@@ -13,7 +13,7 @@ export const DEFAULT_NON_SPENDABLE_CATEGORIES = ["Property", "Real Estate"]
  * ones that exclude them from the spendable pool so the value isn't
  * double-counted against the income column.
  */
-export const INCOME_STREAM_CATEGORIES = ["Retirement Fund"]
+export const INCOME_STREAM_CATEGORIES = ["Policies"]
 
 export interface AssetBreakdown {
   /** Liquid/spendable assets (everything except property) */

--- a/src/lib/utils/independence/messages.ts
+++ b/src/lib/utils/independence/messages.ts
@@ -63,12 +63,12 @@ export const wizardMessages = {
       isPension: "This is a pension fund",
       lumpSum: "Lump sum payout (instead of monthly)",
       // Existing assets without balances
-      assetsNeedingBalance: "Retirement Funds Need Balances",
+      assetsNeedingBalance: "Policies Need Balances",
       assetsNeedingBalanceDescription:
-        "The following retirement accounts don't have a balance recorded. Set their current balance to include them in projections.",
+        "The following policies don't have a balance recorded. Set their current balance to include them in projections.",
       setBalance: "Set Balance",
       settingBalance: "Setting...",
-      checkingAssets: "Checking existing retirement funds...",
+      checkingAssets: "Checking existing policies...",
       transactionDate: "As At Date",
       cashAccount: "Credit To",
       cashAccountHint: "Select cash account for withdrawal",

--- a/src/lib/utils/wealth/__tests__/liquidityGroups.test.ts
+++ b/src/lib/utils/wealth/__tests__/liquidityGroups.test.ts
@@ -87,7 +87,7 @@ describe("isLiquidPortfolio", () => {
       isLiquidPortfolio(
         makePortfolio({
           code: "PEN",
-          assetClassification: { "Retirement Fund": 80000, Cash: 1000 },
+          assetClassification: { Policies: 80000, Cash: 1000 },
         }),
       ),
     ).toBe(true)

--- a/src/lib/utils/wealth/liquidityGroups.ts
+++ b/src/lib/utils/wealth/liquidityGroups.ts
@@ -53,7 +53,7 @@ export function mapToLiquidityGroup(categoryName: string): string {
     case "Superannuation":
     case "Annuity":
     case "Policy":
-    case "Retirement Fund":
+    case "Policies":
       return "Retirement"
     default:
       return "Other"

--- a/src/pages/accounts.tsx
+++ b/src/pages/accounts.tsx
@@ -29,12 +29,12 @@ import {
 } from "@components/features/accounts/accountTypes"
 
 const categoryLabels: Record<string, string> = {
-  PENSION: "Retirement Fund",
+  PENSION: "Policies",
   ACCOUNT: "Bank Account",
   TRADE: "Trade Account",
   RE: "Real Estate",
   "MUTUAL FUND": "Mutual Fund",
-  POLICY: "Retirement Fund",
+  POLICY: "Policies",
 }
 
 function AccountsPage(): React.ReactElement {

--- a/src/pages/admin/assets.tsx
+++ b/src/pages/admin/assets.tsx
@@ -13,7 +13,7 @@ import { getAssetCurrency, getDisplayCode } from "@lib/assets/assetUtils"
 
 const EDITABLE_CATEGORIES = [
   { id: "ACCOUNT", name: "Bank Account" },
-  { id: "POLICY", name: "Retirement Fund" },
+  { id: "POLICY", name: "Policies" },
   { id: "RE", name: "Real Estate" },
   { id: "Equity", name: "Equity" },
 ]

--- a/src/pages/assets/account.tsx
+++ b/src/pages/assets/account.tsx
@@ -338,7 +338,7 @@ export default withPageAuthRequired(
             <div className="mt-6 p-4 rounded-lg border bg-blue-50 border-blue-200">
               <h3 className="font-medium text-gray-900 mb-4 flex items-center">
                 <i className="fas fa-piggy-bank text-blue-500 mr-2"></i>
-                {"Retirement Fund Settings"}
+                {"Policy Settings"}
               </h3>
 
               <CompositeAssetEditor


### PR DESCRIPTION
## Summary
- Singapore users hold CPF + insurance policies, not pensions in the traditional sense. The "Retirement Fund" label was confusing about which buckets the planning screens were grouping.
- Renames the PENSION/POLICY asset category display label to "Policies" everywhere it surfaces as a category — mapping objects, `INCOME_STREAM_CATEGORIES`, the liquidity-group switch, the admin asset seed, and matching test fixtures.
- Also retitles the matching settings dialog ("Retirement Fund Settings" → "Policy Settings"), the EditAccountDialog tooltip, two `independence/messages` strings, and the CPF onboarding E2E expectation.
- The PENSION asset class enum, DB columns, and API contracts are untouched — display-only rename.

## Test plan
- [x] `yarn typecheck && yarn test && yarn prettier && yarn lint` — 119 suites / 1348 tests green.
- [ ] Visual: load Ruby's plan → "Assets by Category" should now read "Policies" (not "Retirement Fund") for the CPF + POLICY block.
- [ ] CPF onboarding E2E (`e2e/tests/onboarding/cpf-onboarding.spec.ts`) — relies on the post-onboarding category heading reading "Policies".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated category terminology from "Retirement Fund" to "Policies" across all account, holdings, and asset management interfaces.
  * Revised UI labels and descriptions to consistently use "Policies" language throughout the application.

* **Documentation**
  * Updated independence wizard messaging to reflect "Policies" terminology instead of "Retirement Fund".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->