### PR TITLE
feat(metrics): reconcile pension funded banner with bridge runway

### DIFF
--- a/src/components/features/independence/FiMetrics.tsx
+++ b/src/components/features/independence/FiMetrics.tsx
@@ -501,6 +501,7 @@ export default function FiMetrics({
           <PensionStrategySection
             retirementAgeFiProgress={backendRetirementAgeFiProgress}
             incomeCoverage={backendIncomeCoverageAtRetirement}
+            bridgeProgress={backendBridgeProgress}
             isClassicFi={isFi}
             active={pensionActive}
             hideValues={hideValues}
@@ -555,6 +556,14 @@ function StrategyHeader({
 interface PensionStrategySectionProps {
   retirementAgeFiProgress?: number
   incomeCoverage?: number
+  /**
+   * Liquid runway through the pre-pension bridge years. Drives the funded
+   * banner so we don't celebrate "On Track for FI" while Sustainable
+   * Spending is simultaneously asking the user to cut back. Optional —
+   * absent when the user is already past pension payout age (no bridge
+   * to fund).
+   */
+  bridgeProgress?: number
   isClassicFi: boolean
   active?: boolean
   hideValues: boolean
@@ -568,6 +577,7 @@ interface PensionStrategySectionProps {
 function PensionStrategySection({
   retirementAgeFiProgress,
   incomeCoverage,
+  bridgeProgress,
   isClassicFi,
   active,
   hideValues,
@@ -599,11 +609,17 @@ function PensionStrategySection({
   }
 
   const sorted = [...gauges].sort((a, b) => b.value - a.value)
-  const showAchievement =
-    !isClassicFi &&
-    !hideValues &&
-    retirementAgeFiProgress != null &&
-    retirementAgeFiProgress >= 100
+
+  // Banner tier — driven by the BRIDGE (liquid coverage of pre-pension
+  // years), not just the lifetime-FI score. Otherwise we end up cheering
+  // "On Track for FI" while Sustainable Spending simultaneously warns the
+  // user to cut SGD950/mo — the exact contradiction Ruby surfaced.
+  const lifetimeFunded =
+    retirementAgeFiProgress != null && retirementAgeFiProgress >= 100
+  const fundedBanner: FundedBanner | null =
+    !isClassicFi && !hideValues && lifetimeFunded
+      ? deriveFundedBanner(bridgeProgress)
+      : null
 
   return (
     <div className="pt-4 border-t border-gray-100 space-y-3">
@@ -622,21 +638,70 @@ function PensionStrategySection({
         sorted.map(({ key, ...rest }) => <PensionGauge key={key} {...rest} />)
       )}
 
-      {showAchievement && (
-        <div className="p-3 bg-green-50 rounded-lg border border-green-200">
-          <div className="flex items-center gap-2 text-green-700">
+      {fundedBanner && (
+        <div className={`p-3 rounded-lg border ${fundedBanner.containerClass}`}>
+          <div className={`flex items-center gap-2 ${fundedBanner.titleClass}`}>
             <i className="fas fa-piggy-bank"></i>
-            <span className="font-medium">On Track for FI at Retirement</span>
+            <span className="font-medium">{fundedBanner.title}</span>
           </div>
-          <p className="text-xs text-green-600 mt-1">
-            Your liquid assets plus the present value of your guaranteed pension
-            income already meet your FI Number. You may not be able to retire
-            early on liquid assets alone, but your full retirement is funded.
+          <p className={`text-xs mt-1 ${fundedBanner.bodyClass}`}>
+            {fundedBanner.body}
           </p>
         </div>
       )}
     </div>
   )
+}
+
+interface FundedBanner {
+  title: string
+  body: string
+  containerClass: string
+  titleClass: string
+  bodyClass: string
+}
+
+/**
+ * Pick a banner tone that reconciles the lifetime-FI win with the
+ * pre-pension liquid runway. `bridgeProgress` is the bridge-years gauge
+ * (liquid / required liquid through to pension payout). When absent we
+ * assume no bridge is needed (user already past pension start).
+ */
+function deriveFundedBanner(bridgeProgress?: number): FundedBanner {
+  const bridgeCovered = bridgeProgress == null || bridgeProgress >= 100
+  if (bridgeCovered) {
+    return {
+      title: "Funded — liquid covers the gap to your pension",
+      body:
+        "Your liquid pot is enough to carry you to your pension start age, " +
+        "and your pension income covers the rest.",
+      containerClass: "bg-green-50 border-green-200",
+      titleClass: "text-green-700",
+      bodyClass: "text-green-600",
+    }
+  }
+  if (bridgeProgress != null && bridgeProgress >= 60) {
+    return {
+      title: "Lifetime funded — but liquid may run short before pension",
+      body:
+        "Your guaranteed income covers full retirement, but at current spending " +
+        "your liquid pot won't last to your pension start age. " +
+        "Reduce monthly spending OR retire later to close the gap.",
+      containerClass: "bg-amber-50 border-amber-200",
+      titleClass: "text-amber-700",
+      bodyClass: "text-amber-600",
+    }
+  }
+  return {
+    title: "Lifetime funded — bridge gap to pension is significant",
+    body:
+      "Pension income covers full retirement, but you'd deplete liquid assets " +
+      "well before your pension starts. Reduce monthly spending, retire later, " +
+      "or grow liquid assets.",
+    containerClass: "bg-orange-50 border-orange-200",
+    titleClass: "text-orange-700",
+    bodyClass: "text-orange-600",
+  }
 }
 
 interface BridgeStrategySectionProps {

--- a/src/components/features/independence/SustainableSpendingCard.tsx
+++ b/src/components/features/independence/SustainableSpendingCard.tsx
@@ -57,9 +57,11 @@ export default function SustainableSpendingCard({
               ending balance
             </div>
           )}
-        <div className="text-xs text-amber-600 bg-amber-50 rounded px-2 py-1">
-          Assumes steady returns with no market volatility. Use Stress Test for
-          a range of outcomes.
+        <div className="text-xs text-gray-500">
+          Gross expense level your liquid assets can sustain across the planning
+          horizon, after netting any pension / rental income that starts during
+          retirement. Assumes steady returns — use Stress Test for a range of
+          outcomes.
         </div>
         <hr />
         {projection.expenseAdjustment != null &&

--- a/src/components/features/independence/__tests__/FiMetrics.test.tsx
+++ b/src/components/features/independence/__tests__/FiMetrics.test.tsx
@@ -528,16 +528,85 @@ describe("FiMetrics", () => {
       expect(labels).toEqual(["Retirement-Age FI", "Income Coverage"])
     })
 
-    it("shows retirement-age FI banner inside Pension section", () => {
+    it("shows green funded banner when bridge is covered (bridgeProgress >= 100)", () => {
       render(
         <FiMetrics
           {...defaultProps}
-          backendFiMetrics={mkFi({ retirementAgeFiProgress: 100 })}
+          backendFiMetrics={mkFi({
+            retirementAgeFiProgress: 106.6,
+            bridgeProgress: 120,
+            bridgeYearsNeeded: 13,
+          })}
         />,
       )
       expect(
-        screen.getByText("On Track for FI at Retirement"),
+        screen.getByText("Funded — liquid covers the gap to your pension"),
       ).toBeInTheDocument()
+    })
+
+    it("shows amber banner when lifetime funded but bridge is partial (60-99%)", () => {
+      render(
+        <FiMetrics
+          {...defaultProps}
+          backendFiMetrics={mkFi({
+            retirementAgeFiProgress: 106.6,
+            bridgeProgress: 70,
+            bridgeYearsNeeded: 13,
+          })}
+        />,
+      )
+      expect(
+        screen.getByText(
+          "Lifetime funded — but liquid may run short before pension",
+        ),
+      ).toBeInTheDocument()
+    })
+
+    it("shows orange banner when bridge gap is significant (<60%)", () => {
+      render(
+        <FiMetrics
+          {...defaultProps}
+          backendFiMetrics={mkFi({
+            retirementAgeFiProgress: 106.6,
+            bridgeProgress: 40,
+            bridgeYearsNeeded: 13,
+          })}
+        />,
+      )
+      expect(
+        screen.getByText(
+          "Lifetime funded — bridge gap to pension is significant",
+        ),
+      ).toBeInTheDocument()
+    })
+
+    it("treats missing bridgeProgress as no-bridge-needed (green banner)", () => {
+      render(
+        <FiMetrics
+          {...defaultProps}
+          backendFiMetrics={mkFi({
+            retirementAgeFiProgress: 106.6,
+            // bridgeProgress omitted — user already past pension start
+          })}
+        />,
+      )
+      expect(
+        screen.getByText("Funded — liquid covers the gap to your pension"),
+      ).toBeInTheDocument()
+    })
+
+    it("shows no funded banner when lifetime FI is not yet achieved", () => {
+      render(
+        <FiMetrics
+          {...defaultProps}
+          backendFiMetrics={mkFi({
+            retirementAgeFiProgress: 85,
+            bridgeProgress: 120,
+          })}
+        />,
+      )
+      expect(screen.queryByText(/Funded — /)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Lifetime funded/)).not.toBeInTheDocument()
     })
 
     it("shows Active badge on FIRE Strategy when effective strategy is FIRE", () => {
@@ -602,7 +671,7 @@ describe("FiMetrics", () => {
       expect(screen.queryByText("Bridge Strategy")).not.toBeInTheDocument()
     })
 
-    it("hides retirement-age FI banner when classic FI already achieved", () => {
+    it("hides funded banner when classic FI already achieved", () => {
       render(
         <FiMetrics
           {...defaultProps}
@@ -612,9 +681,8 @@ describe("FiMetrics", () => {
       )
       // Classic banner wins; pension banner stays hidden to avoid duplication
       expect(screen.getByText("Financially Independent!")).toBeInTheDocument()
-      expect(
-        screen.queryByText("On Track for FI at Retirement"),
-      ).not.toBeInTheDocument()
+      expect(screen.queryByText(/Funded — /)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Lifetime funded/)).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Summary
- The "On Track for FI at Retirement" banner used to fire purely on `retirementAgeFiProgress >= 100`. For Ruby (and any pension saver with a pre-pension bridge gap), this celebrated lifetime FI green while Sustainable Spending was simultaneously asking for a SGD-950/mo cut — two true numbers telling contradictory stories.
- Replaces the banner with a tiered version that reads `bridgeProgress` alongside `retirementAgeFiProgress`:

  | Condition | Banner |
  |---|---|
  | bridge covered (≥100% or no bridge needed) | 🟢 "Funded — liquid covers the gap to your pension" |
  | lifetime funded + bridge 60-99% | 🟡 "Lifetime funded — but liquid may run short before pension" |
  | lifetime funded + bridge <60% | 🟠 "Lifetime funded — bridge gap to pension is significant" |
  | lifetime FI not yet achieved | — (no banner; gauges + Sustainable Spending tell the story) |

- Relabels the Sustainable Spending subtitle so SGD2,735 reads as "gross expense your liquid pot can sustain across the horizon, net of pension/rental income that starts during retirement", not as an absolute spending cap.

## Test plan
- [x] `yarn typecheck && yarn test && yarn prettier && yarn lint` — 119 suites / 1352 tests green.
- [x] Five new FiMetrics tests cover each banner tier (covered / partial / significant / no-bridge-needed / lifetime FI not yet achieved).
- [ ] Visual: load Ruby's plan, Metrics tab — banner now reads amber/orange instead of green, matching the SGD-950 cut warning. (Depends on the bridge-progress value backend returns; svc-retire PR #38 also lights this up.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated retirement funding achievement banner with tiered messaging based on lifetime funding progress and liquid runway before pension starts.
  * Enhanced sustainable spending explanation to clarify expense levels, income timing, and return assumptions.

* **Tests**
  * Added coverage for funded banner states across various funding scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/monowai/bc-view/pull/734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->