### PR TITLE
feat(independence): accept UI for shared INDEPENDENCE_PLAN invites

### DIFF
--- a/src/components/features/shares/PendingResourceSharesPanel.tsx
+++ b/src/components/features/shares/PendingResourceSharesPanel.tsx
@@ -1,0 +1,161 @@
+import React, { useState } from "react"
+import {
+  PendingResourceSharesResponse,
+  ResourceShare,
+  ShareResourceType,
+} from "types/beancounter"
+
+interface PendingResourceSharesPanelProps {
+  pending: PendingResourceSharesResponse
+  /**
+   * When set, only invites/requests for this resource type are rendered.
+   * Lets each owning page (Independence / Rebalance) surface only its own
+   * pending shares without leaking the other type.
+   */
+  resourceType?: ShareResourceType
+  onAction: () => void
+}
+
+const typeLabel = (t: ShareResourceType): string =>
+  t === "INDEPENDENCE_PLAN" ? "Plan" : "Model"
+
+export default function PendingResourceSharesPanel({
+  pending,
+  resourceType,
+  onAction,
+}: PendingResourceSharesPanelProps): React.ReactElement | null {
+  const invites = resourceType
+    ? pending.invites.filter((s) => s.resourceType === resourceType)
+    : pending.invites
+  const requests = resourceType
+    ? pending.requests.filter((s) => s.resourceType === resourceType)
+    : pending.requests
+
+  if (invites.length === 0 && requests.length === 0) {
+    return null
+  }
+
+  const invitationsHeader = resourceType
+    ? `${typeLabel(resourceType)} Invitations for You`
+    : "Invitations for You"
+  const requestsHeader = resourceType
+    ? `Requests for Your ${typeLabel(resourceType)}s`
+    : "Requests for Your Resources"
+
+  return (
+    <div className="space-y-4 mb-6">
+      {invites.length > 0 && (
+        <div className="bg-blue-50 border border-blue-200 rounded-xl p-4">
+          <h3 className="text-sm font-semibold text-blue-800 mb-3">
+            <i className="fas fa-envelope-open mr-2"></i>
+            {invitationsHeader}
+          </h3>
+          <div className="space-y-2">
+            {invites.map((share) => (
+              <PendingResourceShareRow
+                key={share.id}
+                share={share}
+                label={share.createdBy.email || "Unknown"}
+                onAction={onAction}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {requests.length > 0 && (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+          <h3 className="text-sm font-semibold text-amber-800 mb-3">
+            <i className="fas fa-hand-paper mr-2"></i>
+            {requestsHeader}
+          </h3>
+          <div className="space-y-2">
+            {requests.map((share) => (
+              <PendingResourceShareRow
+                key={share.id}
+                share={share}
+                label={share.createdBy.email || "Unknown"}
+                onAction={onAction}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface PendingResourceShareRowProps {
+  share: ResourceShare
+  label: string
+  onAction: () => void
+}
+
+function PendingResourceShareRow({
+  share,
+  label,
+  onAction,
+}: PendingResourceShareRowProps): React.ReactElement {
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleAccept = async (): Promise<void> => {
+    setIsLoading(true)
+    try {
+      await fetch(`/api/resource-shares/${share.id}/accept`, {
+        method: "POST",
+      })
+      onAction()
+    } catch {
+      // error handled silently
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleDecline = async (): Promise<void> => {
+    setIsLoading(true)
+    try {
+      await fetch(`/api/resource-shares/${share.id}`, { method: "DELETE" })
+      onAction()
+    } catch {
+      // error handled silently
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between bg-white rounded-lg p-3 shadow-sm">
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-gray-900 truncate">
+          <span className="text-wealth-600 mr-2">
+            {typeLabel(share.resourceType)}
+          </span>
+          {share.resourceName || share.resourceId}
+        </div>
+        <div className="text-xs text-gray-500">
+          {"From"}: {label}
+          <span className="ml-2 text-gray-400">
+            {share.accessLevel === "VIEW" ? "View Only" : "Full Access"}
+          </span>
+        </div>
+      </div>
+      <div className="flex items-center space-x-2 ml-3">
+        <button
+          onClick={handleAccept}
+          disabled={isLoading}
+          className="bg-green-500 text-white text-xs px-3 py-1.5 rounded hover:bg-green-600 transition-colors disabled:opacity-50"
+        >
+          {"Accept"}
+        </button>
+        <button
+          onClick={handleDecline}
+          disabled={isLoading}
+          className="bg-gray-300 text-gray-700 text-xs px-3 py-1.5 rounded hover:bg-gray-400 transition-colors disabled:opacity-50"
+        >
+          {"Decline"}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/shares/PendingResourceSharesPanel.tsx
+++ b/src/components/features/shares/PendingResourceSharesPanel.tsx
@@ -97,65 +97,82 @@ function PendingResourceShareRow({
   onAction,
 }: PendingResourceShareRowProps): React.ReactElement {
   const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
-  const handleAccept = async (): Promise<void> => {
+  const runAction = async (
+    url: string,
+    method: "POST" | "DELETE",
+    failureMessage: string,
+  ): Promise<void> => {
     setIsLoading(true)
+    setError(null)
     try {
-      await fetch(`/api/resource-shares/${share.id}/accept`, {
-        method: "POST",
-      })
+      const res = await fetch(url, { method })
+      if (!res.ok) {
+        setError(`${failureMessage} (${res.status})`)
+        return
+      }
       onAction()
-    } catch {
-      // error handled silently
+    } catch (err) {
+      setError(err instanceof Error ? err.message : failureMessage)
     } finally {
       setIsLoading(false)
     }
   }
 
-  const handleDecline = async (): Promise<void> => {
-    setIsLoading(true)
-    try {
-      await fetch(`/api/resource-shares/${share.id}`, { method: "DELETE" })
-      onAction()
-    } catch {
-      // error handled silently
-    } finally {
-      setIsLoading(false)
-    }
-  }
+  const handleAccept = (): Promise<void> =>
+    runAction(
+      `/api/resource-shares/${share.id}/accept`,
+      "POST",
+      "Failed to accept invitation",
+    )
+
+  const handleDecline = (): Promise<void> =>
+    runAction(
+      `/api/resource-shares/${share.id}`,
+      "DELETE",
+      "Failed to decline invitation",
+    )
 
   return (
-    <div className="flex items-center justify-between bg-white rounded-lg p-3 shadow-sm">
-      <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-gray-900 truncate">
-          <span className="text-wealth-600 mr-2">
-            {typeLabel(share.resourceType)}
-          </span>
-          {share.resourceName || share.resourceId}
+    <div className="bg-white rounded-lg p-3 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-gray-900 truncate">
+            <span className="text-wealth-600 mr-2">
+              {typeLabel(share.resourceType)}
+            </span>
+            {share.resourceName || share.resourceId}
+          </div>
+          <div className="text-xs text-gray-500">
+            {"From"}: {label}
+            <span className="ml-2 text-gray-400">
+              {share.accessLevel === "VIEW" ? "View Only" : "Full Access"}
+            </span>
+          </div>
         </div>
-        <div className="text-xs text-gray-500">
-          {"From"}: {label}
-          <span className="ml-2 text-gray-400">
-            {share.accessLevel === "VIEW" ? "View Only" : "Full Access"}
-          </span>
+        <div className="flex items-center space-x-2 ml-3">
+          <button
+            onClick={handleAccept}
+            disabled={isLoading}
+            className="bg-green-500 text-white text-xs px-3 py-1.5 rounded hover:bg-green-600 transition-colors disabled:opacity-50"
+          >
+            {"Accept"}
+          </button>
+          <button
+            onClick={handleDecline}
+            disabled={isLoading}
+            className="bg-gray-300 text-gray-700 text-xs px-3 py-1.5 rounded hover:bg-gray-400 transition-colors disabled:opacity-50"
+          >
+            {"Decline"}
+          </button>
         </div>
       </div>
-      <div className="flex items-center space-x-2 ml-3">
-        <button
-          onClick={handleAccept}
-          disabled={isLoading}
-          className="bg-green-500 text-white text-xs px-3 py-1.5 rounded hover:bg-green-600 transition-colors disabled:opacity-50"
-        >
-          {"Accept"}
-        </button>
-        <button
-          onClick={handleDecline}
-          disabled={isLoading}
-          className="bg-gray-300 text-gray-700 text-xs px-3 py-1.5 rounded hover:bg-gray-400 transition-colors disabled:opacity-50"
-        >
-          {"Decline"}
-        </button>
-      </div>
+      {error && (
+        <div className="mt-2 text-xs text-red-600" role="alert">
+          {error}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/layout/SharesBadge.tsx
+++ b/src/components/layout/SharesBadge.tsx
@@ -51,9 +51,23 @@ export default function SharesBadge(): React.ReactElement | null {
     return null
   }
 
+  // Pick the most useful landing page based on what's pending. Portfolio shares
+  // take priority because the /portfolios managed tab is the established home
+  // for them; INDEPENDENCE_PLAN-only invites route to /independence where the
+  // PendingResourceSharesPanel can accept them in context.
+  const independenceInvitesOnly =
+    portfolioCount === 0 &&
+    resourceData != null &&
+    [...resourceData.invites, ...resourceData.requests].every(
+      (s) => s.resourceType === "INDEPENDENCE_PLAN",
+    )
+  const href = independenceInvitesOnly
+    ? "/independence"
+    : "/portfolios?tab=managed"
+
   return (
     <Link
-      href="/portfolios?tab=managed"
+      href={href}
       className="relative p-2 text-gray-300 hover:text-white transition-colors"
       title={`${count} pending share action${count === 1 ? "" : "s"}`}
     >

--- a/src/pages/independence/index.tsx
+++ b/src/pages/independence/index.tsx
@@ -4,9 +4,17 @@ import Head from "next/head"
 import Link from "next/link"
 import { useRouter } from "next/router"
 import useSwr from "swr"
-import { simpleFetcher, holdingKey } from "@utils/api/fetchHelper"
+import {
+  simpleFetcher,
+  fetcher,
+  holdingKey,
+  resourceSharesPendingKey,
+} from "@utils/api/fetchHelper"
 import { PlansResponse, RetirementPlan, PlanExport } from "types/independence"
-import { HoldingContract } from "types/beancounter"
+import {
+  HoldingContract,
+  PendingResourceSharesResponse,
+} from "types/beancounter"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
 import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
 import { sortPlansByCompositeOrder } from "@lib/independence/planOrdering"
@@ -19,6 +27,7 @@ import CompositeTab from "@components/features/independence/CompositeTab"
 import ScenarioList from "@components/features/independence/scenarios/ScenarioList"
 import IndependenceSettingsPanel from "@components/features/independence/IndependenceSettingsPanel"
 import ResourceShareInviteDialog from "@components/features/shares/ResourceShareInviteDialog"
+import PendingResourceSharesPanel from "@components/features/shares/PendingResourceSharesPanel"
 import Alert from "@components/ui/Alert"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
 import Dialog from "@components/ui/Dialog"
@@ -279,6 +288,24 @@ function RetirementPlanning(): React.ReactElement {
     plansKey,
     simpleFetcher(plansKey),
   )
+
+  // Pending INDEPENDENCE_PLAN invites/requests so users can accept shares
+  // from inside the page where the shared plan will land — without this the
+  // SharesBadge counts INDEPENDENCE_PLAN invites but has no accept surface
+  // (ManagedPortfolios only renders PORTFOLIO shares).
+  const {
+    data: pendingResourceShares,
+    mutate: mutatePendingResourceShares,
+  } = useSwr<PendingResourceSharesResponse>(resourceSharesPendingKey, fetcher, {
+    refreshInterval: 300000,
+    revalidateOnFocus: false,
+    dedupingInterval: 60000,
+  })
+
+  const handlePendingResourceSharesAction = (): void => {
+    mutatePendingResourceShares()
+    mutate()
+  }
 
   // Fetch aggregated holdings once at page level for consistent FI calculation across all plans
   // Use SWR caching to persist across refreshes (revalidateOnFocus: false)
@@ -617,6 +644,14 @@ function RetirementPlanning(): React.ReactElement {
               </button>
             )}
           </div>
+
+          {pendingResourceShares && (
+            <PendingResourceSharesPanel
+              pending={pendingResourceShares}
+              resourceType="INDEPENDENCE_PLAN"
+              onAction={handlePendingResourceSharesAction}
+            />
+          )}
 
           {isLoading && (
             <div className="text-center py-12">


### PR DESCRIPTION
## Summary
- New \`PendingResourceSharesPanel\` mirrors \`PendingSharesPanel\` pattern, accepts via \`/api/resource-shares/{id}/accept\`, declines via \`DELETE\`
- Rendered at top of \`/independence\` page, filtered to \`resourceType=INDEPENDENCE_PLAN\` so invites land where the plan will live
- \`SharesBadge\` now routes to \`/independence\` when only \`INDEPENDENCE_PLAN\` invites are pending; portfolio invites still take priority and route to \`/portfolios?tab=managed\`

## Why
\`SharesBadge\` was already counting \`resource-shares/pending\` invites toward the red dot, but the link target only renders portfolio shares. Result: badge showed \"1\" with nowhere to accept.

## Test plan
- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean
- [ ] Manual: Ruby shares her independence plan with mike; mike logs in → badge shows 1 → click → lands on \`/independence\` with invite at top → Accept → plan appears in list

## Pairs with
- monowai/svc-retire PR scoping shared-plan demographics to plan owner (work scenarios / age / life expectancy now come from owner, not viewer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display and manage pending resource share invitations and requests with Accept/Decline actions and success callbacks.
  * Integrated pending resource shares view into the independence plans area.
* **Bug Fixes / UX**
  * Show inline error messages and disable action buttons while requests are in progress.
* **Navigation**
  * Updated badge navigation to route to the most relevant pending-share destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->