### PR TITLE
fix(independence): resource-share routes thread shareId; debug page tolerates missing demographics

### DIFF
--- a/src/pages/api/resource-shares/[shareId].ts
+++ b/src/pages/api/resource-shares/[shareId].ts
@@ -1,7 +1,13 @@
-import { createApiHandler } from "@utils/api/createApiHandler"
+import {
+  createApiHandler,
+  sanitizePathParam,
+} from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
 
 export default createApiHandler({
-  url: getDataUrl("/resource-shares"),
+  url: (req) => {
+    const shareId = sanitizePathParam(req.query.shareId, "shareId")
+    return getDataUrl(`/resource-shares/${shareId}`)
+  },
   methods: ["DELETE"],
 })

--- a/src/pages/api/resource-shares/[shareId]/accept.ts
+++ b/src/pages/api/resource-shares/[shareId]/accept.ts
@@ -1,7 +1,13 @@
-import { createApiHandler } from "@utils/api/createApiHandler"
+import {
+  createApiHandler,
+  sanitizePathParam,
+} from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
 
 export default createApiHandler({
-  url: getDataUrl("/resource-shares"),
+  url: (req) => {
+    const shareId = sanitizePathParam(req.query.shareId, "shareId")
+    return getDataUrl(`/resource-shares/${shareId}/accept`)
+  },
   methods: ["POST"],
 })

--- a/src/pages/independence/debug.tsx
+++ b/src/pages/independence/debug.tsx
@@ -12,6 +12,7 @@ import {
 } from "types/independence"
 import { HoldingContract } from "types/beancounter"
 import { useAssetBreakdown } from "@components/features/independence"
+import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
 import Spinner from "@components/ui/Spinner"
 import Alert from "@components/ui/Alert"
 
@@ -31,20 +32,35 @@ interface Sliders {
   inflationRate: number
 }
 
+const DEFAULT_LIFE_EXPECTANCY = 90
+const DEFAULT_CURRENT_AGE = 50
+
 function planToSliders(
   plan: RetirementPlan,
   liquidFromAssets: number,
+  settingsYearOfBirth: number | undefined,
+  settingsLifeExpectancy: number | undefined,
 ): Sliders {
   const currentYear = new Date().getFullYear()
-  const currentAge = plan.yearOfBirth ? currentYear - plan.yearOfBirth : 50
+  // RetirementPlan entity doesn't persist yearOfBirth/lifeExpectancy —
+  // those live on UserIndependenceSettings. Fall through plan → settings →
+  // sensible default. Without this Wookie-shape plans (no yearOfBirth on
+  // settings, no lifeExpectancy on plan) produced NaN slider bounds and
+  // crashed the page.
+  const yearOfBirth = plan.yearOfBirth ?? settingsYearOfBirth
+  const currentAge = yearOfBirth
+    ? currentYear - yearOfBirth
+    : DEFAULT_CURRENT_AGE
+  const lifeExpectancy =
+    plan.lifeExpectancy ?? settingsLifeExpectancy ?? DEFAULT_LIFE_EXPECTANCY
   const retirementAge = Math.min(
-    plan.lifeExpectancy - 1,
+    lifeExpectancy - 1,
     Math.max(currentAge + 1, currentAge + 5),
   )
   return {
     currentAge,
     retirementAge,
-    lifeExpectancy: plan.lifeExpectancy,
+    lifeExpectancy,
     liquidAssets: Math.round(liquidFromAssets),
     monthlyExpenses: plan.monthlyExpenses,
     pensionMonthly: plan.pensionMonthly,
@@ -282,6 +298,8 @@ function IndependenceDebug(): React.ReactElement {
   const holdingsData = holdingsLoading ? undefined : holdingsResponse?.data
   const assets = useAssetBreakdown(holdingsData)
 
+  const { settings } = useIndependenceSettings()
+
   const plans = useMemo(() => plansData?.data ?? [], [plansData])
   const selectedPlan = useMemo(
     () => plans.find((p) => p.id === selectedPlanId) ?? null,
@@ -295,11 +313,24 @@ function IndependenceDebug(): React.ReactElement {
     setSelectedPlanId(primary.id)
   }, [plans, selectedPlanId])
 
-  // Seed sliders when plan or assets change
+  // Seed sliders when plan, assets, or settings change
   useEffect(() => {
     if (!selectedPlan || !assets.hasAssets) return
-    setSliders(planToSliders(selectedPlan, assets.liquidAssets))
-  }, [selectedPlan, assets.hasAssets, assets.liquidAssets])
+    setSliders(
+      planToSliders(
+        selectedPlan,
+        assets.liquidAssets,
+        settings?.yearOfBirth,
+        settings?.lifeExpectancy,
+      ),
+    )
+  }, [
+    selectedPlan,
+    assets.hasAssets,
+    assets.liquidAssets,
+    settings?.yearOfBirth,
+    settings?.lifeExpectancy,
+  ])
 
   // Debounced backend recalculation.
   // AbortController per scheduled request prevents stale responses (slider drag


### PR DESCRIPTION
## Summary
Two pre-existing bugs surfaced by yesterday's INDEPENDENCE_PLAN accept UI and debug page work.

### Bug 1 — resource-share accept/decline 404
\`/api/resource-shares/[shareId]/accept.ts\` and \`/api/resource-shares/[shareId].ts\` (DELETE) hit \`/resource-shares\` without the \`{shareId}\` segment, returning 404 from svc-data on every accept/decline attempt. Now thread \`shareId\` through via \`sanitizePathParam\`, matching the pattern in \`/api/shares/[shareId]/accept.ts\`.

### Bug 2 — debug page crash
\`/independence/debug\` threw \"Oops!\" when \`RetirementPlan.lifeExpectancy\` was absent. The entity doesn't persist that field (lives on \`UserIndependenceSettings\`) so \`plan.lifeExpectancy - 1\` produced NaN slider bounds and React threw. Fall through plan → settings → default 90; same for \`yearOfBirth\` → default 50.

## Test plan
- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean
- [x] \`semgrep\` clean
- [ ] Manual: shared invite Accept on \`/independence\` → invite disappears, plan appears
- [ ] Manual: \`/independence/debug\` loads for Wookie (no \`yearOfBirth\`/\`lifeExpectancy\` on plan)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invalid slider bounds in the independence debug interface when selecting different plans and assets. Sliders now properly initialize with saved settings.

* **Refactor**
  * Enhanced API parameter handling for resource share operations to ensure accurate endpoint targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->