### PR TITLE
feat(independence): render shared plans in dedicated Shared tab

### DIFF
--- a/src/pages/independence/index.tsx
+++ b/src/pages/independence/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react"
+import React, { useMemo, useRef, useState } from "react"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import Head from "next/head"
 import Link from "next/link"
@@ -275,7 +275,7 @@ function RetirementPlanning(): React.ReactElement {
   const { settings } = useIndependenceSettings()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [activeView, setActiveView] = useState<
-    "profile" | "work" | "plans" | "composite"
+    "profile" | "work" | "plans" | "shared" | "composite"
   >("plans")
   const [isImporting, setIsImporting] = useState(false)
   const [importError, setImportError] = useState<string | null>(null)
@@ -328,7 +328,16 @@ function RetirementPlanning(): React.ReactElement {
   // they've defined on the Composite tab — a timeline like Singapore → NZ →
   // Thailand should show those cards in that order everywhere. Plans not in
   // the composite retain their backend order behind the sequenced ones.
-  const plans = sortPlansByCompositeOrder(data?.data || [], settings)
+  const sharedPlanIdSet = useMemo(
+    () => new Set(data?.sharedPlanIds ?? []),
+    [data?.sharedPlanIds],
+  )
+  const allPlans = sortPlansByCompositeOrder(data?.data || [], settings)
+  const ownedPlans = allPlans.filter((p) => !sharedPlanIdSet.has(p.id))
+  const sharedPlans = allPlans.filter((p) => sharedPlanIdSet.has(p.id))
+  // Backwards-compatible alias — most code below refers to the user's own
+  // plans; sharing UI references sharedPlans directly.
+  const plans = ownedPlans
 
   const handleExportPlan = async (plan: RetirementPlan): Promise<void> => {
     try {
@@ -630,6 +639,22 @@ function RetirementPlanning(): React.ReactElement {
               <i className="fas fa-th-large mr-2"></i>
               Plans
             </button>
+            {sharedPlans.length > 0 && (
+              <button
+                onClick={() => setActiveView("shared")}
+                className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                  activeView === "shared"
+                    ? "bg-white text-independence-700 shadow-sm"
+                    : "text-gray-600 hover:text-gray-800"
+                }`}
+              >
+                <i className="fas fa-share-alt mr-2"></i>
+                Shared
+                <span className="ml-1.5 text-xs text-gray-500">
+                  ({sharedPlans.length})
+                </span>
+              </button>
+            )}
             {plans.length > 1 && (
               <button
                 onClick={() => setActiveView("composite")}
@@ -688,6 +713,23 @@ function RetirementPlanning(): React.ReactElement {
           {!isLoading && plans.length > 0 && activeView === "plans" && (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {plans.map((plan: RetirementPlan) => (
+                <PlanCard
+                  key={plan.id}
+                  plan={plan}
+                  assets={assets}
+                  hideValues={hideValues}
+                  onDelete={setDeletePlanId}
+                  onExport={handleExportPlan}
+                  onCopy={handleCopyClick}
+                  onSetPrimary={handleSetPrimary}
+                />
+              ))}
+            </div>
+          )}
+
+          {!isLoading && activeView === "shared" && (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {sharedPlans.map((plan: RetirementPlan) => (
                 <PlanCard
                   key={plan.id}
                   plan={plan}

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -213,6 +213,11 @@ export interface PlanResponse {
 
 export interface PlansResponse {
   data: RetirementPlan[]
+  /**
+   * Ids in `data` the caller does NOT own but has accepted a resource share
+   * for. Used to populate the Shared tab on /independence.
+   */
+  sharedPlanIds?: string[]
 }
 
 // ============ Category Labels ============


### PR DESCRIPTION
## Summary
- \`PlansResponse\` now optionally carries \`sharedPlanIds\` — ids the user accepted a share for, distinct from owned plans
- Split the plan list into \`ownedPlans\` (existing Plans tab) and \`sharedPlans\` (new Shared tab); Shared tab only renders when at least one shared plan exists
- Count badge on the Shared tab so it's clear what's there

## Why
User accepted Ruby's shared INDEPENDENCE_PLAN invite but the plan didn't appear anywhere — Plans tab only showed owned plans. New tab routes shared plans into the right place.

## Test plan
- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean
- [x] semgrep clean
- [ ] Manual: shared INDEPENDENCE_PLAN appears under Shared tab; selecting it opens projection using owner's demographics

## Pairs with
- monowai/svc-retire PR adding \`sharedPlanIds\` to \`PlansResponse\`