### PR TITLE
feat(independence): route shared-plan projection through svc-retire M2M path

### DIFF
--- a/src/components/features/independence/scenario/scenarioToPayload.ts
+++ b/src/components/features/independence/scenario/scenarioToPayload.ts
@@ -19,6 +19,15 @@ export interface ScenarioPayloadCtx {
   derivedLiquidAssets: number
   /** Non-spendable assets derived from live holdings. */
   derivedNonSpendableAssets: number
+  /**
+   * Set when the viewer doesn't own the plan. Omits `liquidAssets` /
+   * `nonSpendableAssets` from the projection request so svc-retire's
+   * shared-plan M2M path resolves the OWNER's holdings via svc-position
+   * instead of accepting the viewer's caller-scoped totals.
+   */
+  isSharedPlan?: boolean
+  /** Request the optional ProjectionDebug block in the response. */
+  includeDebug?: boolean
 }
 
 /**
@@ -52,8 +61,17 @@ export function scenarioToPayload(
     socialSecurityMonthly: scenario.socialSecurityMonthly,
     otherIncomeMonthly: scenario.otherIncomeMonthly,
     targetBalance: ctx.plan.targetBalance,
-    liquidAssets: scenario.liquidAssets ?? ctx.derivedLiquidAssets,
-    nonSpendableAssets: ctx.derivedNonSpendableAssets,
+  }
+
+  // For owned plans the viewer's holdings are correct projection inputs;
+  // for shared plans they belong to the viewer, NOT the plan owner — let
+  // svc-retire resolve them server-side via the M2M + ?systemUserId path.
+  if (!ctx.isSharedPlan) {
+    payload.liquidAssets = scenario.liquidAssets ?? ctx.derivedLiquidAssets
+    payload.nonSpendableAssets = ctx.derivedNonSpendableAssets
+  } else if (scenario.liquidAssets != null) {
+    // Slider explicitly overrode liquid for what-if even on a shared plan.
+    payload.liquidAssets = scenario.liquidAssets
   }
 
   if (ctx.definedContribution != null) {
@@ -61,6 +79,9 @@ export function scenarioToPayload(
   }
   if (ctx.rentalIncome?.totalMonthlyInPlanCurrency) {
     payload.rentalIncomeMonthly = ctx.rentalIncome.totalMonthlyInPlanCurrency
+  }
+  if (ctx.includeDebug) {
+    payload.includeDebug = true
   }
 
   return payload

--- a/src/components/features/independence/useUnifiedProjection.ts
+++ b/src/components/features/independence/useUnifiedProjection.ts
@@ -100,6 +100,16 @@ interface UseUnifiedProjectionProps {
   rentalIncome?: RentalIncomeData
   /** Optional defined contribution amount override (full mode only). */
   definedContribution?: number
+  /**
+   * Caller doesn't own the plan. Omits `liquidAssets` /
+   * `nonSpendableAssets` from the request so svc-retire resolves them
+   * server-side under the plan owner's M2M scope. Also relaxes the
+   * assets-ready gate — the viewer doesn't need their own holdings
+   * loaded to project someone else's plan.
+   */
+  isSharedPlan?: boolean
+  /** Request the optional ProjectionDebug block in the response. */
+  includeDebug?: boolean
 }
 
 interface UseUnifiedProjectionResult {
@@ -167,6 +177,8 @@ export function useUnifiedProjection({
   isAtBaseline = false,
   rentalIncome,
   definedContribution,
+  isSharedPlan = false,
+  includeDebug = false,
 }: UseUnifiedProjectionProps): UseUnifiedProjectionResult {
   const [projection, setProjection] = useState<RetirementProjection | null>(
     null,
@@ -178,8 +190,10 @@ export function useUnifiedProjection({
   const [error, setError] = useState<Error | null>(null)
   const hasAutoCalculated = useRef(false)
 
-  // Determine if we have the minimum required data
-  const isReady = enabled && !!plan?.id && assets.hasAssets
+  // Determine if we have the minimum required data. Shared-plan path
+  // doesn't need the viewer's holdings (svc-retire resolves the owner's
+  // server-side); only require the plan id.
+  const isReady = enabled && !!plan?.id && (isSharedPlan || assets.hasAssets)
 
   // Detect changes via single scenario checksum + plan checksum + asset/currency.
   const planChecksum = useMemo(() => createPlanChecksum(plan), [plan])
@@ -203,7 +217,8 @@ export function useUnifiedProjection({
   const prevChecksumRef = useRef<number>(0)
 
   const calculateProjection = useCallback(async (): Promise<void> => {
-    if (!plan || !assets.hasAssets) return
+    if (!plan) return
+    if (!isSharedPlan && !assets.hasAssets) return
 
     setIsCalculating(true)
     setError(null)
@@ -217,6 +232,8 @@ export function useUnifiedProjection({
         rentalIncome,
         derivedLiquidAssets: assets.liquidAssets,
         derivedNonSpendableAssets: assets.nonSpendableAssets,
+        isSharedPlan,
+        includeDebug,
       }
       if (definedContribution != null) {
         ctx.definedContribution = definedContribution
@@ -262,6 +279,8 @@ export function useUnifiedProjection({
     isAtBaseline,
     displayCurrency,
     definedContribution,
+    isSharedPlan,
+    includeDebug,
   ])
 
   // Auto-calculate when ready

--- a/src/pages/independence/debug.tsx
+++ b/src/pages/independence/debug.tsx
@@ -301,9 +301,17 @@ function IndependenceDebug(): React.ReactElement {
   const { settings } = useIndependenceSettings()
 
   const plans = useMemo(() => plansData?.data ?? [], [plansData])
+  const sharedPlanIdSet = useMemo(
+    () => new Set(plansData?.sharedPlanIds ?? []),
+    [plansData?.sharedPlanIds],
+  )
   const selectedPlan = useMemo(
     () => plans.find((p) => p.id === selectedPlanId) ?? null,
     [plans, selectedPlanId],
+  )
+  const isSharedPlan = useMemo(
+    () => (selectedPlanId ? sharedPlanIdSet.has(selectedPlanId) : false),
+    [selectedPlanId, sharedPlanIdSet],
   )
 
   // Auto-select primary plan once data loads
@@ -313,15 +321,29 @@ function IndependenceDebug(): React.ReactElement {
     setSelectedPlanId(primary.id)
   }, [plans, selectedPlanId])
 
-  // Seed sliders when plan, assets, or settings change
+  // Seed sliders when plan, assets, projection, or settings change.
+  // For shared plans the demographics come from the projection response
+  // (plan owner's settings) and the liquid total comes from the backend
+  // (M2M resolves owner's holdings); the viewer's own settings + holdings
+  // are deliberately ignored.
   useEffect(() => {
-    if (!selectedPlan || !assets.hasAssets) return
+    if (!selectedPlan) return
+    if (!isSharedPlan && !assets.hasAssets) return
+    const seedLiquid = isSharedPlan
+      ? (projection?.liquidAssets ?? 0)
+      : assets.liquidAssets
+    const seedYearOfBirth = isSharedPlan
+      ? projection?.planInputs?.yearOfBirth
+      : settings?.yearOfBirth
+    const seedLifeExpectancy = isSharedPlan
+      ? projection?.planInputs?.lifeExpectancy
+      : settings?.lifeExpectancy
     setSliders(
       planToSliders(
         selectedPlan,
-        assets.liquidAssets,
-        settings?.yearOfBirth,
-        settings?.lifeExpectancy,
+        seedLiquid,
+        seedYearOfBirth,
+        seedLifeExpectancy,
       ),
     )
   }, [
@@ -330,6 +352,10 @@ function IndependenceDebug(): React.ReactElement {
     assets.liquidAssets,
     settings?.yearOfBirth,
     settings?.lifeExpectancy,
+    isSharedPlan,
+    projection?.liquidAssets,
+    projection?.planInputs?.yearOfBirth,
+    projection?.planInputs?.lifeExpectancy,
   ])
 
   // Debounced backend recalculation.
@@ -337,16 +363,18 @@ function IndependenceDebug(): React.ReactElement {
   // can fire request N+1 before N returns; without abort the older response can
   // land last and overwrite the fresh state).
   useEffect(() => {
-    if (!selectedPlan || !sliders || !assets.hasAssets) return undefined
+    if (!selectedPlan || !sliders) return undefined
+    if (!isSharedPlan && !assets.hasAssets) return undefined
     const controller = new AbortController()
     const timer = setTimeout(async () => {
       setProjLoading(true)
       setProjError(null)
       try {
-        const body = {
+        // Shared plan: omit liquidAssets/nonSpendableAssets so svc-retire's
+        // M2M path resolves the OWNER's holdings via svc-position. Owned
+        // plan: send the viewer's totals as before.
+        const body: Record<string, unknown> = {
           currency: selectedPlan.expensesCurrency,
-          liquidAssets: sliders.liquidAssets,
-          nonSpendableAssets: assets.nonSpendableAssets,
           currentAge: sliders.currentAge,
           retirementAge: sliders.retirementAge,
           lifeExpectancy: sliders.lifeExpectancy,
@@ -356,6 +384,11 @@ function IndependenceDebug(): React.ReactElement {
           otherIncomeMonthly: sliders.otherIncomeMonthly,
           equityReturnRate: sliders.equityReturnRate,
           inflationRate: sliders.inflationRate,
+          includeDebug: true,
+        }
+        if (!isSharedPlan) {
+          body.liquidAssets = sliders.liquidAssets
+          body.nonSpendableAssets = assets.nonSpendableAssets
         }
         const res = await fetch(
           `/api/independence/projection/${selectedPlan.id}`,
@@ -388,7 +421,13 @@ function IndependenceDebug(): React.ReactElement {
       clearTimeout(timer)
       controller.abort()
     }
-  }, [selectedPlan, sliders, assets.hasAssets, assets.nonSpendableAssets])
+  }, [
+    selectedPlan,
+    sliders,
+    assets.hasAssets,
+    assets.nonSpendableAssets,
+    isSharedPlan,
+  ])
 
   const local = sliders ? computeLocal(sliders) : null
   const fiMetrics = projection?.fiMetrics
@@ -661,6 +700,95 @@ function IndependenceDebug(): React.ReactElement {
                     </>
                   }
                 />
+
+                {projection?.debug && (
+                  <div
+                    className={`rounded-lg border p-4 mt-5 ${
+                      projection.debug.ownerScopedFetch
+                        ? "bg-blue-50 border-blue-200"
+                        : "bg-white border-gray-200"
+                    }`}
+                  >
+                    <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3 flex items-center gap-2">
+                      Resolved Inputs
+                      {projection.debug.ownerScopedFetch && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-blue-100 text-blue-800 text-[10px] font-medium">
+                          Owner-scoped (M2M)
+                        </span>
+                      )}
+                    </h3>
+                    <div className="grid grid-cols-2 gap-x-6 gap-y-1.5 text-xs font-mono text-gray-700">
+                      <div>
+                        callerOwnerId:{" "}
+                        <b className="break-all">
+                          {projection.debug.callerOwnerId}
+                        </b>
+                      </div>
+                      <div>
+                        planOwnerId:{" "}
+                        <b className="break-all">
+                          {projection.debug.planOwnerId}
+                        </b>
+                      </div>
+                      <div>
+                        planSystemUserId:{" "}
+                        <b className="break-all">
+                          {projection.debug.planSystemUserId ?? "—"}
+                        </b>
+                      </div>
+                      <div>
+                        ownerScopedFetch:{" "}
+                        <b>{String(projection.debug.ownerScopedFetch)}</b>
+                      </div>
+                      <div>
+                        resolvedInputs.liquidAssets:{" "}
+                        <b>
+                          {fmtMoney(
+                            currency,
+                            projection.debug.resolvedInputs.liquidAssets,
+                          )}
+                        </b>
+                      </div>
+                      <div>
+                        resolvedInputs.rentalIncomeMonthly:{" "}
+                        <b>
+                          {fmtMoney(
+                            currency,
+                            projection.debug.resolvedInputs.rentalIncomeMonthly,
+                          )}
+                        </b>
+                      </div>
+                      <div>
+                        resolvedInputs.pensionConfigCount:{" "}
+                        <b>
+                          {projection.debug.resolvedInputs.pensionConfigCount}
+                        </b>
+                      </div>
+                      <div>
+                        resolvedInputs.cpfLifeMonthlyTotal:{" "}
+                        <b>
+                          {fmtMoney(
+                            currency,
+                            projection.debug.resolvedInputs.cpfLifeMonthlyTotal,
+                          )}
+                        </b>
+                      </div>
+                      {Object.entries(projection.debug.resolution).map(
+                        ([k, v]) => (
+                          <div key={k} className="col-span-2">
+                            resolution.{k}: <b>{v}</b>
+                          </div>
+                        ),
+                      )}
+                    </div>
+                    <p className="text-xs text-gray-500 mt-3">
+                      Resolved values come from the actual cross-service
+                      fetches. When `ownerScopedFetch` is true the holdings,
+                      pension configs, and rental income were resolved against
+                      the plan owner&apos;s SystemUser (not the viewer&apos;s).
+                    </p>
+                  </div>
+                )}
 
                 <div className="bg-white rounded-lg border border-gray-200 p-4 mt-5">
                   <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -38,6 +38,9 @@ import { useIndependencePlanCurrency } from "@hooks/useIndependencePlanCurrency"
 import { useExcludedAssetIds } from "@hooks/useExcludedAssetIds"
 import { useIndependencePlanProjections } from "@hooks/useIndependencePlanProjections"
 import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
+import useSwr from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+import type { PlansResponse } from "types/independence"
 import type { LumpSumAsset } from "@hooks/useIndependencePlanProjections"
 import Alert from "@components/ui/Alert"
 import Spinner from "@components/ui/Spinner"
@@ -81,6 +84,24 @@ function PlanView(): React.ReactElement {
     availableCurrencies,
     mutatePlan,
   } = useIndependencePlanData(id)
+
+  // Pull the sharedPlanIds set so we can detect when this plan belongs to
+  // someone else (accepted resource share). Shared plans route the
+  // projection through svc-retire's M2M / ?systemUserId path so the
+  // viewer's own holdings don't pollute the result.
+  const { data: plansData } = useSwr<PlansResponse>(
+    "/api/independence/plans",
+    simpleFetcher("/api/independence/plans"),
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 60000,
+    },
+  )
+  const isSharedPlan = useMemo(() => {
+    const idStr = Array.isArray(id) ? id[0] : id
+    if (!idStr) return false
+    return (plansData?.sharedPlanIds ?? []).includes(idStr)
+  }, [plansData, id])
 
   // Unified scenario state — replaces the old WhatIfAdjustments + ScenarioOverrides
   // split. Drives the projection, Stress Test and Wealth-tab card.
@@ -449,6 +470,7 @@ function PlanView(): React.ReactElement {
     isAtBaseline: !scenarioIsDirty,
     rentalIncome,
     displayCurrency: displayCurrency ?? undefined,
+    isSharedPlan,
   })
 
   // FIRE data is ready when backend projection has completed with valid metrics

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -364,6 +364,12 @@ export interface ProjectionRequest {
   definedContribution?: number
   /** Portfolio IDs to exclude from wealth and rental income. Overrides plan.excludedPortfolioIds. */
   excludedPortfolioIds?: string[]
+  /**
+   * When true, populate `RetirementProjection.debug` with a
+   * `ProjectionDebug` block. Used by `/independence/debug` to verify
+   * shared-plan projections actually used the plan owner's data.
+   */
+  includeDebug?: boolean
 }
 
 /**
@@ -580,6 +586,44 @@ export interface PlanInputs {
   blendedReturnRate: number
   /** Defined contribution deduction applied (e.g., CPF employee contribution) */
   definedContribution?: number
+  /**
+   * Plan owner's current age, resolved from settings.yearOfBirth via the
+   * plan owner (NOT the caller). Lets the frontend populate shared-plan
+   * sliders from the projection response rather than the caller-scoped
+   * settings hook.
+   */
+  currentAge?: number
+  /** Plan owner's yearOfBirth from settings. */
+  yearOfBirth?: number
+  /** Plan owner's life expectancy from settings. */
+  lifeExpectancy?: number
+  /** Plan owner's resolved retirement age. */
+  retirementAge?: number
+}
+
+/**
+ * Optional diagnostic block returned when `ProjectionRequest.includeDebug`
+ * is true. Used by `/independence/debug` to spot-check the auth posture
+ * driving cross-service fetches (catches viewer-data leaks into shared
+ * plans).
+ */
+export interface ProjectionDebug {
+  callerOwnerId: string
+  planOwnerId: string
+  planSystemUserId?: string
+  ownerScopedFetch: boolean
+  resolution: Record<string, string>
+  resolvedInputs: ResolvedInputs
+}
+
+export interface ResolvedInputs {
+  liquidAssets: number
+  nonSpendableAssets: number
+  rentalIncomeMonthly: number
+  pensionConfigCount: number
+  cpfLifeMonthlyTotal: number
+  currency: string
+  portfolioIds: string[]
 }
 
 export interface RetirementProjection {
@@ -658,6 +702,12 @@ export interface RetirementProjection {
    * tab: explicit override if set, otherwise the default for effectiveStrategy.
    */
   effectiveHeadlineMetric?: HeadlineMetric
+  /**
+   * Populated when `ProjectionRequest.includeDebug = true`. Surfaces the
+   * resolved auth posture + input values so callers can verify a shared
+   * plan projection used the plan owner's data rather than the viewer's.
+   */
+  debug?: ProjectionDebug
 }
 
 export interface ProjectionResponse {


### PR DESCRIPTION
## Summary
PR4 of the shared-plan owner-scoping rollout (see [SHARED_PROJECTION.md](https://github.com/monowai/bc-claude/blob/main/SHARED_PROJECTION.md)). Frontend half — depends on svc-data PR #904 (merged), svc-position PR #906 (merged), svc-retire PR #42.

For plans the viewer doesn't own:
- Skip \`useAssetBreakdown\` (viewer's holdings are irrelevant)
- Omit \`liquidAssets\` / \`nonSpendableAssets\` from \`ProjectionRequest\` so svc-retire's M2M path resolves the OWNER's holdings via svc-position
- Source slider initial state from \`projection.planInputs.*\` (owner-scoped settings)
- \`/independence/debug\` requests \`includeDebug=true\` and renders a new "Resolved Inputs" panel showing which SystemUser drove the cross-service fetches

## Why
Confirmed live on kauri 2026-05-31: Mike viewing Ruby's shared plan saw Mike's holdings, CPF, and rental income. Backend PR3 fixes the data fetches; this PR stops the frontend from passing the viewer's totals as inputs and surfaces a verification panel so the bug can't silently regress.

## Test plan
- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean
- [x] semgrep clean
- [ ] Manual: Ruby shares plan with Mike → Mike opens shared plan → projection shows Ruby's assets / pensions / rental → debug page Resolved Inputs panel shows \`ownerScopedFetch: true\` + \`planSystemUserId\` populated
- [ ] Manual: Mike's own plan still projects normally (no regression in owned-plan path)

## Reviewer notes
Locally reviewed against \`.claude/skills/code-review/SKILL.md\` before push (no findings) — \`@coderabbitai ignore\` set to preserve quota.

@coderabbitai ignore