### PR TITLE
feat(independence): owner-scoped Assets-by-Category for shared plans

### DIFF
--- a/src/components/features/independence/DetailsTabContent.tsx
+++ b/src/components/features/independence/DetailsTabContent.tsx
@@ -270,21 +270,21 @@ export default function DetailsTabContent({
       </div>
 
       {/* Assets by Category — swapped in from the Metrics tab.
-          For shared plans the per-category breakdown would echo the
-          viewer's caller-scoped holdings, which is the same leak the M2M
-          projection path was built to plug. Show a small notice instead;
-          the projection's owner-scoped liquid/non-spendable totals are
-          surfaced on the Metrics tab and the /independence/debug page. */}
-      {isSharedPlan ? (
+          For shared plans we filter to portfolios owned by the plan
+          owner (via accepted portfolio shares). When the caller has
+          plan-share but no portfolio-shares, categorySlices is empty —
+          show a small notice explaining what's missing. */}
+      {isSharedPlan && categorySlices.length === 0 ? (
         <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 text-sm text-blue-900">
           <p className="font-medium mb-1">
             <i className="fas fa-share-alt mr-2"></i>
             Owner-scoped projection
           </p>
           <p>
-            Per-category asset breakdown isn&apos;t available for shared
-            plans. The projection (left panel and Metrics tab) uses the
-            plan owner&apos;s holdings via a server-side fetch.
+            Per-category asset breakdown for this shared plan needs the
+            plan owner to also share their portfolios with you. The
+            projection (left panel and Metrics tab) uses the owner&apos;s
+            holdings via a server-side fetch.
           </p>
         </div>
       ) : (

--- a/src/hooks/__tests__/useIndependencePlanData.test.ts
+++ b/src/hooks/__tests__/useIndependencePlanData.test.ts
@@ -97,9 +97,10 @@ describe("useIndependencePlanData", () => {
     buildSwrMock({
       0: { data: { data: makePlan() } },
       1: {}, // portfolios
-      2: {}, // holdings
-      3: { data: { data: scenarios } }, // scenarios
-      4: {}, // currencies
+      2: {}, // managed shares (shared-plan path)
+      3: {}, // holdings
+      4: { data: { data: scenarios } }, // scenarios
+      5: {}, // currencies
     })
     const { result } = renderHook(() => useIndependencePlanData("plan-1"))
 

--- a/src/hooks/useIndependencePlanData.ts
+++ b/src/hooks/useIndependencePlanData.ts
@@ -1,13 +1,21 @@
 import { useMemo } from "react"
 import useSwr from "swr"
-import { simpleFetcher, portfoliosKey } from "@utils/api/fetchHelper"
+import {
+  simpleFetcher,
+  portfoliosKey,
+  sharesManagedKey,
+} from "@utils/api/fetchHelper"
 import {
   PlanResponse,
   QuickScenariosResponse,
   RetirementPlan,
   QuickScenario,
 } from "types/independence"
-import { Portfolio, HoldingContract } from "types/beancounter"
+import {
+  Portfolio,
+  HoldingContract,
+  PortfolioShare,
+} from "types/beancounter"
 import type { KeyedMutator } from "swr"
 import { parseExcludedPortfolioIds } from "@lib/independence/planHelpers"
 
@@ -31,6 +39,15 @@ export interface UseIndependencePlanDataResult {
 
 export function useIndependencePlanData(
   id: string | string[] | undefined,
+  /**
+   * Plan owner's SystemUser.id when the caller doesn't own the plan
+   * (shared INDEPENDENCE_PLAN). When set, holdings are filtered to
+   * portfolios owned by that SystemUser. Caller still needs an accepted
+   * portfolio share for those portfolios — svc-position's canView
+   * decides what comes back; mismatched ids are silently dropped. Pass
+   * undefined for owned plans.
+   */
+  ownerSystemUserId?: string,
 ): UseIndependencePlanDataResult {
   const normalizedId = Array.isArray(id) ? id[0] : id
   const planKey = normalizedId
@@ -62,18 +79,50 @@ export function useIndependencePlanData(
     portfoliosEndpoint ? simpleFetcher(portfoliosEndpoint) : null,
   )
 
-  // Compute included portfolio codes (all minus excluded)
+  // Shared-plan caller: also pull the portfolios shared WITH them so we
+  // can spot the plan owner's portfolios for category-breakdown filtering.
+  // `/api/shares/managed` returns PortfolioShare rows; the `.portfolio`
+  // field has the share-target details. Only fetched when needed.
+  const { data: managedSharesData } = useSwr<{ data: PortfolioShare[] }>(
+    ownerSystemUserId ? sharesManagedKey : null,
+    ownerSystemUserId ? simpleFetcher(sharesManagedKey) : null,
+    { revalidateOnFocus: false, dedupingInterval: 60000 },
+  )
+
+  // Compute included portfolio codes (all minus excluded).
+  // Shared plans further filter to portfolios owned by the plan owner —
+  // surfacing the viewer's own portfolios alongside would replay the
+  // category-leak bug the M2M projection path was built to plug.
   const includedPortfolioCodes = useMemo(() => {
     if (!portfoliosData?.data || !planData?.data) return null
     const excluded = new Set(
       parseExcludedPortfolioIds(planData.data.excludedPortfolioIds),
     )
+    let pool = portfoliosData.data.filter((p) => !excluded.has(p.id))
+    if (ownerSystemUserId) {
+      // Pool of caller-viewable portfolios = owned + accepted shares.
+      // Mike's `/portfolios` is owned-only; pull share-target portfolios
+      // from `/shares/managed` and union them.
+      const shared =
+        managedSharesData?.data
+          ?.map((s) => s.portfolio)
+          ?.filter((p): p is Portfolio => !!p && !excluded.has(p.id)) ?? []
+      const seen = new Set(pool.map((p) => p.id))
+      for (const p of shared) {
+        if (!seen.has(p.id)) {
+          pool.push(p)
+          seen.add(p.id)
+        }
+      }
+      pool = pool.filter((p) => p.owner?.id === ownerSystemUserId)
+      // No matching portfolios = caller has plan share but not portfolio
+      // shares. Empty string signals "skip holdings fetch" downstream so
+      // we don't fall back to the caller-scoped aggregate.
+      return pool.length > 0 ? pool.map((p) => p.code).join(",") : ""
+    }
     if (excluded.size === 0) return null // null = fetch all
-    const included = portfoliosData.data
-      .filter((p) => !excluded.has(p.id))
-      .map((p) => p.code)
-    return included.length > 0 ? included.join(",") : null
-  }, [portfoliosData, planData])
+    return pool.length > 0 ? pool.map((p) => p.code).join(",") : null
+  }, [portfoliosData, planData, ownerSystemUserId, managedSharesData])
 
   // Fetch aggregated holdings to get category breakdown
   // For client plans, skip holdings fetch (adviser's token returns adviser's data)
@@ -81,6 +130,11 @@ export function useIndependencePlanData(
   const planCurrency = planData?.data?.expensesCurrency
   const holdingsEndpoint = useMemo(() => {
     if (!hasResolvedPlan || isClientPlan) return null
+    // Empty-string codes means a shared-plan caller with no portfolio
+    // shares from the plan owner — skip the fetch entirely so we don't
+    // accidentally hit svc-position's "no codes = all callers'
+    // portfolios" fallback (which would re-introduce the leak).
+    if (includedPortfolioCodes === "") return null
     const params = new URLSearchParams({ asAt: "today" })
     if (includedPortfolioCodes) params.set("codes", includedPortfolioCodes)
     if (planCurrency) params.set("currency", planCurrency)

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -72,19 +72,6 @@ function PlanView(): React.ReactElement {
   // Version counter to force modal re-initialization after save
   const [planVersion, setPlanVersion] = useState(0)
 
-  // Data-fetching hooks
-  const {
-    plan,
-    planError,
-    isClientPlan,
-    portfoliosData,
-    holdingsData,
-    refreshHoldings,
-    isRefreshingHoldings,
-    availableCurrencies,
-    mutatePlan,
-  } = useIndependencePlanData(id)
-
   // Pull the sharedPlanIds set so we can detect when this plan belongs to
   // someone else (accepted resource share). Shared plans route the
   // projection through svc-retire's M2M / ?systemUserId path so the
@@ -102,6 +89,30 @@ function PlanView(): React.ReactElement {
     if (!idStr) return false
     return (plansData?.sharedPlanIds ?? []).includes(idStr)
   }, [plansData, id])
+  // Owner's SystemUser.id from the shared plan row. Drives the owner-
+  // scoped portfolio filter on the holdings SWR — when set, the
+  // Assets-by-Category panel renders the plan owner's categories (via
+  // accepted portfolio shares), not the viewer's. Null until the
+  // backfill on svc-retire has populated `plan.systemUserId`.
+  const sharedPlanOwnerSystemUserId = useMemo(() => {
+    if (!isSharedPlan) return undefined
+    const idStr = Array.isArray(id) ? id[0] : id
+    const match = plansData?.data?.find((p) => p.id === idStr)
+    return match?.systemUserId ?? undefined
+  }, [isSharedPlan, plansData, id])
+
+  // Data-fetching hooks
+  const {
+    plan,
+    planError,
+    isClientPlan,
+    portfoliosData,
+    holdingsData,
+    refreshHoldings,
+    isRefreshingHoldings,
+    availableCurrencies,
+    mutatePlan,
+  } = useIndependencePlanData(id, sharedPlanOwnerSystemUserId)
 
   // Unified scenario state — replaces the old WhatIfAdjustments + ScenarioOverrides
   // split. Drives the projection, Stress Test and Wealth-tab card.

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -120,6 +120,13 @@ export interface RetirementPlan {
   isPrimary: boolean
   createdDate: string
   updatedDate: string
+  /**
+   * Plan owner's SystemUser.id, dual-populated on write. Null for legacy
+   * rows pre-dating the system_user_id column; svc-retire lazy-backfills
+   * during shared-plan projection. Used by bc-view to drive
+   * owner-scoped portfolio filtering for shared plans.
+   */
+  systemUserId?: string
 }
 
 export interface PlanCopyRequest {


### PR DESCRIPTION
## Summary
Replaces PR741's blanket "Owner-scoped projection" notice with the real Assets-by-Category panel when the plan owner has also shared their portfolios with the viewer. Falls back to the notice only when portfolio-shares aren't in place.

## How it works
- Page-level \`useMemo\` derives \`ownerSystemUserId\` from \`PlansResponse[planId].systemUserId\` — null for legacy rows until svc-retire's lazy backfill (PR43) populates it on first projection
- \`useIndependencePlanData\` accepts \`ownerSystemUserId\`. When set:
  - Pulls \`/api/shares/managed\` and unions the portfolio-share targets with the caller's owned portfolios
  - Filters the pool to portfolios where \`owner.id === ownerSystemUserId\`
  - Codes from that filtered set drive the existing \`holdings/aggregated\` fetch; svc-position's \`canView\` enforces share grants
- Empty codes (caller has plan-share but not portfolio-shares) skips the holdings fetch entirely so we don't fall back to the caller-scoped aggregate; the page-level notice covers this case
- \`RetirementPlan\` type extended with optional \`systemUserId\` so the TypeScript signal matches the wire shape

## Test plan
- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn test\` — 1352/1352 passing (existing \`useIndependencePlanData\` test indices updated for the new \`/shares/managed\` SWR call)
- [x] semgrep clean
- [ ] Manual on kauri: Wookie plan now shows Ruby's Cash / ETF (her actual holdings only, no Mike-pollution)

## Limits / follow-ups
- First projection of an unbackfilled plan: \`plan.systemUserId\` is null → categories panel falls back to notice. Second view (after PR43's lazy backfill) renders the real panel. Could chain to \`projection.debug.planSystemUserId\` for instant resolution but adds a render cycle — deferred.
- Owner-scoped category breakdown requires Ruby's portfolios shared with Mike. Plan-share alone is not enough; the notice explains this.

## Pairs with
- svc-retire PR43 — populates \`plan.systemUserId\` lazily so this filter activates on the second projection without manual SQL

## Reviewer notes
Locally reviewed against the in-repo code-review skill before push (no findings) — \`@coderabbitai ignore\` set to preserve quota.

@coderabbitai ignore