### PR TITLE
fix(independence): omit viewer age from shared-plan projection payload

### DIFF
--- a/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
+++ b/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
@@ -87,6 +87,20 @@ describe("scenarioToPayload", () => {
     expect(payload.lifeExpectancy).toBe(92)
   })
 
+  it("omits age / retirementAge / lifeExpectancy when isSharedPlan is true", () => {
+    // Regression: those fields seed from the VIEWER'S UserIndependenceSettings.
+    // Sending them on a shared plan made svc-retire's StartingStateResolver
+    // skip the plan-owner settings fallback, so the projection used the
+    // viewer's retirement timeline instead of the owner's.
+    const payload = scenarioToPayload(scenario, {
+      ...ctx,
+      isSharedPlan: true,
+    })
+    expect(payload.currentAge).toBeUndefined()
+    expect(payload.retirementAge).toBeUndefined()
+    expect(payload.lifeExpectancy).toBeUndefined()
+  })
+
   it("passes plan return rates unchanged when realReturn is null", () => {
     const payload = scenarioToPayload(scenario, ctx)
     expect(payload.cashReturnRate).toBe(0.03)

--- a/src/components/features/independence/scenario/scenarioToPayload.ts
+++ b/src/components/features/independence/scenario/scenarioToPayload.ts
@@ -48,9 +48,6 @@ export function scenarioToPayload(
     portfolioIds: ctx.selectedPortfolioIds,
     currency: ctx.plan.expensesCurrency,
     displayCurrency: ctx.displayCurrency,
-    currentAge: scenario.currentAge,
-    retirementAge: scenario.retirementAge,
-    lifeExpectancy: scenario.lifeExpectancy,
     monthlyContribution: ctx.monthlyInvestment,
     monthlyExpenses: scenario.monthlyExpenses,
     cashReturnRate,
@@ -61,6 +58,20 @@ export function scenarioToPayload(
     socialSecurityMonthly: scenario.socialSecurityMonthly,
     otherIncomeMonthly: scenario.otherIncomeMonthly,
     targetBalance: ctx.plan.targetBalance,
+  }
+
+  // Age-related inputs come from the viewer's UserIndependenceSettings via
+  // seedFromPlan — Mike's age, not Ruby's. Sending them on a shared plan
+  // overrides the server's owner-scoped fallback (StartingStateResolver.kt
+  // line 57: `request.currentAge ?: settings.yearOfBirth`) and the
+  // resulting projection uses the VIEWER'S retirement timeline (Mike retired
+  // already vs Ruby's 15 working years to go). Omit on the shared path —
+  // svc-retire resolves them from plan-owner settings. Per-field dirty
+  // tracking for legitimate what-if overrides is a follow-up.
+  if (!ctx.isSharedPlan) {
+    payload.currentAge = scenario.currentAge
+    payload.retirementAge = scenario.retirementAge
+    payload.lifeExpectancy = scenario.lifeExpectancy
   }
 
   // For owned plans the viewer's holdings are correct projection inputs;


### PR DESCRIPTION
@coderabbitai ignore

## Summary
- `seedFromPlan` builds `currentAge` / `retirementAge` / `lifeExpectancy` from the VIEWER'S `UserIndependenceSettings`. On a shared plan those are Mike's values, not Ruby's. The payload then overrode svc-retire's owner-scoped fallback at `StartingStateResolver.kt:57`, so the projection rendered the viewer's retirement timeline (Mike retired) over the owner's (Ruby has 15 working years left).
- Omits the three fields from the payload when `isSharedPlan` — svc-retire resolves them from the plan-owner's settings.
- Regression test in `scenarioToPayload.test.ts`.

Per-field dirty tracking so the user can legitimately what-if "what if Ruby retired 5 years later" on a shared plan is a follow-up; this stops the silent data leak first.

## Test plan
- [ ] Open Ruby's shared plan on kauri, Income Breakdown tab — ages should align with Ruby's retirement (~65), not Mike's.