### PR TITLE
fix(independence): shared-plan tabs use owner ages from projection echo

### DIFF
--- a/src/pages/independence/debug.tsx
+++ b/src/pages/independence/debug.tsx
@@ -40,6 +40,7 @@ function planToSliders(
   liquidFromAssets: number,
   settingsYearOfBirth: number | undefined,
   settingsLifeExpectancy: number | undefined,
+  resolvedRetirementAge?: number,
 ): Sliders {
   const currentYear = new Date().getFullYear()
   // RetirementPlan entity doesn't persist yearOfBirth/lifeExpectancy —
@@ -53,10 +54,13 @@ function planToSliders(
     : DEFAULT_CURRENT_AGE
   const lifeExpectancy =
     plan.lifeExpectancy ?? settingsLifeExpectancy ?? DEFAULT_LIFE_EXPECTANCY
-  const retirementAge = Math.min(
-    lifeExpectancy - 1,
-    Math.max(currentAge + 1, currentAge + 5),
-  )
+  // Shared plans pass `resolvedRetirementAge` from the projection's
+  // planInputs echo (server-resolved from the OWNER's settings).
+  // currentAge+5 is the wrong baseline for shared — Ruby retires ~15
+  // years from now, not 5.
+  const retirementAge =
+    resolvedRetirementAge ??
+    Math.min(lifeExpectancy - 1, Math.max(currentAge + 1, currentAge + 5))
   return {
     currentAge,
     retirementAge,
@@ -338,12 +342,16 @@ function IndependenceDebug(): React.ReactElement {
     const seedLifeExpectancy = isSharedPlan
       ? projection?.planInputs?.lifeExpectancy
       : settings?.lifeExpectancy
+    const seedRetirementAge = isSharedPlan
+      ? projection?.planInputs?.retirementAge
+      : undefined
     setSliders(
       planToSliders(
         selectedPlan,
         seedLiquid,
         seedYearOfBirth,
         seedLifeExpectancy,
+        seedRetirementAge,
       ),
     )
   }, [
@@ -356,6 +364,7 @@ function IndependenceDebug(): React.ReactElement {
     projection?.liquidAssets,
     projection?.planInputs?.yearOfBirth,
     projection?.planInputs?.lifeExpectancy,
+    projection?.planInputs?.retirementAge,
   ])
 
   // Debounced backend recalculation.
@@ -370,14 +379,13 @@ function IndependenceDebug(): React.ReactElement {
       setProjLoading(true)
       setProjError(null)
       try {
-        // Shared plan: omit liquidAssets/nonSpendableAssets so svc-retire's
-        // M2M path resolves the OWNER's holdings via svc-position. Owned
-        // plan: send the viewer's totals as before.
+        // Shared plan: omit ages + liquidAssets/nonSpendableAssets so
+        // svc-retire resolves them from the OWNER's settings + holdings.
+        // Sending the viewer's slider values overrides StartingStateResolver's
+        // owner-settings fallback and yields the viewer's retirement
+        // timeline instead of the owner's (same leak as scenarioToPayload).
         const body: Record<string, unknown> = {
           currency: selectedPlan.expensesCurrency,
-          currentAge: sliders.currentAge,
-          retirementAge: sliders.retirementAge,
-          lifeExpectancy: sliders.lifeExpectancy,
           monthlyExpenses: sliders.monthlyExpenses,
           pensionMonthly: sliders.pensionMonthly,
           socialSecurityMonthly: sliders.socialSecurityMonthly,
@@ -387,6 +395,9 @@ function IndependenceDebug(): React.ReactElement {
           includeDebug: true,
         }
         if (!isSharedPlan) {
+          body.currentAge = sliders.currentAge
+          body.retirementAge = sliders.retirementAge
+          body.lifeExpectancy = sliders.lifeExpectancy
           body.liquidAssets = sliders.liquidAssets
           body.nonSpendableAssets = assets.nonSpendableAssets
         }

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -484,6 +484,31 @@ function PlanView(): React.ReactElement {
     isSharedPlan,
   })
 
+  // For shared plans, demographics + retirement age MUST come from the
+  // projection's planInputs echo (server resolves them from the plan
+  // OWNER's settings via the M2M path). Falling through to
+  // independenceSettings here renders the VIEWER's age + "Independence
+  // (60)" marker on someone else's plan. Owned plans keep the existing
+  // settings-driven path so pre-projection rendering still works.
+  const planInputsAges = (
+    adjustedProjection as unknown as {
+      planInputs?: {
+        currentAge?: number
+        retirementAge?: number
+        lifeExpectancy?: number
+      }
+    } | null | undefined
+  )?.planInputs
+  const displayCurrentAge = isSharedPlan
+    ? (planInputsAges?.currentAge ?? currentAge)
+    : currentAge
+  const displayRetirementAge = isSharedPlan
+    ? (planInputsAges?.retirementAge ?? retirementAge)
+    : retirementAge
+  const displayLifeExpectancy = isSharedPlan
+    ? (planInputsAges?.lifeExpectancy ?? lifeExpectancy)
+    : lifeExpectancy
+
   // FIRE data is ready when backend projection has completed with valid metrics
   const fireDataReady =
     !!plan &&
@@ -876,8 +901,8 @@ function PlanView(): React.ReactElement {
               totalAssets={totalAssets}
               liquidAssets={liquidAssets}
               blendedReturnRate={blendedReturnRate}
-              currentAge={currentAge}
-              retirementAge={retirementAge}
+              currentAge={displayCurrentAge}
+              retirementAge={displayRetirementAge}
               effectiveFxRate={effectiveFxRate}
               isCalculating={isCalculating}
               holdingsLoaded={!!holdingsData}
@@ -895,8 +920,8 @@ function PlanView(): React.ReactElement {
               projection={adjustedProjection}
               effectivePlanValues={effectivePlanValues}
               blendedReturnRate={blendedReturnRate}
-              currentAge={currentAge}
-              retirementAge={retirementAge}
+              currentAge={displayCurrentAge}
+              retirementAge={displayRetirementAge}
               effectiveCurrency={effectiveCurrency}
               fireDataReady={fireDataReady}
               view={
@@ -910,8 +935,8 @@ function PlanView(): React.ReactElement {
             <TimelineTabContent
               projection={adjustedProjection}
               baselineProjection={baselineProjection}
-              retirementAge={retirementAge}
-              lifeExpectancy={lifeExpectancy}
+              retirementAge={displayRetirementAge}
+              lifeExpectancy={displayLifeExpectancy}
               hideValues={hideValues}
               isCalculating={isCalculating}
               effectiveCurrency={effectiveCurrency}


### PR DESCRIPTION
@coderabbitai ignore

## Summary
- The plan-detail page sourced \`currentAge\` / \`retirementAge\` / \`lifeExpectancy\` from the viewer's \`UserIndependenceSettings\`. On a shared plan that surfaced the viewer's "Independence (60)" marker on the Wealth Journey chart, the viewer's age on Metrics/Timeline tabs, etc.
- Adds \`displayCurrentAge\` / \`displayRetirementAge\` / \`displayLifeExpectancy\` resolved after \`useUnifiedProjection\` lands: when \`isSharedPlan\`, prefer \`projection.planInputs.{...}\` (server resolves from the OWNER's settings via the M2M path); otherwise fall through to settings.
- Threaded into Metrics, Assets, and Timeline tab JSX.

## Out of scope (filed as separate)
- Backend: \`yearlyProjections\` emits ages starting at \`retirementAge + 1\`. UI shows cashflow first row at age 66 for a retire-at-65 plan. Convention change is risky for owned plans — separate ticket.
- \`useIndependencePlanProjections\` (pension FV) still receives the viewer's \`currentAge\`; minor secondary leak for owned-plan numeric outputs on the shared view. Same follow-up.

## Test plan
- [ ] Wookie plan on kauri: Wealth Journey shows "Independence (65)", Metrics/Timeline tabs use age 51 (Ruby), not Mike's age.