### PR TITLE
fix(independence): omit viewer portfolioIds + rental income on shared plan projection

### DIFF
--- a/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
+++ b/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
@@ -101,6 +101,21 @@ describe("scenarioToPayload", () => {
     expect(payload.lifeExpectancy).toBeUndefined()
   })
 
+  it("omits portfolioIds / monthlyContribution / rentalIncomeMonthly when isSharedPlan", () => {
+    // Regression: those values come from the VIEWER'S holdings, contributions
+    // and PrivateAssetConfig entries. Sending them on a shared plan made
+    // svc-retire run the projection against Mike's 9 portfolios + Mike's
+    // rental income instead of the owner's M2M-resolved data.
+    const payload = scenarioToPayload(scenario, {
+      ...ctx,
+      isSharedPlan: true,
+      rentalIncome: { monthlyNetByCurrency: { SGD: 1500 }, totalMonthlyInPlanCurrency: 1500 },
+    })
+    expect("portfolioIds" in payload).toBe(false)
+    expect("monthlyContribution" in payload).toBe(false)
+    expect("rentalIncomeMonthly" in payload).toBe(false)
+  })
+
   it("passes plan return rates unchanged when realReturn is null", () => {
     const payload = scenarioToPayload(scenario, ctx)
     expect(payload.cashReturnRate).toBe(0.03)

--- a/src/components/features/independence/scenario/scenarioToPayload.ts
+++ b/src/components/features/independence/scenario/scenarioToPayload.ts
@@ -45,10 +45,8 @@ export function scenarioToPayload(
     applyRealReturn(scenario, ctx.plan)
 
   const payload: Record<string, unknown> = {
-    portfolioIds: ctx.selectedPortfolioIds,
     currency: ctx.plan.expensesCurrency,
     displayCurrency: ctx.displayCurrency,
-    monthlyContribution: ctx.monthlyInvestment,
     monthlyExpenses: scenario.monthlyExpenses,
     cashReturnRate,
     equityReturnRate,
@@ -58,6 +56,16 @@ export function scenarioToPayload(
     socialSecurityMonthly: scenario.socialSecurityMonthly,
     otherIncomeMonthly: scenario.otherIncomeMonthly,
     targetBalance: ctx.plan.targetBalance,
+  }
+
+  // `portfolioIds` and `monthlyContribution` come from the viewer's own
+  // holdings + contributions. On a shared plan svc-retire resolves the
+  // OWNER's portfolios + contributions via the M2M path — sending the
+  // viewer's values overrides that and re-introduces the leak (Mike's
+  // 9 portfolios + his monthly investment land on Ruby's projection).
+  if (!ctx.isSharedPlan) {
+    payload.portfolioIds = ctx.selectedPortfolioIds
+    payload.monthlyContribution = ctx.monthlyInvestment
   }
 
   // Age-related inputs come from the viewer's UserIndependenceSettings via
@@ -88,7 +96,11 @@ export function scenarioToPayload(
   if (ctx.definedContribution != null) {
     payload.definedContribution = ctx.definedContribution
   }
-  if (ctx.rentalIncome?.totalMonthlyInPlanCurrency) {
+  // `rentalIncome` is computed from the viewer's PrivateAssetConfig
+  // entries. Ruby has none locally — Mike's rental income would override
+  // svc-retire's owner-scoped resolution. Omit on the shared path; server
+  // resolves rental income from plan-owner's configs.
+  if (!ctx.isSharedPlan && ctx.rentalIncome?.totalMonthlyInPlanCurrency) {
     payload.rentalIncomeMonthly = ctx.rentalIncome.totalMonthlyInPlanCurrency
   }
   if (ctx.includeDebug) {


### PR DESCRIPTION
@coderabbitai ignore

## Summary
Captured the real shared-plan projection payload from kauri — it was still sending three viewer-scoped fields that overrode svc-retire's M2M-resolved owner data:

- \`portfolioIds\` — 9 of the viewer's portfolios injected over the owner's M2M-resolved list
- \`monthlyContribution\` — derived from the viewer's holdings + working income
- \`rentalIncomeMonthly\` — computed from the viewer's PrivateAssetConfigs (\`$2,822\` for Mike vs \`$0\` for Ruby)

Result: server returned a projection partly using owner's data (ages, settings) and partly using viewer's data (portfolios, rental, contributions). Income Breakdown / Cash Flows charts rendered the contaminated payload.

Fix: gate all three fields behind \`!isSharedPlan\`. On the shared path, svc-retire's owner-scoped fallback resolves them from \`plan.ownerId\` settings + \`PrivateAssetConfig\` rows via M2M.

## Test plan
- [ ] Open Ruby's shared plan on kauri. Income Breakdown investment column matches server probe (\`$4,660\` at age 66) — not the contaminated values (\`$3,328\` at age 61).