### PR TITLE
feat(independence): unify Cash Flows + Income Breakdown axis with Wealth Journey

### DIFF
--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -454,14 +454,27 @@ export default function TimelineTabContent({
         <div className="h-64">
           <ResponsiveContainer width="100%" height="100%">
             <ComposedChart
-              data={projection.yearlyProjections.map((y) => ({
-                ...y,
-                // Life event expenses are already in withdrawals (backend includes them)
-                // Life event income needs to be added to the positive bar
-                investmentAndIncome:
-                  y.investment + (y.incomeBreakdown?.lifeEventIncome ?? 0),
-                negWithdrawals: -y.withdrawals,
-              }))}
+              data={[
+                // Accumulation rows: pre-retirement contributions + growth are
+                // the positive ("Returns & Income") bar; there are no
+                // withdrawals yet. Mirrors the Wealth Journey's axis so the
+                // viewer can read all three charts on the same timeline.
+                ...(projection.accumulationProjections ?? []).map((y) => ({
+                  age: y.age,
+                  year: y.year,
+                  investmentAndIncome:
+                    y.contribution + y.investmentGrowth + (y.lumpSumPayout ?? 0),
+                  negWithdrawals: 0,
+                })),
+                ...projection.yearlyProjections.map((y) => ({
+                  ...y,
+                  // Life event expenses are already in withdrawals (backend includes them)
+                  // Life event income needs to be added to the positive bar
+                  investmentAndIncome:
+                    y.investment + (y.incomeBreakdown?.lifeEventIncome ?? 0),
+                  negWithdrawals: -y.withdrawals,
+                })),
+              ]}
               margin={{ top: 10, right: 30, left: 20, bottom: 20 }}
             >
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
@@ -533,7 +546,37 @@ export default function TimelineTabContent({
         onToggle={() => toggleSection("incomeBreakdown")}
       >
         <IncomeBreakdownTable
-          projections={projection.yearlyProjections}
+          projections={[
+            // Normalize accumulation rows into YearlyProjection shape so
+            // the table shares the same axis as Wealth Journey + Cash Flows.
+            // Pre-retirement rows have no withdrawals; contributions +
+            // investment growth feed the Investment column via the
+            // incomeBreakdown.investmentReturns slot.
+            ...(projection.accumulationProjections ?? []).map((y) => ({
+              year: y.year,
+              age: y.age,
+              startingBalance: y.startingBalance,
+              investment: y.contribution + y.investmentGrowth,
+              withdrawals: 0,
+              endingBalance: y.endingBalance,
+              inflationAdjustedExpenses: 0,
+              currency: y.currency,
+              nonSpendableValue: y.nonSpendableValue,
+              totalWealth: y.totalWealth,
+              incomeBreakdown: {
+                investmentReturns:
+                  y.contribution + y.investmentGrowth + (y.lumpSumPayout ?? 0),
+                pension: 0,
+                socialSecurity: 0,
+                otherIncome: 0,
+                rentalIncome: 0,
+                totalIncome:
+                  y.contribution + y.investmentGrowth + (y.lumpSumPayout ?? 0),
+                lumpSumPayout: y.lumpSumPayout,
+              },
+            })),
+            ...projection.yearlyProjections,
+          ]}
           embedded
         />
       </CollapsibleSection>

--- a/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
+++ b/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
@@ -101,6 +101,21 @@ describe("scenarioToPayload", () => {
     expect(payload.lifeExpectancy).toBeUndefined()
   })
 
+  it("omits portfolioIds / monthlyContribution / rentalIncomeMonthly when isSharedPlan", () => {
+    // Regression: those values come from the VIEWER'S holdings, contributions
+    // and PrivateAssetConfig entries. Sending them on a shared plan made
+    // svc-retire run the projection against Mike's 9 portfolios + Mike's
+    // rental income instead of the owner's M2M-resolved data.
+    const payload = scenarioToPayload(scenario, {
+      ...ctx,
+      isSharedPlan: true,
+      rentalIncome: { monthlyNetByCurrency: { SGD: 1500 }, totalMonthlyInPlanCurrency: 1500 },
+    })
+    expect("portfolioIds" in payload).toBe(false)
+    expect("monthlyContribution" in payload).toBe(false)
+    expect("rentalIncomeMonthly" in payload).toBe(false)
+  })
+
   it("passes plan return rates unchanged when realReturn is null", () => {
     const payload = scenarioToPayload(scenario, ctx)
     expect(payload.cashReturnRate).toBe(0.03)

--- a/src/components/features/independence/scenario/scenarioToPayload.ts
+++ b/src/components/features/independence/scenario/scenarioToPayload.ts
@@ -45,10 +45,8 @@ export function scenarioToPayload(
     applyRealReturn(scenario, ctx.plan)
 
   const payload: Record<string, unknown> = {
-    portfolioIds: ctx.selectedPortfolioIds,
     currency: ctx.plan.expensesCurrency,
     displayCurrency: ctx.displayCurrency,
-    monthlyContribution: ctx.monthlyInvestment,
     monthlyExpenses: scenario.monthlyExpenses,
     cashReturnRate,
     equityReturnRate,
@@ -58,6 +56,16 @@ export function scenarioToPayload(
     socialSecurityMonthly: scenario.socialSecurityMonthly,
     otherIncomeMonthly: scenario.otherIncomeMonthly,
     targetBalance: ctx.plan.targetBalance,
+  }
+
+  // `portfolioIds` and `monthlyContribution` come from the viewer's own
+  // holdings + contributions. On a shared plan svc-retire resolves the
+  // OWNER's portfolios + contributions via the M2M path — sending the
+  // viewer's values overrides that and re-introduces the leak (Mike's
+  // 9 portfolios + his monthly investment land on Ruby's projection).
+  if (!ctx.isSharedPlan) {
+    payload.portfolioIds = ctx.selectedPortfolioIds
+    payload.monthlyContribution = ctx.monthlyInvestment
   }
 
   // Age-related inputs come from the viewer's UserIndependenceSettings via
@@ -88,7 +96,11 @@ export function scenarioToPayload(
   if (ctx.definedContribution != null) {
     payload.definedContribution = ctx.definedContribution
   }
-  if (ctx.rentalIncome?.totalMonthlyInPlanCurrency) {
+  // `rentalIncome` is computed from the viewer's PrivateAssetConfig
+  // entries. Ruby has none locally — Mike's rental income would override
+  // svc-retire's owner-scoped resolution. Omit on the shared path; server
+  // resolves rental income from plan-owner's configs.
+  if (!ctx.isSharedPlan && ctx.rentalIncome?.totalMonthlyInPlanCurrency) {
     payload.rentalIncomeMonthly = ctx.rentalIncome.totalMonthlyInPlanCurrency
   }
   if (ctx.includeDebug) {

--- a/src/pages/independence/debug.tsx
+++ b/src/pages/independence/debug.tsx
@@ -284,6 +284,14 @@ function IndependenceDebug(): React.ReactElement {
   const [projection, setProjection] = useState<RetirementProjection | null>(null)
   const [projError, setProjError] = useState<string | null>(null)
   const [projLoading, setProjLoading] = useState(false)
+  // Last POSTed body — surfaced on the debug page so any viewer-scoped
+  // value sneaking into a shared-plan projection request is visible
+  // without DevTools. Catches the class of leak that produced the
+  // shared-plan rollout bugs (portfolioIds, rentalIncomeMonthly, ages).
+  const [lastRequestBody, setLastRequestBody] = useState<Record<
+    string,
+    unknown
+  > | null>(null)
 
   const { data: plansData, isLoading: plansLoading } = useSwr<PlansResponse>(
     plansKey,
@@ -401,6 +409,7 @@ function IndependenceDebug(): React.ReactElement {
           body.liquidAssets = sliders.liquidAssets
           body.nonSpendableAssets = assets.nonSpendableAssets
         }
+        setLastRequestBody(body)
         const res = await fetch(
           `/api/independence/projection/${selectedPlan.id}`,
           {
@@ -798,6 +807,70 @@ function IndependenceDebug(): React.ReactElement {
                       pension configs, and rental income were resolved against
                       the plan owner&apos;s SystemUser (not the viewer&apos;s).
                     </p>
+                  </div>
+                )}
+
+                {lastRequestBody && (
+                  <div
+                    className={`rounded-lg border p-4 mt-5 ${
+                      isSharedPlan
+                        ? "bg-amber-50 border-amber-200"
+                        : "bg-white border-gray-200"
+                    }`}
+                  >
+                    <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3 flex items-center gap-2">
+                      Last Request Body
+                      {isSharedPlan && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 text-[10px] font-medium">
+                          Shared plan — viewer-scoped fields are leaks
+                        </span>
+                      )}
+                    </h3>
+                    <div className="space-y-1 text-xs font-mono">
+                      {Object.entries(lastRequestBody).map(([k, v]) => {
+                        // Viewer-scoped fields: server overrides its
+                        // owner-resolved fallback when ANY of these are
+                        // present. On a shared plan they MUST be absent.
+                        const isViewerScoped = [
+                          "portfolioIds",
+                          "monthlyContribution",
+                          "rentalIncomeMonthly",
+                          "currentAge",
+                          "retirementAge",
+                          "lifeExpectancy",
+                          "liquidAssets",
+                          "nonSpendableAssets",
+                        ].includes(k)
+                        const leak = isSharedPlan && isViewerScoped
+                        return (
+                          <div
+                            key={k}
+                            className={`flex items-start gap-2 ${
+                              leak ? "text-red-700" : "text-gray-700"
+                            }`}
+                          >
+                            <span className="font-semibold w-44 shrink-0">
+                              {leak && "🚨 "}
+                              {k}:
+                            </span>
+                            <span className="break-all">
+                              {typeof v === "object"
+                                ? JSON.stringify(v)
+                                : String(v)}
+                            </span>
+                          </div>
+                        )
+                      })}
+                    </div>
+                    {isSharedPlan && (
+                      <p className="text-xs text-amber-700 mt-3">
+                        Any 🚨 field overrides svc-retire&apos;s owner-scoped
+                        fallback at <code>StartingStateResolver.kt</code>. On a
+                        shared plan the request body should contain ONLY
+                        scenario sliders + plan-rate fields — never holdings,
+                        portfolio ids, contributions, or ages.
+                      </p>
+                    )}
                   </div>
                 )}
 


### PR DESCRIPTION
@coderabbitai ignore

## Summary
- Cash Flows + Income Breakdown previously rendered only \`yearlyProjections\` (retirement years). Wealth Journey already shows the full \`currentAge → depletion\` span by concatenating \`accumulationProjections\` + \`yearlyProjections\`.
- Cash Flows: prepend accumulation rows as positive "Returns & Income" bars (\`contribution + investmentGrowth + lumpSumPayout\`) with zero withdrawals — pre-retirement cashflow now visible alongside drawdown.
- Income Breakdown: normalize accumulation rows into the \`YearlyProjection\` shape so the table extends back to \`currentAge\`; pre-retirement \`Investment\` column reflects total contributions + growth + lump sums.

All three charts on the My Path tab now share the same x-axis.

## Test plan
- [ ] Ruby's Wookie plan: Cash Flows spans 51 → 76, green bars only through 64, mixed bars from 66+; Income Breakdown table opens at age 51.
- [ ] Owned plan: behavior unchanged (accumulation already populated for current-user plans).