### PR TITLE
fix(independence): gate projection on resolved share state; pension view falls back to Coast FI

### DIFF
--- a/src/components/features/independence/StrategyGaugesStrip.tsx
+++ b/src/components/features/independence/StrategyGaugesStrip.tsx
@@ -97,6 +97,13 @@ function buildGauges(
     },
   ]
 
+  // Always emit the retirement-age-fi gauge so the PENSION view headline
+  // slot has the right LABEL even before pension income is configured
+  // (e.g., CPF LIFE not yet set up). Without this the picker falls
+  // through to "FIRE Progress" on pension-strategy plans and the headline
+  // reads as a FIRE metric instead of a pension metric. Use coastFiProgress
+  // as the most-informative pension-strategy fallback when retirement-age
+  // FI is unavailable.
   if (fi?.retirementAgeFiProgress != null) {
     out.push({
       key: "retirement-age-fi",
@@ -104,6 +111,16 @@ function buildGauges(
       tooltip:
         "Liquid plus the present value of your guaranteed pension income, compared to your FI Number.",
       value: fi.retirementAgeFiProgress,
+      hideValues,
+      format: (v) => `${v.toFixed(1)}%`,
+    })
+  } else if (fi?.coastFiProgress != null) {
+    out.push({
+      key: "retirement-age-fi",
+      label: "Coast FI Progress",
+      tooltip:
+        "On-track signal for pension-strategy plans without configured guaranteed income. Compares current liquid assets to the amount that would compound to your FI Number by retirement age.",
+      value: fi.coastFiProgress,
       hideValues,
       format: (v) => `${v.toFixed(1)}%`,
     })

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -84,6 +84,12 @@ function PlanView(): React.ReactElement {
       dedupingInterval: 60000,
     },
   )
+  // True once plansData has resolved — until then we can't tell whether
+  // the plan is owned or shared, and firing the projection prematurely
+  // sends a viewer-scoped payload that pollutes svc-retire's response.
+  // On a hard refresh of a shared plan that meant the first render
+  // would briefly show the viewer's data before plansData arrived.
+  const isSharedPlanResolved = plansData?.data != null
   const isSharedPlan = useMemo(() => {
     const idStr = Array.isArray(id) ? id[0] : id
     if (!idStr) return false
@@ -482,6 +488,7 @@ function PlanView(): React.ReactElement {
     rentalIncome,
     displayCurrency: displayCurrency ?? undefined,
     isSharedPlan,
+    enabled: isSharedPlanResolved,
   })
 
   // For shared plans, demographics + retirement age MUST come from the


### PR DESCRIPTION
@coderabbitai ignore

## Summary
Two refresh-time issues on the shared plan view.

### 1. Hard refresh reverted to viewer SystemUser
\`isSharedPlan\` derives from \`plansData.sharedPlanIds\`. On a hard refresh \`plansData\` is undefined for one render → \`isSharedPlan = false\` → \`useUnifiedProjection\` fires with the viewer-scoped payload before \`/api/independence/plans\` resolves. Server returns viewer data, render sticks.

Fix: derive \`isSharedPlanResolved = plansData?.data != null\` and pass it as \`enabled\` to \`useUnifiedProjection\` so the projection only fires once we can answer "owned or shared".

### 2. Pension-strategy plan shows "FIRE Progress" headline
\`buildGauges\` only emits the \`retirement-age-fi\` gauge when \`retirementAgeFiProgress\` is non-null. For pension-strategy plans without configured guaranteed income (e.g., CPF LIFE not yet set up) the server returns \`null\`; the PENSION view then falls through to the FIRE gauge, mislabelling the headline.

Fix: when \`retirementAgeFiProgress\` is null, fall back to \`coastFiProgress\` under the same key + a "Coast FI Progress" label. Keeps the PENSION view headline pension-strategy-shaped.

## Test plan
- [ ] Hard-refresh a shared plan on kauri — page renders owner data on first paint, no flash of viewer data.
- [ ] Open a pension-strategy plan with no pension income — headline reads "Coast FI Progress", not "FIRE Progress".