### PR TITLE
feat(landing): public landing page for signed-out visitors

### DIFF
--- a/__tests__/pages/app.test.tsx
+++ b/__tests__/pages/app.test.tsx
@@ -4,6 +4,9 @@ import { render, screen, waitFor } from "@testing-library/react"
 import { registrationSuccess, portfolioResult } from "../fixtures"
 import { enableFetchMocks } from "jest-fetch-mock"
 import simpleGit from "../../__mocks__/simple-git"
+import { useUser } from "@auth0/nextjs-auth0/client"
+
+const mockUseUser = useUser as jest.MockedFunction<typeof useUser>
 
 enableFetchMocks()
 
@@ -68,5 +71,52 @@ describe("<Home />", () => {
     expect(screen.getByText("Manage Wealth")).toBeInTheDocument()
     expect(screen.getByText("Plan Independence")).toBeInTheDocument()
     expect(screen.getByText("Investment Strategy")).toBeInTheDocument()
+
+    // Auth'd cards point to functional routes
+    expect(
+      screen.getByRole("link", { name: /View Net Worth/i }),
+    ).toHaveAttribute("href", "/wealth")
+    expect(
+      screen.getByRole("link", { name: /Independence Plans/i }),
+    ).toHaveAttribute("href", "/independence")
+    expect(screen.getByRole("link", { name: /View Models/i })).toHaveAttribute(
+      "href",
+      "/rebalance/models",
+    )
+  })
+
+  test("renders unauth landing with Sign In CTA when no user", async () => {
+    mockUseUser.mockReturnValue({
+      user: undefined,
+      error: undefined,
+      isLoading: false,
+      invalidate: jest.fn(),
+    } as unknown as ReturnType<typeof useUser>)
+
+    render(<Home />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /Welcome\./i }),
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Login or Signup/i)).toBeInTheDocument()
+
+    const signIn = screen.getByRole("link", { name: /Sign In/i })
+    expect(signIn).toHaveAttribute("href", "/auth/login")
+
+    // Cards still rendered, but pointing to marketing routes
+    expect(
+      screen.getByRole("link", { name: /Manage Wealth/i }),
+    ).toHaveAttribute("href", "/learn/wealth")
+    expect(
+      screen.getByRole("link", { name: /Plan Independence/i }),
+    ).toHaveAttribute("href", "/learn/independence")
+    expect(
+      screen.getByRole("link", { name: /Investment Strategy/i }),
+    ).toHaveAttribute("href", "/learn/strategy")
+
+    // No portfolio "Getting Started" prompt for unauth
+    expect(screen.queryByText(/Let's Get You Started/i)).not.toBeInTheDocument()
   })
 })

--- a/src/components/layout/HeaderBrand.tsx
+++ b/src/components/layout/HeaderBrand.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react"
 import { useRouter } from "next/router"
 import Link from "next/link"
+import { useUser } from "@auth0/nextjs-auth0/client"
 import { useIsAdmin } from "@hooks/useIsAdmin"
 import { usePermissions } from "@hooks/usePermissions"
 
@@ -213,10 +214,12 @@ function DesktopDropdown({
 
 function HeaderBrand(): React.ReactElement {
   const router = useRouter()
+  const { user } = useUser()
   const { isAdmin } = useIsAdmin()
   const { ai: canRunAi } = usePermissions()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const mobileMenuRef = useRef<HTMLDivElement>(null)
+  const isAuthed = !!user
 
   // Close mobile menu when clicking outside
   useEffect(() => {
@@ -250,80 +253,85 @@ function HeaderBrand(): React.ReactElement {
 
   return (
     <div className="flex items-center" ref={mobileMenuRef}>
-      {/* Mobile Menu Button */}
-      <div className="relative lg:hidden mr-3">
-        <button
-          onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-          onKeyDown={handleKeyDown}
-          className="p-2 rounded-md hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
-          aria-expanded={mobileMenuOpen}
-          aria-haspopup="true"
-          aria-label="Navigation menu"
-        >
-          {mobileMenuOpen ? (
-            <i className="fas fa-times text-white text-lg w-5"></i>
-          ) : (
-            <i className="fas fa-bars text-white text-lg w-5"></i>
-          )}
-        </button>
+      {/* Mobile Menu Button — hidden when unauthenticated */}
+      {isAuthed && (
+        <div className="relative lg:hidden mr-3">
+          <button
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            onKeyDown={handleKeyDown}
+            className="p-2 rounded-md hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
+            aria-expanded={mobileMenuOpen}
+            aria-haspopup="true"
+            aria-label="Navigation menu"
+          >
+            {mobileMenuOpen ? (
+              <i className="fas fa-times text-white text-lg w-5"></i>
+            ) : (
+              <i className="fas fa-bars text-white text-lg w-5"></i>
+            )}
+          </button>
 
-        {/* Mobile Dropdown */}
-        {mobileMenuOpen && (
-          <div className="absolute left-0 mt-2 w-64 bg-white rounded-xl shadow-2xl border border-gray-200 z-50 overflow-hidden text-gray-800">
-            <div className="py-2 max-h-[75vh] overflow-y-auto">
-              {navSections.map((section, sectionIdx) => {
-                const filteredItems = section.items.filter(
-                  (item) =>
-                    (!item.adminOnly || isAdmin) && (!item.aiOnly || canRunAi),
-                )
-                if (filteredItems.length === 0) return null
-                return (
-                  <div key={section.title}>
-                    {sectionIdx > 0 && (
-                      <hr className="my-1.5 border-gray-100" />
-                    )}
-                    <div className="px-3 py-1">
-                      <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
-                        {section.title}
-                      </p>
-                    </div>
-                    {filteredItems.map((item) => {
-                      const active = isActiveRoute(router.pathname, item.href)
-                      const colors =
-                        sectionColors[section.title] || defaultSectionColor
-                      return (
-                        <Link
-                          key={item.href}
-                          href={item.href}
-                          className={`flex items-center gap-2.5 px-3 py-2 transition-colors ${
-                            active
-                              ? `${colors.bg} border-l-2 ${colors.border} ${colors.text}`
-                              : "text-gray-700 hover:bg-gray-50"
-                          }`}
-                        >
-                          <i
-                            className={`fas ${item.icon} w-4 text-center text-xs ${
-                              active ? colors.text : "text-gray-400"
+          {/* Mobile Dropdown */}
+          {mobileMenuOpen && (
+            <div className="absolute left-0 mt-2 w-64 bg-white rounded-xl shadow-2xl border border-gray-200 z-50 overflow-hidden text-gray-800">
+              <div className="py-2 max-h-[75vh] overflow-y-auto">
+                {navSections.map((section, sectionIdx) => {
+                  const filteredItems = section.items.filter(
+                    (item) =>
+                      (!item.adminOnly || isAdmin) &&
+                      (!item.aiOnly || canRunAi),
+                  )
+                  if (filteredItems.length === 0) return null
+                  return (
+                    <div key={section.title}>
+                      {sectionIdx > 0 && (
+                        <hr className="my-1.5 border-gray-100" />
+                      )}
+                      <div className="px-3 py-1">
+                        <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
+                          {section.title}
+                        </p>
+                      </div>
+                      {filteredItems.map((item) => {
+                        const active = isActiveRoute(router.pathname, item.href)
+                        const colors =
+                          sectionColors[section.title] || defaultSectionColor
+                        return (
+                          <Link
+                            key={item.href}
+                            href={item.href}
+                            className={`flex items-center gap-2.5 px-3 py-2 transition-colors ${
+                              active
+                                ? `${colors.bg} border-l-2 ${colors.border} ${colors.text}`
+                                : "text-gray-700 hover:bg-gray-50"
                             }`}
-                          ></i>
-                          <span className="text-sm">{item.label}</span>
-                        </Link>
-                      )
-                    })}
-                  </div>
-                )
-              })}
+                          >
+                            <i
+                              className={`fas ${item.icon} w-4 text-center text-xs ${
+                                active ? colors.text : "text-gray-400"
+                              }`}
+                            ></i>
+                            <span className="text-sm">{item.label}</span>
+                          </Link>
+                        )
+                      })}
+                    </div>
+                  )
+                })}
+              </div>
+              <div className="bg-gray-50 px-3 py-1.5 border-t border-gray-100">
+                <p className="text-[10px] text-gray-400">
+                  Press{" "}
+                  <kbd className="px-1 bg-gray-200 rounded text-[10px]">
+                    Esc
+                  </kbd>{" "}
+                  to close
+                </p>
+              </div>
             </div>
-            <div className="bg-gray-50 px-3 py-1.5 border-t border-gray-100">
-              <p className="text-[10px] text-gray-400">
-                Press{" "}
-                <kbd className="px-1 bg-gray-200 rounded text-[10px]">Esc</kbd>{" "}
-                to close
-              </p>
-            </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
 
       {/* Brand */}
       <a
@@ -335,18 +343,20 @@ function HeaderBrand(): React.ReactElement {
         Holds<i>worth</i>
       </a>
 
-      {/* Desktop Navigation */}
-      <nav className="hidden lg:flex items-center ml-8 space-x-1">
-        {navSections.map((section) => (
-          <DesktopDropdown
-            key={section.title}
-            section={section}
-            isAdmin={isAdmin}
-            canRunAi={canRunAi}
-            router={router}
-          />
-        ))}
-      </nav>
+      {/* Desktop Navigation — hidden when unauthenticated */}
+      {isAuthed && (
+        <nav className="hidden lg:flex items-center ml-8 space-x-1">
+          {navSections.map((section) => (
+            <DesktopDropdown
+              key={section.title}
+              section={section}
+              isAdmin={isAdmin}
+              canRunAi={canRunAi}
+              router={router}
+            />
+          ))}
+        </nav>
+      )}
     </div>
   )
 }

--- a/src/components/layout/HeaderUserControls.tsx
+++ b/src/components/layout/HeaderUserControls.tsx
@@ -26,7 +26,10 @@ function Avatar({
 }
 
 export default function HeaderUserControls(): React.ReactElement {
-  const { user, error, isLoading } = useUser()
+  // Auth0 v4 surfaces 401 from /auth/profile as `error` rather than a clean
+  // `user: undefined` — for header UX, treat error the same as unauthenticated
+  // and show the Sign In CTA.
+  const { user, isLoading } = useUser()
   const { preferences } = useUserPreferences()
   const { isAdmin } = useIsAdmin()
   const { hideValues, toggleHideValues } = usePrivacyMode()
@@ -57,17 +60,11 @@ export default function HeaderUserControls(): React.ReactElement {
         <div className="bg-gray-300 h-4 w-20 rounded"></div>
       </div>
     )
-  if (error)
-    return (
-      <div className="text-red-500 text-sm">
-        {"Error"}: {error.message}
-      </div>
-    )
   if (!user)
     return (
-      <div>
-        <Link href="/auth/login">{"Login"}</Link>
-      </div>
+      <Link href="/auth/login" className="btn-primary btn-primary--sm">
+        {"Sign In"}
+      </Link>
     )
 
   return (

--- a/src/components/layout/__tests__/HeaderBrand.test.tsx
+++ b/src/components/layout/__tests__/HeaderBrand.test.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import HeaderBrand from "../HeaderBrand"
+import { useUser } from "@auth0/nextjs-auth0/client"
+
+const mockUseUser = useUser as jest.MockedFunction<typeof useUser>
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    pathname: "/",
+    events: { on: jest.fn(), off: jest.fn() },
+    push: jest.fn(),
+  }),
+}))
+
+jest.mock("@hooks/useIsAdmin", () => ({
+  useIsAdmin: () => ({ isAdmin: false, isLoading: false }),
+}))
+
+jest.mock("@hooks/usePermissions", () => ({
+  usePermissions: () => ({
+    ai: false,
+    preview: false,
+    admin: false,
+    isLoading: false,
+  }),
+}))
+
+describe("HeaderBrand", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders nav dropdowns for authenticated user", () => {
+    render(<HeaderBrand />)
+    expect(screen.getByRole("button", { name: /^Wealth/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^Invest/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^Plan/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^Tools/i })).toBeInTheDocument()
+  })
+
+  it("hides nav dropdowns when unauthenticated", () => {
+    mockUseUser.mockReturnValueOnce({
+      user: undefined,
+      error: undefined,
+      isLoading: false,
+      invalidate: jest.fn(),
+    } as unknown as ReturnType<typeof useUser>)
+
+    render(<HeaderBrand />)
+    expect(
+      screen.queryByRole("button", { name: /^Wealth/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /^Invest/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /^Plan/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /^Tools/i }),
+    ).not.toBeInTheDocument()
+    // Mobile hamburger also hidden
+    expect(
+      screen.queryByRole("button", { name: /Navigation menu/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/layout/__tests__/HeaderUserControls.test.tsx
+++ b/src/components/layout/__tests__/HeaderUserControls.test.tsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import HeaderUserControls from "../HeaderUserControls"
+import { useUser } from "@auth0/nextjs-auth0/client"
+
+const mockUseUser = useUser as jest.MockedFunction<typeof useUser>
+
+jest.mock("@contexts/UserPreferencesContext", () => ({
+  useUserPreferences: () => ({
+    preferences: { preferredName: "Test User" },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+jest.mock("@hooks/useIsAdmin", () => ({
+  useIsAdmin: () => ({ isAdmin: false, isLoading: false }),
+}))
+
+jest.mock("@hooks/usePrivacyMode", () => ({
+  usePrivacyMode: () => ({ hideValues: false, toggleHideValues: jest.fn() }),
+}))
+
+describe("HeaderUserControls", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders styled Sign In button when not authenticated", () => {
+    mockUseUser.mockReturnValueOnce({
+      user: undefined,
+      error: undefined,
+      isLoading: false,
+      invalidate: jest.fn(),
+    } as unknown as ReturnType<typeof useUser>)
+
+    render(<HeaderUserControls />)
+    const cta = screen.getByRole("link", { name: /Sign In/i })
+    expect(cta).toHaveAttribute("href", "/auth/login")
+    // Privacy toggle hidden when unauth
+    expect(
+      screen.queryByRole("button", { name: /Hide values|Show values/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
-import { useUser, withPageAuthRequired } from "@auth0/nextjs-auth0/client"
+import { useUser } from "@auth0/nextjs-auth0/client"
 import Link from "next/link"
-import React, { useEffect, useState } from "react"
+import React from "react"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import { useMilestones } from "@contexts/MilestonesContext"
 import useSwr from "swr"
@@ -59,10 +59,12 @@ function RecentMilestones(): React.ReactElement | null {
   )
 }
 
-export default withPageAuthRequired(function Home(): React.ReactElement {
-  const { user, error, isLoading } = useUser()
+export default function Home(): React.ReactElement {
+  // Auth0 v4 surfaces 401 from /auth/profile as `error` rather than a clean
+  // `user: undefined` — treat any error here as "unauthenticated" and let the
+  // marketing branch render.
+  const { user, isLoading } = useUser()
   const { preferences, isLoading: prefsLoading } = useUserPreferences()
-  const [checkingOnboarding, setCheckingOnboarding] = useState(true)
 
   // Get registration state from context
   const { isChecking, isRegistered, isOnboardingComplete } = useRegistration()
@@ -74,31 +76,16 @@ export default withPageAuthRequired(function Home(): React.ReactElement {
     simpleFetcher(portfoliosKey),
   )
 
-  // Check if data is ready
-  useEffect(() => {
-    if (isLoading || isChecking || prefsLoading) return
-
-    // If onboarding is complete (from context), show the home page
-    if (isOnboardingComplete) {
-      setCheckingOnboarding(false)
-      return
-    }
-
-    // Wait for portfolios data to load before deciding
-    if (!isRegistered || portfoliosData === undefined) {
-      return // Still loading portfolios
-    }
-
-    // Data is loaded, show the page (with or without portfolios)
-    setCheckingOnboarding(false)
-  }, [
-    isLoading,
-    isChecking,
-    prefsLoading,
-    isRegistered,
-    isOnboardingComplete,
-    portfoliosData,
-  ])
+  // For authed users we wait for onboarding state (and portfolios when not yet
+  // marked complete) before rendering. Unauth visitors render the marketing
+  // landing immediately.
+  const checkingOnboarding =
+    !!user &&
+    !isOnboardingComplete &&
+    (isChecking ||
+      prefsLoading ||
+      !isRegistered ||
+      portfoliosData === undefined)
 
   const displayName = preferences?.preferredName
     ? preferences.preferredName
@@ -106,202 +93,215 @@ export default withPageAuthRequired(function Home(): React.ReactElement {
       ? capitalize(user.nickname)
       : user?.name || ""
 
-  if (isLoading || isChecking || checkingOnboarding)
+  if (isLoading || checkingOnboarding)
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
       </div>
     )
-  if (error)
-    return (
-      <div className="flex items-center justify-center min-h-screen text-red-600">
-        {error.message}
-      </div>
-    )
 
-  if (user) {
-    return (
-      <div className="min-h-screen bg-gray-50">
-        {/* Hero Section */}
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-8">
-          <div className="text-center">
-            <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
-              {"Welcome!"} <span className="text-gray-700">{displayName}</span>
-            </h1>
-            <p className="text-gray-500 text-lg">
-              Connecting goals, strategy, and assets — making progress visible
-            </p>
-          </div>
-        </div>
+  const isAuthed = !!user
+  const cardHref = {
+    wealth: isAuthed ? "/wealth" : "/learn/wealth",
+    independence: isAuthed ? "/independence" : "/learn/independence",
+    strategy: isAuthed ? "/rebalance/models" : "/learn/strategy",
+  }
 
-        {/* Getting Started - shown when user has no portfolios */}
-        {portfoliosData?.data?.length === 0 && (
-          <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 pb-8">
-            <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8">
-              <h2 className="text-xl font-bold text-gray-900 mb-2 text-center">
-                {"Let's Get You Started"}
-              </h2>
-              <p className="text-gray-600 mb-6 text-center">
-                {"No portfolios yet"}
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Hero Section */}
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-8">
+        <div className="text-center">
+          {isAuthed ? (
+            <>
+              <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
+                {"Welcome!"}{" "}
+                <span className="text-gray-700">{displayName}</span>
+              </h1>
+              <p className="text-gray-500 text-lg">
+                Connecting goals, strategy, and assets — making progress visible
               </p>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {/* Guided Setup - for novice users */}
-                <Link
-                  href="/onboarding"
-                  className="border border-gray-200 rounded-xl p-5 text-center hover:border-blue-300 hover:shadow-md transition-all"
-                >
-                  <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                    <i className="fas fa-rocket text-xl text-blue-500"></i>
-                  </div>
-                  <h3 className="font-semibold text-gray-900 mb-1">
-                    {"Start Setup"}
-                  </h3>
-                  <p className="text-gray-500 text-sm">
-                    {"Guided setup for bank accounts, property, and pensions"}
-                  </p>
-                </Link>
-                {/* Direct Add - for professional users */}
-                <Link
-                  href="/portfolios/__NEW__"
-                  className="border border-gray-200 rounded-xl p-5 text-center hover:border-green-300 hover:shadow-md transition-all"
-                >
-                  <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                    <i className="fas fa-plus text-xl text-green-500"></i>
-                  </div>
-                  <h3 className="font-semibold text-gray-900 mb-1">{"Add"}</h3>
-                  <p className="text-gray-500 text-sm">
-                    {"Create a portfolio directly with full control"}
-                  </p>
-                </Link>
-              </div>
+            </>
+          ) : (
+            <>
+              <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
+                {"Welcome."}
+              </h1>
+              <p className="text-gray-500 text-lg mb-6">{"Login or Signup"}</p>
+              <Link href="/auth/login" className="btn-primary">
+                {"Sign In"}
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Getting Started - shown when authed user has no portfolios */}
+      {isAuthed && portfoliosData?.data?.length === 0 && (
+        <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 pb-8">
+          <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8">
+            <h2 className="text-xl font-bold text-gray-900 mb-2 text-center">
+              {"Let's Get You Started"}
+            </h2>
+            <p className="text-gray-600 mb-6 text-center">
+              {"No portfolios yet"}
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {/* Guided Setup - for novice users */}
+              <Link
+                href="/onboarding"
+                className="border border-gray-200 rounded-xl p-5 text-center hover:border-blue-300 hover:shadow-md transition-all"
+              >
+                <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                  <i className="fas fa-rocket text-xl text-blue-500"></i>
+                </div>
+                <h3 className="font-semibold text-gray-900 mb-1">
+                  {"Start Setup"}
+                </h3>
+                <p className="text-gray-500 text-sm">
+                  {"Guided setup for bank accounts, property, and pensions"}
+                </p>
+              </Link>
+              {/* Direct Add - for professional users */}
+              <Link
+                href="/portfolios/__NEW__"
+                className="border border-gray-200 rounded-xl p-5 text-center hover:border-green-300 hover:shadow-md transition-all"
+              >
+                <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                  <i className="fas fa-plus text-xl text-green-500"></i>
+                </div>
+                <h3 className="font-semibold text-gray-900 mb-1">{"Add"}</h3>
+                <p className="text-gray-500 text-sm">
+                  {"Create a portfolio directly with full control"}
+                </p>
+              </Link>
             </div>
           </div>
-        )}
-
-        {/* Three Domains */}
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-12">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {/* Wealth - Blue */}
-            <Link
-              href="/wealth"
-              className="group relative overflow-hidden rounded-2xl bg-linear-to-br from-blue-500 to-blue-600 p-6 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
-            >
-              <div className="absolute top-0 right-0 -mt-4 -mr-4 h-24 w-24 rounded-full bg-white/10"></div>
-              <div className="absolute bottom-0 left-0 -mb-8 -ml-8 h-32 w-32 rounded-full bg-white/5"></div>
-              <div className="relative">
-                <div className="mb-4">
-                  <i className="fas fa-coins text-4xl text-white/90"></i>
-                </div>
-                <h2 className="text-2xl font-bold text-white mb-2">
-                  Manage Wealth
-                </h2>
-                <p className="text-blue-100 text-sm mb-4">
-                  What do I have? See net worth across brokers, assets and
-                  currencies in one place.
-                </p>
-                <ul className="text-blue-100 text-xs space-y-1">
-                  <li>
-                    <i className="fas fa-check mr-2"></i>Multi-currency
-                  </li>
-                  <li>
-                    <i className="fas fa-check mr-2"></i>Multi-broker
-                  </li>
-                  <li>
-                    <i className="fas fa-check mr-2"></i>Multi-asset
-                  </li>
-                </ul>
-                <div className="mt-4 flex items-center text-white font-medium">
-                  View Net Worth
-                  <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform"></i>
-                </div>
-              </div>
-            </Link>
-
-            {/* Independence - Sunset */}
-            <Link
-              href="/independence"
-              className="group relative overflow-hidden rounded-2xl bg-linear-to-br from-orange-400 via-orange-500 to-rose-500 p-6 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
-            >
-              <div className="absolute top-0 right-0 -mt-4 -mr-4 h-24 w-24 rounded-full bg-white/10"></div>
-              <div className="absolute bottom-0 left-0 -mb-8 -ml-8 h-32 w-32 rounded-full bg-white/5"></div>
-              <div className="relative">
-                <div className="mb-4">
-                  <i className="fas fa-umbrella-beach text-4xl text-white/90"></i>
-                </div>
-                <h2 className="text-2xl font-bold text-white mb-2">
-                  Plan Independence
-                </h2>
-                <p className="text-orange-100 text-sm mb-4">
-                  What do I want? Plan your financial independence with
-                  withdrawal strategies and identify when work becomes optional.
-                </p>
-                <ul className="text-orange-100 text-xs space-y-1">
-                  <li>
-                    <i className="fas fa-check mr-2"></i>Withdrawal strategies
-                  </li>
-                  <li>
-                    <i className="fas fa-check mr-2"></i>Inflation modeling
-                  </li>
-                  <li>
-                    <i className="fas fa-check mr-2"></i>FIRE calculations
-                  </li>
-                </ul>
-                <div className="mt-4 flex items-center text-white font-medium">
-                  Independence Plans
-                  <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform"></i>
-                </div>
-              </div>
-            </Link>
-
-            {/* Invest - Green */}
-            <Link
-              href="/rebalance/models"
-              className="group relative overflow-hidden rounded-2xl bg-linear-to-br from-emerald-500 to-emerald-700 p-6 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
-            >
-              <div className="absolute top-0 right-0 -mt-4 -mr-4 h-24 w-24 rounded-full bg-white/10"></div>
-              <div className="absolute bottom-0 left-0 -mb-8 -ml-8 h-32 w-32 rounded-full bg-white/5"></div>
-              <div className="relative">
-                <div className="mb-4">
-                  <i className="fas fa-balance-scale text-4xl text-white/90"></i>
-                </div>
-                <h2 className="text-2xl font-bold text-white mb-2">
-                  Investment Strategy
-                </h2>
-                <p className="text-emerald-100 text-sm mb-4">
-                  How will I get there? Turn goals and assets into coherent,
-                  rebalanceable investment strategies
-                </p>
-                <ul className="text-emerald-100 text-xs space-y-1">
-                  <li>
-                    <i className="fas fa-check mr-2"></i>Model portfolios
-                  </li>
-                  <li>
-                    <i className="fas fa-check mr-2"></i>Invest cash against
-                    models
-                  </li>
-                  <li>
-                    <i className="fas fa-check mr-2"></i>Rebalance portfolios to
-                    models
-                  </li>
-                </ul>
-                <div className="mt-4 flex items-center text-white font-medium">
-                  View Models
-                  <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform"></i>
-                </div>
-              </div>
-            </Link>
-          </div>
-
-          {/* Recent Milestones */}
-          <RecentMilestones />
-
-          {/* Tagline */}
-          <p className="text-center text-gray-500 mt-8">
-            Start anywhere. Everything connects over time.
-          </p>
         </div>
+      )}
+
+      {/* Three Domains */}
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-12">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {/* Wealth - Blue */}
+          <Link
+            href={cardHref.wealth}
+            className="group relative overflow-hidden rounded-2xl bg-linear-to-br from-blue-500 to-blue-600 p-6 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
+          >
+            <div className="absolute top-0 right-0 -mt-4 -mr-4 h-24 w-24 rounded-full bg-white/10"></div>
+            <div className="absolute bottom-0 left-0 -mb-8 -ml-8 h-32 w-32 rounded-full bg-white/5"></div>
+            <div className="relative">
+              <div className="mb-4">
+                <i className="fas fa-coins text-4xl text-white/90"></i>
+              </div>
+              <h2 className="text-2xl font-bold text-white mb-2">
+                Manage Wealth
+              </h2>
+              <p className="text-blue-100 text-sm mb-4">
+                What do I have? See net worth across brokers, assets and
+                currencies in one place.
+              </p>
+              <ul className="text-blue-100 text-xs space-y-1">
+                <li>
+                  <i className="fas fa-check mr-2"></i>Multi-currency
+                </li>
+                <li>
+                  <i className="fas fa-check mr-2"></i>Multi-broker
+                </li>
+                <li>
+                  <i className="fas fa-check mr-2"></i>Multi-asset
+                </li>
+              </ul>
+              <div className="mt-4 flex items-center text-white font-medium">
+                View Net Worth
+                <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform"></i>
+              </div>
+            </div>
+          </Link>
+
+          {/* Independence - Sunset */}
+          <Link
+            href={cardHref.independence}
+            className="group relative overflow-hidden rounded-2xl bg-linear-to-br from-orange-400 via-orange-500 to-rose-500 p-6 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
+          >
+            <div className="absolute top-0 right-0 -mt-4 -mr-4 h-24 w-24 rounded-full bg-white/10"></div>
+            <div className="absolute bottom-0 left-0 -mb-8 -ml-8 h-32 w-32 rounded-full bg-white/5"></div>
+            <div className="relative">
+              <div className="mb-4">
+                <i className="fas fa-umbrella-beach text-4xl text-white/90"></i>
+              </div>
+              <h2 className="text-2xl font-bold text-white mb-2">
+                Plan Independence
+              </h2>
+              <p className="text-orange-100 text-sm mb-4">
+                What do I want? Plan your financial independence with withdrawal
+                strategies and identify when work becomes optional.
+              </p>
+              <ul className="text-orange-100 text-xs space-y-1">
+                <li>
+                  <i className="fas fa-check mr-2"></i>Withdrawal strategies
+                </li>
+                <li>
+                  <i className="fas fa-check mr-2"></i>Inflation modeling
+                </li>
+                <li>
+                  <i className="fas fa-check mr-2"></i>FIRE calculations
+                </li>
+              </ul>
+              <div className="mt-4 flex items-center text-white font-medium">
+                Independence Plans
+                <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform"></i>
+              </div>
+            </div>
+          </Link>
+
+          {/* Invest - Green */}
+          <Link
+            href={cardHref.strategy}
+            className="group relative overflow-hidden rounded-2xl bg-linear-to-br from-emerald-500 to-emerald-700 p-6 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
+          >
+            <div className="absolute top-0 right-0 -mt-4 -mr-4 h-24 w-24 rounded-full bg-white/10"></div>
+            <div className="absolute bottom-0 left-0 -mb-8 -ml-8 h-32 w-32 rounded-full bg-white/5"></div>
+            <div className="relative">
+              <div className="mb-4">
+                <i className="fas fa-balance-scale text-4xl text-white/90"></i>
+              </div>
+              <h2 className="text-2xl font-bold text-white mb-2">
+                Investment Strategy
+              </h2>
+              <p className="text-emerald-100 text-sm mb-4">
+                How will I get there? Turn goals and assets into coherent,
+                rebalanceable investment strategies
+              </p>
+              <ul className="text-emerald-100 text-xs space-y-1">
+                <li>
+                  <i className="fas fa-check mr-2"></i>Model portfolios
+                </li>
+                <li>
+                  <i className="fas fa-check mr-2"></i>Invest cash against
+                  models
+                </li>
+                <li>
+                  <i className="fas fa-check mr-2"></i>Rebalance portfolios to
+                  models
+                </li>
+              </ul>
+              <div className="mt-4 flex items-center text-white font-medium">
+                View Models
+                <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform"></i>
+              </div>
+            </div>
+          </Link>
+        </div>
+
+        {/* Recent Milestones */}
+        {isAuthed && <RecentMilestones />}
+
+        {/* Tagline */}
+        <p className="text-center text-gray-500 mt-8">
+          Start anywhere. Everything connects over time.
+        </p>
       </div>
-    )
-  }
-  return <Link href={"/auth/login"}>{"Login"}</Link>
-})
+    </div>
+  )
+}

--- a/src/pages/learn/independence.tsx
+++ b/src/pages/learn/independence.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+import React from "react"
+
+export default function LearnIndependence(): React.ReactElement {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="text-center mb-10">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-linear-to-br from-orange-400 via-orange-500 to-rose-500 mb-6">
+            <i className="fas fa-umbrella-beach text-3xl text-white"></i>
+          </div>
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
+            {"Plan Independence"}
+          </h1>
+          <p className="text-gray-600 text-lg leading-relaxed">
+            {
+              "Plan your financial independence with withdrawal strategies, inflation modeling and FIRE calculations. Identify when work becomes optional — and what trade-offs get you there."
+            }
+          </p>
+        </div>
+        <div className="text-center">
+          <Link href="/auth/login" className="btn-primary">
+            {"Sign In"}
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/learn/strategy.tsx
+++ b/src/pages/learn/strategy.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+import React from "react"
+
+export default function LearnStrategy(): React.ReactElement {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="text-center mb-10">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-linear-to-br from-emerald-500 to-emerald-700 mb-6">
+            <i className="fas fa-balance-scale text-3xl text-white"></i>
+          </div>
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
+            {"Investment Strategy"}
+          </h1>
+          <p className="text-gray-600 text-lg leading-relaxed">
+            {
+              "Turn goals and assets into coherent, rebalanceable investment strategies. Model portfolios, invest cash against targets, and rebalance back to plan as the market drifts."
+            }
+          </p>
+        </div>
+        <div className="text-center">
+          <Link href="/auth/login" className="btn-primary">
+            {"Sign In"}
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/learn/wealth.tsx
+++ b/src/pages/learn/wealth.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+import React from "react"
+
+export default function LearnWealth(): React.ReactElement {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="text-center mb-10">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-linear-to-br from-blue-500 to-blue-600 mb-6">
+            <i className="fas fa-coins text-3xl text-white"></i>
+          </div>
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
+            {"Manage Wealth"}
+          </h1>
+          <p className="text-gray-600 text-lg leading-relaxed">
+            {
+              "See your net worth across brokers, assets and currencies in one place. Multi-currency, multi-broker, multi-asset — all the moving parts, one consistent view."
+            }
+          </p>
+        </div>
+        <div className="text-center">
+          <Link href="/auth/login" className="btn-primary">
+            {"Sign In"}
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,11 @@
 @import "tailwindcss";
 @tailwind utilities;
 
+/* Dark mode: opt-in via `dark` class on <html>. Pair with a future theme
+   toggle that flips the class. `prefers-color-scheme` not used so the user's
+   choice always wins over OS setting. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   /* Capability color tokens */
   --color-wealth-50: #eff6ff;
@@ -29,6 +34,13 @@
   --color-gain-bg: #ecfdf5;
   --color-loss: #dc2626;
   --color-loss-bg: #fef2f2;
+
+  /* Semantic primary CTA tokens — light defaults. Dark variants are scoped
+     under `.dark` below. Use `bg-primary text-primary-fg` (or the
+     `.btn-primary` component class) so theme changes flip in one place. */
+  --color-primary: #2563eb; /* blue-600 */
+  --color-primary-hover: #1d4ed8; /* blue-700 */
+  --color-primary-fg: #ffffff;
 
   /* Font stacks — DM Sans and JetBrains Mono are loaded by next/font in
      _app.tsx. We reference the font names directly here so Tailwind's
@@ -74,9 +86,47 @@ body {
   margin: 0;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
+@layer base {
+  /* Anchor reset lives in @layer base so Tailwind utilities (which sit in
+     the later `utilities` layer) win when a CTA needs an explicit
+     color — without this, `text-white` on a <Link> renders inherited
+     gray because bare element rules beat layered utility rules. */
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
+/* Dark-mode token overrides — applied when <html class="dark"> is set. */
+.dark {
+  --color-primary: #3b82f6; /* blue-500 — lighter for contrast on dark bg */
+  --color-primary-hover: #60a5fa; /* blue-400 */
+  --color-primary-fg: #ffffff;
+}
+
+@layer components {
+  /* Reusable primary CTA. Uses semantic tokens so light/dark themes flip
+     in one place instead of per-component utility chains. */
+  .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.625rem 1.5rem; /* py-2.5 px-6 */
+    border-radius: 0.5rem; /* rounded-lg */
+    background-color: var(--color-primary);
+    color: var(--color-primary-fg);
+    font-size: 0.875rem; /* text-sm */
+    font-weight: 600; /* font-semibold */
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); /* shadow-sm */
+    transition: background-color 150ms;
+  }
+  .btn-primary:hover {
+    background-color: var(--color-primary-hover);
+  }
+  .btn-primary--sm {
+    padding: 0.375rem 1rem; /* py-1.5 px-4 */
+    border-radius: 0.375rem; /* rounded-md */
+    box-shadow: none;
+  }
 }
 
 * {


### PR DESCRIPTION
## Summary

- `/` renders for unauthenticated visitors: hero ("Welcome." + "Login or Signup" + Sign In CTA) and the three feature cards (now linking to new `/learn/*` marketing stubs). Authenticated users see the existing dashboard unchanged.
- Header dropdowns (Wealth/Invest/Plan/Tools) and ChatFab hidden when unauthed; nav shows only brand + styled Sign In button.
- Dark-mode groundwork: `@custom-variant dark` + semantic CSS-var tokens (`--color-primary*`) + `.btn-primary` component class replacing five duplicated `bg-blue-600 text-white hover:bg-blue-700 …` chains. `a { color: inherit }` moved into `@layer base` so utility text colours win (was the root of the white-text-on-blue-button regression).
- Removed `withPageAuthRequired` on `/`; refactored stale `useState`/`useEffect` gating in `index.tsx` into a derived `checkingOnboarding` (silences `react-hooks/set-state-in-effect`).

## Test plan

- [x] `yarn test` (121 suites / 1359 tests) + `yarn lint` + `yarn typecheck` + `yarn prettier` — all green
- [x] Browser-verified unauth `/` and `/learn/wealth` — Sign In renders white, three cards link correctly, no nav dropdowns, no ChatFab
- [ ] Browser-verify authed `/` after merge (Auth0 flow not driven in Playwright)
- [ ] Smoke-test that direct nav to `/wealth` (still auth-gated) redirects to Auth0 login as before

@coderabbitai ignore