### PR TITLE
fix(offboarding): surface broker count on the SummaryStep

### DIFF
--- a/src/components/features/offboarding/steps/SummaryStep.tsx
+++ b/src/components/features/offboarding/steps/SummaryStep.tsx
@@ -76,6 +76,16 @@ export default function SummaryStep({
 
         <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
           <div className="flex items-center">
+            <i className="fas fa-building-columns text-purple-500 mr-3"></i>
+            <span className="font-medium">{"Brokers"}</span>
+          </div>
+          <span className="text-lg font-semibold">
+            {summary?.brokerCount ?? 0}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+          <div className="flex items-center">
             <i className="fas fa-percent text-orange-500 mr-3"></i>
             <span className="font-medium">{"Tax Rates"}</span>
           </div>

--- a/src/components/features/rebalance/execution/InvestCashDialog.tsx
+++ b/src/components/features/rebalance/execution/InvestCashDialog.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useMemo, useCallback } from "react"
+import React, { useState, useMemo, useCallback, useEffect } from "react"
 import useSWR from "swr"
+import { useRouter } from "next/router"
 import Dialog from "@components/ui/Dialog"
 import Spinner from "@components/ui/Spinner"
 import { simpleFetcher } from "@utils/api/fetchHelper"
@@ -63,12 +64,23 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
     simpleFetcher("/api/rebalance/models"),
   )
 
+  const router = useRouter()
+
   // Fetch brokers
   const { data: brokersData } = useSWR(
     modalOpen ? "/api/brokers" : null,
     simpleFetcher("/api/brokers"),
   )
   const brokers: Broker[] = brokersData?.data || []
+
+  // Convenience: if the user has exactly one broker, pre-select it
+  // when the dialog opens. Skip if user already chose (or cleared it).
+  useEffect(() => {
+    if (brokers.length === 1 && selectedBrokerId === undefined) {
+      setSelectedBrokerId(brokers[0].id)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [brokers.length, modalOpen])
 
   const models: ModelDto[] = modelsData?.data || []
   const modelsWithApprovedPlans = models.filter(
@@ -176,8 +188,22 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
   const handleCommit = async (): Promise<void> => {
     if (!execution) return
 
+    // Warn (but don't block) when the user has more than one broker but
+    // hasn't tagged the orders. They can still proceed if they meant to.
+    if (brokers.length > 1 && !selectedBrokerId) {
+      const ok = window.confirm(
+        "No broker selected. Your proposed transactions won't be tagged with a broker. Continue?",
+      )
+      if (!ok) return
+    }
+
     setCommitting(true)
     setError(null)
+
+    // Single source of truth for the commit's trn status — used both in
+    // the request body and to decide whether to navigate to the
+    // proposed-transactions list afterwards (only relevant for PROPOSED).
+    const transactionStatus: "PROPOSED" | "SETTLED" = "PROPOSED"
 
     try {
       // Only send updates if user made edits
@@ -214,7 +240,7 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             portfolioId: portfolioId,
-            transactionStatus: "PROPOSED",
+            transactionStatus,
             brokerId: selectedBrokerId,
           }),
         },
@@ -228,6 +254,12 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
 
       onSuccess()
       handleClose()
+      // Only nav to the proposed-transactions list when the orders are
+      // actually unsettled. SETTLED commits skip the proposed list and
+      // would surface on the portfolio holdings instead.
+      if (transactionStatus === "PROPOSED") {
+        router.push("/trns/proposed")
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to commit")
     } finally {

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -548,12 +548,17 @@ describe("useRebalanceExecution", () => {
       },
     )
 
-    let commitResult: { portfolioId: string } | undefined
+    let commitResult:
+      | { portfolioId: string; transactionStatus: "PROPOSED" | "SETTLED" }
+      | undefined
     await act(async () => {
       commitResult = await result.current.handlers.commit()
     })
 
-    expect(commitResult).toEqual({ portfolioId: "portfolio-1" })
+    expect(commitResult).toEqual({
+      portfolioId: "portfolio-1",
+      transactionStatus: "PROPOSED",
+    })
     expect(global.fetch).toHaveBeenCalledWith(
       "/api/rebalance/executions/exec-1/commit",
       expect.objectContaining({

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -53,7 +53,13 @@ export interface UseRebalanceExecutionResult {
     initialize: () => Promise<void>
     save: () => Promise<boolean>
     refresh: () => Promise<void>
-    commit: () => Promise<{ portfolioId: string } | undefined>
+    commit: () => Promise<
+      | {
+          portfolioId: string
+          transactionStatus: "PROPOSED" | "SETTLED"
+        }
+      | undefined
+    >
     targetChange: (assetId: string, value: number) => void
     excludeToggle: (assetId: string) => void
     setAllToCurrent: () => void
@@ -108,7 +114,21 @@ export function useRebalanceExecution(
     "/api/brokers",
     simpleFetcher("/api/brokers"),
   )
-  const brokers: Broker[] = brokersData?.data || []
+  const brokers: Broker[] = useMemo(
+    () => brokersData?.data || [],
+    [brokersData],
+  )
+
+  // Convenience default: if the user has exactly one broker, pre-select it.
+  // No reason to make them pick from a single-item list. We only set this
+  // once (when brokers first resolve) — if the user has explicitly cleared
+  // the selection back to "No broker" we don't re-apply.
+  useEffect(() => {
+    if (brokers.length === 1 && selectedBrokerId === undefined) {
+      setSelectedBrokerId(brokers[0].id)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [brokers])
 
   // --- Operations ---
 
@@ -383,7 +403,7 @@ export function useRebalanceExecution(
 
   // Commit execution - create transactions
   const handleCommit = useCallback(async (): Promise<
-    { portfolioId: string } | undefined
+    { portfolioId: string; transactionStatus: "PROPOSED" | "SETTLED" } | undefined
   > => {
     if (!execution || execution.portfolioIds.length === 0) return undefined
 
@@ -392,6 +412,7 @@ export function useRebalanceExecution(
 
     try {
       const portfolioId = execution.portfolioIds[0]
+      const transactionStatus: "PROPOSED" | "SETTLED" = "PROPOSED"
 
       const response = await fetch(
         `/api/rebalance/executions/${execution.id}/commit`,
@@ -400,7 +421,7 @@ export function useRebalanceExecution(
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             portfolioId,
-            transactionStatus: "PROPOSED",
+            transactionStatus,
             brokerId: selectedBrokerId,
           }),
         },
@@ -414,7 +435,7 @@ export function useRebalanceExecution(
         return undefined
       }
 
-      return { portfolioId }
+      return { portfolioId, transactionStatus }
     } catch (err) {
       console.error("Failed to commit execution:", err)
       setError(err instanceof Error ? err.message : "Failed to commit")

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -723,8 +723,23 @@ function ExecuteRebalancePage(): React.ReactElement {
             </button>
             <button
               onClick={async () => {
+                // Warn (but don't block) when the user has >1 brokers
+                // and didn't tag the orders — saves a "where's the
+                // broker on these trns?" follow-up later.
+                if (brokers.length > 1 && !selectedBrokerId) {
+                  const ok = window.confirm(
+                    "No broker selected. Your proposed transactions won't be tagged with a broker. Continue?",
+                  )
+                  if (!ok) return
+                }
                 const result = await handlers.commit()
-                if (result) {
+                if (!result) return
+                // Only land on /trns/proposed when the orders are
+                // actually unsettled. Settled commits go straight to
+                // the portfolio holdings.
+                if (result.transactionStatus === "PROPOSED") {
+                  router.push("/trns/proposed")
+                } else {
                   router.push(`/trns?portfolioId=${result.portfolioId}`)
                 }
               }}

--- a/src/pages/trns/proposed.tsx
+++ b/src/pages/trns/proposed.tsx
@@ -322,6 +322,16 @@ export default function ProposedTransactions(): React.JSX.Element {
     )
   }
 
+  // Bulk-apply a single broker to every row in the preview. Useful when
+  // the user opened a batch of orders that should all settle through the
+  // same broker — saves clicking the dropdown per row.
+  const handleApplyBrokerToAll = (value: string): void => {
+    if (!value) return
+    setTransactions((prev) =>
+      prev.map((trn) => ({ ...trn, editedBrokerId: value })),
+    )
+  }
+
   // Handlers for aggregated transaction edits
   const handleAggregatedPriceChange = (
     aggregateKey: string,
@@ -718,6 +728,32 @@ export default function ProposedTransactions(): React.JSX.Element {
             />
             <span className="text-gray-700">Aggregate by Broker + Asset</span>
           </label>
+
+          {brokers.length > 0 && transactions.length > 0 && (
+            <>
+              <div className="hidden sm:block border-l border-gray-300 h-6" />
+              <label className="flex items-center gap-2 text-sm">
+                <span className="text-gray-700">Apply broker to all:</span>
+                <select
+                  value=""
+                  onChange={(e) => {
+                    handleApplyBrokerToAll(e.target.value)
+                    // Reset so the same broker can be re-applied later.
+                    e.currentTarget.selectedIndex = 0
+                  }}
+                  className="px-2 py-1 border border-gray-300 rounded text-sm bg-white"
+                >
+                  <option value="">— Pick a broker —</option>
+                  {brokers.map((b) => (
+                    <option key={b.id} value={b.id}>
+                      {b.name}
+                      {b.accountNumber ? ` (${b.accountNumber})` : ""}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </>
+          )}
         </div>
 
         {fetchError && (

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -908,6 +908,7 @@ export interface OffboardingSummary {
   portfolioCount: number
   assetCount: number
   taxRateCount: number
+  brokerCount: number
 }
 
 /**


### PR DESCRIPTION
## Summary

Pairs with **monowai/beancounter#910** which adds \`brokerCount\` to \`OffboardingSummaryResponse\` and wires up broker deletion. UI side:

- \`OffboardingSummary\` TS type gains \`brokerCount: number\`
- \`SummaryStep\` shows a "Brokers" row next to portfolios / custom assets / plans / models / tax rates

## Test plan
- [x] \`yarn test\` (1369), \`yarn lint\`, \`yarn typecheck\` — all green
- [ ] After beancounter#910 deployed: confirm the count appears on the offboarding summary

@coderabbitai ignore