### PR TITLE
fix(trade): default settlement is generic {ccy} Cash, not a bank account

### DIFF
--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -495,13 +495,8 @@ const TradeInputForm: React.FC<{
   }, [allCashBalances, currentTradeCurrency])
 
   const defaultCashAsset = useMemo(
-    () =>
-      buildDefaultCashAsset(
-        filteredCashAssets,
-        currentTradeCurrency,
-        allBankAccounts,
-      ),
-    [filteredCashAssets, currentTradeCurrency, allBankAccounts],
+    () => buildDefaultCashAsset(filteredCashAssets, currentTradeCurrency),
+    [filteredCashAssets, currentTradeCurrency],
   )
 
   // Cash assets for dropdown - all currency balances are already included

--- a/src/lib/utils/trns/tradeFormHelpers.test.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.test.ts
@@ -429,7 +429,7 @@ describe("tradeFormHelpers", () => {
       }
       const result = buildInitialSettlementAccount(trn as any)
       expect(result!.label).toContain("USD")
-      expect(result!.label).toContain("Balance")
+      expect(result!.label).toContain("Cash")
     })
   })
 
@@ -524,7 +524,7 @@ describe("tradeFormHelpers", () => {
       const result = buildDefaultCashAsset(filtered, "NZD")
       expect(result).toEqual({
         value: "c1",
-        label: "NZD Balance",
+        label: "NZD",
         currency: "NZD",
         market: "CASH",
       })
@@ -534,7 +534,7 @@ describe("tradeFormHelpers", () => {
       const result = buildDefaultCashAsset([], "GBP")
       expect(result).toEqual({
         value: "cash:GBP",
-        label: "GBP Balance",
+        label: "GBP Cash",
         currency: "GBP",
         market: "CASH",
       })

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -236,7 +236,7 @@ export const buildInitialSettlementAccount = (
     value: asset.id,
     label:
       asset.name ||
-      `${getDisplayCode(asset)} ${asset.market?.code === "CASH" ? "Balance" : ""}`,
+      `${getDisplayCode(asset)}${asset.market?.code === "CASH" ? " Cash" : ""}`,
     currency:
       asset.accountingType?.currency?.code ||
       asset.priceSymbol ||
@@ -302,38 +302,28 @@ export const buildAllCashBalances = (
 }
 
 /**
- * Build default settlement option for a trade currency.
- * Prefers a matching bank account over a generic cash balance.
+ * Build default settlement option for a trade currency. Always returns the
+ * generic `{ccy} Cash` asset so a broker with no explicit settlement
+ * mapping doesn't accidentally route trades to an unrelated bank account
+ * in the linked funding portfolio. Caller can still override via the
+ * dropdown or via the broker's settlement-accounts mapping.
  */
 export const buildDefaultCashAsset = (
   filteredCashAssets: AssetLike[],
   tradeCurrency: string,
-  bankAccounts: AssetLike[] = [],
 ): SettlementAccountOption => {
-  // Prefer a bank account matching the trade currency
-  const matchingBank = bankAccounts.find(
-    (a) => getAssetCurrency(a) === tradeCurrency,
-  )
-  if (matchingBank) {
-    return {
-      value: matchingBank.id,
-      label: `${matchingBank.name || matchingBank.code} (${tradeCurrency})`,
-      currency: tradeCurrency,
-      market: "PRIVATE",
-    }
-  }
   const cashAsset = filteredCashAssets[0]
   if (cashAsset) {
     return {
       value: cashAsset.id,
-      label: `${cashAsset.name || cashAsset.code} Balance`,
+      label: cashAsset.name || `${cashAsset.code} Cash`,
       currency: cashAsset.code,
       market: "CASH",
     }
   }
   return {
     value: `cash:${tradeCurrency}`,
-    label: `${tradeCurrency} Balance`,
+    label: `${tradeCurrency} Cash`,
     currency: tradeCurrency,
     market: "CASH",
   }


### PR DESCRIPTION
## Summary

When a broker has no explicit per-currency settlement mapping ("default"), the trade form used to pre-select the first bank account whose currency matched the trade currency — picking up funding-portfolio bank accounts attached via `cashPortfolioId` and routing the cash leg into the wrong portfolio.

Default settlement is now the generic `${ccy} Cash` asset (CASH market). Broker-specific settlement mappings still win when present via `resolveBrokerSettlementAccount`. Users can still override by picking a bank account from the dropdown.

Matches svc-rebalance commit behaviour, which already falls back to `CASH/{currency}` when no `cashAssetId` is passed.

Also dropped the stray "Balance" suffix in the initial-settlement label builder so cash assets whose stored name already ends in "Balance" don't double up.

## Test plan
- [x] `yarn test` (1369), `yarn lint`, `yarn typecheck` — green
- [ ] In trade dialog with broker that has no settlement set: default Settlement Account = "USD Cash" (or matching ccy), not "DBS US (USD)"

@coderabbitai ignore