### PR TITLE
fix(auth0): single transaction cookie to stop InvalidStateError

### DIFF
--- a/src/lib/utils/auth0.ts
+++ b/src/lib/utils/auth0.ts
@@ -3,13 +3,18 @@ import { Auth0Client } from "@auth0/nextjs-auth0/server"
 // Scope and audience are configured here rather than via env vars because
 // Auth0 v4 removed AUTH0_SCOPE/AUTH0_AUDIENCE env var support.
 // Audience must match the API identifier in Auth0 dashboard.
+// enableParallelTransactions:false uses a single __txn cookie that is
+// overwritten on each /auth/login. With the v4 default (true), every login
+// flow writes a new __txn_<state> cookie; abandoned/back-buttoned flows
+// accumulate until the browser per-host cookie cap evicts the entry for the
+// state that finally completes, producing "The state parameter is invalid."
 export const auth0 = new Auth0Client({
+  enableParallelTransactions: false,
   authorizationParameters: {
     scope:
       "openid profile email offline_access " +
       "beancounter beancounter:user beancounter:admin " +
       "beancounter:ai beancounter:preview",
     audience: "https://holdsworth.app",
-    prompt: "login",
   },
 })


### PR DESCRIPTION
## Summary
- Set `enableParallelTransactions: false` on `Auth0Client` so login uses one overwriting `__txn` cookie instead of a fresh `__txn_<state>` cookie per flow.
- Drop `prompt: "login"` so Auth0 SSO is reused when valid (halves the rate of new transaction cookies and avoids forcing the login screen).

## Why
v4 SDK default is `enableParallelTransactions: true`. Every `/auth/login` writes a new `__txn_<state>` cookie; abandoned / back-buttoned / refreshed flows are never cleaned up. The browser per-host cookie cap (~50 in Chrome) eventually evicts older `__txn_*` entries. When the user finally completes a flow whose state cookie has been evicted, `auth-client.js` throws `InvalidStateError("The state parameter is invalid.")` and the only user-side fix is clearing cookies.

Matches the reported intermittent symptom: page fails to load with "The state parameter is invalid.", resolved by trashing cookies.

## Trade-offs
- Only one in-flight login per browser at a time (acceptable for normal use).
- Auth0 SSO short-circuits the login screen when the upstream session is still valid; if forced re-auth is ever required, request `prompt: "login"` on a specific call rather than globally.

## Test plan
- [ ] Deploy to kauri.
- [ ] Open kauri.monowai.com → log in → confirm devtools shows a single `__txn` cookie during the flow (not `__txn_<state>`).
- [ ] Repeatedly start/abandon logins (back button, close tab, re-open) → confirm no `__txn_*` accumulation and no `InvalidStateError` on the next successful login.
- [ ] Sanity check protected pages still load after a fresh login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication reliability and stability in transaction handling.
  * Simplified the login experience by removing unnecessary prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->