### PR TITLE
fix(sentry): inject NEXT_PUBLIC_SENTRY_DSN at build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,7 @@ jobs:
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
           CI: true
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
         run: yarn build
 
       - name: Upload build artifacts


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_*` env vars are inlined into the Next.js client bundle at **build time**, not runtime
- Kauri injects `NEXT_PUBLIC_SENTRY_DSN` via K8s `kauri.yaml`, which only reaches the server side
- Browser bundle shipped with `process.env.NEXT_PUBLIC_SENTRY_DSN === undefined` → `instrumentation-client.ts` else-branch logs `"No DSN configured, skipping initialization"` → no `browserTracingIntegration` → no pageload/navigation transactions → no trace propagation header on `/api/*` fetches → every server API call starts a fresh root trace

This adds the secret to the CI build env so the value is baked into the client bundle.

### Evidence

24h of bc-view traces on Sentry: **0** spans matching `span.op:[pageload,navigation]`. Same-instant clusters of `/api/markets`, `/api/currencies`, `/api/permissions`, `/api/brokers/index`, `/auth/profile` at one timestamp — clearly a single page mount — each had a distinct `traceId`. Sample trace contained only:

```
http.server GET /api/brokers/index
  └─ default "executing api route (pages) /api/brokers/index"
       └─ http.client GET http://bc-data/api/brokers
```

After this lands, a pageload root span should wrap all the sibling API calls into one trace.

### Prereq

A repo secret `NEXT_PUBLIC_SENTRY_DSN` must exist. The DSN is a public-safe client token (Sentry designed it as such — also visible in `bc-deploy/env/kauri.yaml:454`), so could alternatively be hardcoded as a fallback in `instrumentation-client.ts`. Using a secret keeps the source of truth in one place.

Once the secret is added we can drop `NEXT_PUBLIC_SENTRY_DSN` from `bc-deploy/env/kauri.yaml` since it's no longer needed at runtime — that's a follow-up.

## Test plan

- [ ] Add `NEXT_PUBLIC_SENTRY_DSN` secret to the bc-view GitHub repo
- [ ] Merge + deploy
- [ ] Open kauri.monowai.com, DevTools console → expect `[Sentry Client] Initialized successfully`
- [ ] DevTools Network → filter `sentry` → expect POSTs to `*.ingest.de.sentry.io/api/.../envelope/`
- [ ] Sentry → Explore → Traces query `span.op:[pageload,navigation]` → expect rows
- [ ] Pick a recent trace → expect pageload root with `/api/*` child spans (server side already wired via `tracePropagationTargets: [/^\\/api\\//]`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to enhance error tracking and monitoring capabilities in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->