### PR TITLE
ci(sentry): fail build if NEXT_PUBLIC_SENTRY_DSN missing or not inlined

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,12 +103,43 @@ jobs:
           restore-keys: |
             nextjs-cache-
 
+      - name: Verify Sentry DSN secret is present
+        env:
+          DSN_PRESENT: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN != '' }}
+        run: |
+          if [ "$DSN_PRESENT" != "true" ]; then
+            echo "::error::NEXT_PUBLIC_SENTRY_DSN repo secret is missing or empty."
+            echo "Browser-side Sentry will silently bail out — no pageload traces."
+            echo "Add the secret at: https://github.com/monowai/bc-view/settings/secrets/actions"
+            exit 1
+          fi
+          echo "NEXT_PUBLIC_SENTRY_DSN secret is set."
+
       - name: Build application
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
           CI: true
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
         run: yarn build
+
+      - name: Verify Sentry DSN is inlined into client bundle
+        env:
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+        run: |
+          # Extract Sentry project ID (last path segment of DSN URL) - public identifier, safe to grep
+          PROJECT_ID="${NEXT_PUBLIC_SENTRY_DSN##*/}"
+          if [ -z "$PROJECT_ID" ]; then
+            echo "::error::Could not extract project ID from NEXT_PUBLIC_SENTRY_DSN."
+            exit 1
+          fi
+          if grep -rqF "$PROJECT_ID" .next/static/chunks 2>/dev/null; then
+            echo "Sentry DSN inlined into client bundle."
+          else
+            echo "::error::Sentry DSN NOT found in .next/static/chunks — browser tracing would be dead."
+            echo "Next.js did not inline NEXT_PUBLIC_SENTRY_DSN despite the env var being set at build time."
+            echo "Check that instrumentation-client.ts references process.env.NEXT_PUBLIC_SENTRY_DSN directly (no indirection)."
+            exit 1
+          fi
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

Two CI guards so the build fails loudly if the browser Sentry init would silently bail out:

1. **Pre-build** — `Verify Sentry DSN secret is present`: fails fast if the `NEXT_PUBLIC_SENTRY_DSN` repo secret is missing or empty. Uses a boolean GitHub expression so the secret value is never echoed.
2. **Post-build** — `Verify Sentry DSN is inlined into client bundle`: extracts the public project ID from the DSN URL and greps `.next/static/chunks` for it. Catches cases where the env var is set at build time but Next.js bundler substitution does not fire (e.g. wrong `instrumentation-client.ts` location under Turbopack, indirect `process.env` reference).

Both steps print actionable error messages pointing at either the repo settings URL or the instrumentation file.

### Motivation

After #762 the secret was added and the build env shows `NEXT_PUBLIC_SENTRY_DSN: ***` (masked = present), yet 24h of production traffic produced **zero** `pageload`/`navigation` spans — browser SDK is still silent. We don't have visibility into whether the DSN actually made it into the client bundle, so the next step is to assert it post-build.

If guard 2 fails on this run, that confirms Next.js is not inlining the value and we have a substitution bug to chase (likely a Next.js 16 / Turbopack file-convention issue with `src/instrumentation-client.ts`). If guard 2 passes, the DSN is in the bundle and the silence is elsewhere (cache, runtime crash, integration mis-config).

## Test plan

- [ ] CI run on this PR passes both new steps (proves they're not flaky on a known-good DSN)
- [ ] Locally remove the secret in a fork or comment out the secret reference → expect the pre-build guard to fail with the secret-missing message
- [ ] If post-build guard fails on the actual `main` build → investigation handoff: check `src/instrumentation-client.ts` location vs Next.js 16 conventions, or use the kauri-published DSN as a hardcoded fallback in source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD build pipeline with validation checks to verify required environment configuration is present before build execution and confirm build artifacts contain necessary integration components after compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->