### PR TITLE
ci(cache): bust Next.js build cache when workflow file changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,11 +95,17 @@ jobs:
       # the key minted a fresh ~100 MB cache on every source commit and blew
       # past the repo cache budget. .next/cache is designed to restore stale —
       # Next handles incremental compilation from there.
+      # Include the workflow file in the cache key so changes to build env
+      # (env vars, secret references, build flags) bust the Turbopack persistent
+      # cache. Without this, .next/cache can pin a stale compiled version of
+      # process.env.NEXT_PUBLIC_* values — observed on 2026-06-04 when a chunk
+      # built BEFORE the Sentry DSN secret existed was reused AFTER the secret
+      # was added, leaving the browser bundle with an undefined DSN.
       - name: Restore Next.js build cache
         uses: actions/cache@v5
         with:
           path: .next/cache
-          key: nextjs-cache-${{ hashFiles('yarn.lock', 'next.config.js') }}
+          key: nextjs-cache-${{ hashFiles('yarn.lock', 'next.config.js', '.github/workflows/build.yml') }}
           restore-keys: |
             nextjs-cache-
 


### PR DESCRIPTION
Follow-up to #762 / #763.

## Summary

Add `.github/workflows/build.yml` to the cache key's `hashFiles()` set so any change to build env (env vars, secret references, build flags) invalidates the Turbopack persistent cache.

Without this, `.next/cache` can pin a stale compiled version of `process.env.NEXT_PUBLIC_*` values.

## Evidence (2026-06-04)

After #762 was merged, playwright fetched the live chunk from kauri and found:

| Field | Value |
|---|---|
| `last-modified` | `2026-06-04T23:07:36Z` (within the #762 build window) |
| `hasLoadingLog` | `true` |
| `hasProjectId` (`4508155588182096`) | **`false`** |
| `hasDsnHost` (`o4508146873466880.ingest.de.sentry.io`) | **`false`** |

The chunk was timestamped during the #762 build but compiled with `undefined` DSN. Tracing back: `actions/cache@v5` restored `nextjs-cache-e985d2feb...` written `2026-06-02T06:32:26Z` — well before the `NEXT_PUBLIC_SENTRY_DSN` repo secret was added on `2026-06-04T23:02:26Z`. Turbopack reused the pre-compiled `instrumentation-client.ts` module with the stale env value baked in.

The three stale cache entries (main, PR-merge ref, feat/cost-stack-page branch) have been deleted via `gh api -X DELETE` so the next build is cold. This PR ensures the trap can't recur.

## Test plan

- [ ] Merge → main build → cache miss expected (key changed) → cold compile
- [ ] Post-build guard from #763 still passes (project ID grepped in `.next/static/chunks`)
- [ ] After deploy, refetch the live chunk via playwright → expect `hasProjectId: true`
- [ ] Sentry `span.op:[pageload,navigation]` returns rows within 5 min of user activity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline caching strategy to invalidate cache appropriately when build configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->