### PR TITLE
ci(sentry): scope cache restore-keys and tighten DSN inline guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,23 +91,26 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 8
 
-      # Key on lockfile + next.config only. Including hashFiles('src/**/*') in
-      # the key minted a fresh ~100 MB cache on every source commit and blew
-      # past the repo cache budget. .next/cache is designed to restore stale —
-      # Next handles incremental compilation from there.
-      # Include the workflow file in the cache key so changes to build env
-      # (env vars, secret references, build flags) bust the Turbopack persistent
-      # cache. Without this, .next/cache can pin a stale compiled version of
-      # process.env.NEXT_PUBLIC_* values — observed on 2026-06-04 when a chunk
-      # built BEFORE the Sentry DSN secret existed was reused AFTER the secret
-      # was added, leaving the browser bundle with an undefined DSN.
+      # Key structure: nextjs-cache-<workflow-hash>-<deps-hash>
+      # Including hashFiles('src/**/*') in the key minted a fresh ~100 MB cache on every
+      # source commit and blew past the repo cache budget. .next/cache is designed to
+      # restore stale — Next handles incremental compilation from there.
+      #
+      # Workflow hash comes FIRST so the restore-keys fallback is anchored to it: a
+      # change to .github/workflows/build.yml (env vars, secret references, build flags)
+      # produces a new workflow hash, so the restore-keys prefix never matches a cache
+      # built under the previous workflow. Without this anchoring, .next/cache can pin
+      # a stale compiled version of process.env.NEXT_PUBLIC_* values — observed on
+      # 2026-06-04 when a chunk built BEFORE the Sentry DSN secret existed was reused
+      # AFTER the secret was added, leaving the browser bundle with an undefined DSN.
+      # Routine yarn.lock / next.config.js changes still benefit from partial restore.
       - name: Restore Next.js build cache
         uses: actions/cache@v5
         with:
           path: .next/cache
-          key: nextjs-cache-${{ hashFiles('yarn.lock', 'next.config.js', '.github/workflows/build.yml') }}
+          key: nextjs-cache-${{ hashFiles('.github/workflows/build.yml') }}-${{ hashFiles('yarn.lock', 'next.config.js') }}
           restore-keys: |
-            nextjs-cache-
+            nextjs-cache-${{ hashFiles('.github/workflows/build.yml') }}-
 
       - name: Verify Sentry DSN secret is present
         env:
@@ -138,12 +141,23 @@ jobs:
             echo "::error::Could not extract project ID from NEXT_PUBLIC_SENTRY_DSN."
             exit 1
           fi
-          if grep -rqF "$PROJECT_ID" .next/static/chunks 2>/dev/null; then
-            echo "Sentry DSN inlined into client bundle."
+          # Find the chunk that actually runs instrumentation-client.ts — that's the one
+          # that has to reference the DSN. Greping all of .next/static/chunks is too
+          # lenient: a build could have the DSN in some unrelated chunk while the
+          # init module still inlined `undefined` (this happened on 2026-06-04).
+          CHUNK=$(grep -lrF "instrumentation-client.ts loading" .next/static/chunks 2>/dev/null | head -1)
+          if [ -z "$CHUNK" ]; then
+            echo "::error::Could not locate the instrumentation-client chunk in .next/static/chunks."
+            echo "If instrumentation-client.ts was renamed, update this guard."
+            exit 1
+          fi
+          if grep -qF "$PROJECT_ID" "$CHUNK"; then
+            echo "Sentry DSN inlined into instrumentation-client chunk: $CHUNK"
           else
-            echo "::error::Sentry DSN NOT found in .next/static/chunks — browser tracing would be dead."
-            echo "Next.js did not inline NEXT_PUBLIC_SENTRY_DSN despite the env var being set at build time."
-            echo "Check that instrumentation-client.ts references process.env.NEXT_PUBLIC_SENTRY_DSN directly (no indirection)."
+            echo "::error::Sentry DSN NOT found in $CHUNK — browser tracing would be dead."
+            echo "Next.js did not inline NEXT_PUBLIC_SENTRY_DSN into the instrumentation chunk despite the env var being set at build time."
+            echo "Likely cause: Turbopack persistent cache reused a pre-compiled module with the old (undefined) DSN value."
+            echo "Fix: invalidate .next/cache (delete the relevant Actions cache, then re-run)."
             exit 1
           fi
 


### PR DESCRIPTION
Follow-up to #763 / #764. After #764 the live kauri chunk still shipped without the DSN.

## Root cause this time

#764 changed the cache key to include `.github/workflows/build.yml`, but `restore-keys: nextjs-cache-` is a bare prefix match. The main build after #764 missed the new primary key `6de41f42…` then fell through to a stale `0d1c931be…` cache written `2026-05-31`, perpetuating the no-DSN compiled module.

Verified via playwright fetch of the live chunk on kauri:

```
url:           https://kauri.monowai.com/_next/static/chunks/0lba_1mrrq65z.js
last-modified: 2026-06-04T23:53:48Z   (post-#764 build)
length:        ~ chunk size
hasLoadingLog: true
hasProjectId:  false   (4508155588182096 — DSN's project ID)
hasDsnHost:    false   (o4508146873466880.ingest.de.sentry.io)
```

## Changes

1. **Cache key structure** is now `nextjs-cache-<workflow-hash>-<deps-hash>` and `restore-keys` is anchored to the workflow hash. A workflow-file change produces a new workflow hash → the restore-keys prefix can't fall through to a pre-change cache. Routine `yarn.lock` / `next.config.js` changes still benefit from partial restore.

2. **Post-build guard** now greps the **specific chunk** containing the `instrumentation-client.ts loading` log instead of the whole `.next/static/chunks` tree. In #763's run the bare recursive grep passed because the project ID appeared in some chunk, but the actual instrumentation chunk had `undefined` DSN. Targeted grep catches that.

All five `nextjs-cache-*` entries in the bc-view Actions cache have already been deleted via `gh api -X DELETE` so the next build is cold.

## Test plan

- [ ] PR build: cache miss → cold compile → guard passes against the instrumentation chunk
- [ ] On merge / deploy: refetch the live chunk → `hasProjectId: true`
- [ ] Sentry `span.op:[pageload,navigation]` returns rows within 5 min of user activity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the Next.js build cache strategy to improve cache efficiency and reuse.
  * Enhanced the Sentry DSN verification step in the build process with more targeted detection and improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->