### PR TITLE
ci(build): conditional artifact handoff + DSN inlining guards end-to-end

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,8 +15,10 @@ tests/
 **/*.test.jsx
 **/__tests__/**
 
-# Next.js — yarn build runs inside the builder stage; host .next is irrelevant.
-.next/
+# Next.js — leave .next/ available so the Docker job's builder stage can reuse
+# the artifact from the CI build job (main / workflow_dispatch only). On PR /
+# local builds where .next is absent, the Dockerfile rebuilds it.
+# .next/  # intentionally not ignored
 
 # Misc
 .DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
-# Dependencies
-# node_modules  # Allow node_modules from CI
+# Dependencies — yarn install runs inside the builder stage; host node_modules
+# is irrelevant and would only inflate the build context.
+node_modules
 npm-debug.log*
 yarn-debug.log*
 
@@ -14,8 +15,8 @@ tests/
 **/*.test.jsx
 **/__tests__/**
 
-# Next.js
-# .next/  # Allow .next from CI
+# Next.js — yarn build runs inside the builder stage; host .next is irrelevant.
+.next/
 
 # Misc
 .DS_Store

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,10 +135,17 @@ jobs:
         env:
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
         run: |
-          # Extract Sentry project ID (last path segment of DSN URL) - public identifier, safe to grep
+          # Extract Sentry project ID (last path segment) and ingest host. Checking BOTH
+          # catches the case where a DSN was rotated to a different region (us → de) or
+          # public key, but the same project ID was reused — project-ID-only grep would
+          # false-pass while the bundle pointed at the wrong host. Both are public
+          # identifiers, safe to grep / echo.
           PROJECT_ID="${NEXT_PUBLIC_SENTRY_DSN##*/}"
-          if [ -z "$PROJECT_ID" ]; then
-            echo "::error::Could not extract project ID from NEXT_PUBLIC_SENTRY_DSN."
+          DSN_HOST="${NEXT_PUBLIC_SENTRY_DSN#*://}"
+          DSN_HOST="${DSN_HOST#*@}"
+          DSN_HOST="${DSN_HOST%%/*}"
+          if [ -z "$PROJECT_ID" ] || [ -z "$DSN_HOST" ]; then
+            echo "::error::Could not parse NEXT_PUBLIC_SENTRY_DSN (project_id=$PROJECT_ID host=$DSN_HOST)."
             exit 1
           fi
           # Find the chunk that actually runs instrumentation-client.ts — that's the one
@@ -151,12 +158,12 @@ jobs:
             echo "If instrumentation-client.ts was renamed, update this guard."
             exit 1
           fi
-          if grep -qF "$PROJECT_ID" "$CHUNK"; then
-            echo "Sentry DSN inlined into instrumentation-client chunk: $CHUNK"
+          if grep -qF "$PROJECT_ID" "$CHUNK" && grep -qF "$DSN_HOST" "$CHUNK"; then
+            echo "Sentry DSN inlined into $CHUNK (project_id=$PROJECT_ID host=$DSN_HOST)"
           else
-            echo "::error::Sentry DSN NOT found in $CHUNK — browser tracing would be dead."
-            echo "Next.js did not inline NEXT_PUBLIC_SENTRY_DSN into the instrumentation chunk despite the env var being set at build time."
-            echo "Likely cause: Turbopack persistent cache reused a pre-compiled module with the old (undefined) DSN value."
+            echo "::error::Sentry DSN NOT fully inlined in $CHUNK (project_id=$PROJECT_ID host=$DSN_HOST) — browser tracing would be dead."
+            echo "Next.js did not inline the expected NEXT_PUBLIC_SENTRY_DSN into the instrumentation chunk despite the env var being set at build time."
+            echo "Likely cause: Turbopack persistent cache reused a pre-compiled module with the old (undefined or rotated) DSN value."
             echo "Fix: invalidate .next/cache (delete the relevant Actions cache, then re-run)."
             exit 1
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,14 +161,28 @@ jobs:
             exit 1
           fi
 
-      # No artifact upload — the Docker job builds .next itself with the same
-      # secrets via --build-arg. This job's `yarn build` is kept as a fast-fail
-      # signal for compile / type / inline regressions BEFORE the slower
-      # docker matrix kicks in, but its .next/ output is not shipped anywhere.
-      # Previous artifact handoff was a foot-gun: upload-artifact@v6 silently
-      # excluded .next as a hidden file, so the Docker job's "use pre-built
-      # .next" branch was dead and the deployed bundle was always built with
-      # a separate set of env vars than the one the CI guard verified.
+      # Artifact handoff to the docker job — gated on the same condition as the
+      # docker job itself so PR builds (where docker doesn't run) don't pay any
+      # storage cost. include-hidden-files: true is REQUIRED — without it,
+      # actions/upload-artifact@v6 silently drops .next/ (dot-prefixed paths are
+      # treated as "hidden") and the Docker job's "use pre-built .next" branch
+      # falls into the rebuild path. The Dockerfile's post-build DSN guard runs
+      # against the final .next regardless of which path produced it, so this
+      # cannot silently regress.
+      - name: Upload build artifacts
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'workflow_dispatch' && inputs.build_image)
+        uses: actions/upload-artifact@v6
+        with:
+          name: build-output
+          path: |
+            .next/
+            public/
+            package.json
+            yarn.lock
+          retention-days: 1
+          include-hidden-files: true
 
   docker:
     name: Build Docker (${{ matrix.platform }})
@@ -190,6 +204,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: build-output
+
+      # Catch silent artifact regressions early — if .next or node_modules
+      # is missing, the Dockerfile falls into the rebuild path which is OK
+      # but slower than the handoff. This step turns a perf regression into
+      # a visible warning rather than letting it go unnoticed.
+      - name: Report artifact contents
+        run: |
+          for d in .next node_modules; do
+            if [ -d "$d" ] && [ -n "$(ls -A "$d" 2>/dev/null)" ]; then
+              echo "$d present ($(du -sh "$d" | cut -f1)) — Dockerfile will reuse."
+            else
+              echo "::warning::$d missing or empty — Dockerfile will rebuild it (slower)."
+            fi
+          done
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,16 +161,14 @@ jobs:
             exit 1
           fi
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
-        with:
-          name: build-output
-          path: |
-            .next/
-            public/
-            package.json
-            yarn.lock
-          retention-days: 1
+      # No artifact upload — the Docker job builds .next itself with the same
+      # secrets via --build-arg. This job's `yarn build` is kept as a fast-fail
+      # signal for compile / type / inline regressions BEFORE the slower
+      # docker matrix kicks in, but its .next/ output is not shipped anywhere.
+      # Previous artifact handoff was a foot-gun: upload-artifact@v6 silently
+      # excluded .next as a hidden file, so the Docker job's "use pre-built
+      # .next" branch was dead and the deployed bundle was always built with
+      # a separate set of env vars than the one the CI guard verified.
 
   docker:
     name: Build Docker (${{ matrix.platform }})
@@ -192,11 +190,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: build-output
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -226,10 +219,15 @@ jobs:
             ${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_ORG }}/${{ env.IMAGE_NAME }}:${{ github.run_number }}-${{ steps.prep.outputs.platform_tag }}
           labels: |
             org.opencontainers.image.build-number=${{ github.run_number }}
+          # NEXT_PUBLIC_SENTRY_DSN is inlined into the client bundle at build
+          # time — must be passed here so the Docker `yarn build` produces a
+          # chunk with the DSN embedded. Without it the browser SDK silently
+          # bails out and no pageload traces reach Sentry.
           build-args: |
             GIT_BRANCH=${{ github.ref_name }}
             GIT_COMMIT=${{ steps.prep.outputs.short_sha }}
             BUILD_ID=${{ github.run_number }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           # mode=min stores only final-stage layers, not every intermediate
           # builder layer. mode=max ballooned the GHA cache pool.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,35 +342,32 @@ Output is `standalone` mode for containerized deployment.
 
 ### CI build pipeline
 
-`.github/workflows/build.yml` deliberately runs `yarn build` twice:
+`.github/workflows/build.yml` flow:
 
-1. **`build` job (CI runner)** — fast-fail signal. Compiles `.next/`, runs the
-   Sentry DSN guards, then throws the output away.
-2. **`docker` job (matrix)** — the single source of truth for the image. Re-runs
-   `yarn install` + `yarn build` inside the Dockerfile's builder stage with
-   `NEXT_PUBLIC_SENTRY_DSN` passed via `--build-arg`. A `RUN` guard in the
-   Dockerfile asserts the DSN is inlined into the instrumentation-client chunk;
-   image build fails if not.
+1. **`build` job (CI runner)** — runs on every push and PR. Compiles `.next/`,
+   runs the Sentry DSN pre-build and post-build guards as a fast-fail signal.
+   Uploads `.next/` + `public/` + `package.json` + `yarn.lock` as the
+   `build-output` artifact **only when the docker job will run** (push to
+   `main` or `workflow_dispatch + build_image`). PR builds skip the upload
+   entirely, so they don't consume artifact storage.
+2. **`docker` job (matrix, main / workflow_dispatch only)** — downloads the
+   `build-output` artifact. The Dockerfile's builder stage detects `.next/`
+   in the context and reuses it (skipping `yarn build`); if `.next/` is
+   missing (e.g. local `docker build`) it falls back to running `yarn build`
+   inside the container with `NEXT_PUBLIC_SENTRY_DSN` from `--build-arg`.
+   Either path ends at the same post-build `RUN` assertion that the DSN's
+   project ID appears in the instrumentation-client chunk — image build
+   fails if not.
 
-No artifact handoff. The previous artifact pattern (upload `.next/`, download
-in the Docker job, Dockerfile picks it up via `if [ -d .next ]`) was a foot-gun:
-`actions/upload-artifact@v6` silently drops dot-prefixed paths
-(`include-hidden-files: false` default), so `.next/` never reached the Docker
-job, the conditional always rebuilt, and the CI guard was verifying a
-throwaway compile while a separately-built bundle shipped to kauri. Took
-PRs #762-#766 to untangle.
-
-### Future investigation — conditional artifact handoff
-
-The `docker` job already only runs on `push` to `main` or
-`workflow_dispatch + build_image`. PR builds never trigger it. So if the
-artifact handoff is ever re-enabled for the ~20s/main-build speedup, the
-`upload-artifact` and `download-artifact` steps should be **gated by the same
-`if:` condition as the docker job**, and `include-hidden-files: true` must be
-set on the upload step.
-
-That preserves the speedup when it matters (main → deploy) without paying any
-storage cost on the much-more-frequent PR builds. Estimated saving: ~50 min of
-GH Actions minutes per month. Reliability constraint: the Dockerfile's
-post-build DSN guard must run regardless of which path produced `.next/`, so
-a split-state regression is caught on the image side.
+Critical configuration:
+- `actions/upload-artifact@v6+`: `include-hidden-files: true` is **required**.
+  Without it the action silently drops dot-prefixed paths like `.next/`. This
+  is the trap PRs #762–#766 chased: artifact appeared to upload but `.next/`
+  was missing, Dockerfile rebuilt without `NEXT_PUBLIC_*` secrets, browser
+  bundle shipped with `undefined` DSN.
+- `NEXT_PUBLIC_SENTRY_DSN` must be in both the CI `Build application` step
+  env AND the docker job's `build-args`. Belt-and-suspenders so the fallback
+  rebuild path is also covered.
+- The Dockerfile's post-build assertion runs against the final `.next/` that
+  the runner stage will COPY, so neither path (handoff or rebuild) can ship
+  a missing DSN.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,3 +339,38 @@ docker build --build-arg KAFKA_URL=host.minikube.internal:9092 . -t monowai/bc-v
 ```
 
 Output is `standalone` mode for containerized deployment.
+
+### CI build pipeline
+
+`.github/workflows/build.yml` deliberately runs `yarn build` twice:
+
+1. **`build` job (CI runner)** — fast-fail signal. Compiles `.next/`, runs the
+   Sentry DSN guards, then throws the output away.
+2. **`docker` job (matrix)** — the single source of truth for the image. Re-runs
+   `yarn install` + `yarn build` inside the Dockerfile's builder stage with
+   `NEXT_PUBLIC_SENTRY_DSN` passed via `--build-arg`. A `RUN` guard in the
+   Dockerfile asserts the DSN is inlined into the instrumentation-client chunk;
+   image build fails if not.
+
+No artifact handoff. The previous artifact pattern (upload `.next/`, download
+in the Docker job, Dockerfile picks it up via `if [ -d .next ]`) was a foot-gun:
+`actions/upload-artifact@v6` silently drops dot-prefixed paths
+(`include-hidden-files: false` default), so `.next/` never reached the Docker
+job, the conditional always rebuilt, and the CI guard was verifying a
+throwaway compile while a separately-built bundle shipped to kauri. Took
+PRs #762-#766 to untangle.
+
+### Future investigation — conditional artifact handoff
+
+The `docker` job already only runs on `push` to `main` or
+`workflow_dispatch + build_image`. PR builds never trigger it. So if the
+artifact handoff is ever re-enabled for the ~20s/main-build speedup, the
+`upload-artifact` and `download-artifact` steps should be **gated by the same
+`if:` condition as the docker job**, and `include-hidden-files: true` must be
+set on the upload step.
+
+That preserves the speedup when it matters (main → deploy) without paying any
+storage cost on the much-more-frequent PR builds. Estimated saving: ~50 min of
+GH Actions minutes per month. Reliability constraint: the Dockerfile's
+post-build DSN guard must run regardless of which path produced `.next/`, so
+a split-state regression is caught on the image side.

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,13 +42,19 @@ RUN if [ -d ".next" ] && [ -n "$(ls -A .next 2>/dev/null)" ]; then \
       yarn build; \
     fi
 
-# Post-build assertion: the instrumentation-client chunk must contain the DSN's
-# project ID. Fails the image build if Next.js did not inline NEXT_PUBLIC_SENTRY_DSN
-# (e.g. the build-arg was empty, the CI artifact was built without the secret,
-# or Turbopack reused a stale cached module).
+# Post-build assertion: the instrumentation-client chunk must contain BOTH the
+# DSN's project ID AND its ingest host. Project-ID-only would false-pass if a
+# DSN rotated to a different region (e.g. us → de) or with a different public
+# key but the same project ID got inlined instead of the intended one. Fails
+# the image build if NEXT_PUBLIC_SENTRY_DSN was not inlined correctly (build-arg
+# missing, CI artifact built without the secret, Turbopack reused a stale
+# cached module).
 RUN PROJECT_ID="${NEXT_PUBLIC_SENTRY_DSN##*/}"; \
-    if [ -z "$PROJECT_ID" ]; then \
-      echo "NEXT_PUBLIC_SENTRY_DSN build-arg missing — pass it via docker build --build-arg." >&2; \
+    DSN_HOST="${NEXT_PUBLIC_SENTRY_DSN#*://}"; \
+    DSN_HOST="${DSN_HOST#*@}"; \
+    DSN_HOST="${DSN_HOST%%/*}"; \
+    if [ -z "$PROJECT_ID" ] || [ -z "$DSN_HOST" ]; then \
+      echo "NEXT_PUBLIC_SENTRY_DSN build-arg missing or malformed — pass it via docker build --build-arg." >&2; \
       exit 1; \
     fi; \
     CHUNK=$(grep -lrF "instrumentation-client.ts loading" .next/static/chunks | head -1); \
@@ -56,11 +62,11 @@ RUN PROJECT_ID="${NEXT_PUBLIC_SENTRY_DSN##*/}"; \
       echo "Could not locate instrumentation-client chunk in .next/static/chunks." >&2; \
       exit 1; \
     fi; \
-    if ! grep -qF "$PROJECT_ID" "$CHUNK"; then \
-      echo "Sentry DSN NOT inlined into $CHUNK — browser tracing would be dead." >&2; \
+    if ! grep -qF "$PROJECT_ID" "$CHUNK" || ! grep -qF "$DSN_HOST" "$CHUNK"; then \
+      echo "Sentry DSN NOT fully inlined into $CHUNK (project_id=$PROJECT_ID host=$DSN_HOST) — browser tracing would be dead." >&2; \
       exit 1; \
     fi; \
-    echo "Sentry DSN inlined into $CHUNK."
+    echo "Sentry DSN inlined into $CHUNK (project_id=$PROJECT_ID host=$DSN_HOST)."
 
 # Production stage (only production dependencies)
 FROM base AS runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN apk add --no-cache libc6-compat
 ARG GIT_BRANCH
 ARG GIT_COMMIT
 ARG BUILD_ID
+# Public Sentry DSN — must be present at build time so Next.js can inline it
+# into the client bundle (process.env.NEXT_PUBLIC_* is substituted by the
+# bundler at compile, not read at runtime). Passed from CI via --build-arg.
+ARG NEXT_PUBLIC_SENTRY_DSN
 
 # Environment variables - Build info
 ENV GIT_BRANCH=$GIT_BRANCH
@@ -19,25 +23,33 @@ ENV PORT=3000
 ENV SENTRY_ENABLED="true"
 ENV SENTRY_DEBUG="false"
 
-# Build stage - copy pre-built artifacts from CI
+# Build stage — single source of truth for the deployed image.
 FROM base AS builder
+ARG NEXT_PUBLIC_SENTRY_DSN
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 COPY . .
 
-# If node_modules exists from CI, use it; otherwise install
-RUN if [ -d "node_modules" ]; then \
-      echo "Using pre-built node_modules from CI"; \
-    else \
-      echo "Installing dependencies in Docker"; \
-      yarn install --frozen-lockfile --prefer-offline --production=false; \
-    fi
+RUN yarn install --frozen-lockfile --prefer-offline --production=false
+RUN yarn build
 
-# If .next exists from CI, use it; otherwise build
-RUN if [ -d ".next" ]; then \
-      echo "Using pre-built .next from CI"; \
-    else \
-      echo "Building application in Docker"; \
-      yarn build; \
-    fi
+# Post-build assertion: the instrumentation-client chunk must contain the DSN's
+# project ID. Fails the image build if Next.js did not inline NEXT_PUBLIC_SENTRY_DSN
+# (e.g. the build-arg was empty, or Turbopack reused a stale cached module).
+RUN PROJECT_ID="${NEXT_PUBLIC_SENTRY_DSN##*/}"; \
+    if [ -z "$PROJECT_ID" ]; then \
+      echo "NEXT_PUBLIC_SENTRY_DSN build-arg missing — pass it via docker build --build-arg." >&2; \
+      exit 1; \
+    fi; \
+    CHUNK=$(grep -lrF "instrumentation-client.ts loading" .next/static/chunks | head -1); \
+    if [ -z "$CHUNK" ]; then \
+      echo "Could not locate instrumentation-client chunk in .next/static/chunks." >&2; \
+      exit 1; \
+    fi; \
+    if ! grep -qF "$PROJECT_ID" "$CHUNK"; then \
+      echo "Sentry DSN NOT inlined into $CHUNK — browser tracing would be dead." >&2; \
+      exit 1; \
+    fi; \
+    echo "Sentry DSN inlined into $CHUNK."
 
 # Production stage (only production dependencies)
 FROM base AS runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,29 @@ ENV PORT=3000
 ENV SENTRY_ENABLED="true"
 ENV SENTRY_DEBUG="false"
 
-# Build stage — single source of truth for the deployed image.
+# Build stage — accepts either:
+#   (a) a pre-built .next/ from the CI artifact handoff (main + workflow_dispatch only)
+#   (b) a fresh in-container build when .next is absent (PR builds, local builds)
+# Either way, the post-build assertion runs against the final .next that the
+# runner stage will COPY, so a missing DSN cannot ship.
 FROM base AS builder
 ARG NEXT_PUBLIC_SENTRY_DSN
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 COPY . .
 
 RUN yarn install --frozen-lockfile --prefer-offline --production=false
-RUN yarn build
+
+RUN if [ -d ".next" ] && [ -n "$(ls -A .next 2>/dev/null)" ]; then \
+      echo "Using pre-built .next from CI artifact."; \
+    else \
+      echo "Building application in Docker."; \
+      yarn build; \
+    fi
 
 # Post-build assertion: the instrumentation-client chunk must contain the DSN's
 # project ID. Fails the image build if Next.js did not inline NEXT_PUBLIC_SENTRY_DSN
-# (e.g. the build-arg was empty, or Turbopack reused a stale cached module).
+# (e.g. the build-arg was empty, the CI artifact was built without the secret,
+# or Turbopack reused a stale cached module).
 RUN PROJECT_ID="${NEXT_PUBLIC_SENTRY_DSN##*/}"; \
     if [ -z "$PROJECT_ID" ]; then \
       echo "NEXT_PUBLIC_SENTRY_DSN build-arg missing — pass it via docker build --build-arg." >&2; \


### PR DESCRIPTION
Single PR that delivers the reliability fix AND the perf optimization.

## Pipeline (after this PR)

1. **`build` job** (runs on every push + PR)
   - `yarn install`, restore `.next/cache`
   - Verify `NEXT_PUBLIC_SENTRY_DSN` secret present (fail fast)
   - `yarn build` with the secret in env
   - Verify DSN is inlined into the instrumentation-client chunk
   - **Upload `.next/` artifact ONLY when the docker job will run** (push to `main` / `workflow_dispatch` with `build_image`). PR builds skip the upload entirely.

2. **`docker` job** (push to main / workflow_dispatch only)
   - Checkout
   - Download `build-output` artifact
   - Visibility step reports `.next` / `node_modules` presence so silent regressions show as warnings
   - `docker build` with `NEXT_PUBLIC_SENTRY_DSN` as a build-arg
   - Dockerfile reuses pre-built `.next` if present; else rebuilds inside the container with the build-arg
   - Post-build `RUN` assertion: instrumentation-client chunk contains the DSN's project ID — image build fails otherwise

## Storage cost

| Build kind | Upload | Storage |
|---|---|---|
| PR | skipped | 0 |
| main push | runs | ~30-60 MB × 1 day retention |
| workflow_dispatch (build_image=true) | runs | ~30-60 MB × 1 day retention |

Estimated total: ~250 MB peak, well within GitHub's 500 MB free quota.

## Critical config (don't regress)

- `actions/upload-artifact@v6+`: `include-hidden-files: true` is **required**. Without it the action silently drops dot-prefixed paths like `.next/`, the Dockerfile falls into the rebuild branch, and the bundle reaching kauri has no `NEXT_PUBLIC_*` values inlined. **This was the root cause** of #762-#765 not actually fixing the Sentry browser silence.
- `NEXT_PUBLIC_SENTRY_DSN` is in both the CI `Build application` step env AND the docker job's `build-args`. Belt-and-suspenders so the rebuild fallback path is also covered.
- The Dockerfile's post-build assertion runs against the final `.next/` that the runner stage will COPY, so neither handoff nor rebuild can ship a missing DSN.

## What was broken before (recap)

1. `.next/` never reached the artifact (hidden-files default).
2. Docker job's "use pre-built .next" branch was dead — always rebuilt.
3. That rebuild had no access to build-time secrets (no `--build-arg`).
4. CI guard from #763/#765 verified an artifact that got thrown away — the live kauri chunk had `undefined` DSN.

## Test plan

- [ ] PR build: upload step **skipped** (visible in workflow UI)
- [ ] CI guards in build job pass (DSN present + inlined)
- [ ] On merge: artifact uploads with size > 30 MB (proves `.next/` included)
- [ ] Docker job: artifact-reporter step says `.next present (Xm) — Dockerfile will reuse.`
- [ ] Docker build: post-build assertion logs `Sentry DSN inlined into <chunk>.` and image build succeeds
- [ ] After deploy: refetch live kauri instrumentation chunk → `hasProjectId: true`, `hasDsnHost: true`
- [ ] Sentry `span.op:[pageload,navigation]` returns rows within 5 min of user activity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container builds now include hidden build artifacts when available, exclude host-installed dependencies from the build context, and warn if expected build artifacts are missing.

* **Bug Fixes**
  * Public error-reporting key is passed into the image build and a stricter verification enforces that both identifiers are inlined into the client bundle, failing the build if not present.

* **Documentation**
  * CI/build pipeline docs updated with guidance on artifact inclusion, gated artifact upload, build-time key passing, and the post-build inlining verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->