### PR TITLE
perf(sentry): drop OTel-emitted duplicate http.server transactions

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -63,6 +63,31 @@ if (!enabled) {
         return null
       }
 
+      // Drop the duplicate http.server transaction that the OpenTelemetry
+      // HTTP integration emits for every inbound API request. @sentry/nextjs's
+      // Pages-Router wrapper emits a SECOND http.server transaction for the
+      // same request with the resolved route name (e.g.
+      // "GET /api/holdings/[code]" instead of "GET /api/holdings/USV") and
+      // that one carries the "executing api route" child + downstream
+      // http.client spans. The OTel one is just a thin HTTP envelope with
+      // no useful children — keeping both doubles span ingestion on every
+      // API request and clutters traces (observed 2026-06-05: every
+      // /api/* request on /holdings/[code] produced two http.server spans).
+      //
+      // Heuristic: http.server transaction whose span list contains no
+      // "executing api route" entry is the OTel one — drop it. The Pages
+      // Router wrapper always emits that child, so this is robust to route
+      // shape (top-level routes, /index files, [param] segments).
+      const txnOp = event.contexts?.trace?.op
+      const isApiInbound =
+        txnOp === "http.server" && txn.includes(" /api/") && !isMiddleware
+      const hasApiRouteChild = event.spans?.some((s) =>
+        (s.description || "").startsWith("executing api route"),
+      )
+      if (isApiInbound && !hasApiRouteChild && !hasException) {
+        return null
+      }
+
       // Rename generic transactions to include the URL path
       if (
         event.transaction === "middleware" ||


### PR DESCRIPTION
Every inbound API request was producing **two** `http.server` transactions in Sentry. Confirmed via [trace c896c078](https://monowai-developments-ltd.sentry.io/explore/traces/trace/c896c078f6e441f68cb902253c6c2147/) on `/holdings/[code]`: each browser-side `/api/*` fetch produced two server spans on the bc-view receive side.

## What's happening

1. **`@sentry/nextjs` Pages-Router wrapper** emits a span with the resolved route name (e.g. `GET /api/holdings/[code]`) carrying the `executing api route` child + downstream `http.client` spans (the actual handler work).
2. **OpenTelemetry HTTP integration** emits a second span with the raw URL form (e.g. `GET /api/holdings/USV`) as a thin HTTP envelope with no useful children.

The OTel duplicate doubles Sentry span ingestion for every API request and makes single-endpoint traces look like double fetches — which is exactly the confusion we hit on `/holdings/[code]`.

## Fix

Filter the OTel duplicate inside `beforeSendTransaction`:

```ts
const isApiInbound = txnOp === "http.server" && txn.includes(" /api/") && !isMiddleware
const hasApiRouteChild = event.spans?.some((s) =>
  (s.description || "").startsWith("executing api route"),
)
if (isApiInbound && !hasApiRouteChild && !hasException) return null
```

Robust to route shape — top-level routes, `/index` files, and `[param]` segments all share the `executing api route` child marker. Exceptions still flow regardless. Page renders (`/wealth`, `/holdings/[code]` etc.) and middleware transactions are excluded by the `/api/` prefix + `isMiddleware` guard.

## Expected outcome

- ~50% reduction in `http.server` transactions ingested on bc-view (one per API request instead of two).
- Traces stop looking like duplicate fetches for endpoints with `[param]` routing.
- Sentry quota usage drops accordingly.

## Test plan

- [ ] After deploy, pull a fresh `/holdings/[code]` trace → expect one `http.server` per browser `/api/*` fetch (not two).
- [ ] Confirm 5xx error events on API routes still arrive (the filter explicitly preserves `hasException`).
- [ ] Confirm Sentry "Performance → Insights" graph for bc-view shows ~halved transaction count and ratio of routes-with-handler-children stays 100%.

`yarn typecheck` clean. 1367 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved trace data quality by filtering redundant transaction events in API request monitoring, reducing unnecessary span duplication and trace clutter for cleaner visualization
* Results in more efficient distributed tracing operations with reduced data processing overhead and enhanced performance monitoring visibility
* Provides clearer insights into application behavior, system performance characteristics, and service interactions for improved observability and troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->