### PR TITLE
perf(currencies): migrate raw fetch('/api/currencies') callers to SWR

### DIFF
--- a/__tests__/pages/portfolios.test.tsx
+++ b/__tests__/pages/portfolios.test.tsx
@@ -89,11 +89,8 @@ describe("Portfolios Page", () => {
     ;(useSWR as jest.Mock).mockImplementation(() => mockUseSWR())
     render(<PortfoliosPage user={mockUserProfile} />)
 
-    // Wait for async currency fetch to complete
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
+      expect(screen.getByText("You have no portfolios")).toBeInTheDocument()
     })
-
-    expect(screen.getByText("You have no portfolios")).toBeInTheDocument()
   })
 })

--- a/src/hooks/__tests__/usePortfolios.test.ts
+++ b/src/hooks/__tests__/usePortfolios.test.ts
@@ -114,13 +114,7 @@ describe("usePortfolios", () => {
     await act(async () => {})
   })
 
-  it("fetches currencies on mount", async () => {
-    const currencies = [makeCurrency("USD"), makeCurrency("NZD")]
-    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ data: currencies }),
-    })
-
+  it("requests currencies via SWR using the shared ccyKey", async () => {
     mockUseSwr.mockReturnValue({
       data: undefined,
       mutate: jest.fn(),
@@ -131,7 +125,12 @@ describe("usePortfolios", () => {
 
     renderHook(() => usePortfolios())
 
-    expect(global.fetch).toHaveBeenCalledWith("/api/currencies")
+    // usePortfolios calls useSwr twice — once for portfoliosKey, once for
+    // ccyKey. The currencies call must use the shared "/api/currencies" key
+    // so SWR can collapse it with other consumers of useCurrencies /
+    // useDisplayCurrencyConversion.
+    const calledKeys = mockUseSwr.mock.calls.map(([key]) => key)
+    expect(calledKeys).toContain("/api/currencies")
 
     await act(async () => {})
   })

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect, useMemo, useCallback } from "react"
+import { useMemo, useCallback } from "react"
 import useSwr from "swr"
 import { Portfolio, Currency } from "types/beancounter"
-import { portfoliosKey, simpleFetcher } from "@utils/api/fetchHelper"
+import { ccyKey, portfoliosKey, simpleFetcher } from "@utils/api/fetchHelper"
 import { useFxRates } from "./useFxRates"
 
 interface UsePortfoliosResult {
@@ -23,18 +23,14 @@ export function usePortfolios(): UsePortfoliosResult {
     simpleFetcher(portfoliosKey),
   )
 
-  const [currencies, setCurrencies] = useState<Currency[]>([])
-
-  useEffect(() => {
-    fetch("/api/currencies")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.data) {
-          setCurrencies(data.data)
-        }
-      })
-      .catch(console.error)
-  }, [])
+  // Shared SWR key with useCurrencies / useDisplayCurrencyConversion so all
+  // consumers in a render tree collapse to one /api/currencies fetch.
+  const { data: currenciesPayload } = useSwr<{ data: Currency[] }>(
+    ccyKey,
+    simpleFetcher(ccyKey),
+    { revalidateOnFocus: false, dedupingInterval: 60_000 },
+  )
+  const currencies = currenciesPayload?.data ?? []
 
   const sourceCurrencyCodes = useMemo(
     () => (data?.data || []).map((p: Portfolio) => p.base.code),

--- a/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
+++ b/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
@@ -93,7 +93,9 @@ export function useDisplayCurrencyConversion({
   // key on the mode keeps the request off the hot path for non-CUSTOM use.
   // The /api/currencies key is shared with useCurrencies / usePortfolios so
   // SWR collapses concurrent consumers across the tree to one fetch.
-  const { data: currenciesData } = useSWR<{ data: Currency[] }>(
+  const { data: currenciesData, isLoading: currenciesLoading } = useSWR<{
+    data: Currency[]
+  }>(
     mode === "CUSTOM" && customCode ? ccyKey : null,
     simpleFetcher(ccyKey),
     SWR_CURRENCIES_CONFIG,
@@ -171,8 +173,14 @@ export function useDisplayCurrencyConversion({
 
   // Loading is derived: pending iff we expect an async result we don't yet
   // have. No setIsLoading(true) / setIsLoading(false) inside an effect.
+  //
+  // CUSTOM-mode pending tracks SWR's isLoading rather than !customCurrency
+  // so an invalid customCode (one absent from the response) clears loading
+  // when the fetch resolves. Otherwise the hook would stay stuck on the
+  // first render after the bad code was selected (downstream falls back to
+  // sourceCurrency at rate 1 — the right UX for a missing code).
   const customFetchPending =
-    mode === "CUSTOM" && !!customCode && !customCurrency
+    mode === "CUSTOM" && !!customCode && currenciesLoading
   const fxFetchPending =
     syncFxRate === null &&
     !!sourceCurrency &&

--- a/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
+++ b/src/lib/utils/hooks/useDisplayCurrencyConversion.ts
@@ -1,32 +1,16 @@
 import { useEffect, useState } from "react"
+import useSWR from "swr"
 import { Currency, Portfolio, FxResponse } from "types/beancounter"
+import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
 import { useHoldingState } from "@lib/holdings/holdingState"
 
-// Cache for currencies to avoid repeated fetches
-let currenciesCache: Currency[] | null = null
-let currenciesFetchPromise: Promise<Currency[]> | null = null
-
-function fetchCurrencies(): Promise<Currency[]> {
-  if (currenciesCache) return Promise.resolve(currenciesCache)
-
-  if (!currenciesFetchPromise) {
-    currenciesFetchPromise = fetch("/api/currencies")
-      .then((res) => res.json())
-      .then((data): Currency[] => {
-        currenciesCache = data.data || []
-        return currenciesCache as Currency[]
-      })
-      .catch((err): Currency[] => {
-        console.error("Failed to fetch currencies:", err)
-        currenciesFetchPromise = null
-        return []
-      })
-  }
-
-  return currenciesFetchPromise as Promise<Currency[]>
+const SWR_CURRENCIES_CONFIG = {
+  revalidateOnFocus: false,
+  dedupingInterval: 60_000,
 }
 
-// Cache for FX rates - keyed by "FROM:TO"
+// Cache for FX rates — keyed by "FROM:TO". Module-level because the same
+// rate is reused across many components within a session.
 const fxRateCache = new Map<string, { rate: number; timestamp: number }>()
 const FX_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
 
@@ -81,11 +65,6 @@ interface UseDisplayCurrencyConversionProps {
   portfolio: Portfolio
 }
 
-interface AsyncCustom {
-  code: string
-  currency: Currency
-}
-
 interface AsyncFx {
   fromCode: string
   toCode: string
@@ -110,16 +89,22 @@ export function useDisplayCurrencyConversion({
   const mode = displayCurrencyOption.mode
   const customCode = displayCurrencyOption.customCode
 
-  // Async-fetched currency for CUSTOM mode. We track which code it was
-  // fetched for so a stale value doesn't leak when customCode changes.
-  const [asyncCustom, setAsyncCustom] = useState<AsyncCustom | null>(null)
+  // Currencies are only needed when CUSTOM mode is active. Gating the SWR
+  // key on the mode keeps the request off the hot path for non-CUSTOM use.
+  // The /api/currencies key is shared with useCurrencies / usePortfolios so
+  // SWR collapses concurrent consumers across the tree to one fetch.
+  const { data: currenciesData } = useSWR<{ data: Currency[] }>(
+    mode === "CUSTOM" && customCode ? ccyKey : null,
+    simpleFetcher(ccyKey),
+    SWR_CURRENCIES_CONFIG,
+  )
+  const currencies = currenciesData?.data
 
-  // Async-fetched FX rate keyed by from/to pair, for the same reason.
   const [asyncFx, setAsyncFx] = useState<AsyncFx | null>(null)
 
   const customCurrency =
-    mode === "CUSTOM" && customCode && asyncCustom?.code === customCode
-      ? asyncCustom.currency
+    mode === "CUSTOM" && customCode && currencies
+      ? (currencies.find((c) => c.code === customCode) ?? null)
       : null
 
   // Determine target currency synchronously for non-CUSTOM modes.
@@ -146,22 +131,6 @@ export function useDisplayCurrencyConversion({
   } else {
     syncFxRate = null
   }
-
-  // Fetch CUSTOM-mode currency only when in that mode and we don't already
-  // have a fresh result for the requested code.
-  useEffect(() => {
-    if (mode !== "CUSTOM" || !customCode) return () => {}
-    if (asyncCustom?.code === customCode) return () => {}
-    let cancelled = false
-    fetchCurrencies().then((currencies) => {
-      if (cancelled) return
-      const found = currencies.find((c) => c.code === customCode)
-      if (found) setAsyncCustom({ code: customCode, currency: found })
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [mode, customCode, asyncCustom])
 
   // Fetch FX rate only when sync path can't satisfy the request.
   useEffect(() => {
@@ -203,7 +172,7 @@ export function useDisplayCurrencyConversion({
   // Loading is derived: pending iff we expect an async result we don't yet
   // have. No setIsLoading(true) / setIsLoading(false) inside an effect.
   const customFetchPending =
-    mode === "CUSTOM" && !!customCode && asyncCustom?.code !== customCode
+    mode === "CUSTOM" && !!customCode && !customCurrency
   const fxFetchPending =
     syncFxRate === null &&
     !!sourceCurrency &&
@@ -230,41 +199,20 @@ export function useDisplayCurrencyConversion({
 }
 
 /**
- * Get cached currencies list (for use in components that just need the list)
+ * Get the currency list. SWR-backed so consumers share a single in-flight
+ * request with usePortfolios / useDisplayCurrencyConversion.
  */
 export function useCurrencies(): {
   currencies: Currency[]
   isLoading: boolean
 } {
-  // Lazy initial state: if the module cache is already populated we expose
-  // it immediately and skip the effect entirely. The "no cache yet" path
-  // initialises with [] + isLoading=true and is filled by the effect's
-  // async .then() callback.
-  const [state, setState] = useState<{
-    currencies: Currency[]
-    isLoading: boolean
-  }>(() =>
-    currenciesCache
-      ? { currencies: currenciesCache, isLoading: false }
-      : { currencies: [], isLoading: true },
+  const { data, isLoading } = useSWR<{ data: Currency[] }>(
+    ccyKey,
+    simpleFetcher(ccyKey),
+    SWR_CURRENCIES_CONFIG,
   )
-
-  useEffect(() => {
-    if (currenciesCache) return () => {}
-    let cancelled = false
-    fetchCurrencies()
-      .then((currencies) => {
-        if (cancelled) return
-        setState({ currencies, isLoading: false })
-      })
-      .catch(() => {
-        if (cancelled) return
-        setState({ currencies: [], isLoading: false })
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  return state
+  return {
+    currencies: data?.data ?? [],
+    isLoading,
+  }
 }

--- a/src/pages/allocation.tsx
+++ b/src/pages/allocation.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect } from "react"
 import { useRouter } from "next/router"
 import useSwr from "swr"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
-import { simpleFetcher } from "@utils/api/fetchHelper"
+import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
 import { errorOut } from "@components/errors/ErrorOut"
 import { rootLoader } from "@components/ui/PageLoader"
 import { Currency, FxResponse, HoldingContract } from "types/beancounter"
@@ -30,7 +30,6 @@ export default withPageAuthRequired(function Allocation(): React.ReactElement {
   const [valueIn, setValueIn] = useState<ValueIn>(ValueIn.PORTFOLIO)
 
   // Currency display state (same pattern as portfolios)
-  const [currencies, setCurrencies] = useState<Currency[]>([])
   const [displayCurrency, setDisplayCurrency] = useState<Currency | null>(null)
   const [baseCurrency, setBaseCurrency] = useState<Currency | null>(null)
   const [fxRate, setFxRate] = useState<number>(1)
@@ -40,17 +39,14 @@ export default withPageAuthRequired(function Allocation(): React.ReactElement {
     simpleFetcher(aggregatedHoldingsKey),
   )
 
-  // Fetch available currencies
-  useEffect(() => {
-    fetch("/api/currencies")
-      .then((res) => res.json())
-      .then((result) => {
-        if (result.data) {
-          setCurrencies(result.data)
-        }
-      })
-      .catch(console.error)
-  }, [])
+  // Shared SWR key with useCurrencies / usePortfolios — collapses to one
+  // /api/currencies request across the tree.
+  const { data: currenciesPayload } = useSwr<{ data: Currency[] }>(
+    ccyKey,
+    simpleFetcher(ccyKey),
+    { revalidateOnFocus: false, dedupingInterval: 60_000 },
+  )
+  const currencies = currenciesPayload?.data ?? []
 
   // Set default display currency from portfolio's currency
   useEffect(() => {


### PR DESCRIPTION
Trace [`b3230c44`](https://monowai-developments-ltd.sentry.io/explore/traces/trace/b3230c44a2fd455a9f8ac9a12b34e2c1/) (post-#767 #768) showed **two** browser `/api/currencies` fetches per `/holdings/[code]` pageload. Three independent caches for the same endpoint:

1. `useDisplayCurrencyConversion.ts` — module-level `currenciesCache` + promise.
2. `usePortfolios.ts` — `useState + useEffect + fetch`.
3. SWR consumers using `ccyKey` (e.g. holdings page's edit-asset path).

Unify on SWR with the shared `ccyKey` (`"/api/currencies"`). All consumers within a render tree share one in-flight request via SWR's `dedupingInterval: 60_000`.

## Changes

- **`useDisplayCurrencyConversion.ts`**: drop module-level cache + standalone `fetchCurrencies`. Use `useSWR` gated on `mode === "CUSTOM" && customCode`.
- **`useCurrencies`** (same file): replace `useEffect + setState` with `useSwr`.
- **`usePortfolios.ts`**: drop `useState + useEffect + fetch`, use `useSwr` with `ccyKey`.
- **`allocation.tsx`**: same migration as `usePortfolios`.

## Out of scope

- `settings.tsx` — one of four fetches in a `Promise.all` batch; converting one regresses the batching pattern with no benefit on a cold page.
- `admin/accounting-types.tsx` — rarely-loaded admin page; not worth the refactor.

## Expected runtime impact

- `/api/currencies` fetches per page mount drop **2× → 1×** on hot routes.
- ~120ms saved per pageload + corresponding bc-data load drop.

## Tests

- `usePortfolios.test.ts` "fetches currencies on mount" was asserting raw `global.fetch` with the URL string. Rewritten to assert `useSwr` was called with the shared `ccyKey`.
- `__tests__/pages/portfolios.test.tsx` "handles no portfolios correctly" waited on `mockFetch` (no longer fires under SWR). Now waits on the empty-state text directly.

All 1367 tests pass. `yarn typecheck` clean.

## Verify after deploy

- [ ] Re-pull a `/holdings/[code]` trace → expect 1× `/api/currencies` instead of 2×.
- [ ] Re-pull a `/allocation?codes=...` trace → expect 1× `/api/currencies`.
- [ ] Custom display currency mode still resolves (covers the CUSTOM-mode-gated SWR call).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified currency loading across pages and components into a shared cache, removing duplicated local fetching and improving loading state consistency and deduplication.

* **Tests**
  * Updated tests to assert the new shared currency-loading behavior and the “no portfolios” message timing under the unified caching approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->