### PR TITLE
fix(corporate-events): denormalize trns envelope on /api/trns/events

### DIFF
--- a/src/pages/api/trns/events/[...events].ts
+++ b/src/pages/api/trns/events/[...events].ts
@@ -3,6 +3,7 @@ import {
   sanitizePathParam,
 } from "@utils/api/createApiHandler"
 import { getDataUrl } from "@utils/api/bcConfig"
+import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export default createApiHandler({
   url: (req) => {
@@ -11,4 +12,10 @@ export default createApiHandler({
     const assetId = sanitizePathParam(events[1], "assetId")
     return getDataUrl(`/trns/${portfolioId}/asset/${assetId}/events`)
   },
+  // Backend returns the normalised { data: TrnPayload } envelope; denormalize
+  // here so browser consumers (e.g. CorporateActionsPopup) receive the legacy
+  // { data: Transaction[] } shape they iterate with .find / .filter.
+  // Without this, portfolioTransactions is { trns: [...] } (an object) and
+  // getMatchingTransaction throws "t.find is not a function" (BC-VIEW-3Q).
+  transformJson: transformTrnEnvelopeJson,
 })


### PR DESCRIPTION
Fixes [BC-VIEW-3Q](https://monowai-developments-ltd.sentry.io/issues/BC-VIEW-3Q) — `TypeError: t.find is not a function` on `/holdings/[code]` when opening the Corporate Actions popup.

## Root cause

`/api/trns/events/[portfolioId]/[assetId]` was the only `/api/trns/*` handler missing `transformJson: transformTrnEnvelopeJson`. Every sibling trns proxy already applies it (`settled`, `move`, `trades`, `index`, `proposed`, `patch`, etc.).

Backend returns the normalised `{ data: TrnPayload }` envelope where `data = { trns: Transaction[] }`. Without the transform, the browser received `{ data: { trns: [...] } }` and `CorporateActionsPopup` did:

```ts
portfolioTransactions = portfolioTrnsData?.data || []
```

`portfolioTrnsData?.data` was the object `{ trns: [...] }` — truthy, so the `|| []` fallback didn't fire. `portfolioTransactions` became the object, and `getMatchingTransaction` called `.find` on it → `t.find is not a function`.

## Fix

Add `transformJson: transformTrnEnvelopeJson` to the events handler. Unwraps the envelope to the legacy `{ data: Transaction[] }` shape that browser consumers iterate with `.find` / `.filter`. Same fix all sibling trns handlers already use.

## Test plan

- [ ] Open Corporate Actions popup on `/holdings/[code]` for an asset that previously crashed — should render the events list.
- [ ] BC-VIEW-3Q stops accumulating events after deploy.
- [ ] Verify pay-date override + process-event flows still work (they read portfolioTransactions for reconciliation matching).

1367 tests pass. `yarn typecheck` clean. Commit message includes `Fixes BC-VIEW-3Q` so Sentry auto-closes on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction API response formatting to resolve runtime errors and ensure transaction data displays correctly in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->