### PR TITLE
perf(portfolios): dedupe /api/portfolios on /holdings/[code]

### DIFF
--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -23,6 +23,7 @@ import {
   categoriesKey,
   holdingByIdKey,
   holdingKey,
+  portfoliosKey,
   simpleFetcher,
 } from "@utils/api/fetchHelper"
 import dynamic from "next/dynamic"
@@ -209,10 +210,17 @@ function HoldingsPage(): React.ReactElement {
   const [createModelModalOpen, setCreateModelModalOpen] = useState(false)
   const [investCashModalOpen, setInvestCashModalOpen] = useState(false)
 
-  // Fetch portfolios for cash transfer dialog
+  // Fetch portfolios for cash transfer / move-position / share dialogs.
+  // Use the shared portfoliosKey (?inactive=true) so this consumer collapses
+  // into the same SWR cache as the header dropdown and the Portfolios page —
+  // one /api/portfolios fetch per pageload instead of two. Inactive entries
+  // are filtered client-side because none of the dialogs want them.
   const { data: portfoliosData } = useSwr(
-    "/api/portfolios",
-    simpleFetcher("/api/portfolios"),
+    portfoliosKey,
+    simpleFetcher(portfoliosKey),
+  )
+  const activePortfolios = (portfoliosData?.data || []).filter(
+    (p: { active?: boolean }) => p.active !== false,
   )
 
   // Edit-asset dialog needs the same reference data as the accounts page.
@@ -840,7 +848,7 @@ function HoldingsPage(): React.ReactElement {
           modalOpen={!!cashTransferData}
           onClose={handleCashTransferClose}
           sourceData={cashTransferData}
-          portfolios={portfoliosData?.data || []}
+          portfolios={activePortfolios}
         />
       )}
       {movePositionData && (
@@ -848,7 +856,7 @@ function HoldingsPage(): React.ReactElement {
           modalOpen={!!movePositionData}
           onClose={handleMovePositionClose}
           sourceData={movePositionData}
-          portfolios={portfoliosData?.data || []}
+          portfolios={activePortfolios}
         />
       )}
       {costAdjustData && (
@@ -913,7 +921,7 @@ function HoldingsPage(): React.ReactElement {
       />
       {showShareDialog && portfoliosData?.data && (
         <ShareInviteDialog
-          portfolios={portfoliosData.data}
+          portfolios={activePortfolios}
           preSelectedPortfolioId={holdingResults.portfolio.id}
           onClose={() => setShowShareDialog(false)}
           onSuccess={() => setShowShareDialog(false)}


### PR DESCRIPTION
Trace [`dbbe9c30`](https://monowai-developments-ltd.sentry.io/explore/traces/trace/dbbe9c3047fe41cdabb34b80f69edc90/) on `/holdings/[code]` showed **two** browser `/api/portfolios` fetches per pageload — one via `portfoliosKey` (`?inactive=true`, used by the header dropdown / Portfolios page / rebalance flows), and one via bare `"/api/portfolios"` (used by the holdings page itself for the cash transfer / move position / share invite dialogs). Same endpoint, two SWR cache slots.

## Fix

Migrate the `/holdings/[code]` consumer to `portfoliosKey` so it collapses into the shared cache. Inactive entries are filtered client-side via `activePortfolios = portfoliosData.data.filter(p => p.active !== false)`; that filtered list is passed to all three dialogs (`CashTransferDialog`, `MovePositionDialog`, `ShareInviteDialog`) — none of them want inactive portfolios as destinations.

## Out of scope

`TradeInputForm`, `OpenBrokerageWizard`, and `OnboardingWizard` also fetch bare `"/api/portfolios"`. Migrating those files trips **pre-existing** `react-hooks/set-state-in-effect` and `react-hooks/incompatible-library` lint errors that lint-staged blocks on file-touch. The hot path is `/holdings/[code]` — that's the trace win. The wizards are once-per-user (onboarding) / rarely-opened (broker open) / on-demand (trade input) so their dedup gain is marginal. Park until the file-level lint debt is paid down.

## Expected runtime impact (on `/holdings/[code]`)

- `/api/portfolios` browser fetches **2× → 1×** per pageload.
- ~80ms saved + lower bc-data load.

## Verify after deploy

- [ ] Refetch a `/holdings/[code]` trace → expect 1× `/api/portfolios`.
- [ ] Cash transfer / move position / share invite dialogs still show only active portfolios as destinations.

1367 tests pass. `yarn typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inactive portfolios are now properly filtered out and no longer appear in cash transfer, move-position, and share-invite dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->