### PR TITLE
perf(holdings): lazy-mount TradeInputForm so it stops fetching on pageload

### DIFF
--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -537,12 +537,20 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
           />
         </div>
       </div>
-      <TradeInputForm
-        portfolio={holdingResults.portfolio}
-        modalOpen={tradeModalOpen}
-        setModalOpen={handleTradeModalClose}
-        initialValues={quickSellData}
-      />
+      {tradeModalOpen && (
+        // Lazy-mount: TradeInputForm calls useSwr("/api/portfolios") in its
+        // body. Mounting it unconditionally fires the fetch on every holdings
+        // pageload even when the trade dialog is closed, producing a duplicate
+        // /api/portfolios call alongside the page's own keyed fetch (the bare
+        // URL doesn't match the portfoliosKey cache slot). Gate on
+        // tradeModalOpen so the form's hooks only run when the dialog opens.
+        <TradeInputForm
+          portfolio={holdingResults.portfolio}
+          modalOpen={tradeModalOpen}
+          setModalOpen={handleTradeModalClose}
+          initialValues={quickSellData}
+        />
+      )}
       <CashInputForm
         portfolio={holdingResults.portfolio}
         modalOpen={cashModalOpen}


### PR DESCRIPTION
Trace [`5b71e96a`](https://monowai-developments-ltd.sentry.io/explore/traces/trace/5b71e96a3d7d4dc9a0017d7984cce711/) on `/holdings/[code]` (post-#771) still showed **2× `/api/portfolios`**. Sentry's `http.url` field exposed which two:

| Span | URL |
|---|---|
| `8e063257…` (52ms) | `/api/portfolios?inactive=true` ← post-#771 keyed caller |
| `87afaccd…` (92ms) | `/api/portfolios` ← **bare** |

The bare caller is `TradeInputForm`. `HoldingActions` mounted it unconditionally (line 540 — `modalOpen` only controlled visibility, the component body always ran). That fired `useSwr("/api/portfolios")` on every holdings pageload regardless of whether the trade dialog was open. Bare `"/api/portfolios"` doesn't match the `portfoliosKey` (`?inactive=true`) SWR cache slot, so the two fetches don't collapse.

## Fix

Wrap the `<TradeInputForm />` mount in `{tradeModalOpen && …}`. The form's hooks only execute when the dialog actually opens. When closed, the duplicate fetch is gone.

Migrating `TradeInputForm` to use `portfoliosKey` directly was attempted in #771 and blocked by pre-existing `react-hooks/set-state-in-effect` and `react-hooks/incompatible-library` lint debt in that file. Gating the mount at the HoldingActions side avoids touching TradeInputForm.

## Expected runtime impact

- `/api/portfolios` browser fetches per `/holdings/[code]` pageload **2× → 1×**.
- ~90ms saved + corresponding bc-data load drop.

## Behaviour notes

- Trade dialog UX is unchanged when opened — React instantiates the form on open and unmounts it on close.
- Internal form state is not preserved between open/close cycles (matches the existing close behaviour — `setModalOpen(false)` already drops the modal).
- `CashInputForm` and other modals on the same page use the same always-mounted pattern but don't fetch portfolios (so they aren't an issue here). They could be lazy-mounted too as a follow-up if we want to shave more.

## Verify

- [ ] Open Trade dialog from a holding row → form renders normally.
- [ ] Refetch a `/holdings/[code]` trace → expect 1× `/api/portfolios` (the keyed `?inactive=true` one).

1367 tests pass. `yarn typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized the holdings page load speed by deferring trade form initialization until the trade dialog is opened, reducing unnecessary data fetching on initial page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->