### PR TITLE
perf(registration): cache /api/register check per user with configurable TTL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,10 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=4096"
           CI: true
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+          # Days the cached registration check survives in localStorage before
+          # the browser revalidates against /api/register. Set via repo Variable
+          # (Settings → Variables), defaults to 30 if unset.
+          NEXT_PUBLIC_REGISTRATION_TTL_DAYS: ${{ vars.NEXT_PUBLIC_REGISTRATION_TTL_DAYS || '30' }}
         run: yarn build
 
       - name: Verify Sentry DSN is inlined into client bundle
@@ -268,6 +272,7 @@ jobs:
             GIT_COMMIT=${{ steps.prep.outputs.short_sha }}
             BUILD_ID=${{ github.run_number }}
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+            NEXT_PUBLIC_REGISTRATION_TTL_DAYS=${{ vars.NEXT_PUBLIC_REGISTRATION_TTL_DAYS || '30' }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           # mode=min stores only final-stage layers, not every intermediate
           # builder layer. mode=max ballooned the GHA cache pool.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ ARG BUILD_ID
 # into the client bundle (process.env.NEXT_PUBLIC_* is substituted by the
 # bundler at compile, not read at runtime). Passed from CI via --build-arg.
 ARG NEXT_PUBLIC_SENTRY_DSN
+# Days the cached registration check survives in localStorage before the
+# browser revalidates against /api/register. Inlined at build time; defaults
+# in code to 30 if absent. Configurable via repo Variable NEXT_PUBLIC_REGISTRATION_TTL_DAYS.
+ARG NEXT_PUBLIC_REGISTRATION_TTL_DAYS
 
 # Environment variables - Build info
 ENV GIT_BRANCH=$GIT_BRANCH
@@ -31,6 +35,8 @@ ENV SENTRY_DEBUG="false"
 FROM base AS builder
 ARG NEXT_PUBLIC_SENTRY_DSN
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+ARG NEXT_PUBLIC_REGISTRATION_TTL_DAYS
+ENV NEXT_PUBLIC_REGISTRATION_TTL_DAYS=$NEXT_PUBLIC_REGISTRATION_TTL_DAYS
 COPY . .
 
 RUN yarn install --frozen-lockfile --prefer-offline --production=false

--- a/src/contexts/RegistrationContext.tsx
+++ b/src/contexts/RegistrationContext.tsx
@@ -2,6 +2,53 @@ import React, { createContext, useContext, useEffect, useState } from "react"
 import { useUser } from "@auth0/nextjs-auth0/client"
 
 const ONBOARDING_COMPLETE_KEY = "bc_onboarding_complete"
+const REGISTERED_KEY_PREFIX = "bc_registered:"
+const DEFAULT_TTL_DAYS = 30
+
+// Externally configured at build time via NEXT_PUBLIC_REGISTRATION_TTL_DAYS.
+// Number(undefined) is NaN; NaN || fallback collapses to the default. Treat
+// non-positive values as the default so a stray 0 doesn't force every load
+// to hit /api/register again.
+function resolveTtlMs(): number {
+  const raw = Number(process.env.NEXT_PUBLIC_REGISTRATION_TTL_DAYS)
+  const days = raw > 0 ? raw : DEFAULT_TTL_DAYS
+  return days * 24 * 60 * 60 * 1000
+}
+
+const REGISTRATION_TTL_MS = resolveTtlMs()
+
+interface CachedRegistration {
+  since?: string
+  checkedAt: number
+}
+
+function registeredKey(sub: string): string {
+  return `${REGISTERED_KEY_PREFIX}${sub}`
+}
+
+function readCachedRegistration(sub: string): CachedRegistration | null {
+  try {
+    const raw = localStorage.getItem(registeredKey(sub))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as CachedRegistration
+    if (typeof parsed.checkedAt !== "number") return null
+    if (Date.now() - parsed.checkedAt > REGISTRATION_TTL_MS) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeCachedRegistration(sub: string, since?: string): void {
+  try {
+    localStorage.setItem(
+      registeredKey(sub),
+      JSON.stringify({ since, checkedAt: Date.now() } satisfies CachedRegistration),
+    )
+  } catch {
+    // localStorage may be unavailable (private mode, quota); just skip caching.
+  }
+}
 
 interface RegistrationContextValue {
   isChecking: boolean
@@ -44,7 +91,26 @@ export function RegistrationProvider({
       return
     }
 
-    if (!user) {
+    if (!user?.sub) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- terminal state when no auth user
+      setIsChecking(false)
+      return
+    }
+
+    const sub = user.sub
+    const onboardingComplete =
+      localStorage.getItem(ONBOARDING_COMPLETE_KEY) === "true"
+
+    // Fast path: a recent cached registration (per user.sub) skips /api/register.
+    // bc-data's SystemUser is created on first /register call and never removed,
+    // so re-checking on every pageload is wasted work — ~90ms + bc-data lookup
+    // per load with no behaviour change. The TTL exists so users whose backend
+    // record is rotated externally (rare) eventually re-validate.
+    const cached = readCachedRegistration(sub)
+    if (cached) {
+      setIsRegistered(true)
+      setIsNewlyRegistered(false)
+      setIsOnboardingComplete(onboardingComplete)
       setIsChecking(false)
       return
     }
@@ -52,10 +118,6 @@ export function RegistrationProvider({
     const ensureRegistered = async (): Promise<void> => {
       setIsChecking(true)
       setError(null)
-
-      // Check onboarding status from localStorage
-      const onboardingComplete =
-        localStorage.getItem(ONBOARDING_COMPLETE_KEY) === "true"
       setIsOnboardingComplete(onboardingComplete)
 
       try {
@@ -67,10 +129,12 @@ export function RegistrationProvider({
 
         if (response.ok) {
           const data = await response.json()
+          const since = data.data?.since as string | undefined
+          writeCachedRegistration(sub, since)
           setIsRegistered(true)
 
           // Check if this is a newly created user
-          const isNew = isNewUser(data.data?.since)
+          const isNew = isNewUser(since)
           if (isNew && !onboardingComplete) {
             localStorage.removeItem(ONBOARDING_COMPLETE_KEY)
             setIsNewlyRegistered(true)


### PR DESCRIPTION
`POST /api/register` was firing on every `/holdings/[code]` pageload — ~90ms + a bc-data lookup per load. Confirmed via iOS Safari trace `038cb472` (1125ms pageload). `RegistrationContext`'s `useEffect` calls it whenever `[user, isLoading]` resolves, which is every page mount.

## Why it's not strictly redundant

Auth0's post-login Action (AUTH0.md "New User Signup — Role Assignment") handles **role assignment + email claim** only. It does **not** create the `SystemUser` row in bc-data.

`svc-data/SystemUserService.getOrThrow()`:

```kotlin
return getActiveUser()
    ?: throw ForbiddenException(
         "User is authenticated but not registered. Please call /register first."
       )
```

So `/api/register` is needed for first-time signup — but bc-data's `SystemUser` is permanent after that. Re-checking on every load is pure waste.

## Fix

`RegistrationContext` now caches the registration check in `localStorage` keyed on `user.sub`. Subsequent loads within the TTL skip the API call entirely.

```ts
const cached = readCachedRegistration(sub)
if (cached) {
  setIsRegistered(true)
  setIsChecking(false)
  return
}
// else POST /api/register, cache on success
```

## Configurable TTL

`NEXT_PUBLIC_REGISTRATION_TTL_DAYS` — repo Variable (Settings → Variables), defaults to **30 days** in code. Stale entries cause a single re-validation on next load, covering the rare case of a bc-data `SystemUser` being rotated externally.

### Wiring (mirrors `NEXT_PUBLIC_SENTRY_DSN`)

- `.github/workflows/build.yml`: env on `Build application` step + `build-args` on `docker/build-push-action`.
- `Dockerfile`: `ARG` + `ENV` declared at the top and re-declared in the builder stage (Docker ARG scoping requires both).

## Behaviour preserved

- First load per `user.sub`: `/api/register` fires, captures `since` → `isNewlyRegistered` onboarding signal works as before.
- `bc_onboarding_complete` localStorage flag (separate key) still drives wizard skip independently.
- Failure paths fall through to `setIsRegistered(true)` to avoid infinite loading.

## Expected runtime impact

- Existing users: `POST /api/register` per `/holdings/[code]` pageload **2nd onwards → 0**.
- ~90ms saved per pageload + corresponding bc-data load drop.
- First-ever load and TTL refresh still hit `/register` once.

## Test plan

- [ ] Sign in as existing user → first pageload calls `/api/register` once → subsequent reloads skip it (DevTools Network filter `register`).
- [ ] Sign in as new user → onboarding wizard still triggers (`isNewlyRegistered=true` on first load).
- [ ] Clear localStorage → reload → `/api/register` fires again.
- [ ] Set repo Variable `NEXT_PUBLIC_REGISTRATION_TTL_DAYS=1`, redeploy → cache expires next day.

1367 tests pass. `yarn typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration status is now cached locally with automatic expiration, reducing unnecessary server requests and improving app load times when returning to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->