### PR TITLE
perf(holdings): lazy-mount CashInputForm so it stops fetching on pageload

### DIFF
--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -551,11 +551,19 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
           initialValues={quickSellData}
         />
       )}
-      <CashInputForm
-        portfolio={holdingResults.portfolio}
-        modalOpen={cashModalOpen}
-        setModalOpen={setCashModalOpen}
-      />
+      {cashModalOpen && (
+        // Lazy-mount: CashInputForm calls useSwr for both
+        // /api/assets?category=ACCOUNT and /api/assets?category=TRADE in its
+        // body. Mounting unconditionally fires both fetches on every holdings
+        // pageload even when the cash dialog is closed (~62ms + 64ms apiece in
+        // the trace). Gate on cashModalOpen so the hooks only run when the
+        // dialog opens — same pattern as TradeInputForm.
+        <CashInputForm
+          portfolio={holdingResults.portfolio}
+          modalOpen={cashModalOpen}
+          setModalOpen={setCashModalOpen}
+        />
+      )}
       <CopyPopup
         columns={columns}
         data={holdingResults.positions}


### PR DESCRIPTION
Trace [`038cb472`](https://monowai-developments-ltd.sentry.io/explore/traces/trace/038cb472a0d74f53a2bc3c936ae0f2ce/) on `/holdings/USV` (iOS Safari, 1125ms pageload) showed two `/api/assets` fetches:

| `http.url` | ms |
|---|---|
| `/api/assets?category=ACCOUNT` | 64 |
| `/api/assets?category=TRADE` | 62 |

Both come from `CashInputForm.tsx:162-167` — it `useSwr`s both category-keyed endpoints in its body. `HoldingActions` mounts it unconditionally (line 554); `cashModalOpen=false` only hides the UI but the hooks still execute on every holdings pageload.

## Fix

Wrap `<CashInputForm />` in `{cashModalOpen && (...)}`. Component instantiates on demand. Same pattern as #772 for `TradeInputForm`.

## Expected runtime impact

- `/api/assets?category=ACCOUNT` and `/api/assets?category=TRADE` no longer fire on `/holdings/[code]` pageload when the cash dialog is closed.
- ~126ms saved per pageload + corresponding bc-data load drop.

## Other dialogs

`SetBalanceDialog` and `CashTransferDialog` also fetch `?category=ACCOUNT` but they already gate `useSwr` on `modalOpen ? key : null` so they don't fire on pageload. SWR dedup collapses any concurrent reuse.

## Behaviour notes

- Cash dialog UX unchanged when opened — React instantiates the form on open and unmounts on close.
- Form state not preserved across close/open cycles (matches existing close behaviour).
- HoldingActions had this exact pattern with TradeInputForm — #772 lazy-mounted that one, this PR finishes the same job for CashInputForm.

## Verify

- [ ] Open Cash dialog from a holding row → form renders normally.
- [ ] Refetch a `/holdings/[code]` trace → expect 0× `/api/assets?category=ACCOUNT` and 0× `?category=TRADE` on the pageload tree.

1367 tests pass. `yarn typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cash modal performance by eliminating unnecessary background network activity when the dialog is closed, enhancing overall app responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->