### PR TITLE
fix(auth0): handle trailing-callback errors + capture to Sentry

### DIFF
--- a/src/lib/utils/auth0.ts
+++ b/src/lib/utils/auth0.ts
@@ -1,4 +1,6 @@
 import { Auth0Client } from "@auth0/nextjs-auth0/server"
+import { NextResponse } from "next/server"
+import * as Sentry from "@sentry/nextjs"
 
 // Scope and audience are configured here rather than via env vars because
 // Auth0 v4 removed AUTH0_SCOPE/AUTH0_AUDIENCE env var support.
@@ -16,5 +18,49 @@ export const auth0 = new Auth0Client({
       "beancounter beancounter:user beancounter:admin " +
       "beancounter:ai beancounter:preview",
     audience: "https://holdsworth.app",
+  },
+  // The default onCallback unconditionally renders a "An error occurred during
+  // the authorization flow." 500 page whenever the SDK passes an `error`,
+  // even if the session cookie has already been set (the SDK runs internal
+  // post-callback steps after persistence). Users who hit a trailing-handler
+  // error would land on the error page but actually be authenticated — they
+  // had to manually reload to discover their session was live.
+  //
+  // This hook splits the two cases:
+  //   - `error && !session` → real auth failure: log to Sentry + redirect to
+  //     /auth/login so the user can re-attempt cleanly.
+  //   - `error && session`  → session persisted but trailing step threw:
+  //     capture for visibility (with the actual SdkError, not the generic
+  //     wrapper message) + redirect to the intended returnTo target.
+  //   - `!error` → default behaviour, redirect to returnTo / "/".
+  // eslint-disable-next-line require-await -- OnCallbackHook signature returns Promise<NextResponse>; async keyword keeps the implementation consistent with that contract.
+  onCallback: async (error, ctx, session) => {
+    const appBaseUrl =
+      ctx.appBaseUrl ||
+      process.env.APP_BASE_URL ||
+      "https://kauri.monowai.com"
+    const target = new URL(ctx.returnTo || "/", appBaseUrl)
+
+    if (error && !session) {
+      Sentry.captureException(error, {
+        tags: { component: "auth0", phase: "callback", recovered: "false" },
+      })
+      console.error("[Auth0] callback failed (no session):", error)
+      return NextResponse.redirect(new URL("/auth/login", appBaseUrl))
+    }
+
+    if (error && session) {
+      Sentry.captureException(error, {
+        level: "warning",
+        tags: { component: "auth0", phase: "callback", recovered: "true" },
+      })
+      console.warn(
+        "[Auth0] post-callback non-fatal error (session persisted):",
+        error,
+      )
+      return NextResponse.redirect(target)
+    }
+
+    return NextResponse.redirect(target)
   },
 })


### PR DESCRIPTION
Users hitting Google login on kauri saw **"An error occurred during the authorization flow."** despite a working session — reloading the page showed they were authenticated.

## Root cause

`@auth0/nextjs-auth0` v4 calls the configured `onCallback` hook **after** session-cookie persistence. Internal post-callback steps can throw errors that the default `onCallback` unconditionally surfaces as a 500 page (`error.message`), regardless of whether the session was actually written.

From the SDK's `defaultOnCallback`:

\`\`\`ts
async defaultOnCallback(error, ctx) {
  if (error) return new NextResponse(error.message, { status: 500 });
  // … else redirect
}
\`\`\`

Result: user already has a valid session, but the error page hides it. Forces a manual reload.

## Fix

Add an explicit \`onCallback\` in \`src/lib/utils/auth0.ts\` that splits the two cases:

| Scenario | Action |
|---|---|
| \`error && !session\` | Capture to Sentry as \`error\` + redirect to \`/auth/login\` for clean re-attempt |
| \`error && session\` | Capture to Sentry as \`warning\` (with the real \`SdkError\`, not the generic wrapper) + redirect to the intended \`returnTo\` |
| \`!error\` | Default — redirect to \`returnTo ?? "/"\` |

## Why this is also diagnostic

The default 500 page hides the actual \`SdkError\` shape inside \`error.message\`. Now every callback failure is captured with the real exception, tagged \`phase:callback\` and \`recovered:true|false\`. After merge we'll have:

1. A **count** of how often the trailing-handler error happens (was invisible before).
2. The specific underlying errors so we can fix the source if there's a fixable bug, or accept the "post-callback-glitch-but-session-set" pattern as known noise.

## Test plan

- [ ] Sign in via Google on kauri → should land on intended page (no error page).
- [ ] If a real auth failure happens (bad code / expired state) → redirects to \`/auth/login\`, not the legacy 500.
- [ ] Sentry tag \`recovered:true\` accrues counts on the trailing-glitch path.

1367 tests pass. \`yarn typecheck\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling and user redirects during login callbacks with enhanced error tracking and recovery mechanisms for failed authentication attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->