### PR TITLE
fix(rebalance): pass selected market when resolving an added asset

### DIFF
--- a/__tests__/pages/tools/cost-stack.test.tsx
+++ b/__tests__/pages/tools/cost-stack.test.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import CostStackPage from "@pages/tools/cost-stack"
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ pathname: "/tools/cost-stack" }),
+}))
+
+describe("/tools/cost-stack", () => {
+  it("renders the playground iframe pointing at the public asset", () => {
+    const { container } = render(<CostStackPage />)
+    const iframe = container.querySelector("iframe")
+    expect(iframe).not.toBeNull()
+    expect(iframe).toHaveAttribute("src", "/tools/cost-stack.html")
+    expect(iframe).toHaveAttribute("title")
+  })
+
+  it("renders a Sign In CTA so unauth visitors funnel back to login", () => {
+    render(<CostStackPage />)
+    const cta = screen.getByRole("link", { name: /Sign In/i })
+    expect(cta).toHaveAttribute("href", "/auth/login")
+  })
+
+  it("renders a heading explaining what the page is", () => {
+    render(<CostStackPage />)
+    expect(
+      screen.getByRole("heading", { name: /Cost Stack|Fee Impact/i }),
+    ).toBeInTheDocument()
+  })
+})

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -13,8 +13,11 @@ setup("authenticate via Auth0", async ({ page }) => {
     )
   }
 
-  // Navigate to app which should redirect to login
-  await page.goto("/")
+  // Navigate directly to the Auth0 login route. Since PR #752 made `/`
+  // public, hitting the root no longer auto-redirects to Auth0 — the user
+  // has to opt in via "Sign In". `/auth/login` is handled by Auth0 v4
+  // middleware and always redirects to the IdP.
+  await page.goto("/auth/login")
 
   // Wait for Auth0 login page
   await page.waitForURL(/beancounter\.eu\.auth0\.com/)

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -29,6 +29,13 @@ export interface TestHelpers {
     base?: string,
   ) => Promise<TestPortfolio>
   deletePortfolio: (id: string) => Promise<void>
+  /**
+   * Delete every broker whose name starts with the given prefix
+   * (defaults to "E2E"). Used after the Open Brokerage wizard runs;
+   * the wizard creates a broker but doesn't expose its id to the spec,
+   * so we sweep by name prefix instead.
+   */
+  cleanupBrokersByPrefix: (prefix?: string) => Promise<void>
   cleanupTestData: () => Promise<void>
 }
 
@@ -120,6 +127,31 @@ export function createTestHelpers(page: Page): TestHelpers {
 
       if (!result.ok && result.status !== 404) {
         console.warn(`Failed to delete portfolio ${id}: ${result.status}`)
+      }
+    },
+
+    async cleanupBrokersByPrefix(prefix = "E2E"): Promise<void> {
+      await ensureAppDomain(page)
+      try {
+        const result = await page.evaluate(async () => {
+          const r = await fetch("/api/brokers")
+          if (!r.ok) return { ok: false, brokers: [] }
+          const j = await r.json()
+          return {
+            ok: true,
+            brokers: (j.data ?? []) as Array<{ id: string; name: string }>,
+          }
+        })
+        if (!result.ok) return
+        for (const b of result.brokers) {
+          if (b.name?.startsWith(prefix)) {
+            await page.evaluate(async (brokerId) => {
+              await fetch(`/api/brokers/${brokerId}`, { method: "DELETE" })
+            }, b.id)
+          }
+        }
+      } catch (e) {
+        console.warn("Failed to cleanup brokers:", e)
       }
     },
 

--- a/e2e/health-check.setup.ts
+++ b/e2e/health-check.setup.ts
@@ -20,12 +20,12 @@ const services: ServiceCheck[] = [
   {
     name: "bc-event",
     url: process.env.BC_EVENT_ACTUATOR || "http://localhost:9521",
-    required: true,
+    required: process.env.E2E_SKIP_EVENT_CHECK !== "true",
   },
   {
     name: "bc-retire",
     url: process.env.BC_RETIRE_ACTUATOR || "http://localhost:9541",
-    required: true,
+    required: process.env.E2E_SKIP_RETIRE_CHECK !== "true",
   },
   {
     name: "bc-rebalance",
@@ -67,6 +67,6 @@ setup("backends are up", async ({ request }) => {
 
   expect(
     failures,
-    `Required backend services not healthy:\n  - ${failures.join("\n  - ")}\nStart them via ./gradlew bootRun in the relevant repo, or set E2E_SKIP_REBALANCE_CHECK=true to skip bc-rebalance.`,
+    `Required backend services not healthy:\n  - ${failures.join("\n  - ")}\nStart them via ./gradlew bootRun in the relevant repo, or skip the auxiliary services with E2E_SKIP_EVENT_CHECK / E2E_SKIP_RETIRE_CHECK / E2E_SKIP_REBALANCE_CHECK = true (bc-data + bc-position remain required).`,
   ).toHaveLength(0)
 })

--- a/e2e/tests/tools/open-brokerage.spec.ts
+++ b/e2e/tests/tools/open-brokerage.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect } from "@playwright/test"
+import { createTestHelpers, generateTestId } from "../../fixtures/test-data"
+
+test.describe("/tools/open-brokerage", () => {
+  test("renders wizard at the Broker step", async ({ page }) => {
+    await page.goto("/tools/open-brokerage")
+    await expect(
+      page.getByRole("heading", { name: /^Broker$/i }),
+    ).toBeVisible()
+    await expect(page.getByText(/Step 1 of 4/i)).toBeVisible()
+  })
+
+  // Note: the onboarding-link click-through test was removed when the
+  // brokerage CTA moved from WelcomeStep (step 1) to CompleteStep (final
+  // step). Reaching it from /onboarding now requires walking the entire
+  // wizard — too expensive for this spec. A direct /tools/open-brokerage
+  // smoke test covers the destination; CompleteStep itself is verified
+  // by jest renders rather than the browser.
+
+  test("creates a broker + portfolio with no funding @smoke", async ({
+    page,
+  }) => {
+    const helpers = createTestHelpers(page)
+    const testId = generateTestId() // E2Exxx — 6 chars
+    const brokerName = `E2E Broker ${testId}`
+    const portfolioCode = testId
+    const portfolioName = `E2E Brokerage ${testId}`
+
+    try {
+      // Land on home first to settle auth context
+      await page.goto("/")
+      await page.waitForLoadState("domcontentloaded")
+
+      await page.goto("/tools/open-brokerage")
+      await page.waitForLoadState("domcontentloaded")
+
+      // Step 1 — Broker
+      await expect(
+        page.getByRole("heading", { name: /^Broker$/i }),
+      ).toBeVisible()
+      await page.getByLabel(/Broker name/i).fill(brokerName)
+      await page.getByRole("button", { name: "Next →" }).click()
+
+      // Step 2 — Portfolio
+      await expect(
+        page.getByRole("heading", { name: /^Portfolio$/i }),
+      ).toBeVisible()
+      await page.getByLabel(/Portfolio code/i).fill(portfolioCode)
+      await page.getByLabel(/Portfolio name/i).fill(portfolioName)
+      // Currency defaults to USD
+      await page.getByRole("button", { name: "Next →" }).click()
+
+      // Step 3 — Funding: skip
+      await expect(
+        page.getByRole("heading", { name: /Funding|Deposit/i }),
+      ).toBeVisible()
+      await page.getByRole("button", { name: /Skip|No deposit/i }).click()
+
+      // Step 4 — Review
+      await expect(
+        page.getByRole("heading", { name: /^Review$/i }),
+      ).toBeVisible()
+      await expect(page.getByText(`${brokerName} (new)`)).toBeVisible()
+      await expect(
+        page.getByText(`${portfolioCode} — ${portfolioName} (new, USD)`),
+      ).toBeVisible()
+
+      await page
+        .getByRole("button", { name: /Create|Confirm|Open Brokerage/i })
+        .click()
+
+      // Done screen
+      await expect(
+        page.getByRole("heading", { name: /Done|Complete|Success/i }),
+      ).toBeVisible({ timeout: 15000 })
+
+      // Verify portfolio actually persisted via API + register for cleanup
+      const result = await page.evaluate(async (code) => {
+        const r = await fetch("/api/portfolios")
+        if (!r.ok) return null
+        const j = await r.json()
+        return (
+          j.data?.find(
+            (p: { code: string; id: string }) => p.code === code,
+          ) ?? null
+        )
+      }, portfolioCode)
+      expect(result).not.toBeNull()
+      expect(result.code).toBe(portfolioCode)
+    } finally {
+      await helpers.cleanupTestData()
+      // Wizard creates a broker that cleanupTestData doesn't know about.
+      // Sweep by name prefix so it doesn't leak between runs.
+      await helpers.cleanupBrokersByPrefix("E2E")
+    }
+  })
+
+  test("creates a broker + portfolio + DEPOSIT/WITHDRAWAL pair with a source portfolio @smoke", async ({
+    page,
+  }) => {
+    const helpers = createTestHelpers(page)
+    const sourceCode = generateTestId()
+
+    let sourcePortfolio: { id: string; code: string } | null = null
+    try {
+      // Seed a USD source portfolio + an initial DEPOSIT so it has cash
+      sourcePortfolio = await helpers.createPortfolio(
+        `E2E Source ${sourceCode}`,
+        "USD",
+        "USD",
+      )
+      const seedOk = await page.evaluate(async (sourceId) => {
+        // Ensure a CASH/USD asset exists
+        const assetResp = await fetch("/api/assets", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            data: { USD: { market: "CASH", code: "USD" } },
+          }),
+        })
+        const assetJson = await assetResp.json()
+        const cashAssetId = Object.values(
+          assetJson.data as Record<string, { id: string }>,
+        )[0].id
+
+        const trnResp = await fetch("/api/trns", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            portfolioId: sourceId,
+            data: [
+              {
+                assetId: cashAssetId,
+                cashAssetId,
+                trnType: "DEPOSIT",
+                quantity: 10000,
+                price: 1,
+                tradeCurrency: "USD",
+                cashCurrency: "USD",
+                cashAmount: 10000,
+                tradeDate: new Date().toISOString().split("T")[0],
+                status: "SETTLED",
+              },
+            ],
+          }),
+        })
+        return trnResp.ok
+      }, sourcePortfolio.id)
+      expect(seedOk).toBeTruthy()
+
+      const testId = generateTestId()
+      const brokerName = `E2E Broker ${testId}`
+      const newCode = testId
+      const newName = `E2E Brokerage ${testId}`
+
+      await page.goto("/tools/open-brokerage")
+      await page.waitForLoadState("domcontentloaded")
+
+      // Step 1 — Broker
+      await page.getByLabel(/Broker name/i).fill(brokerName)
+      await page.getByRole("button", { name: "Next →" }).click()
+
+      // Step 2 — Portfolio (USD)
+      await page.getByLabel(/Portfolio code/i).fill(newCode)
+      await page.getByLabel(/Portfolio name/i).fill(newName)
+      await page.getByRole("button", { name: "Next →" }).click()
+
+      // Step 3 — Funding from source
+      await expect(
+        page.getByRole("heading", { name: /Funding|Deposit/i }),
+      ).toBeVisible()
+      await page.getByLabel(/Amount/i).fill("2500")
+      // Select by portfolio id (option `value`) to avoid building a runtime
+      // regex from test data (ReDoS lint) and to be resilient to label
+      // formatting changes.
+      await page.getByLabel(/Source portfolio/i).selectOption(sourcePortfolio.id)
+      await page.getByRole("button", { name: "Next →" }).click()
+
+      // Step 4 — Review + submit
+      await expect(
+        page.getByRole("heading", { name: /^Review$/i }),
+      ).toBeVisible()
+      await page
+        .getByRole("button", { name: /Create|Confirm|Open Brokerage/i })
+        .click()
+
+      await expect(
+        page.getByRole("heading", { name: /Done|Complete|Success/i }),
+      ).toBeVisible({ timeout: 20000 })
+
+      // The Done screen reports how many cash transactions were posted
+      await expect(page.getByText(/2\s+cash transaction/i)).toBeVisible()
+    } finally {
+      await helpers.cleanupTestData()
+      // Wizard creates a broker that cleanupTestData doesn't know about.
+      // Sweep by name prefix so it doesn't leak between runs.
+      await helpers.cleanupBrokersByPrefix("E2E")
+    }
+  })
+})

--- a/next.config.js
+++ b/next.config.js
@@ -68,8 +68,12 @@ const nextConfig = {
         source: "/(.*)",
         headers: [
           {
+            // SAMEORIGIN (not DENY) so first-party tools/marketing pages
+            // can embed the static playgrounds under /tools/*.html in an
+            // iframe (e.g. /tools/cost-stack embeds /tools/cost-stack.html).
+            // Still blocks any cross-origin clickjacking attempt.
             key: "X-Frame-Options",
-            value: "DENY",
+            value: "SAMEORIGIN",
           },
           {
             key: "X-Content-Type-Options",

--- a/public/tools/cost-stack.html
+++ b/public/tools/cost-stack.html
@@ -1,0 +1,672 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Cost Stack — long-term fee impact</title>
+<style>
+  :root {
+    --bg: #0f1217;
+    --panel: #161b22;
+    --panel-2: #1c222b;
+    --border: #2a313c;
+    --text: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --good: #3fb950;
+    --bad: #f85149;
+    --warn: #d29922;
+    --c1: #f85149;
+    --c2: #db61a2;
+    --c3: #d29922;
+    --c4: #58a6ff;
+    --c5: #3fb950;
+    --c6: #a13130;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+  }
+  .wrap { max-width: 1280px; margin: 0 auto; padding: 24px; }
+  h1 { margin: 0 0 4px; font-size: 22px; }
+  h2 { margin: 0 0 12px; font-size: 16px; color: var(--muted); font-weight: 500; }
+  h3 { margin: 0 0 8px; font-size: 14px; }
+  .sub { color: var(--muted); font-size: 13px; margin-bottom: 20px; }
+
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .grid-inputs {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+  }
+  .input-row { display: flex; flex-direction: column; gap: 4px; }
+  .input-row label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  .input-row .val { font-size: 18px; font-weight: 600; color: var(--text); }
+  input[type="range"] {
+    width: 100%;
+    accent-color: var(--accent);
+  }
+  input[type="number"] {
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 6px 8px;
+    border-radius: 6px;
+    width: 100%;
+    font-size: 14px;
+  }
+  input[type="number"]:focus { outline: 1px solid var(--accent); }
+
+  .presets {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .preset {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--accent);
+    border-radius: 8px;
+    padding: 14px;
+  }
+  .preset.p1 { border-left-color: var(--c1); }
+  .preset.p2 { border-left-color: var(--c2); }
+  .preset.p3 { border-left-color: var(--c3); }
+  .preset.p4 { border-left-color: var(--c4); }
+  .preset.p5 { border-left-color: var(--c5); }
+  .preset.p6 { border-left-color: var(--c6); }
+  .preset header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 8px;
+  }
+  .preset h3 { font-size: 14px; }
+  .preset .fees {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    margin: 8px 0;
+  }
+  .fee { display: flex; flex-direction: column; gap: 2px; }
+  .fee label { font-size: 10px; color: var(--muted); text-transform: uppercase; }
+  .pros-cons { font-size: 12px; margin-top: 8px; }
+  .pros-cons ul { margin: 4px 0 6px; padding-left: 18px; }
+  .pros-cons .pros li { color: var(--good); }
+  .pros-cons .cons li { color: var(--bad); }
+  .pros-cons strong { color: var(--text); display: block; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; margin-top: 4px; }
+
+  .chart-wrap {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 16px;
+  }
+  svg { width: 100%; height: auto; display: block; }
+  .legend { display: flex; gap: 16px; flex-wrap: wrap; margin: 8px 0 4px; font-size: 13px; }
+  .legend .dot { width: 10px; height: 10px; border-radius: 2px; display: inline-block; margin-right: 6px; vertical-align: middle; }
+
+  .stats {
+    margin-top: 16px;
+    overflow-x: auto;
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { padding: 8px 10px; text-align: right; border-bottom: 1px solid var(--border); }
+  th:first-child, td:first-child { text-align: left; }
+  th { color: var(--muted); font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+  td .label-pill { display: inline-block; width: 8px; height: 8px; border-radius: 2px; margin-right: 8px; vertical-align: middle; }
+  .delta-bad { color: var(--bad); }
+  .delta-good { color: var(--good); }
+
+  .actions { display: flex; gap: 8px; margin-bottom: 16px; flex-wrap: wrap; }
+  button {
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 13px;
+  }
+  button:hover { border-color: var(--accent); }
+  button.primary { background: var(--accent); color: #0d1117; border-color: var(--accent); }
+
+  .footnote { color: var(--muted); font-size: 12px; margin-top: 12px; }
+  .footnote code { background: var(--panel-2); padding: 2px 5px; border-radius: 3px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Cost Stack — long-term fee impact</h1>
+  <h2>For Ruby: how much do platform/wrapper fees really cost over 30 years?</h2>
+  <p class="sub">
+    All six paths buy the same global equity exposure. Only the fee stack differs.
+    Compounded over decades, fee drag eats more than most investors realise.
+    Numbers are currency-agnostic — read as your local currency.
+  </p>
+
+  <div class="actions">
+    <button class="primary" id="resetBtn">Reset to defaults</button>
+    <button id="rubyBtn">Ruby scenario (50k + 1k/mo · 30y · 7%)</button>
+    <button id="aggrBtn">Aggressive scenario (10k + 500/mo · 40y · 8%)</button>
+  </div>
+
+  <div class="panel">
+    <h3>Scenario inputs</h3>
+    <div class="grid-inputs">
+      <div class="input-row">
+        <label>Starting capital</label>
+        <input type="number" id="lump" value="50000" step="1000" min="0" />
+      </div>
+      <div class="input-row">
+        <label>Monthly contribution</label>
+        <input type="number" id="monthly" value="1000" step="100" min="0" />
+      </div>
+      <div class="input-row">
+        <label>Investment horizon (years): <span class="val" id="yearsLabel">30</span></label>
+        <input type="range" id="years" min="5" max="50" step="1" value="30" />
+      </div>
+      <div class="input-row">
+        <label>Gross return p.a. (%): <span class="val" id="grossLabel">7.0</span></label>
+        <input type="range" id="gross" min="2" max="12" step="0.1" value="7" />
+      </div>
+    </div>
+  </div>
+
+  <div class="presets" id="presets"></div>
+
+  <div class="chart-wrap">
+    <h3>Portfolio value over time</h3>
+    <div class="legend" id="legend"></div>
+    <svg id="chart" viewBox="0 0 900 380" preserveAspectRatio="none"></svg>
+    <div class="stats">
+      <table>
+        <thead>
+          <tr>
+            <th>Path</th>
+            <th>Final balance</th>
+            <th>Total contributions</th>
+            <th>Total fees paid</th>
+            <th>Fees as % of gains</th>
+            <th>Cost vs cheapest</th>
+          </tr>
+        </thead>
+        <tbody id="statsBody"></tbody>
+      </table>
+    </div>
+    <p class="footnote">
+      Monthly compounding. Fees applied as monthly drag on balance (TER + platform). Front-load
+      taken off each contribution. Trade commissions applied per rebalance month. FX cost taken
+      off each contribution where applicable. Inflation not modelled — all numbers are nominal.
+    </p>
+  </div>
+</div>
+
+<script>
+"use strict";
+
+// ---- Preset definitions ----------------------------------------------------
+const PRESETS = [
+  {
+    id: "p1",
+    name: "Bank wrapped UT",
+    sub: "e.g. DBS / UOB unit trust sold by relationship manager",
+    color: "var(--c1)",
+    hex: "#f85149",
+    fees: {
+      frontLoad: 3.0,   // % off each contribution and lump sum
+      ter: 1.75,        // % p.a. ongoing
+      platform: 0.0,    // % p.a. (absorbed into TER for wrapped UT)
+      tradeCost: 0,     // flat per rebalance
+      rebalanceMonths: 0,
+      fx: 0,            // % off each contribution
+      subscription: 0,  // flat USD per month (e.g. BC $5/mo)
+    },
+    pros: [
+      "Single relationship — bank handles everything",
+      "No separate account opening; uses existing bank login",
+      "Auto-debit GIRO funding is trivial",
+    ],
+    cons: [
+      "Front-load is real cash gone day one (3% of lump = lost forever)",
+      "TER ~1.75% compounds against you for 30 years",
+      "Trail commission incentivises the RM to recommend higher-cost funds",
+      "Often actively managed — underperforms passive index in ~80% of 10y windows",
+    ],
+  },
+  {
+    id: "p2",
+    name: "Bank robo (DBS digiPortfolio)",
+    sub: "DBS Global/Asia tier: 0.75% mgmt + 0.20–0.30% underlying TER. Min S$1k lump or S$100/mo.",
+    color: "var(--c2)",
+    hex: "#db61a2",
+    fees: {
+      frontLoad: 0,
+      ter: 0.25,       // DBS Global/Asia underlying ETF TER published range 0.20-0.30%, midpoint
+      platform: 0.75,  // DBS Global/Asia management fee, published
+      tradeCost: 0,    // rebalancing included in mgmt fee
+      rebalanceMonths: 0,
+      fx: 0,           // not separately disclosed by DBS; embedded in ETF spread
+      subscription: 0,
+    },
+    pros: [
+      "No front-load, no sales charge (explicit on DBS marketing)",
+      "Bank brand trust — same login as your savings account",
+      "Auto-debit GIRO from existing DBS account",
+      "DBS handles rebalancing 'whenever necessary' (ad-hoc, not scheduled)",
+      "Low minimum: S$1k lump or S$100/mo recurring (May 2025+)",
+      "Cheaper SaveUp tier exists (0.25% mgmt) but cash-equivalent, not equity",
+    ],
+    cons: [
+      "Management fee 0.75% p.a. — 3-4× brokerage all-in cost",
+      "Combined drag ~1.0% — twice fintech robos like Endowus/Stashaway",
+      "Fund universe restricted to DBS custodian's selection",
+      "FX cost on USD-denominated underlyings not disclosed (embedded in spread)",
+      "Bank can change fees or restructure portfolio with 30-day notice",
+      "Rebalancing 'whenever necessary' = no published schedule, no SLA",
+    ],
+  },
+  {
+    id: "p3",
+    name: "Fintech robo / platform",
+    sub: "e.g. Endowus, Stashaway, Syfe",
+    color: "var(--c3)",
+    hex: "#d29922",
+    fees: {
+      frontLoad: 0,
+      ter: 0.20,
+      platform: 0.30,
+      tradeCost: 0,
+      rebalanceMonths: 0,
+      fx: 0,
+      subscription: 0,
+    },
+    pros: [
+      "No front-load — every dollar invested",
+      "Automated rebalancing and tax-aware allocation",
+      "Clean UX; works for anyone with internet banking",
+      "Aggregated ETF pricing gives near-institutional TER",
+    ],
+    cons: [
+      "Platform fee on top of ETF TER — still ~0.50% combined drag",
+      "Limited fund universe — locked to provider's curated list",
+      "Counterparty risk — your assets sit in the platform's custody arrangement",
+      "Switching out later may incur exit friction",
+    ],
+  },
+  {
+    id: "p4",
+    name: "Brokerage + DIY ETF",
+    sub: "e.g. IBKR + VWRA (Vanguard FTSE All-World)",
+    color: "var(--c4)",
+    hex: "#58a6ff",
+    fees: {
+      frontLoad: 0,
+      ter: 0.22,
+      platform: 0,
+      tradeCost: 2,
+      rebalanceMonths: 3, // quarterly batching of contributions
+      fx: 0.30,
+      subscription: 0,
+    },
+    pros: [
+      "Lowest ongoing drag — just the ETF TER (~0.22%)",
+      "Full ownership in your name at the broker",
+      "Free to switch ETFs or sell at any time",
+      "No platform lock-in",
+    ],
+    cons: [
+      "Requires a brokerage account (KYC, funding, FX conversion)",
+      "You execute trades — small operational burden",
+      "Need to learn order types, market vs limit, settlement",
+      "FX cost on each USD/SGD conversion (negotiable on IBKR)",
+    ],
+  },
+  {
+    id: "p5",
+    name: "Brokerage + BC model portfolio",
+    sub: "Your broker, beancounter tells you what to buy",
+    color: "var(--c5)",
+    hex: "#3fb950",
+    fees: {
+      frontLoad: 0,
+      ter: 0.15,
+      platform: 0,
+      tradeCost: 2,
+      rebalanceMonths: 3,
+      fx: 0.30,
+      subscription: 5,
+    },
+    pros: [
+      "Same low TER as DIY but with guided allocation",
+      "BC handles rebalancing logic — you just execute the trades",
+      "Education baked into the flow — you understand what you own",
+      "No platform fee, no front-load, no trail commission",
+    ],
+    cons: [
+      "You still have to place the trades manually",
+      "Still requires brokerage account setup (same friction as DIY)",
+      "BC is not a regulated advisor — recommendations not personalised",
+      "Discipline required — easy to skip a rebalance",
+    ],
+  },
+  {
+    id: "p6",
+    name: "Investment-Linked Policy (ILP)",
+    sub: "e.g. AIA Pro Achiever, Prudential PRUlink, Manulife ManuInvest. Insurance + investment wrapper.",
+    color: "var(--c6)",
+    hex: "#a13130",
+    fees: {
+      frontLoad: 5.0,    // bid-offer spread on each premium (5% typical retail)
+      ter: 1.0,          // underlying fund TER (sub-funds usually actively managed)
+      platform: 2.5,     // M&E charge + admin fee + cost of insurance, annualised
+      tradeCost: 0,
+      rebalanceMonths: 0,
+      fx: 0,
+      subscription: 0,
+    },
+    pros: [
+      "Bundles death + critical-illness coverage with investment — useful if you have no separate term policy",
+      "Forced savings discipline — premium can't be skipped without surrender penalty (helps undisciplined savers stay invested through market crashes)",
+      "Premium waiver on disability (some products) — keeps investing for you if you can't work",
+      "SG Insurance Act §73 — death proceeds to nominated beneficiaries are protected from creditors and bypass probate",
+      "Single product for those who genuinely want one bill, one statement, one agent",
+      "Loyalty / bonus units added in later policy years (year 10+)",
+      "Premium holiday flexibility once minimum premium term met",
+    ],
+    cons: [
+      "Front-load ~5% bid-offer on every premium — gone forever",
+      "First-year allocation rate often <100% — large chunk of year-1 premium consumed by distribution costs",
+      "M&E + admin + cost of insurance ~2.5% p.a. on top of fund TER",
+      "Combined drag ~3.5% p.a. — half of expected long-term equity return",
+      "Surrender charge for first 10–15 years — locked in",
+      "Switching funds capped (typically 4 free switches/yr)",
+      "Insurance component often duplicates a cheaper standalone term policy",
+      "Agent paid trail commission — incentive misalignment baked in",
+    ],
+  },
+];
+
+// ---- Simulation ------------------------------------------------------------
+function simulate(scenario, fees) {
+  const { lump, monthly, years, gross } = scenario;
+  const months = years * 12;
+  const rMonthly = Math.pow(1 + gross / 100, 1 / 12) - 1;
+  const terMonthly = (fees.ter + fees.platform) / 100 / 12;
+
+  let balance = lump * (1 - fees.frontLoad / 100);
+  let totalContrib = lump;
+  let totalFees = lump * (fees.frontLoad / 100); // front-load on lump
+
+  // Track ongoing drag separately so we can report
+  const series = new Array(months + 1);
+  const balanceNoFee = new Array(months + 1);
+  series[0] = balance;
+  balanceNoFee[0] = lump;
+
+  let bNoFee = lump;
+  let cumulative = lump;
+
+  for (let m = 1; m <= months; m++) {
+    // Contribution
+    const grossContribution = monthly;
+    const fxCost = grossContribution * (fees.fx / 100);
+    const afterFx = grossContribution - fxCost;
+    const frontLoadCost = afterFx * (fees.frontLoad / 100);
+    const invested = afterFx - frontLoadCost;
+
+    balance += invested;
+    totalContrib += grossContribution;
+    totalFees += fxCost + frontLoadCost;
+
+    // Trade commission if this is a rebalance month
+    if (fees.rebalanceMonths > 0 && m % fees.rebalanceMonths === 0) {
+      balance -= fees.tradeCost;
+      totalFees += fees.tradeCost;
+    } else if (fees.rebalanceMonths === 0 && fees.tradeCost > 0) {
+      // No rebalance schedule but per-trade cost: charge monthly
+      balance -= fees.tradeCost;
+      totalFees += fees.tradeCost;
+    }
+
+    // Flat monthly subscription (e.g. BC $5/mo)
+    if (fees.subscription > 0) {
+      balance -= fees.subscription;
+      totalFees += fees.subscription;
+    }
+
+    // Growth - ongoing drag
+    const gain = balance * rMonthly;
+    const drag = balance * terMonthly;
+    balance += gain - drag;
+    totalFees += drag;
+
+    // No-fee comparison
+    bNoFee += monthly;
+    bNoFee *= 1 + rMonthly;
+
+    series[m] = Math.max(0, balance);
+    balanceNoFee[m] = bNoFee;
+  }
+
+  return {
+    series,
+    balanceNoFee,
+    finalBalance: series[months],
+    totalContrib,
+    totalFees,
+    grossGain: balanceNoFee[months] - totalContrib,
+  };
+}
+
+// ---- State -----------------------------------------------------------------
+let state = {
+  scenario: { lump: 50000, monthly: 1000, years: 30, gross: 7 },
+  presets: structuredClone(PRESETS),
+};
+
+// ---- Render presets --------------------------------------------------------
+const presetsEl = document.getElementById("presets");
+function renderPresets() {
+  presetsEl.innerHTML = "";
+  state.presets.forEach((p, i) => {
+    const card = document.createElement("div");
+    card.className = `preset ${p.id}`;
+    card.innerHTML = `
+      <header>
+        <div>
+          <h3>${p.name}</h3>
+          <div style="font-size:11px;color:var(--muted)">${p.sub}</div>
+        </div>
+      </header>
+      <div class="fees">
+        ${feeInput(i, "frontLoad", "Front-load %", p.fees.frontLoad)}
+        ${feeInput(i, "ter", "ETF TER %", p.fees.ter)}
+        ${feeInput(i, "platform", "Platform %", p.fees.platform)}
+        ${feeInput(i, "fx", "FX cost %", p.fees.fx)}
+        ${feeInput(i, "tradeCost", "Trade cost (flat)", p.fees.tradeCost)}
+        ${feeInput(i, "rebalanceMonths", "Rebalance (months)", p.fees.rebalanceMonths)}
+        ${feeInput(i, "subscription", "BC sub $/mo", p.fees.subscription)}
+      </div>
+      <div class="pros-cons">
+        <strong>Pros</strong>
+        <ul class="pros">${p.pros.map(x => `<li>${x}</li>`).join("")}</ul>
+        <strong>Cons</strong>
+        <ul class="cons">${p.cons.map(x => `<li>${x}</li>`).join("")}</ul>
+      </div>
+    `;
+    presetsEl.appendChild(card);
+  });
+  presetsEl.querySelectorAll("input[data-preset]").forEach(inp => {
+    inp.addEventListener("input", e => {
+      const idx = +e.target.dataset.preset;
+      const key = e.target.dataset.key;
+      const val = parseFloat(e.target.value);
+      state.presets[idx].fees[key] = isNaN(val) ? 0 : val;
+      recalc();
+    });
+  });
+}
+function feeInput(idx, key, label, value) {
+  return `
+    <div class="fee">
+      <label>${label}</label>
+      <input type="number" step="0.05" min="0" data-preset="${idx}" data-key="${key}" value="${value}" />
+    </div>
+  `;
+}
+
+// ---- Render chart ----------------------------------------------------------
+const chartEl = document.getElementById("chart");
+const legendEl = document.getElementById("legend");
+const statsBody = document.getElementById("statsBody");
+
+function recalc() {
+  const sims = state.presets.map(p => simulate(state.scenario, p.fees));
+  drawChart(sims);
+  drawStats(sims);
+}
+
+function drawChart(sims) {
+  const W = 900, H = 380;
+  const padL = 64, padR = 12, padT = 16, padB = 32;
+  const innerW = W - padL - padR;
+  const innerH = H - padT - padB;
+  const months = state.scenario.years * 12;
+  const maxY = Math.max(...sims.flatMap(s => s.series), 1);
+  const yTickStep = niceStep(maxY, 5);
+  const yMax = Math.ceil(maxY / yTickStep) * yTickStep;
+
+  const xScale = m => padL + (m / months) * innerW;
+  const yScale = v => padT + innerH - (v / yMax) * innerH;
+
+  const lines = sims.map((s, i) => {
+    let d = "";
+    s.series.forEach((v, m) => {
+      d += (m === 0 ? "M" : "L") + xScale(m).toFixed(1) + "," + yScale(v).toFixed(1) + " ";
+    });
+    return `<path d="${d}" stroke="${PRESETS[i].hex}" stroke-width="2" fill="none" />`;
+  }).join("");
+
+  // y-axis ticks
+  let yTicks = "";
+  for (let v = 0; v <= yMax; v += yTickStep) {
+    const y = yScale(v);
+    yTicks += `<line x1="${padL}" y1="${y}" x2="${W - padR}" y2="${y}" stroke="#2a313c" stroke-width="0.5" />`;
+    yTicks += `<text x="${padL - 6}" y="${y + 4}" text-anchor="end" font-size="10" fill="#8b949e">${fmt(v)}</text>`;
+  }
+  // x-axis ticks (every 5 years)
+  let xTicks = "";
+  for (let yr = 0; yr <= state.scenario.years; yr += 5) {
+    const x = xScale(yr * 12);
+    xTicks += `<line x1="${x}" y1="${padT + innerH}" x2="${x}" y2="${padT + innerH + 4}" stroke="#8b949e" />`;
+    xTicks += `<text x="${x}" y="${padT + innerH + 16}" text-anchor="middle" font-size="10" fill="#8b949e">${yr}y</text>`;
+  }
+
+  chartEl.innerHTML = `
+    <rect x="${padL}" y="${padT}" width="${innerW}" height="${innerH}" fill="none" stroke="#2a313c" />
+    ${yTicks}
+    ${xTicks}
+    ${lines}
+  `;
+
+  legendEl.innerHTML = PRESETS.map((p, i) =>
+    `<span><span class="dot" style="background:${p.hex}"></span>${p.name}</span>`
+  ).join("");
+}
+
+function drawStats(sims) {
+  const cheapestFinal = Math.max(...sims.map(s => s.finalBalance));
+  statsBody.innerHTML = sims.map((s, i) => {
+    const feesPctGains = s.grossGain > 0 ? (s.totalFees / s.grossGain * 100) : 0;
+    const deltaVsCheapest = s.finalBalance - cheapestFinal;
+    const deltaCls = deltaVsCheapest < 0 ? "delta-bad" : "delta-good";
+    return `
+      <tr>
+        <td><span class="label-pill" style="background:${PRESETS[i].hex}"></span>${PRESETS[i].name}</td>
+        <td>${fmt(s.finalBalance)}</td>
+        <td>${fmt(s.totalContrib)}</td>
+        <td>${fmt(s.totalFees)}</td>
+        <td>${feesPctGains.toFixed(1)}%</td>
+        <td class="${deltaCls}">${deltaVsCheapest === 0 ? "—" : (deltaVsCheapest > 0 ? "+" : "") + fmt(deltaVsCheapest)}</td>
+      </tr>
+    `;
+  }).join("");
+}
+
+function fmt(n) {
+  if (Math.abs(n) >= 1e6) return (n / 1e6).toFixed(2) + "M";
+  if (Math.abs(n) >= 1e3) return (n / 1e3).toFixed(1) + "k";
+  return n.toFixed(0);
+}
+function niceStep(max, ticks) {
+  const raw = max / ticks;
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const norm = raw / mag;
+  let step;
+  if (norm < 1.5) step = 1;
+  else if (norm < 3) step = 2;
+  else if (norm < 7) step = 5;
+  else step = 10;
+  return step * mag;
+}
+
+// ---- Input wiring ----------------------------------------------------------
+function bindScenarioInputs() {
+  const map = {
+    lump: ["lump", null],
+    monthly: ["monthly", null],
+    years: ["years", "yearsLabel"],
+    gross: ["gross", "grossLabel"],
+  };
+  Object.entries(map).forEach(([key, [inputId, labelId]]) => {
+    const el = document.getElementById(inputId);
+    el.addEventListener("input", e => {
+      const val = parseFloat(e.target.value);
+      state.scenario[key] = isNaN(val) ? 0 : val;
+      if (labelId) document.getElementById(labelId).textContent =
+        key === "gross" ? val.toFixed(1) : val.toFixed(0);
+      recalc();
+    });
+  });
+}
+
+function applyScenario(s) {
+  state.scenario = { ...s };
+  document.getElementById("lump").value = s.lump;
+  document.getElementById("monthly").value = s.monthly;
+  document.getElementById("years").value = s.years;
+  document.getElementById("gross").value = s.gross;
+  document.getElementById("yearsLabel").textContent = s.years.toFixed(0);
+  document.getElementById("grossLabel").textContent = s.gross.toFixed(1);
+  recalc();
+}
+
+document.getElementById("resetBtn").addEventListener("click", () => {
+  state.presets = structuredClone(PRESETS);
+  renderPresets();
+  applyScenario({ lump: 50000, monthly: 1000, years: 30, gross: 7 });
+});
+document.getElementById("rubyBtn").addEventListener("click", () => {
+  applyScenario({ lump: 50000, monthly: 1000, years: 30, gross: 7 });
+});
+document.getElementById("aggrBtn").addEventListener("click", () => {
+  applyScenario({ lump: 10000, monthly: 500, years: 40, gross: 8 });
+});
+
+// ---- Init ------------------------------------------------------------------
+renderPresets();
+bindScenarioInputs();
+recalc();
+</script>
+</body>
+</html>

--- a/src/components/features/independence/DetailsTabContent.tsx
+++ b/src/components/features/independence/DetailsTabContent.tsx
@@ -281,10 +281,10 @@ export default function DetailsTabContent({
             Owner-scoped projection
           </p>
           <p>
-            Per-category asset breakdown for this shared plan needs the
-            plan owner to also share their portfolios with you. The
-            projection (left panel and Metrics tab) uses the owner&apos;s
-            holdings via a server-side fetch.
+            Per-category asset breakdown for this shared plan needs the plan
+            owner to also share their portfolios with you. The projection (left
+            panel and Metrics tab) uses the owner&apos;s holdings via a
+            server-side fetch.
           </p>
         </div>
       ) : (

--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -463,7 +463,9 @@ export default function TimelineTabContent({
                   age: y.age,
                   year: y.year,
                   investmentAndIncome:
-                    y.contribution + y.investmentGrowth + (y.lumpSumPayout ?? 0),
+                    y.contribution +
+                    y.investmentGrowth +
+                    (y.lumpSumPayout ?? 0),
                   negWithdrawals: 0,
                 })),
                 ...projection.yearlyProjections.map((y) => ({

--- a/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
+++ b/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
@@ -109,7 +109,10 @@ describe("scenarioToPayload", () => {
     const payload = scenarioToPayload(scenario, {
       ...ctx,
       isSharedPlan: true,
-      rentalIncome: { monthlyNetByCurrency: { SGD: 1500 }, totalMonthlyInPlanCurrency: 1500 },
+      rentalIncome: {
+        monthlyNetByCurrency: { SGD: 1500 },
+        totalMonthlyInPlanCurrency: 1500,
+      },
     })
     expect("portfolioIds" in payload).toBe(false)
     expect("monthlyContribution" in payload).toBe(false)

--- a/src/components/features/offboarding/OffboardingWizard.tsx
+++ b/src/components/features/offboarding/OffboardingWizard.tsx
@@ -41,13 +41,30 @@ export default function OffboardingWizard(): React.ReactElement {
       }
 
       if (plansRes?.ok) {
-        const plansData = await plansRes.json()
-        setPlanCount(plansData.data?.length ?? 0)
+        // /api/independence/plans returns plans the caller can SEE,
+        // which includes shared plans they don't own. The offboarding
+        // delete only removes plans the caller owns, so the count
+        // displayed has to exclude `sharedPlanIds`.
+        const plansData = (await plansRes.json()) as {
+          data?: Array<{ id: string }>
+          sharedPlanIds?: string[]
+        }
+        const shared = new Set(plansData.sharedPlanIds ?? [])
+        const owned = (plansData.data ?? []).filter((p) => !shared.has(p.id))
+        setPlanCount(owned.length)
       }
 
       if (modelsRes?.ok) {
-        const modelsData = await modelsRes.json()
-        setModelCount(modelsData.data?.length ?? 0)
+        // ModelDto exposes `isOwner` directly. Shared models (where
+        // the caller is a viewer, not the owner) are excluded so the
+        // count matches what offboarding will actually delete.
+        const modelsData = (await modelsRes.json()) as {
+          data?: Array<{ isOwner?: boolean }>
+        }
+        const owned = (modelsData.data ?? []).filter(
+          (m) => m.isOwner !== false,
+        )
+        setModelCount(owned.length)
       }
     } catch (error) {
       console.error("Failed to fetch offboarding summary:", error)

--- a/src/components/features/offboarding/steps/SummaryStep.tsx
+++ b/src/components/features/offboarding/steps/SummaryStep.tsx
@@ -76,6 +76,16 @@ export default function SummaryStep({
 
         <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
           <div className="flex items-center">
+            <i className="fas fa-building-columns text-purple-500 mr-3"></i>
+            <span className="font-medium">{"Brokers"}</span>
+          </div>
+          <span className="text-lg font-semibold">
+            {summary?.brokerCount ?? 0}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+          <div className="flex items-center">
             <i className="fas fa-percent text-orange-500 mr-3"></i>
             <span className="font-medium">{"Tax Rates"}</span>
           </div>

--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router"
 import useSwr from "swr"
 import { useUser } from "@auth0/nextjs-auth0/client"
 import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
-import { Currency, PolicyType, SubAccountRequest } from "types/beancounter"
+import { Currency, PolicyType, Portfolio, SubAccountRequest } from "types/beancounter"
 import OnboardingProgress from "./OnboardingProgress"
 import WelcomeStep from "./steps/WelcomeStep"
 import CurrencyStep from "./steps/CurrencyStep"
@@ -12,6 +12,9 @@ import AssetsStep from "./steps/AssetsStep"
 import ReviewStep from "./steps/ReviewStep"
 import CompleteStep from "./steps/CompleteStep"
 import IndependencePlanStep from "./steps/IndependencePlanStep"
+import BrokerageStep from "./steps/BrokerageStep"
+import type { SourceValue } from "./steps/BrokerageStep"
+import { openBrokerage } from "@lib/openBrokerage/orchestrate"
 import { useRegistration } from "@contexts/RegistrationContext"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import Spinner from "@components/ui/Spinner"
@@ -64,19 +67,23 @@ export interface OnboardingState {
   insurances: Insurance[]
 }
 
+/**
+ * Build a short asset code from a user-typed name. Splits on any
+ * non-alphanumeric (whitespace, hyphens, dots, underscores) so that
+ * names like "DBS-SGD" and "DBS-USD" produce distinct codes
+ * ("DBS-SGD" / "DBS-USD") instead of colliding on a truncated prefix
+ * ("DBS-" each). Caps at 16 chars to stay within DB column bounds and
+ * to avoid hand-typed paragraphs becoming the code.
+ */
 function generateAssetCode(name: string): string {
-  const words = name
-    .trim()
-    .split(/\s+/)
-    .filter((w) => w.length > 0)
-  if (words.length === 0) return "ASSET"
-  if (words.length >= 2) {
-    return words
-      .map((w) => w[0])
-      .join("")
-      .toUpperCase()
-  }
-  return words[0].substring(0, 4).toUpperCase()
+  const upper = name.trim().toUpperCase()
+  if (!upper) return "ASSET"
+  const parts = upper.split(/[^A-Z0-9]+/).filter(Boolean)
+  if (parts.length === 0) return "ASSET"
+  // Preserve hyphenation so user-typed identifiers stay distinct.
+  // Single-token names still get the original short-prefix behaviour
+  // (e.g. "Savings" → "SAVINGS"), capped to 16 chars.
+  return parts.join("-").slice(0, 16)
 }
 
 const OnboardingWizard: React.FC = () => {
@@ -88,6 +95,13 @@ const OnboardingWizard: React.FC = () => {
   // Fetch currencies from backend
   const { data: ccyResponse } = useSwr(ccyKey, simpleFetcher(ccyKey))
   const currencies: Currency[] = ccyResponse?.data || []
+
+  // Fetch portfolios for the Brokerage step's source-portfolio dropdown
+  const { data: portfoliosResponse } = useSwr<{ data: Portfolio[] }>(
+    "/api/portfolios",
+    simpleFetcher("/api/portfolios"),
+  )
+  const existingPortfolios: Portfolio[] = portfoliosResponse?.data ?? []
 
   // Wizard state - no pre-selection, user must explicitly choose
   const [currentStep, setCurrentStep] = useState(1)
@@ -143,6 +157,14 @@ const OnboardingWizard: React.FC = () => {
   const [independenceTargetAge, setIndependenceTargetAge] = useState(65)
   const [independencePlanCreated, setIndependencePlanCreated] = useState(false)
 
+  // Brokerage step (optional, post-default-portfolio creation)
+  const [brokerageEnabled, setBrokerageEnabled] = useState(false)
+  const [brokerageBrokerName, setBrokerageBrokerName] = useState("")
+  const [brokerageSource, setBrokerageSource] = useState<SourceValue>("")
+  const [brokerageAmount, setBrokerageAmount] = useState("")
+  const [brokerageCurrency, setBrokerageCurrency] = useState("")
+  const [brokerageCreated, setBrokerageCreated] = useState(false)
+
   // Steps configuration
   const steps = useMemo(
     () => [
@@ -152,7 +174,8 @@ const OnboardingWizard: React.FC = () => {
       { id: 4, label: "Assets" },
       { id: 5, label: "Review" },
       { id: 6, label: "Independence" },
-      { id: 7, label: "Complete" },
+      { id: 7, label: "Brokerage" },
+      { id: 8, label: "Complete" },
     ],
     [],
   )
@@ -190,6 +213,8 @@ const OnboardingWizard: React.FC = () => {
       case 6:
         return true // Independence - always can proceed (optional step)
       case 7:
+        return true // Brokerage - always can proceed (optional step)
+      case 8:
         return true
       default:
         return false
@@ -321,7 +346,10 @@ const OnboardingWizard: React.FC = () => {
     return extractAsset(assetData)
   }
 
-  const createAssets = async (portfolioId: string): Promise<void> => {
+  const createAssets = async (
+    portfolioId: string,
+  ): Promise<{ bankAccountAssetIds: Record<string, string> }> => {
+    const bankAccountAssetIds: Record<string, string> = {}
     // Fetch existing user assets to avoid creating duplicates
     const existingResponse = await fetch("/api/assets")
     const existingAssets: Record<string, { id: string }> = existingResponse.ok
@@ -342,6 +370,10 @@ const OnboardingWizard: React.FC = () => {
         category: "ACCOUNT",
         currency: account.currency,
       })
+
+      if (asset?.id) {
+        bankAccountAssetIds[account.name] = asset.id
+      }
 
       if (asset?.id && account.balance && account.balance > 0) {
         await createTransaction(
@@ -502,6 +534,8 @@ const OnboardingWizard: React.FC = () => {
         })
       }
     }
+
+    return { bankAccountAssetIds }
   }
 
   const handleComplete = async (): Promise<void> => {
@@ -521,35 +555,47 @@ const OnboardingWizard: React.FC = () => {
       })
 
       // Create portfolio with reporting currency as display currency
-      // and base currency as cost tracking currency
-      const portfolioResponse = await fetch("/api/portfolios", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          data: [
-            {
-              code: portfolioCode,
-              name: portfolioName,
-              currency: reportingCurrency,
-              base: baseCurrency,
-            },
-          ],
-        }),
-      })
+      // and base currency as cost tracking currency. Make the call
+      // idempotent so a retry after a downstream failure (e.g. the
+      // optional Brokerage step erroring out) doesn't trip the
+      // (code, owner_id) unique constraint and 409 — reuse the
+      // existing portfolio with the same code instead.
+      const existingPortfolio = existingPortfolios.find(
+        (p) => p.code === portfolioCode,
+      )
+      let portfolioId: string | undefined = existingPortfolio?.id
+      if (!portfolioId) {
+        const portfolioResponse = await fetch("/api/portfolios", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            data: [
+              {
+                code: portfolioCode,
+                name: portfolioName,
+                currency: reportingCurrency,
+                base: baseCurrency,
+              },
+            ],
+          }),
+        })
 
-      if (!portfolioResponse.ok) {
-        const errorData = await portfolioResponse.json().catch(() => ({}))
-        setError(errorData.error || "Failed to create portfolio")
-        setIsSubmitting(false)
-        return
+        if (!portfolioResponse.ok) {
+          const errorData = await portfolioResponse.json().catch(() => ({}))
+          setError(errorData.error || "Failed to create portfolio")
+          setIsSubmitting(false)
+          return
+        }
+
+        const portfolioData = await portfolioResponse.json()
+        portfolioId = portfolioData.data[0]?.id
       }
+      setCreatedPortfolioId(portfolioId ?? null)
 
-      const portfolioData = await portfolioResponse.json()
-      // Response is { data: [Portfolio] }
-      const portfolioId = portfolioData.data[0]?.id
-      setCreatedPortfolioId(portfolioId)
-
-      // Create assets if any
+      // Create assets if any. The returned bankAccountAssetIds map is
+      // used below to wire the optional brokerage step's source to a
+      // specific bank-account asset.
+      let bankAccountAssetIds: Record<string, string> = {}
       if (
         portfolioId &&
         (bankAccounts.length > 0 ||
@@ -557,7 +603,8 @@ const OnboardingWizard: React.FC = () => {
           pensions.length > 0 ||
           insurances.length > 0)
       ) {
-        await createAssets(portfolioId)
+        const created = await createAssets(portfolioId)
+        bankAccountAssetIds = created.bankAccountAssetIds
       }
 
       // Trigger portfolio valuation by fetching holdings
@@ -627,8 +674,95 @@ const OnboardingWizard: React.FC = () => {
         }
       }
 
+      // Optional: open a brokerage as part of the onboarding flow. Runs
+      // AFTER the default portfolio is created so the user can fund the new
+      // broker cash from it. Failures are surfaced but don't abort the
+      // wizard — the user can retry from /tools/open-brokerage.
+      // Use the local `portfolioId` variable (set just above), not the
+      // React state `createdPortfolioId` — setState hasn't flushed inside
+      // the same async function call.
+      if (brokerageEnabled && brokerageBrokerName.trim() && portfolioId) {
+        const amt = parseFloat(brokerageAmount)
+        try {
+          // Brokerage gets its own dedicated portfolio (named after the
+          // broker) so its cash + future trades stay separate from the
+          // user's day-to-day bank-account portfolio. Source still
+          // resolves to a bank-account asset on the default portfolio
+          // when the user picked one, so a paired WITHDRAWAL hits the
+          // right line.
+          const brokerCode = brokerageBrokerName.trim()
+          // Reporting currency for the brokerage portfolio. User-picked in
+          // step 7; falls back to baseCurrency if they didn't touch the
+          // dropdown. `base` stays as the user's overall base currency for
+          // consolidated reporting upstream.
+          const brokerageCcy = brokerageCurrency || baseCurrency
+          const brokerageResult = await openBrokerage({
+            broker: { mode: "new", newName: brokerCode },
+            portfolio: {
+              mode: "new",
+              code: brokerCode,
+              name: `${brokerCode} Portfolio`,
+              currency: brokerageCcy,
+              base: baseCurrency,
+            },
+            funding:
+              Number.isFinite(amt) && amt > 0
+                ? (() => {
+                    const fund: {
+                      amount: number
+                      currency: string
+                      sourcePortfolioId?: string
+                      sourceAssetId?: string
+                    } = { amount: amt, currency: brokerageCcy }
+                    if (brokerageSource.startsWith("portfolio:")) {
+                      fund.sourcePortfolioId = brokerageSource.slice(
+                        "portfolio:".length,
+                      )
+                    } else if (brokerageSource.startsWith("bankAccount:")) {
+                      const name = brokerageSource.slice(
+                        "bankAccount:".length,
+                      )
+                      const assetId = bankAccountAssetIds[name]
+                      if (assetId) {
+                        fund.sourceAssetId = assetId
+                        // Bank-account assets live on the default
+                        // portfolio, not the new brokerage portfolio
+                        // being created — pin the WITHDRAWAL there.
+                        fund.sourcePortfolioId = portfolioId
+                      }
+                    }
+                    return fund
+                  })()
+                : undefined,
+          })
+          setBrokerageCreated(true)
+          // Trigger valuation for the new brokerage portfolio (same as we
+          // do for the default portfolio earlier); otherwise the home /
+          // portfolios list shows it with no market value until the user
+          // opens it.
+          try {
+            await fetch(`/api/holdings/${brokerCode}?asAt=${today}`, {
+              credentials: "include",
+            })
+          } catch (vErr) {
+            console.warn(
+              "Failed to trigger brokerage portfolio valuation:",
+              vErr,
+            )
+          }
+          // Touch result so eslint sees it as used; future caller may want
+          // the broker / portfolio ids for navigation.
+          void brokerageResult
+        } catch (bErr) {
+          console.warn("Onboarding brokerage setup failed:", bErr)
+          setError(
+            `Brokerage setup failed: ${bErr instanceof Error ? bErr.message : String(bErr)}. The rest of your setup was saved.`,
+          )
+        }
+      }
+
       // Move to complete step
-      setCurrentStep(7)
+      setCurrentStep(8)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Setup failed")
     } finally {
@@ -715,6 +849,29 @@ const OnboardingWizard: React.FC = () => {
         )
       case 7:
         return (
+          <BrokerageStep
+            enabled={brokerageEnabled}
+            brokerName={brokerageBrokerName}
+            source={brokerageSource}
+            amount={brokerageAmount}
+            currency={brokerageCurrency || baseCurrency || "USD"}
+            currencyCodes={
+              currencies.length > 0
+                ? currencies.map((c) => c.code)
+                : [baseCurrency || "USD"]
+            }
+            existingPortfolios={existingPortfolios}
+            bankAccounts={bankAccounts}
+            defaultPortfolioName={portfolioName}
+            onEnabledChange={setBrokerageEnabled}
+            onBrokerNameChange={setBrokerageBrokerName}
+            onSourceChange={setBrokerageSource}
+            onAmountChange={setBrokerageAmount}
+            onCurrencyChange={setBrokerageCurrency}
+          />
+        )
+      case 8:
+        return (
           <CompleteStep
             portfolioName={portfolioName}
             bankAccountCount={bankAccounts.length}
@@ -723,6 +880,7 @@ const OnboardingWizard: React.FC = () => {
             insuranceCount={insurances.length}
             portfolioId={createdPortfolioId}
             independencePlanCreated={independencePlanCreated}
+            brokerageCreated={brokerageCreated}
           />
         )
       default:
@@ -730,8 +888,42 @@ const OnboardingWizard: React.FC = () => {
     }
   }
 
+  // Per-step heading + lead, lifted out of the individual step
+  // components so the user sees what the step is for BEFORE the
+  // progress bar takes the visual focus. Renders right under the page's
+  // "Account Setup" title.
+  const stepIntro: Record<number, { title: string; lead: string }> = {
+    1: {
+      title: "Welcome to Beancounter!",
+      lead: "Quick setup — currency, portfolio, accounts. Skip and finish later in settings if you like.",
+    },
+    2: {
+      title: "Set your currencies",
+      lead: "Base currency tracks costs; reporting currency displays values. Default to the same one — they can differ.",
+    },
+    4: {
+      title: "Add your accounts",
+      lead: "Tell us about your assets to get a complete picture of your wealth. Optional.",
+    },
+    6: {
+      title: "Quick Independence Check",
+      lead: "Want to see how your finances might look in retirement? Just three quick questions.",
+    },
+    7: {
+      title: "Brokerage account",
+      lead: "Optional — set up a broker, a brokerage portfolio, and your opening cash deposit.",
+    },
+  }
+  const intro = stepIntro[currentStep]
+
   return (
     <div className="max-w-2xl mx-auto">
+      {intro && (
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-gray-900">{intro.title}</h2>
+          <p className="text-sm text-gray-600">{intro.lead}</p>
+        </div>
+      )}
       <OnboardingProgress currentStep={currentStep} steps={steps} />
 
       {error && (
@@ -747,7 +939,7 @@ const OnboardingWizard: React.FC = () => {
       {/* Navigation */}
       <div className="flex justify-between mt-6">
         <div>
-          {currentStep > 1 && currentStep < 7 && (
+          {currentStep > 1 && currentStep < 8 && (
             <button
               type="button"
               onClick={handleBack}
@@ -769,7 +961,7 @@ const OnboardingWizard: React.FC = () => {
             </button>
           )}
 
-          {currentStep < 6 && (
+          {currentStep < 7 && (
             <button
               type="button"
               onClick={handleNext}
@@ -784,7 +976,7 @@ const OnboardingWizard: React.FC = () => {
             </button>
           )}
 
-          {currentStep === 6 && (
+          {currentStep === 7 && (
             <button
               type="button"
               onClick={handleComplete}
@@ -806,7 +998,7 @@ const OnboardingWizard: React.FC = () => {
             </button>
           )}
 
-          {currentStep === 7 && (
+          {currentStep === 8 && (
             <button
               type="button"
               onClick={handleFinish}

--- a/src/components/features/onboarding/steps/AssetsStep.tsx
+++ b/src/components/features/onboarding/steps/AssetsStep.tsx
@@ -236,16 +236,10 @@ const AssetsStep: React.FC<AssetsStepProps> = ({
   }
 
   return (
-    <div className="py-4">
-      <h2 className="text-xl font-bold text-gray-900 mb-2">
-        {"Add your accounts"}
-      </h2>
-
-      <p className="text-gray-600 mb-6">
-        {
-          "Tell us about your assets to get a complete picture of your wealth. This step is optional."
-        }
-      </p>
+    <div className="py-2">
+      {/* Per-step title + lead are rendered by OnboardingWizard above the
+          progress bar so the user sees what the step is for before the
+          form takes the visual focus. */}
 
       {/* Added Assets Summary */}
       {totalAssets > 0 && (
@@ -373,33 +367,32 @@ const AssetsStep: React.FC<AssetsStepProps> = ({
         </div>
       )}
 
-      {/* Asset Type Selection */}
+      {/* Asset Type Selection — 2-col on small, 4-col on md+ so picker
+          stays above the fold even with the summary list. Each card is a
+          compact stack (icon, title, one-line description) instead of a
+          horizontal full-width row. */}
       {!selectedType && (
         <div className="space-y-3">
-          <h3 className="font-medium text-gray-700">
+          <h3 className="text-sm font-medium text-gray-700">
             {totalAssets > 0
               ? "Add another asset"
               : "Choose an asset type to add"}
           </h3>
-          <div className="grid grid-cols-1 gap-3">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
             {assetTypes.map((type) => (
               <button
                 key={type.id}
                 type="button"
                 onClick={() => setSelectedType(type.id)}
-                className={`p-4 rounded-lg border-2 text-left transition-all ${getColorClasses(type.color, false)}`}
+                className={`p-3 rounded-lg border-2 text-left transition-all h-full ${getColorClasses(type.color, false)}`}
               >
-                <div className="flex items-start">
-                  <div className={`text-2xl mr-4 ${getIconColor(type.color)}`}>
-                    <i className={`fas ${type.icon}`}></i>
-                  </div>
-                  <div>
-                    <h4 className="font-medium text-gray-900">{type.title}</h4>
-                    <p className="text-sm text-gray-600 mt-1">
-                      {type.description}
-                    </p>
-                  </div>
+                <div className={`text-2xl mb-2 ${getIconColor(type.color)}`}>
+                  <i className={`fas ${type.icon}`}></i>
                 </div>
+                <h4 className="font-medium text-gray-900 text-sm">
+                  {type.title}
+                </h4>
+                <p className="text-xs text-gray-600 mt-1">{type.description}</p>
               </button>
             ))}
           </div>

--- a/src/components/features/onboarding/steps/BrokerageStep.tsx
+++ b/src/components/features/onboarding/steps/BrokerageStep.tsx
@@ -1,0 +1,225 @@
+import React from "react"
+import Link from "next/link"
+import MathInput from "@components/ui/MathInput"
+import type { Portfolio } from "types/beancounter"
+import type { BankAccount } from "../OnboardingWizard"
+
+// The source dropdown's value encodes WHICH backend object the WITHDRAWAL
+// should hit: a portfolio (uses its generic cash asset) or a specific
+// bank-account asset on the default portfolio (e.g. the "DBS" PRIVATE
+// line the user just added in step 4). Format keeps both shapes in a
+// single <select> value string.
+//   ""                              → no source (standalone deposit)
+//   "portfolio:{id}"                → withdraw from portfolio's CASH/{ccy}
+//   "bankAccount:{name}"            → withdraw from bank-account asset
+export type SourceValue = "" | `portfolio:${string}` | `bankAccount:${string}`
+
+export interface BrokerageStepProps {
+  enabled: boolean
+  brokerName: string
+  source: SourceValue
+  amount: string // free text; parsed at submit
+  // User-chosen reporting currency for the new brokerage portfolio.
+  // Defaults to the user's baseCurrency but they can pick any code from
+  // `currencyCodes` (e.g. USD broker funded from SGD bank balances).
+  currency: string
+  currencyCodes: string[]
+  // Portfolios the user already has — used to populate the source dropdown.
+  // The default portfolio created earlier in this onboarding is NOT in this
+  // list because it lives in component state, not the backend yet; we expose
+  // it as a synthetic "Default portfolio" option via the defaultPortfolioName
+  // prop instead.
+  existingPortfolios: Portfolio[]
+  // Bank accounts the user added in step 4 — surfaced as additional source
+  // options so the brokerage deposit can be funded from a specific
+  // bank-account line on the default portfolio.
+  bankAccounts: BankAccount[]
+  defaultPortfolioName: string
+  onEnabledChange: (v: boolean) => void
+  onBrokerNameChange: (v: string) => void
+  onSourceChange: (v: SourceValue) => void
+  onAmountChange: (v: string) => void
+  onCurrencyChange: (v: string) => void
+}
+
+/**
+ * Optional brokerage setup as a step inside the onboarding wizard.
+ * Compact form — only the fields needed to drive the openBrokerage
+ * orchestrator. Reuses the orchestrator from the standalone wizard at
+ * /tools/open-brokerage so the two surfaces stay consistent.
+ */
+const BrokerageStep: React.FC<BrokerageStepProps> = ({
+  enabled,
+  brokerName,
+  source,
+  amount,
+  currency,
+  currencyCodes,
+  existingPortfolios,
+  bankAccounts,
+  defaultPortfolioName,
+  onEnabledChange,
+  onBrokerNameChange,
+  onSourceChange,
+  onAmountChange,
+  onCurrencyChange,
+}) => {
+  // Filter source options to the chosen currency (same-currency v1).
+  const sameCurrencyPortfolios = existingPortfolios.filter(
+    (p) => p.currency?.code === currency,
+  )
+  const sameCurrencyBankAccounts = bankAccounts.filter(
+    (b) => b.currency === currency,
+  )
+  // If the user has bank accounts but none in the chosen currency, they
+  // probably expected to fund from a different-currency balance. Surface
+  // it explicitly so they don't end up with a silent standalone deposit.
+  const otherCurrencyBankAccounts = bankAccounts.filter(
+    (b) => b.currency !== currency,
+  )
+  const showFxNotice =
+    sameCurrencyBankAccounts.length === 0 &&
+    otherCurrencyBankAccounts.length > 0
+  return (
+    <div className="py-2">
+      <p className="text-gray-500 text-xs mb-3">
+        {"Also available later from "}
+        <Link
+          href="/tools/open-brokerage"
+          className="text-purple-600 hover:underline"
+        >
+          {"Tools → Open Brokerage"}
+        </Link>
+        {"."}
+      </p>
+
+      <label className="flex items-center gap-2 mb-4">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => onEnabledChange(e.target.checked)}
+        />
+        <span className="text-sm font-medium text-gray-700">
+          {"Yes, set up a brokerage account now"}
+        </span>
+      </label>
+
+      {enabled && (
+        <div className="space-y-3 max-w-md">
+          <div>
+            <label
+              htmlFor="ob-broker"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              {"Broker name"}
+            </label>
+            <input
+              id="ob-broker"
+              type="text"
+              value={brokerName}
+              onChange={(e) => onBrokerNameChange(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              placeholder="e.g. IBRK"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              {`A new portfolio "${brokerName || "BROKER"} Portfolio" will be created for your brokerage, keeping its cash and trades separate from your "${defaultPortfolioName}" bank-account portfolio.`}
+            </p>
+          </div>
+
+          <div>
+            <label
+              htmlFor="ob-currency"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              {"Reporting currency"}
+            </label>
+            <select
+              id="ob-currency"
+              value={currency}
+              onChange={(e) => onCurrencyChange(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+            >
+              {currencyCodes.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-gray-500 mt-1">
+              {`Cash and trades in this brokerage portfolio will report in ${currency}. Picking a different currency from the bank-account source needs FX (not handled in v1 — same-currency source only).`}
+            </p>
+          </div>
+
+          <div>
+            <label
+              htmlFor="ob-amount"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              {`Opening deposit (${currency})`}
+            </label>
+            <MathInput
+              id="ob-amount"
+              value={amount}
+              onChange={(v) => onAmountChange(v === 0 ? "" : String(v))}
+              min={0}
+              placeholder="0"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="ob-source"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              {"Source (optional)"}
+            </label>
+            {showFxNotice && (
+              <div className="mb-2 px-3 py-2 rounded bg-amber-50 border border-amber-200 text-xs text-amber-800">
+                {`You have bank accounts in ${otherCurrencyBankAccounts
+                  .map((b) => b.currency)
+                  .filter((c, i, a) => a.indexOf(c) === i)
+                  .join(", ")} but the brokerage currency is ${currency}. Cross-currency funding (FX) isn't supported yet — the opening deposit will be recorded as a standalone cash injection on the new portfolio with no matching withdrawal.`}
+              </div>
+            )}
+            <select
+              id="ob-source"
+              value={source}
+              onChange={(e) =>
+                onSourceChange(e.target.value as SourceValue)
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+            >
+              <option value="">— None (standalone deposit) —</option>
+              {sameCurrencyBankAccounts.length > 0 && (
+                <optgroup label={`Bank accounts on "${defaultPortfolioName}"`}>
+                  {sameCurrencyBankAccounts.map((b) => (
+                    <option key={`b-${b.name}`} value={`bankAccount:${b.name}`}>
+                      {b.name}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+              {sameCurrencyPortfolios.length > 0 && (
+                <optgroup label="Other portfolios">
+                  {sameCurrencyPortfolios.map((p) => (
+                    <option key={`p-${p.id}`} value={`portfolio:${p.id}`}>
+                      {p.name} ({p.code})
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+            </select>
+            <p className="text-xs text-gray-500 mt-1">
+              {
+                "Picking a source posts a matching withdrawal so the source's cash stays accurate."
+              }
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default BrokerageStep

--- a/src/components/features/onboarding/steps/CompleteStep.tsx
+++ b/src/components/features/onboarding/steps/CompleteStep.tsx
@@ -8,8 +8,11 @@ interface CompleteStepProps {
   insuranceCount: number
   portfolioId: string | null
   independencePlanCreated?: boolean
+  brokerageCreated?: boolean
 }
 
+// Compact "you're all set" — single screen. Summary as horizontal chips,
+// next-step pointers side-by-side, no oversized icon header.
 const CompleteStep: React.FC<CompleteStepProps> = ({
   portfolioName,
   bankAccountCount,
@@ -17,69 +20,114 @@ const CompleteStep: React.FC<CompleteStepProps> = ({
   pensionCount,
   insuranceCount,
   independencePlanCreated,
+  brokerageCreated,
 }) => {
-  return (
-    <div className="text-center py-6">
-      <div className="text-5xl mb-6 text-green-500">
-        <i className="fas fa-check-circle"></i>
-      </div>
+  const chips: Array<{ icon: string; color: string; label: string }> = [
+    { icon: "fa-folder", color: "text-blue-500", label: portfolioName },
+    ...(bankAccountCount > 0
+      ? [
+          {
+            icon: "fa-university",
+            color: "text-blue-500",
+            label: `${bankAccountCount} bank account${bankAccountCount === 1 ? "" : "s"}`,
+          },
+        ]
+      : []),
+    ...(propertyCount > 0
+      ? [
+          {
+            icon: "fa-home",
+            color: "text-green-500",
+            label: `${propertyCount} propert${propertyCount === 1 ? "y" : "ies"}`,
+          },
+        ]
+      : []),
+    ...(pensionCount > 0
+      ? [
+          {
+            icon: "fa-piggy-bank",
+            color: "text-purple-500",
+            label: `${pensionCount} pension${pensionCount === 1 ? "" : "s"}`,
+          },
+        ]
+      : []),
+    ...(insuranceCount > 0
+      ? [
+          {
+            icon: "fa-shield-alt",
+            color: "text-teal-500",
+            label: `${insuranceCount} insurance${insuranceCount === 1 ? "" : " policies"}`,
+          },
+        ]
+      : []),
+    ...(brokerageCreated
+      ? [
+          {
+            icon: "fa-building-columns",
+            color: "text-purple-500",
+            label: "Brokerage set up",
+          },
+        ]
+      : []),
+  ]
 
-      <h2 className="text-2xl font-bold text-gray-900 mb-4">
+  return (
+    <div className="py-2">
+      <h2 className="text-xl font-bold text-gray-900 flex items-center gap-2 mb-1">
+        <i className="fas fa-check-circle text-green-500"></i>
         {"You're all set!"}
       </h2>
-
-      <p className="text-gray-600 mb-6">
-        {"Your account has been set up successfully. Here's what was created:"}
+      <p className="text-sm text-gray-600 mb-3">
+        {"Created:"}
       </p>
 
-      {/* Summary */}
-      <div className="bg-gray-50 rounded-lg p-4 max-w-sm mx-auto">
-        <ul className="text-left space-y-2">
-          <li className="flex items-center text-gray-700">
-            <i className="fas fa-folder text-blue-500 w-6"></i>
-            <span>
-              {"Portfolio:"} <strong>{portfolioName}</strong>
-            </span>
-          </li>
-          {bankAccountCount > 0 && (
-            <li className="flex items-center text-gray-700">
-              <i className="fas fa-university text-blue-500 w-6"></i>
-              <span>{`${bankAccountCount} bank account(s)`}</span>
-            </li>
-          )}
-          {propertyCount > 0 && (
-            <li className="flex items-center text-gray-700">
-              <i className="fas fa-home text-green-500 w-6"></i>
-              <span>{`${propertyCount} property(ies)`}</span>
-            </li>
-          )}
-          {pensionCount > 0 && (
-            <li className="flex items-center text-gray-700">
-              <i className="fas fa-piggy-bank text-purple-500 w-6"></i>
-              <span>{`${pensionCount} pension plan(s)`}</span>
-            </li>
-          )}
-          {insuranceCount > 0 && (
-            <li className="flex items-center text-gray-700">
-              <i className="fas fa-shield-alt text-teal-500 w-6"></i>
-              <span>{`${insuranceCount} insurance policy(ies)`}</span>
-            </li>
-          )}
-          {independencePlanCreated && (
-            <li className="flex items-center text-gray-700">
-              <i className="fas fa-chart-line text-independence-500 w-6"></i>
-              <span>
-                {"Independence Plan created"}{" "}
-                <Link
-                  href="/independence"
-                  className="text-independence-600 hover:underline"
-                >
-                  {"View plan"}
-                </Link>
-              </span>
-            </li>
-          )}
-        </ul>
+      {/* Horizontal summary chips */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        {chips.map((c, i) => (
+          <span
+            key={i}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-gray-100 text-xs text-gray-700"
+          >
+            <i className={`fas ${c.icon} ${c.color}`}></i>
+            {c.label}
+          </span>
+        ))}
+        {independencePlanCreated && (
+          <Link
+            href="/independence"
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-independence-50 text-xs text-independence-700 hover:bg-independence-100"
+          >
+            <i className="fas fa-chart-line text-independence-500"></i>
+            {"Independence Plan"}
+            <i className="fas fa-arrow-right text-[10px]"></i>
+          </Link>
+        )}
+      </div>
+
+      {/* Next-step pointers — side-by-side, compact */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="bg-purple-50 border border-purple-200 rounded-lg p-3 text-sm">
+          <div className="font-semibold text-gray-900 flex items-center gap-1.5 mb-1">
+            <i className="fas fa-building-columns text-purple-500"></i>
+            {"More brokerage accounts"}
+          </div>
+          <p className="text-xs text-gray-600">
+            {"Use "}
+            <strong>Tools → Open Brokerage</strong>
+            {" any time to add another broker."}
+          </p>
+        </div>
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-sm">
+          <div className="font-semibold text-gray-900 flex items-center gap-1.5 mb-1">
+            <i className="fas fa-coins text-blue-500"></i>
+            {"Other assets"}
+          </div>
+          <p className="text-xs text-gray-600">
+            {"Use the "}
+            <strong>Wealth</strong>
+            {" menu to record assets BC doesn't natively support — collectibles, alt-investments, anything off-market."}
+          </p>
+        </div>
       </div>
     </div>
   )

--- a/src/components/features/onboarding/steps/CurrencyStep.tsx
+++ b/src/components/features/onboarding/steps/CurrencyStep.tsx
@@ -35,37 +35,24 @@ const CurrencyStep: React.FC<CurrencyStepProps> = ({
   }
 
   return (
-    <div className="py-4">
-      <h2 className="text-xl font-bold text-gray-900 mb-2">
-        {"Set your currencies"}
-      </h2>
-
-      <p className="text-gray-600 mb-6">
-        {
-          "Select the currency you primarily use. This will be used for tracking costs and displaying values."
-        }
-      </p>
-
+    <div className="py-2">
       {/* Base Currency */}
-      <div className="mb-6">
-        <h3 className="font-medium text-gray-900 mb-2">
-          {"System Base Currency"}
+      <div className="mb-3">
+        <h3 className="text-sm font-medium text-gray-900 mb-1">
+          {"Base Currency"}
           {!baseCurrency && (
-            <span className="ml-2 text-sm text-orange-600 font-normal">
+            <span className="ml-2 text-xs text-orange-600 font-normal">
               {"(please select)"}
             </span>
           )}
         </h3>
-        <p className="text-sm text-gray-500 mb-3">
-          {"Used for cost tracking and as the default for new portfolios."}
-        </p>
-        <div className="grid grid-cols-2 gap-3 max-w-md">
+        <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
           {currencies.map((currency) => (
             <button
               key={currency.code}
               type="button"
               onClick={() => handleBaseCurrencyChange(currency.code)}
-              className={`p-3 rounded-lg border-2 text-left transition-all ${
+              className={`px-2 py-1.5 rounded border-2 text-left transition-all text-sm ${
                 baseCurrency === currency.code
                   ? "border-blue-500 bg-blue-50"
                   : "border-gray-200 hover:border-gray-300"
@@ -74,43 +61,37 @@ const CurrencyStep: React.FC<CurrencyStepProps> = ({
               <div className="font-medium text-gray-900">
                 {currency.symbol} {currency.code}
               </div>
-              <div className="text-xs text-gray-500">{currency.name}</div>
             </button>
           ))}
         </div>
       </div>
 
       {/* Same currency toggle */}
-      <div className="mb-6">
-        <label className="flex items-center cursor-pointer">
-          <input
-            type="checkbox"
-            checked={useSameCurrency}
-            onChange={handleToggleSameCurrency}
-            className="w-4 h-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
-          />
-          <span className="ml-2 text-gray-700">
-            {"Use the same currency for reporting values"}
-          </span>
-        </label>
-      </div>
+      <label className="flex items-center cursor-pointer mb-3 text-sm text-gray-700">
+        <input
+          type="checkbox"
+          checked={useSameCurrency}
+          onChange={handleToggleSameCurrency}
+          className="w-4 h-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+        />
+        <span className="ml-2">
+          {"Use the same currency for reporting values"}
+        </span>
+      </label>
 
       {/* Reporting Currency - only show if different from base */}
       {!useSameCurrency && (
         <div>
-          <h3 className="font-medium text-gray-900 mb-2">
+          <h3 className="text-sm font-medium text-gray-900 mb-1">
             {"Reporting Currency"}
           </h3>
-          <p className="text-sm text-gray-500 mb-3">
-            {"The currency used to display portfolio values and reports."}
-          </p>
-          <div className="grid grid-cols-2 gap-3 max-w-md">
+          <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
             {currencies.map((currency) => (
               <button
                 key={currency.code}
                 type="button"
                 onClick={() => onReportingCurrencyChange(currency.code)}
-                className={`p-3 rounded-lg border-2 text-left transition-all ${
+                className={`px-2 py-1.5 rounded border-2 text-left transition-all text-sm ${
                   reportingCurrency === currency.code
                     ? "border-green-500 bg-green-50"
                     : "border-gray-200 hover:border-gray-300"
@@ -119,7 +100,6 @@ const CurrencyStep: React.FC<CurrencyStepProps> = ({
                 <div className="font-medium text-gray-900">
                   {currency.symbol} {currency.code}
                 </div>
-                <div className="text-xs text-gray-500">{currency.name}</div>
               </button>
             ))}
           </div>

--- a/src/components/features/onboarding/steps/IndependencePlanStep.tsx
+++ b/src/components/features/onboarding/steps/IndependencePlanStep.tsx
@@ -26,43 +26,34 @@ const IndependencePlanStep: React.FC<IndependencePlanStepProps> = ({
 }) => {
   return (
     <div className="space-y-6">
-      <div className="text-center">
-        <div className="text-4xl mb-4 text-independence-500">
-          <i className="fas fa-chart-line"></i>
-        </div>
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">
-          {"Quick Independence Check"}
-        </h2>
-        <p className="text-gray-600">
-          {
-            "Want to see how your finances might look in retirement? Just three quick questions."
-          }
-        </p>
-      </div>
-
-      {/* Enable/Skip toggle */}
+      {/* Enable/Skip toggle. Tick follows the selected option so the user
+          sees clear feedback when picking either path (previously hardcoded
+          on "Yes" regardless of state — Skip felt unresponsive). */}
       <div className="flex items-center justify-center gap-4">
         <button
           type="button"
           onClick={() => onEnabledChange(true)}
-          className={`px-6 py-3 rounded-lg font-medium transition-colors ${
+          aria-pressed={enabled}
+          className={`px-6 py-3 rounded-lg font-medium transition-colors border-2 ${
             enabled
-              ? "bg-independence-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              ? "bg-independence-600 text-white border-independence-600"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200 border-transparent"
           }`}
         >
-          <i className="fas fa-check mr-2"></i>
+          {enabled && <i className="fas fa-check mr-2"></i>}
           {"Yes, let's do it"}
         </button>
         <button
           type="button"
           onClick={() => onEnabledChange(false)}
-          className={`px-6 py-3 rounded-lg font-medium transition-colors ${
+          aria-pressed={!enabled}
+          className={`px-6 py-3 rounded-lg font-medium transition-colors border-2 ${
             !enabled
-              ? "bg-gray-200 text-gray-700"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              ? "bg-gray-700 text-white border-gray-700"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200 border-transparent"
           }`}
         >
+          {!enabled && <i className="fas fa-check mr-2"></i>}
           {"Skip for now"}
         </button>
       </div>

--- a/src/components/features/onboarding/steps/WelcomeStep.tsx
+++ b/src/components/features/onboarding/steps/WelcomeStep.tsx
@@ -1,34 +1,23 @@
 import React from "react"
+
 interface WelcomeStepProps {
   preferredName: string
   onPreferredNameChange: (name: string) => void
 }
 
+// Compact Welcome step — single screen, no scroll on a 800x600 viewport.
+// Icon dropped, vertical paddings tightened, "what we'll cover" inlined
+// as a one-line summary rather than a full panel.
 const WelcomeStep: React.FC<WelcomeStepProps> = ({
   preferredName,
   onPreferredNameChange,
 }) => {
   return (
-    <div className="text-center py-6">
-      <div className="text-5xl mb-6">
-        <i className="fas fa-chart-line text-blue-500"></i>
-      </div>
-
-      <h2 className="text-2xl font-bold text-gray-900 mb-4">
-        {"Welcome to Beancounter!"}
-      </h2>
-
-      <p className="text-gray-600 mb-6 max-w-md mx-auto">
-        {
-          "Let's set up your account in a few quick steps. We'll help you create your first portfolio and add your accounts."
-        }
-      </p>
-
-      {/* Preferred Name Input */}
-      <div className="max-w-sm mx-auto mb-6">
+    <div className="py-2">
+      <div className="max-w-sm mb-4">
         <label
           htmlFor="preferredName"
-          className="block text-sm font-medium text-gray-700 mb-2 text-left"
+          className="block text-sm font-medium text-gray-700 mb-1"
         >
           {"What should we call you?"}
         </label>
@@ -38,36 +27,26 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({
           value={preferredName}
           onChange={(e) => onPreferredNameChange(e.target.value)}
           placeholder={"Your first name"}
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          className="w-full px-3 py-2 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         />
-        <p className="text-sm text-gray-500 mt-1 text-left">
-          {"This is how we'll greet you throughout the app."}
-        </p>
       </div>
 
-      <div className="bg-gray-50 rounded-lg p-4 max-w-sm mx-auto">
-        <h3 className="font-medium text-gray-900 mb-3">
-          {"What we'll cover:"}
-        </h3>
-        <ul className="text-left text-gray-600 space-y-2">
-          <li className="flex items-center">
-            <i className="fas fa-dollar-sign text-blue-500 w-5 mr-2"></i>
-            {"Choose your base currency"}
-          </li>
-          <li className="flex items-center">
-            <i className="fas fa-folder text-blue-500 w-5 mr-2"></i>
-            {"Create your first portfolio"}
-          </li>
-          <li className="flex items-center">
-            <i className="fas fa-university text-blue-500 w-5 mr-2"></i>
-            {"Add your bank accounts & property"}
-          </li>
-        </ul>
+      <div className="text-xs text-gray-500 flex flex-wrap gap-x-4 gap-y-1">
+        <span>
+          <i className="fas fa-dollar-sign text-blue-500 mr-1"></i>Currency
+        </span>
+        <span>
+          <i className="fas fa-folder text-blue-500 mr-1"></i>Portfolio
+        </span>
+        <span>
+          <i className="fas fa-university text-blue-500 mr-1"></i>Bank accounts
+          &amp; property
+        </span>
+        <span>
+          <i className="fas fa-building-columns text-purple-500 mr-1"></i>
+          Brokerage
+        </span>
       </div>
-
-      <p className="text-sm text-gray-500 mt-6">
-        {"You can skip this setup and complete it later from settings."}
-      </p>
     </div>
   )
 }

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -1,0 +1,562 @@
+import React, { useEffect, useMemo, useState } from "react"
+import useSwr from "swr"
+import {
+  openBrokerage,
+  type OpenBrokerageResult,
+} from "@lib/openBrokerage/orchestrate"
+import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
+import type { Broker, Currency, Portfolio } from "types/beancounter"
+
+type Step = "broker" | "portfolio" | "funding" | "review" | "done"
+
+interface BrokerState {
+  mode: "existing" | "new"
+  existingId: string
+  newName: string
+  newAccountNumber: string
+}
+
+interface PortfolioState {
+  mode: "new" | "existing"
+  // mode === "new"
+  code: string
+  name: string
+  currency: string
+  // mode === "existing"
+  existingId: string
+}
+
+interface FundingState {
+  amount: string // free-text input; parsed at submit
+  sourcePortfolioId: string // empty = no source (cash injection)
+}
+
+// Fallback list — used only if /api/currencies hasn't returned yet so the
+// dropdown isn't empty on first paint. Replaced by backend response as soon
+// as SWR resolves.
+const FALLBACK_CURRENCIES = ["USD", "SGD", "EUR", "GBP", "AUD", "NZD", "HKD", "JPY"]
+
+const STEP_TITLES: Record<Exclude<Step, "done">, string> = {
+  broker: "Broker",
+  portfolio: "Portfolio",
+  funding: "Funding (optional)",
+  review: "Review",
+}
+
+const STEP_ORDER: Exclude<Step, "done">[] = [
+  "broker",
+  "portfolio",
+  "funding",
+  "review",
+]
+
+function StepHeader({ step }: { step: Exclude<Step, "done"> }): React.ReactElement {
+  const idx = STEP_ORDER.indexOf(step) + 1
+  return (
+    <div className="mb-6">
+      <p className="text-xs uppercase tracking-wider text-gray-500 mb-1">
+        Step {idx} of {STEP_ORDER.length}
+      </p>
+      <h1 className="text-2xl font-bold text-gray-900">{STEP_TITLES[step]}</h1>
+    </div>
+  )
+}
+
+export default function OpenBrokerageWizard(): React.ReactElement {
+  const [step, setStep] = useState<Step>("broker")
+  const [broker, setBroker] = useState<BrokerState>({
+    mode: "new",
+    existingId: "",
+    newName: "",
+    newAccountNumber: "",
+  })
+  const [portfolio, setPortfolio] = useState<PortfolioState>({
+    mode: "new",
+    code: "",
+    name: "",
+    currency: "USD",
+    existingId: "",
+  })
+  const [funding, setFunding] = useState<FundingState>({
+    amount: "",
+    sourcePortfolioId: "",
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<OpenBrokerageResult | null>(null)
+
+  const { data: brokersData } = useSwr<{ data: Broker[] }>(
+    "/api/brokers",
+    simpleFetcher("/api/brokers"),
+  )
+  const { data: portfoliosData } = useSwr<{ data: Portfolio[] }>(
+    "/api/portfolios",
+    simpleFetcher("/api/portfolios"),
+  )
+  const { data: currenciesData } = useSwr<{ data: Currency[] }>(
+    ccyKey,
+    simpleFetcher(ccyKey),
+  )
+  const brokers = useMemo(() => brokersData?.data ?? [], [brokersData])
+  const portfolios = useMemo(
+    () => portfoliosData?.data ?? [],
+    [portfoliosData],
+  )
+  const currencyCodes = useMemo(() => {
+    const codes = currenciesData?.data?.map((c) => c.code)
+    return codes && codes.length > 0 ? codes : FALLBACK_CURRENCIES
+  }, [currenciesData])
+
+  const sameCurrencySources = useMemo(
+    () => portfolios.filter((p) => p.currency?.code === portfolio.currency),
+    [portfolios, portfolio.currency],
+  )
+
+  // If the user backs up and changes the portfolio currency, drop a
+  // previously-picked source portfolio if it no longer matches.
+  // Otherwise a cross-currency source id would sneak through to submit.
+  useEffect(() => {
+    if (
+      funding.sourcePortfolioId &&
+      !sameCurrencySources.some((p) => p.id === funding.sourcePortfolioId)
+    ) {
+      setFunding((f) => ({ ...f, sourcePortfolioId: "" }))
+    }
+  }, [sameCurrencySources, funding.sourcePortfolioId])
+
+  const brokerValid =
+    broker.mode === "existing"
+      ? !!broker.existingId
+      : broker.newName.trim().length > 0
+  const portfolioValid =
+    portfolio.mode === "existing"
+      ? !!portfolio.existingId
+      : portfolio.code.trim().length > 0 && portfolio.name.trim().length > 0
+
+  const back = (): void => {
+    const i = STEP_ORDER.indexOf(step as Exclude<Step, "done">)
+    if (i > 0) setStep(STEP_ORDER[i - 1])
+  }
+
+  const advance = (): void => {
+    const i = STEP_ORDER.indexOf(step as Exclude<Step, "done">)
+    if (i < STEP_ORDER.length - 1) setStep(STEP_ORDER[i + 1])
+  }
+
+  const submit = async (): Promise<void> => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const amount = parseFloat(funding.amount)
+      const res = await openBrokerage({
+        broker: {
+          mode: broker.mode,
+          existingId: broker.existingId || undefined,
+          newName: broker.newName || undefined,
+          newAccountNumber: broker.newAccountNumber || undefined,
+        },
+        portfolio:
+          portfolio.mode === "existing"
+            ? {
+                mode: "existing",
+                existingId: portfolio.existingId,
+                currency: portfolio.currency,
+              }
+            : {
+                mode: "new",
+                code: portfolio.code,
+                name: portfolio.name,
+                currency: portfolio.currency,
+                base: portfolio.currency,
+              },
+        funding:
+          Number.isFinite(amount) && amount > 0
+            ? {
+                amount,
+                currency: portfolio.currency,
+                sourcePortfolioId: funding.sourcePortfolioId || undefined,
+              }
+            : undefined,
+      })
+      setResult(res)
+      setStep("done")
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (step === "done") {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-12 text-center">
+        <h1 className="text-2xl font-bold text-gray-900 mb-3">
+          {"Done — brokerage opened"}
+        </h1>
+        <p className="text-gray-600 mb-6">
+          {`Portfolio ${portfolio.code} ready. `}
+          {result?.trnIds.length
+            ? `${result.trnIds.length} cash transaction(s) posted.`
+            : "No initial deposit posted."}
+        </p>
+        <a
+          href={`/holdings/${result?.portfolioId ?? ""}`}
+          className="btn-primary"
+        >
+          {"View the portfolio"}
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <StepHeader step={step} />
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 px-4 py-3 rounded bg-red-50 border border-red-200 text-sm text-red-700"
+        >
+          {error}
+        </div>
+      )}
+
+      {step === "broker" && (
+        <div className="space-y-4">
+          <fieldset className="space-y-3">
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="broker-mode"
+                checked={broker.mode === "new"}
+                onChange={() => setBroker({ ...broker, mode: "new" })}
+              />
+              <span>Create a new broker</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="broker-mode"
+                checked={broker.mode === "existing"}
+                onChange={() => setBroker({ ...broker, mode: "existing" })}
+                disabled={brokers.length === 0}
+              />
+              <span>
+                Use an existing broker{" "}
+                {brokers.length === 0 && "(none yet)"}
+              </span>
+            </label>
+          </fieldset>
+
+          {broker.mode === "new" ? (
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="broker-name" className="block text-sm font-medium text-gray-700 mb-1">
+                  {"Broker name"}
+                </label>
+                <input
+                  id="broker-name"
+                  type="text"
+                  value={broker.newName}
+                  onChange={(e) =>
+                    setBroker({ ...broker, newName: e.target.value })
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  placeholder="e.g. Interactive Brokers"
+                />
+              </div>
+              <div>
+                <label htmlFor="broker-acct" className="block text-sm font-medium text-gray-700 mb-1">
+                  {"Account number (optional)"}
+                </label>
+                <input
+                  id="broker-acct"
+                  type="text"
+                  value={broker.newAccountNumber}
+                  onChange={(e) =>
+                    setBroker({ ...broker, newAccountNumber: e.target.value })
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                />
+              </div>
+            </div>
+          ) : (
+            <div>
+              <label htmlFor="broker-select" className="block text-sm font-medium text-gray-700 mb-1">
+                {"Existing broker"}
+              </label>
+              <select
+                id="broker-select"
+                value={broker.existingId}
+                onChange={(e) =>
+                  setBroker({ ...broker, existingId: e.target.value })
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              >
+                <option value="">— Select —</option>
+                {brokers.map((b) => (
+                  <option key={b.id} value={b.id}>
+                    {b.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+      )}
+
+      {step === "portfolio" && (
+        <div className="space-y-3">
+          <fieldset className="space-y-3">
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="portfolio-mode"
+                checked={portfolio.mode === "new"}
+                onChange={() => setPortfolio({ ...portfolio, mode: "new" })}
+              />
+              <span>Create a new portfolio for this brokerage</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="portfolio-mode"
+                checked={portfolio.mode === "existing"}
+                onChange={() =>
+                  setPortfolio({ ...portfolio, mode: "existing" })
+                }
+                disabled={portfolios.length === 0}
+              />
+              <span>
+                Attach to an existing portfolio{" "}
+                {portfolios.length === 0 && "(none yet)"}
+              </span>
+            </label>
+          </fieldset>
+
+          {portfolio.mode === "existing" ? (
+            <div>
+              <label
+                htmlFor="pf-existing"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {"Existing portfolio"}
+              </label>
+              <select
+                id="pf-existing"
+                value={portfolio.existingId}
+                onChange={(e) => {
+                  const id = e.target.value
+                  const pf = portfolios.find((p) => p.id === id)
+                  setPortfolio({
+                    ...portfolio,
+                    existingId: id,
+                    currency: pf?.currency?.code ?? portfolio.currency,
+                  })
+                }}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              >
+                <option value="">— Select —</option>
+                {portfolios.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} ({p.code}, {p.currency?.code})
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-gray-500 mt-1">
+                {`Deposits will land on a per-broker cash line (e.g. ${broker.newName || "BROKER"}-${portfolio.currency}) so the brokerage cash stays separate from any existing cash on this portfolio.`}
+              </p>
+            </div>
+          ) : (
+            <>
+              <div>
+                <label htmlFor="pf-code" className="block text-sm font-medium text-gray-700 mb-1">
+                  {"Portfolio code"}
+                </label>
+                <input
+                  id="pf-code"
+                  type="text"
+                  value={portfolio.code}
+                  onChange={(e) =>
+                    setPortfolio({ ...portfolio, code: e.target.value })
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  placeholder="e.g. IBRK"
+                />
+              </div>
+              <div>
+                <label htmlFor="pf-name" className="block text-sm font-medium text-gray-700 mb-1">
+                  {"Portfolio name"}
+                </label>
+                <input
+                  id="pf-name"
+                  type="text"
+                  value={portfolio.name}
+                  onChange={(e) =>
+                    setPortfolio({ ...portfolio, name: e.target.value })
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  placeholder="e.g. Interactive Brokers"
+                />
+              </div>
+            </>
+          )}
+          {portfolio.mode === "new" && (
+            <div>
+              <label
+                htmlFor="pf-ccy"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {"Currency"}
+              </label>
+              <select
+                id="pf-ccy"
+                value={portfolio.currency}
+                onChange={(e) =>
+                  setPortfolio({ ...portfolio, currency: e.target.value })
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              >
+                {currencyCodes.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+      )}
+
+      {step === "funding" && (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            {`Optional — fund the new portfolio in ${portfolio.currency}. Pick a source portfolio (must be in ${portfolio.currency}) to record a matching withdrawal, or leave blank for a standalone deposit.`}
+          </p>
+          <div>
+            <label htmlFor="fund-amount" className="block text-sm font-medium text-gray-700 mb-1">
+              {"Amount"}
+            </label>
+            <input
+              id="fund-amount"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              value={funding.amount}
+              onChange={(e) =>
+                setFunding({ ...funding, amount: e.target.value })
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              placeholder="0"
+            />
+          </div>
+          <div>
+            <label htmlFor="fund-source" className="block text-sm font-medium text-gray-700 mb-1">
+              {"Source portfolio (optional)"}
+            </label>
+            <select
+              id="fund-source"
+              value={funding.sourcePortfolioId}
+              onChange={(e) =>
+                setFunding({ ...funding, sourcePortfolioId: e.target.value })
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+            >
+              <option value="">— None (deposit only) —</option>
+              {sameCurrencySources.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name} ({p.code})
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {step === "review" && (
+        <div className="space-y-4">
+          <div className="bg-gray-50 border border-gray-200 rounded-md p-4 text-sm">
+            <dl className="grid grid-cols-3 gap-y-2">
+              <dt className="text-gray-500">Broker</dt>
+              <dd className="col-span-2 text-gray-900">
+                {broker.mode === "new"
+                  ? `${broker.newName} (new)`
+                  : brokers.find((b) => b.id === broker.existingId)?.name ?? ""}
+              </dd>
+              <dt className="text-gray-500">Portfolio</dt>
+              <dd className="col-span-2 text-gray-900">
+                {portfolio.mode === "existing"
+                  ? `${portfolios.find((p) => p.id === portfolio.existingId)?.name ?? "?"} (existing, ${portfolio.currency})`
+                  : `${portfolio.code} — ${portfolio.name} (new, ${portfolio.currency})`}
+              </dd>
+              <dt className="text-gray-500">Funding</dt>
+              <dd className="col-span-2 text-gray-900">
+                {funding.amount && parseFloat(funding.amount) > 0
+                  ? `${parseFloat(funding.amount).toLocaleString()} ${portfolio.currency} ${
+                      funding.sourcePortfolioId
+                        ? `from ${portfolios.find((p) => p.id === funding.sourcePortfolioId)?.name}`
+                        : "(standalone deposit)"
+                    }`
+                  : "None"}
+              </dd>
+            </dl>
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-between mt-8">
+        <button
+          type="button"
+          onClick={back}
+          disabled={step === "broker" || submitting}
+          className="px-4 py-2 text-sm text-gray-700 hover:text-gray-900 disabled:text-gray-300"
+        >
+          {"← Back"}
+        </button>
+        {step === "funding" ? (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setFunding({ amount: "", sourcePortfolioId: "" })
+                advance()
+              }}
+              className="px-4 py-2 text-sm text-gray-700 hover:text-gray-900"
+            >
+              {"Skip — no deposit"}
+            </button>
+            <button
+              type="button"
+              onClick={advance}
+              disabled={!funding.amount || parseFloat(funding.amount) <= 0}
+              className="btn-primary btn-primary--sm disabled:opacity-50"
+            >
+              {"Next →"}
+            </button>
+          </div>
+        ) : step === "review" ? (
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="btn-primary btn-primary--sm disabled:opacity-50"
+          >
+            {submitting ? "Creating…" : "Open Brokerage"}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={advance}
+            disabled={
+              (step === "broker" && !brokerValid) ||
+              (step === "portfolio" && !portfolioValid)
+            }
+            className="btn-primary btn-primary--sm disabled:opacity-50"
+          >
+            {"Next →"}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
@@ -1,0 +1,316 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { enableFetchMocks } from "jest-fetch-mock"
+import OpenBrokerageWizard from "../OpenBrokerageWizard"
+import type { Broker, Portfolio } from "types/beancounter"
+
+enableFetchMocks()
+
+const existingBrokers: Broker[] = [
+  { id: "broker-ibkr", name: "Interactive Brokers" },
+  { id: "broker-dbs", name: "DBS Vickers" },
+]
+
+const existingPortfolios: Pick<Portfolio, "id" | "code" | "name" | "currency">[] =
+  [
+    {
+      id: "src-pf",
+      code: "SAVINGS",
+      name: "Savings",
+      currency: { code: "USD", name: "US Dollar", symbol: "$" },
+    },
+  ]
+
+function mockEndpoints(): void {
+  fetchMock.mockResponse((req) => handleMock(req))
+}
+
+function handleMock(req: Request): Promise<string> {
+    const url = req.url
+    if (url.includes("/api/brokers") && req.method === "GET") {
+      return Promise.resolve(JSON.stringify({ data: existingBrokers }))
+    }
+    if (url.includes("/api/portfolios") && req.method === "GET") {
+      return Promise.resolve(JSON.stringify({ data: existingPortfolios }))
+    }
+    if (url.includes("/api/brokers") && req.method === "POST") {
+      // Echo the requested name so downstream broker-cash-asset codes
+      // (e.g. `IBRK-USD`) match the broker the wizard just created.
+      return req
+        .clone()
+        .json()
+        .then((body: { name?: string }) =>
+          JSON.stringify({
+            data: { id: "broker-new", name: body.name ?? "New Broker" },
+          }),
+        )
+    }
+    if (url.includes("/api/portfolios") && req.method === "POST") {
+      return Promise.resolve(
+        JSON.stringify({
+          data: [
+            {
+              id: "pf-new",
+              code: "IBKR",
+              name: "IBKR USD",
+              currency: { code: "USD" },
+              base: { code: "USD" },
+            },
+          ],
+        }),
+      )
+    }
+    if (url.includes("/api/assets") && req.method === "POST") {
+      // Echo the requested asset key + market so tests can assert on the
+      // exact code (e.g. broker-cash `IBRK-USD`, market: "PRIVATE").
+      return req
+        .clone()
+        .json()
+        .then(
+          (body: {
+            data?: Record<string, { market?: string; code?: string }>
+          }) => {
+            const code = Object.keys(body.data ?? {})[0] ?? "USD"
+            return JSON.stringify({
+              data: { [code]: { id: `asset-${code}`, code } },
+            })
+          },
+        )
+    }
+    if (url.includes("/api/trns") && req.method === "POST") {
+      return Promise.resolve(
+        JSON.stringify({ data: { trns: [{ id: "trn-1" }] } }),
+      )
+    }
+    return Promise.resolve(JSON.stringify({}))
+}
+
+describe("<OpenBrokerageWizard />", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    mockEndpoints()
+  })
+
+  test("renders the Broker step first", async () => {
+    render(<OpenBrokerageWizard />)
+    expect(
+      await screen.findByRole("heading", { name: /Pick a broker|Broker/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("advances Broker → Portfolio → Funding → Review → Submit", async () => {
+    const user = userEvent.setup()
+    render(<OpenBrokerageWizard />)
+
+    // Step 1 — broker: create new. Use a name not in the existing list so
+    // ensureBroker takes the POST branch (reuse-by-name is covered below).
+    await screen.findByRole("heading", { name: /Broker/i })
+    await user.click(screen.getByRole("radio", { name: /Create a new broker/i }))
+    await user.type(
+      screen.getByLabelText(/Broker name/i),
+      "Brand New Broker",
+    )
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 2 — portfolio: fill code + currency
+    await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.type(screen.getByLabelText(/Portfolio code/i), "IBKR")
+    await user.type(screen.getByLabelText(/Portfolio name/i), "IBKR USD")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 3 — funding: skip
+    await screen.findByRole("heading", { name: /Funding|Deposit/i })
+    await user.click(screen.getByRole("button", { name: /Skip|No deposit/i }))
+
+    // Step 4 — review
+    await screen.findByRole("heading", { name: /Review/i })
+    expect(screen.getByText(/Brand New Broker/)).toBeInTheDocument()
+    expect(screen.getByText(/IBKR/)).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", { name: /Create|Confirm|Open Brokerage/i }),
+    )
+
+    // Step 5 — done
+    await screen.findByRole("heading", { name: /Done|Complete|Success/i })
+
+    // Verify orchestration calls
+    const calls = fetchMock.mock.calls.map((c) => ({
+      url: c[0] as string,
+      method: (c[1] as RequestInit | undefined)?.method ?? "GET",
+    }))
+    const posts = calls.filter((c) => c.method === "POST")
+    expect(posts.some((c) => c.url.includes("/api/brokers"))).toBe(true)
+    expect(posts.some((c) => c.url.includes("/api/portfolios"))).toBe(true)
+    // No trn posted because user skipped funding
+    expect(posts.some((c) => c.url.includes("/api/trns"))).toBe(false)
+  })
+
+  test("posts DEPOSIT + WITHDRAWAL pair when user funds from a source portfolio", async () => {
+    const user = userEvent.setup()
+    render(<OpenBrokerageWizard />)
+
+    // Step 1 — broker: create new (existing-broker selection has its own test)
+    await screen.findByRole("heading", { name: /Broker/i })
+    await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 2 — portfolio
+    await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.type(screen.getByLabelText(/Portfolio code/i), "IBKR")
+    await user.type(screen.getByLabelText(/Portfolio name/i), "IBKR USD")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 3 — funding: enter amount + source
+    await screen.findByRole("heading", { name: /Funding|Deposit/i })
+    await user.type(screen.getByLabelText(/Amount/i), "5000")
+    await user.selectOptions(
+      screen.getByLabelText(/Source portfolio/i),
+      "src-pf",
+    )
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 4 — review
+    await screen.findByRole("heading", { name: /Review/i })
+    await user.click(
+      screen.getByRole("button", { name: /Create|Confirm|Open Brokerage/i }),
+    )
+
+    await screen.findByRole("heading", { name: /Done|Complete|Success/i })
+
+    // Two trn POSTs expected (WITHDRAWAL + DEPOSIT)
+    const trnPosts = fetchMock.mock.calls.filter((c) => {
+      const url = c[0] as string
+      const method = (c[1] as RequestInit | undefined)?.method ?? "GET"
+      return method === "POST" && url.includes("/api/trns")
+    })
+    expect(trnPosts.length).toBeGreaterThanOrEqual(2)
+
+    // Inspect trn bodies for the type pair
+    const bodies = trnPosts.map((c) =>
+      JSON.parse((c[1] as RequestInit).body as string),
+    )
+    const types = bodies.flatMap((b) => b.data.map((d: { trnType: string }) => d.trnType))
+    expect(types).toContain("DEPOSIT")
+    expect(types).toContain("WITHDRAWAL")
+  })
+
+  test("reuses an existing broker by name instead of POSTing a duplicate", async () => {
+    const user = userEvent.setup()
+    render(<OpenBrokerageWizard />)
+
+    // Step 1 — broker: create new, but type a name that already exists
+    await screen.findByRole("heading", { name: /Broker/i })
+    await user.click(screen.getByRole("radio", { name: /Create a new broker/i }))
+    await user.type(
+      screen.getByLabelText(/Broker name/i),
+      "Interactive Brokers",
+    )
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 2 — portfolio
+    await user.type(screen.getByLabelText(/Portfolio code/i), "IBRK")
+    await user.type(
+      screen.getByLabelText(/Portfolio name/i),
+      "Interactive Brokers USD",
+    )
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 3 — skip funding
+    await screen.findByRole("heading", { name: /Funding|Deposit/i })
+    await user.click(screen.getByRole("button", { name: /Skip|No deposit/i }))
+
+    // Step 4 — review + submit
+    await screen.findByRole("heading", { name: /Review/i })
+    await user.click(
+      screen.getByRole("button", { name: /Create|Confirm|Open Brokerage/i }),
+    )
+    await screen.findByRole("heading", { name: /Done|Complete|Success/i })
+
+    // Must NOT POST a duplicate broker — only the existence-check GET happens
+    const brokerPosts = fetchMock.mock.calls.filter((c) => {
+      const url = c[0] as string
+      const method = (c[1] as RequestInit | undefined)?.method ?? "GET"
+      return method === "POST" && url.includes("/api/brokers")
+    })
+    expect(brokerPosts).toHaveLength(0)
+  })
+
+  test("attaches to an existing portfolio with a per-broker PRIVATE cash asset", async () => {
+    const user = userEvent.setup()
+    render(<OpenBrokerageWizard />)
+
+    // Step 1 — broker
+    await screen.findByRole("heading", { name: /Broker/i })
+    await user.type(screen.getByLabelText(/Broker name/i), "IBRK")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 2 — pick existing portfolio (wait for SWR to populate the list
+    // so the radio is enabled)
+    await screen.findByRole("heading", { name: /Portfolio/i })
+    await waitFor(() =>
+      expect(
+        screen.getByRole("radio", {
+          name: /Attach to an existing portfolio/i,
+        }),
+      ).not.toBeDisabled(),
+    )
+    await user.click(
+      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
+    )
+    await user.selectOptions(
+      await screen.findByLabelText("Existing portfolio"),
+      "src-pf",
+    )
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 3 — funding: standalone deposit (no source)
+    await screen.findByRole("heading", { name: /Funding|Deposit/i })
+    await user.type(screen.getByLabelText(/Amount/i), "1000")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 4 — review + submit
+    await screen.findByRole("heading", { name: /Review/i })
+    await user.click(
+      screen.getByRole("button", { name: /Create|Confirm|Open Brokerage/i }),
+    )
+    await screen.findByRole("heading", { name: /Done|Complete|Success/i })
+
+    // No POST /api/portfolios (we attached to an existing one)
+    const portfolioPosts = fetchMock.mock.calls.filter((c) => {
+      const url = c[0] as string
+      const method = (c[1] as RequestInit | undefined)?.method ?? "GET"
+      return method === "POST" && url.includes("/api/portfolios")
+    })
+    expect(portfolioPosts).toHaveLength(0)
+
+    // POST /api/assets must request a PRIVATE asset coded `IBRK-USD`
+    const assetPosts = fetchMock.mock.calls.filter((c) => {
+      const url = c[0] as string
+      const method = (c[1] as RequestInit | undefined)?.method ?? "GET"
+      return method === "POST" && url.includes("/api/assets")
+    })
+    expect(assetPosts.length).toBeGreaterThan(0)
+    const assetBodies = assetPosts.map((c) =>
+      JSON.parse((c[1] as RequestInit).body as string),
+    )
+    const brokerCashAsset = assetBodies.find(
+      (b) => b.data?.["IBRK-USD"]?.market === "PRIVATE",
+    )
+    expect(brokerCashAsset).toBeDefined()
+  })
+
+  test("blocks Next on Portfolio step when code is empty", async () => {
+    const user = userEvent.setup()
+    render(<OpenBrokerageWizard />)
+    await screen.findByRole("heading", { name: /Broker/i })
+    await user.click(screen.getByRole("radio", { name: /Create a new broker/i }))
+    await user.type(screen.getByLabelText(/Broker name/i), "Test Broker")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Portfolio step — Next button disabled while code empty
+    await screen.findByRole("heading", { name: /Portfolio/i })
+    const nextBtn = screen.getByRole("button", { name: /Next|Continue/i })
+    expect(nextBtn).toBeDisabled()
+  })
+})

--- a/src/components/features/rebalance/execution/InvestCashDialog.tsx
+++ b/src/components/features/rebalance/execution/InvestCashDialog.tsx
@@ -252,13 +252,14 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
         return
       }
 
-      onSuccess()
+      // PROPOSED commits navigate away; skip the parent refresh so the
+      // caller's `router.replace(asPath)` doesn't race with our push and
+      // strand the user on the current page.
       handleClose()
-      // Only nav to the proposed-transactions list when the orders are
-      // actually unsettled. SETTLED commits skip the proposed list and
-      // would surface on the portfolio holdings instead.
       if (transactionStatus === "PROPOSED") {
         router.push("/trns/proposed")
+      } else {
+        onSuccess()
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to commit")
@@ -666,11 +667,7 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
                 <div className="text-gray-500">{"Cash After"}</div>
                 <div
                   className={`font-semibold ${
-                    cashAfter < 0
-                      ? "text-red-600"
-                      : cashAfter < portfolioCash * 0.05
-                        ? "text-orange-600"
-                        : "text-blue-600"
+                    cashAfter < 0 ? "text-red-600" : "text-green-600"
                   }`}
                 >
                   {formatCurrency(cashAfter)}

--- a/src/components/features/rebalance/execution/InvestCashDialog.tsx
+++ b/src/components/features/rebalance/execution/InvestCashDialog.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useMemo, useCallback } from "react"
+import React, { useState, useMemo, useCallback, useEffect } from "react"
 import useSWR from "swr"
+import { useRouter } from "next/router"
 import Dialog from "@components/ui/Dialog"
 import Spinner from "@components/ui/Spinner"
 import { simpleFetcher } from "@utils/api/fetchHelper"
@@ -63,12 +64,23 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
     simpleFetcher("/api/rebalance/models"),
   )
 
+  const router = useRouter()
+
   // Fetch brokers
   const { data: brokersData } = useSWR(
     modalOpen ? "/api/brokers" : null,
     simpleFetcher("/api/brokers"),
   )
   const brokers: Broker[] = brokersData?.data || []
+
+  // Convenience: if the user has exactly one broker, pre-select it
+  // when the dialog opens. Skip if user already chose (or cleared it).
+  useEffect(() => {
+    if (brokers.length === 1 && selectedBrokerId === undefined) {
+      setSelectedBrokerId(brokers[0].id)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [brokers.length, modalOpen])
 
   const models: ModelDto[] = modelsData?.data || []
   const modelsWithApprovedPlans = models.filter(
@@ -176,8 +188,22 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
   const handleCommit = async (): Promise<void> => {
     if (!execution) return
 
+    // Warn (but don't block) when the user has more than one broker but
+    // hasn't tagged the orders. They can still proceed if they meant to.
+    if (brokers.length > 1 && !selectedBrokerId) {
+      const ok = window.confirm(
+        "No broker selected. Your proposed transactions won't be tagged with a broker. Continue?",
+      )
+      if (!ok) return
+    }
+
     setCommitting(true)
     setError(null)
+
+    // Single source of truth for the commit's trn status — used both in
+    // the request body and to decide whether to navigate to the
+    // proposed-transactions list afterwards (only relevant for PROPOSED).
+    const transactionStatus: "PROPOSED" | "SETTLED" = "PROPOSED"
 
     try {
       // Only send updates if user made edits
@@ -214,7 +240,7 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             portfolioId: portfolioId,
-            transactionStatus: "PROPOSED",
+            transactionStatus,
             brokerId: selectedBrokerId,
           }),
         },
@@ -228,6 +254,12 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
 
       onSuccess()
       handleClose()
+      // Only nav to the proposed-transactions list when the orders are
+      // actually unsettled. SETTLED commits skip the proposed list and
+      // would surface on the portfolio holdings instead.
+      if (transactionStatus === "PROPOSED") {
+        router.push("/trns/proposed")
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to commit")
     } finally {

--- a/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
+++ b/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
@@ -50,8 +50,16 @@ const AddAssetToModelDialog: React.FC<AddAssetToModelDialogProps> = ({
     setError(null)
     try {
       // Resolve the asset to get a real UUID from svc-data
-      // This also creates the asset if it doesn't exist and fetches its price
-      const resolvedAsset = await resolveAsset(selectedAsset.symbol)
+      // This also creates the asset if it doesn't exist and fetches its price.
+      // Pass the selected market so a non-US listing (e.g. LON-listed UCITS
+      // ETF traded via IBKR in USD) resolves to the right asset row instead
+      // of silently falling back to /api/assets/US/{code} — the previous
+      // behaviour was the root cause of "Fetch Prices" returning nothing
+      // for LON / ASX / NZX picks.
+      const resolvedAsset = await resolveAsset(
+        selectedAsset.symbol,
+        selectedAsset.market,
+      )
 
       if (!resolvedAsset?.id) {
         setError("Could not resolve asset. Please try again.")
@@ -91,6 +99,7 @@ const AddAssetToModelDialog: React.FC<AddAssetToModelDialogProps> = ({
    */
   const resolveAsset = async (
     code: string,
+    market?: string,
   ): Promise<{
     id: string
     code: string
@@ -98,15 +107,17 @@ const AddAssetToModelDialog: React.FC<AddAssetToModelDialogProps> = ({
     market: { code: string }
   } | null> => {
     try {
-      const response = await fetch(`/api/assets/resolve?code=${code}`)
+      const params = new URLSearchParams({ code })
+      if (market) params.set("market", market)
+      const response = await fetch(`/api/assets/resolve?${params.toString()}`)
       if (!response.ok) {
-        console.warn(`Failed to resolve asset ${code}:`, response.status)
+        console.warn("Failed to resolve asset:", code, response.status)
         return null
       }
       const data = await response.json()
       return data.data
     } catch (error) {
-      console.warn(`Error resolving asset ${code}:`, error)
+      console.warn("Error resolving asset:", code, error)
       return null
     }
   }

--- a/src/components/features/transactions/SettlementAccountSelect.tsx
+++ b/src/components/features/transactions/SettlementAccountSelect.tsx
@@ -65,7 +65,7 @@ export const toCashAssetOptions = (
 ): SettlementAccountOption[] => {
   return cashAssets.map((asset) => ({
     value: asset.id,
-    label: `${asset.name || asset.code} Balance`,
+    label: asset.name || `${asset.code} Cash`,
     currency: asset.code,
     market: "CASH",
   }))

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -401,10 +401,8 @@ const TradeInputForm: React.FC<{
     const assetCode = option.symbol || option.value
     // Skip price fetching for private assets - they don't have external market data
     if (market && assetCode && market !== "PRIVATE" && market !== "CASH") {
-      const tradeDate = watch("tradeDate")
-      const today = new Date().toISOString().split("T")[0]
-      const asAt = tradeDate && tradeDate < today ? tradeDate : undefined
-      const fetchedPrice = await fetchAssetPrice(market, assetCode, asAt)
+      const tradeDate = watch("tradeDate") || undefined
+      const fetchedPrice = await fetchAssetPrice(market, assetCode, tradeDate)
       if (fetchedPrice !== null) {
         setValue("price", fetchedPrice)
       }

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -495,13 +495,8 @@ const TradeInputForm: React.FC<{
   }, [allCashBalances, currentTradeCurrency])
 
   const defaultCashAsset = useMemo(
-    () =>
-      buildDefaultCashAsset(
-        filteredCashAssets,
-        currentTradeCurrency,
-        allBankAccounts,
-      ),
-    [filteredCashAssets, currentTradeCurrency, allBankAccounts],
+    () => buildDefaultCashAsset(filteredCashAssets, currentTradeCurrency),
+    [filteredCashAssets, currentTradeCurrency],
   )
 
   // Cash assets for dropdown - all currency balances are already included

--- a/src/components/features/wealth/WealthHeroSection.tsx
+++ b/src/components/features/wealth/WealthHeroSection.tsx
@@ -69,6 +69,17 @@ const WealthHeroSection: React.FC<WealthHeroSectionProps> = ({
               {summary.totalGainOnDay >= 0 ? "+" : ""}
               {displayCurrency?.symbol}
               <FormatValue value={summary.totalGainOnDay} />
+              {summary.totalValue - summary.totalGainOnDay > 0 && (
+                <span className="ml-1">
+                  (
+                  {(
+                    (summary.totalGainOnDay /
+                      (summary.totalValue - summary.totalGainOnDay)) *
+                    100
+                  ).toFixed(2)}
+                  %)
+                </span>
+              )}
               <span className="text-sm ml-1 text-white/60 font-normal">
                 today
               </span>

--- a/src/components/features/wealth/__tests__/WealthHeroSection.test.tsx
+++ b/src/components/features/wealth/__tests__/WealthHeroSection.test.tsx
@@ -1,0 +1,72 @@
+import React from "react"
+import { render, screen, RenderResult } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import WealthHeroSection from "../WealthHeroSection"
+import { USD } from "@test-fixtures/beancounter"
+import { WealthSummary } from "@lib/wealth/liquidityGroups"
+
+jest.mock("@hooks/usePrivacyMode", () => ({
+  usePrivacyMode: () => ({ hideValues: false }),
+}))
+
+function makeSummary(overrides: Partial<WealthSummary> = {}): WealthSummary {
+  return {
+    totalValue: 100_000,
+    totalGainOnDay: 0,
+    portfolioCount: 1,
+    classificationBreakdown: [],
+    portfolioBreakdown: [],
+    ...overrides,
+  }
+}
+
+function renderHero(summary: WealthSummary): RenderResult {
+  return render(
+    <WealthHeroSection
+      summary={summary}
+      displayCurrency={USD}
+      currencies={[USD]}
+      portfolios={[]}
+      onCurrencyChange={() => {}}
+      onShareClick={() => {}}
+    />,
+  )
+}
+
+// Keep React in scope for the @testing-library JSX above without tripping
+// the unused-import diagnostic. react/react-in-jsx-scope demands the
+// import; TS6133 demands a use.
+void React
+
+describe("WealthHeroSection — today's gain percent", () => {
+  it("renders the gain percent next to the dollar gain when totalGainOnDay > 0", () => {
+    // gain 2,500 on prior-day value 97,500 → ~2.56% rise
+    renderHero(makeSummary({ totalValue: 100_000, totalGainOnDay: 2_500 }))
+    expect(screen.getByText(/\(2\.56%\)/)).toBeInTheDocument()
+    expect(screen.getByText(/today/)).toBeInTheDocument()
+  })
+
+  it("renders a negative percent when totalGainOnDay < 0", () => {
+    // -10,830.75 from prior-day value 1,875,476.08 → -0.58%
+    renderHero(
+      makeSummary({
+        totalValue: 1_864_645.33,
+        totalGainOnDay: -10_830.75,
+      }),
+    )
+    expect(screen.getByText(/\(-0\.58%\)/)).toBeInTheDocument()
+  })
+
+  it("omits the percent when totalGainOnDay equals zero (whole gain block is hidden)", () => {
+    renderHero(makeSummary({ totalValue: 100_000, totalGainOnDay: 0 }))
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/today/)).not.toBeInTheDocument()
+  })
+
+  it("omits the percent when prior-day value resolves to zero (avoid divide-by-zero)", () => {
+    // edge case: a new account where today's first deposit equals totalValue
+    renderHero(makeSummary({ totalValue: 500, totalGainOnDay: 500 }))
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument()
+    expect(screen.getByText(/today/)).toBeInTheDocument()
+  })
+})

--- a/src/components/layout/HeaderBrand.tsx
+++ b/src/components/layout/HeaderBrand.tsx
@@ -59,6 +59,11 @@ const navSections: NavSection[] = [
     items: [
       { href: "/chat", label: "Chat", icon: "fa-robot", aiOnly: true },
       {
+        href: "/tools/open-brokerage",
+        label: "Open Brokerage",
+        icon: "fa-building-columns",
+      },
+      {
         href: "/tools/cost-stack",
         label: "Cost Stack",
         icon: "fa-layer-group",

--- a/src/components/layout/HeaderBrand.tsx
+++ b/src/components/layout/HeaderBrand.tsx
@@ -58,6 +58,11 @@ const navSections: NavSection[] = [
     title: "Tools",
     items: [
       { href: "/chat", label: "Chat", icon: "fa-robot", aiOnly: true },
+      {
+        href: "/tools/cost-stack",
+        label: "Cost Stack",
+        icon: "fa-layer-group",
+      },
       { href: "/fx", label: "FX Rates", icon: "fa-exchange-alt" },
       { href: "/fx/calculator", label: "FX Calculator", icon: "fa-calculator" },
       { href: "/tax-rates", label: "Tax Rates", icon: "fa-percent" },

--- a/src/components/layout/HeaderUserControls.tsx
+++ b/src/components/layout/HeaderUserControls.tsx
@@ -115,6 +115,14 @@ export default function HeaderUserControls(): React.ReactElement {
             <i className="fas fa-building w-4 text-center text-xs text-gray-400"></i>
             {"Brokers"}
           </Link>
+          <Link
+            href="/shares"
+            className="flex items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            onClick={() => setDropdownOpen(false)}
+          >
+            <i className="fas fa-share-alt w-4 text-center text-xs text-gray-400"></i>
+            {"Shares"}
+          </Link>
           {isAdmin && (
             <Link
               href="/admin"

--- a/src/components/layout/__tests__/HeaderBrand.test.tsx
+++ b/src/components/layout/__tests__/HeaderBrand.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import HeaderBrand from "../HeaderBrand"
 import { useUser } from "@auth0/nextjs-auth0/client"
 
@@ -37,6 +37,13 @@ describe("HeaderBrand", () => {
     expect(screen.getByRole("button", { name: /^Invest/i })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /^Plan/i })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /^Tools/i })).toBeInTheDocument()
+  })
+
+  it("Tools dropdown includes Cost Stack link", () => {
+    render(<HeaderBrand />)
+    fireEvent.click(screen.getByRole("button", { name: /^Tools/i }))
+    const link = screen.getByRole("link", { name: /Cost Stack/i })
+    expect(link).toHaveAttribute("href", "/tools/cost-stack")
   })
 
   it("hides nav dropdowns when unauthenticated", () => {

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -548,12 +548,17 @@ describe("useRebalanceExecution", () => {
       },
     )
 
-    let commitResult: { portfolioId: string } | undefined
+    let commitResult:
+      | { portfolioId: string; transactionStatus: "PROPOSED" | "SETTLED" }
+      | undefined
     await act(async () => {
       commitResult = await result.current.handlers.commit()
     })
 
-    expect(commitResult).toEqual({ portfolioId: "portfolio-1" })
+    expect(commitResult).toEqual({
+      portfolioId: "portfolio-1",
+      transactionStatus: "PROPOSED",
+    })
     expect(global.fetch).toHaveBeenCalledWith(
       "/api/rebalance/executions/exec-1/commit",
       expect.objectContaining({

--- a/src/hooks/useIndependencePlanData.ts
+++ b/src/hooks/useIndependencePlanData.ts
@@ -11,11 +11,7 @@ import {
   RetirementPlan,
   QuickScenario,
 } from "types/independence"
-import {
-  Portfolio,
-  HoldingContract,
-  PortfolioShare,
-} from "types/beancounter"
+import { Portfolio, HoldingContract, PortfolioShare } from "types/beancounter"
 import type { KeyedMutator } from "swr"
 import { parseExcludedPortfolioIds } from "@lib/independence/planHelpers"
 

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -53,7 +53,13 @@ export interface UseRebalanceExecutionResult {
     initialize: () => Promise<void>
     save: () => Promise<boolean>
     refresh: () => Promise<void>
-    commit: () => Promise<{ portfolioId: string } | undefined>
+    commit: () => Promise<
+      | {
+          portfolioId: string
+          transactionStatus: "PROPOSED" | "SETTLED"
+        }
+      | undefined
+    >
     targetChange: (assetId: string, value: number) => void
     excludeToggle: (assetId: string) => void
     setAllToCurrent: () => void
@@ -108,7 +114,21 @@ export function useRebalanceExecution(
     "/api/brokers",
     simpleFetcher("/api/brokers"),
   )
-  const brokers: Broker[] = brokersData?.data || []
+  const brokers: Broker[] = useMemo(
+    () => brokersData?.data || [],
+    [brokersData],
+  )
+
+  // Convenience default: if the user has exactly one broker, pre-select it.
+  // No reason to make them pick from a single-item list. We only set this
+  // once (when brokers first resolve) — if the user has explicitly cleared
+  // the selection back to "No broker" we don't re-apply.
+  useEffect(() => {
+    if (brokers.length === 1 && selectedBrokerId === undefined) {
+      setSelectedBrokerId(brokers[0].id)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [brokers])
 
   // --- Operations ---
 
@@ -383,7 +403,7 @@ export function useRebalanceExecution(
 
   // Commit execution - create transactions
   const handleCommit = useCallback(async (): Promise<
-    { portfolioId: string } | undefined
+    { portfolioId: string; transactionStatus: "PROPOSED" | "SETTLED" } | undefined
   > => {
     if (!execution || execution.portfolioIds.length === 0) return undefined
 
@@ -392,6 +412,7 @@ export function useRebalanceExecution(
 
     try {
       const portfolioId = execution.portfolioIds[0]
+      const transactionStatus: "PROPOSED" | "SETTLED" = "PROPOSED"
 
       const response = await fetch(
         `/api/rebalance/executions/${execution.id}/commit`,
@@ -400,7 +421,7 @@ export function useRebalanceExecution(
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             portfolioId,
-            transactionStatus: "PROPOSED",
+            transactionStatus,
             brokerId: selectedBrokerId,
           }),
         },
@@ -414,7 +435,7 @@ export function useRebalanceExecution(
         return undefined
       }
 
-      return { portfolioId }
+      return { portfolioId, transactionStatus }
     } catch (err) {
       console.error("Failed to commit execution:", err)
       setError(err instanceof Error ? err.message : "Failed to commit")

--- a/src/lib/utils/auth0.ts
+++ b/src/lib/utils/auth0.ts
@@ -3,13 +3,18 @@ import { Auth0Client } from "@auth0/nextjs-auth0/server"
 // Scope and audience are configured here rather than via env vars because
 // Auth0 v4 removed AUTH0_SCOPE/AUTH0_AUDIENCE env var support.
 // Audience must match the API identifier in Auth0 dashboard.
+// enableParallelTransactions:false uses a single __txn cookie that is
+// overwritten on each /auth/login. With the v4 default (true), every login
+// flow writes a new __txn_<state> cookie; abandoned/back-buttoned flows
+// accumulate until the browser per-host cookie cap evicts the entry for the
+// state that finally completes, producing "The state parameter is invalid."
 export const auth0 = new Auth0Client({
+  enableParallelTransactions: false,
   authorizationParameters: {
     scope:
       "openid profile email offline_access " +
       "beancounter beancounter:user beancounter:admin " +
       "beancounter:ai beancounter:preview",
     audience: "https://holdsworth.app",
-    prompt: "login",
   },
 })

--- a/src/lib/utils/openBrokerage/orchestrate.ts
+++ b/src/lib/utils/openBrokerage/orchestrate.ts
@@ -1,0 +1,270 @@
+/**
+ * Orchestration for the Open Brokerage wizard. Composes existing
+ * `/api/brokers`, `/api/portfolios`, `/api/assets`, and `/api/trns`
+ * endpoints into a single multi-step flow. Kept separate from the
+ * component so it can be unit-tested or reused.
+ */
+
+import type { Broker } from "types/beancounter"
+
+// Local-date YYYY-MM-DD so tradeDate matches the user's calendar day,
+// not UTC's. `new Date().toISOString()` would mis-report the day for any
+// user east of GMT after late afternoon.
+const today = (): string => {
+  const d = new Date()
+  return (
+    `${d.getFullYear()}-` +
+    `${String(d.getMonth() + 1).padStart(2, "0")}-` +
+    `${String(d.getDate()).padStart(2, "0")}`
+  )
+}
+
+interface BrokerStep {
+  mode: "existing" | "new"
+  existingId?: string
+  newName?: string
+  newAccountNumber?: string
+}
+
+interface PortfolioStep {
+  mode: "new" | "existing"
+  // Required when mode === "new"
+  code?: string
+  name?: string
+  currency: string
+  base?: string
+  // Required when mode === "existing"
+  existingId?: string
+}
+
+interface FundingStep {
+  amount: number
+  // Either side may be omitted (no WITHDRAWAL leg = standalone deposit).
+  // When both are given, sourceAssetId takes precedence — use it when the
+  // source is a specific PRIVATE asset (e.g. a bank-account line inside
+  // the same portfolio); fall back to ensureCashAsset(currency) when only
+  // sourcePortfolioId is set.
+  sourcePortfolioId?: string
+  sourceAssetId?: string
+  currency: string
+}
+
+export interface OpenBrokerageRequest {
+  broker: BrokerStep
+  portfolio: PortfolioStep
+  funding?: FundingStep
+}
+
+export interface OpenBrokerageResult {
+  broker: Broker
+  portfolioId: string
+  trnIds: string[]
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error(
+      data?.error || `${url} failed (${res.status} ${res.statusText})`,
+    )
+  }
+  return (await res.json()) as T
+}
+
+async function ensureBroker(step: BrokerStep): Promise<Broker> {
+  if (step.mode === "existing") {
+    if (!step.existingId) throw new Error("Existing broker id required")
+    return { id: step.existingId, name: "" }
+  }
+  if (!step.newName) throw new Error("Broker name required")
+  // Reuse any existing broker with the same name so retrying the wizard
+  // after a downstream failure (e.g. duplicate-portfolio-code 409) doesn't
+  // collide with the backend's unique broker-name-per-owner constraint.
+  const newName = step.newName
+  const existing = await fetch("/api/brokers")
+    .then((r) => (r.ok ? (r.json() as Promise<{ data: Broker[] }>) : null))
+    .then((j) => j?.data.find((b) => b.name === newName))
+    .catch(() => undefined)
+  if (existing) return existing
+  const resp = await postJson<{ data: Broker }>("/api/brokers", {
+    name: step.newName,
+    accountNumber: step.newAccountNumber || undefined,
+  })
+  return resp.data
+}
+
+async function resolvePortfolio(step: PortfolioStep): Promise<string> {
+  if (step.mode === "existing") {
+    if (!step.existingId) throw new Error("Existing portfolio id required")
+    return step.existingId
+  }
+  if (!step.code || !step.name || !step.base) {
+    throw new Error("New portfolio requires code, name and base currency")
+  }
+  const resp = await postJson<{ data: Array<{ id: string }> }>(
+    "/api/portfolios",
+    {
+      data: [
+        {
+          code: step.code,
+          name: step.name,
+          currency: step.currency,
+          base: step.base,
+        },
+      ],
+    },
+  )
+  if (!resp.data?.[0]?.id) throw new Error("Portfolio creation returned no id")
+  return resp.data[0].id
+}
+
+async function ensureAsset(payload: {
+  code: string
+  market: string
+  name?: string
+  currency?: string
+  category?: string
+}): Promise<string> {
+  const resp = await postJson<{
+    data: Record<string, { id: string }>
+  }>("/api/assets", {
+    data: { [payload.code]: payload },
+  })
+  const asset = Object.values(resp.data)[0]
+  if (!asset?.id) throw new Error(`Asset lookup returned no id (${payload.code})`)
+  return asset.id
+}
+
+// Generic CASH/{ccy} asset (e.g. CASH/USD = "USD Balance"). Used when the
+// brokerage gets its own dedicated portfolio — no need to disambiguate
+// cash buckets within a single portfolio.
+const ensureCashAsset = (currency: string): Promise<string> =>
+  ensureAsset({ code: currency, market: "CASH" })
+
+// Per-broker PRIVATE cash asset like "IBRK-USD" / "DBS-SGD". Used when the
+// brokerage attaches to an EXISTING portfolio so the broker's cash is
+// visible as a distinct line ("IBRK USD Balance") alongside any pre-existing
+// generic-cash holdings in the same portfolio. PRIVATE assets MUST carry an
+// explicit `currency` and `category` per svc-data's AssetController
+// validation ("Currency required for private asset {code}").
+const ensureBrokerCashAsset = (
+  brokerName: string,
+  currency: string,
+): Promise<string> =>
+  ensureAsset({
+    code: `${brokerName}-${currency}`,
+    market: "PRIVATE",
+    name: `${brokerName} ${currency} Balance`,
+    currency,
+    category: "ACCOUNT",
+  })
+
+interface TrnLeg {
+  portfolioId: string
+  trnType: "DEPOSIT" | "WITHDRAWAL"
+  assetId: string
+  currency: string
+  amount: number
+}
+
+async function postTrn(leg: TrnLeg): Promise<string> {
+  const resp = await postJson<{ data: { trns?: Array<{ id: string }> } }>(
+    "/api/trns",
+    {
+      portfolioId: leg.portfolioId,
+      data: [
+        {
+          assetId: leg.assetId,
+          cashAssetId: leg.assetId,
+          trnType: leg.trnType,
+          quantity: leg.amount,
+          price: 1,
+          tradeCurrency: leg.currency,
+          cashCurrency: leg.currency,
+          cashAmount: leg.amount,
+          tradeDate: today(),
+          status: "SETTLED",
+        },
+      ],
+    },
+  )
+  // Backend returns a normalised TrnPayload envelope; the first trn id
+  // is what callers care about. If the envelope is empty (shouldn't
+  // happen on 2xx but observed when auto-settle reshapes the response),
+  // log + return an empty string so the wizard still completes and the
+  // user sees the success screen — the trn was persisted upstream.
+  const id = resp.data?.trns?.[0]?.id
+  if (!id) {
+    console.warn("postTrn: backend returned no trn id", resp)
+    return ""
+  }
+  return id
+}
+
+/**
+ * Run the full Open Brokerage flow. Calls are sequential and stop on first
+ * failure — callers should surface the thrown error in the UI. Caller is
+ * responsible for confirming user intent before calling (no idempotency).
+ */
+export async function openBrokerage(
+  req: OpenBrokerageRequest,
+): Promise<OpenBrokerageResult> {
+  const broker = await ensureBroker(req.broker)
+  const portfolioId = await resolvePortfolio(req.portfolio)
+
+  const trnIds: string[] = []
+  if (req.funding && req.funding.amount > 0) {
+    // Attach-to-existing-portfolio path uses a per-broker PRIVATE cash
+    // asset so the brokerage cash is visible as a distinct line in the
+    // existing portfolio's holdings; the new-portfolio path uses the
+    // generic per-currency CASH asset (the portfolio itself segregates).
+    const depositAssetId =
+      req.portfolio.mode === "existing"
+        ? await ensureBrokerCashAsset(broker.name, req.funding.currency)
+        : await ensureCashAsset(req.funding.currency)
+    // Order matters: DEPOSIT first into the freshly-created portfolio
+    // (always succeeds — no balance/code constraints), then WITHDRAWAL
+    // from the source. If WITHDRAWAL fails afterwards the worst-case
+    // state is "cash visible in both portfolios" (a duplicate the user
+    // can spot and reverse), not "phantom debit on the source".
+    trnIds.push(
+      await postTrn({
+        portfolioId,
+        trnType: "DEPOSIT",
+        assetId: depositAssetId,
+        currency: req.funding.currency,
+        amount: req.funding.amount,
+      }),
+    )
+    if (req.funding.sourcePortfolioId || req.funding.sourceAssetId) {
+      // Withdraw from either the specific source asset (e.g. a bank-account
+      // PRIVATE line) when provided, or fall back to the portfolio's
+      // generic CASH/{ccy} asset. Broker-tagged cash only exists on the
+      // destination, never the source.
+      const sourceAssetId =
+        req.funding.sourceAssetId ??
+        (await ensureCashAsset(req.funding.currency))
+      // If sourceAssetId is supplied without an explicit sourcePortfolioId,
+      // assume the asset lives on the same portfolio the wizard is
+      // attaching the broker to (true for the onboarding flow's
+      // bank-account-on-default-portfolio case).
+      const sourcePortfolioId = req.funding.sourcePortfolioId ?? portfolioId
+      trnIds.push(
+        await postTrn({
+          portfolioId: sourcePortfolioId,
+          trnType: "WITHDRAWAL",
+          assetId: sourceAssetId,
+          currency: req.funding.currency,
+          amount: req.funding.amount,
+        }),
+      )
+    }
+  }
+
+  return { broker, portfolioId, trnIds }
+}

--- a/src/lib/utils/trns/tradeFormHelpers.test.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.test.ts
@@ -429,7 +429,7 @@ describe("tradeFormHelpers", () => {
       }
       const result = buildInitialSettlementAccount(trn as any)
       expect(result!.label).toContain("USD")
-      expect(result!.label).toContain("Balance")
+      expect(result!.label).toContain("Cash")
     })
   })
 
@@ -524,7 +524,7 @@ describe("tradeFormHelpers", () => {
       const result = buildDefaultCashAsset(filtered, "NZD")
       expect(result).toEqual({
         value: "c1",
-        label: "NZD Balance",
+        label: "NZD",
         currency: "NZD",
         market: "CASH",
       })
@@ -534,7 +534,7 @@ describe("tradeFormHelpers", () => {
       const result = buildDefaultCashAsset([], "GBP")
       expect(result).toEqual({
         value: "cash:GBP",
-        label: "GBP Balance",
+        label: "GBP Cash",
         currency: "GBP",
         market: "CASH",
       })

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -236,7 +236,7 @@ export const buildInitialSettlementAccount = (
     value: asset.id,
     label:
       asset.name ||
-      `${getDisplayCode(asset)} ${asset.market?.code === "CASH" ? "Balance" : ""}`,
+      `${getDisplayCode(asset)}${asset.market?.code === "CASH" ? " Cash" : ""}`,
     currency:
       asset.accountingType?.currency?.code ||
       asset.priceSymbol ||
@@ -302,38 +302,28 @@ export const buildAllCashBalances = (
 }
 
 /**
- * Build default settlement option for a trade currency.
- * Prefers a matching bank account over a generic cash balance.
+ * Build default settlement option for a trade currency. Always returns the
+ * generic `{ccy} Cash` asset so a broker with no explicit settlement
+ * mapping doesn't accidentally route trades to an unrelated bank account
+ * in the linked funding portfolio. Caller can still override via the
+ * dropdown or via the broker's settlement-accounts mapping.
  */
 export const buildDefaultCashAsset = (
   filteredCashAssets: AssetLike[],
   tradeCurrency: string,
-  bankAccounts: AssetLike[] = [],
 ): SettlementAccountOption => {
-  // Prefer a bank account matching the trade currency
-  const matchingBank = bankAccounts.find(
-    (a) => getAssetCurrency(a) === tradeCurrency,
-  )
-  if (matchingBank) {
-    return {
-      value: matchingBank.id,
-      label: `${matchingBank.name || matchingBank.code} (${tradeCurrency})`,
-      currency: tradeCurrency,
-      market: "PRIVATE",
-    }
-  }
   const cashAsset = filteredCashAssets[0]
   if (cashAsset) {
     return {
       value: cashAsset.id,
-      label: `${cashAsset.name || cashAsset.code} Balance`,
+      label: cashAsset.name || `${cashAsset.code} Cash`,
       currency: cashAsset.code,
       market: "CASH",
     }
   }
   return {
     value: `cash:${tradeCurrency}`,
-    label: `${tradeCurrency} Balance`,
+    label: `${tradeCurrency} Cash`,
     currency: tradeCurrency,
     market: "CASH",
   }

--- a/src/pages/api/resource-shares/granted/[resourceType].ts
+++ b/src/pages/api/resource-shares/granted/[resourceType].ts
@@ -1,0 +1,16 @@
+import {
+  createApiHandler,
+  sanitizePathParam,
+} from "@utils/api/createApiHandler"
+import { getDataUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: (req) => {
+    const resourceType = sanitizePathParam(
+      req.query.resourceType,
+      "resourceType",
+    )
+    return getDataUrl(`/resource-shares/granted/${resourceType}`)
+  },
+  methods: ["GET"],
+})

--- a/src/pages/api/shares/granted.ts
+++ b/src/pages/api/shares/granted.ts
@@ -1,0 +1,7 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getDataUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: getDataUrl("/shares/granted"),
+  methods: ["GET"],
+})

--- a/src/pages/independence/debug.tsx
+++ b/src/pages/independence/debug.tsx
@@ -123,12 +123,14 @@ function computeLocal(s: Sliders): LocalMetrics {
 
   let bridgePct: number | null = null
   const annualExp = s.monthlyExpenses * 12
-  const bridgeYears = annualExp > 0 ? s.liquidAssets / annualExp : yearsToRetirement
+  const bridgeYears =
+    annualExp > 0 ? s.liquidAssets / annualExp : yearsToRetirement
   if (yearsToRetirement > 0 && pensionMonthly > 0) {
     bridgePct = Math.min((bridgeYears / yearsToRetirement) * 100, 100)
   }
 
-  const covPct = s.monthlyExpenses > 0 ? (pensionMonthly / s.monthlyExpenses) * 100 : 100
+  const covPct =
+    s.monthlyExpenses > 0 ? (pensionMonthly / s.monthlyExpenses) * 100 : 100
 
   return {
     fiNumber,
@@ -219,7 +221,9 @@ function Gauge({
           <div className="text-xs text-gray-500 font-mono">{formula}</div>
         </div>
         <div className="text-right">
-          <div className={`text-2xl font-mono font-semibold ${textColorFor(backendPct)}`}>
+          <div
+            className={`text-2xl font-mono font-semibold ${textColorFor(backendPct)}`}
+          >
             {fmtPct(backendPct)}
           </div>
           <div className="text-xs text-gray-500 font-mono">
@@ -281,7 +285,9 @@ function SliderField({
 function IndependenceDebug(): React.ReactElement {
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null)
   const [sliders, setSliders] = useState<Sliders | null>(null)
-  const [projection, setProjection] = useState<RetirementProjection | null>(null)
+  const [projection, setProjection] = useState<RetirementProjection | null>(
+    null,
+  )
   const [projError, setProjError] = useState<string | null>(null)
   const [projLoading, setProjLoading] = useState(false)
   // Last POSTed body — surfaced on the debug page so any viewer-scoped
@@ -620,13 +626,14 @@ function IndependenceDebug(): React.ReactElement {
 
                 <div className="bg-white rounded-lg border border-gray-200 p-4 mb-4 text-sm text-gray-700">
                   <div className="flex justify-between items-baseline mb-1">
-                    <strong className="text-gray-900">{selectedPlan.name}</strong>
+                    <strong className="text-gray-900">
+                      {selectedPlan.name}
+                    </strong>
                     {projLoading && <Spinner label="Recalculating…" />}
                   </div>
                   Age <b>{sliders.currentAge}</b>, retire at{" "}
-                  <b>{sliders.retirementAge}</b> (in{" "}
-                  {local?.yearsToRetirement}y), live to{" "}
-                  <b>{sliders.lifeExpectancy}</b>. Liquid{" "}
+                  <b>{sliders.retirementAge}</b> (in {local?.yearsToRetirement}
+                  y), live to <b>{sliders.lifeExpectancy}</b>. Liquid{" "}
                   <b>{fmtMoney(currency, sliders.liquidAssets)}</b>. Expenses{" "}
                   <b>{fmtMoney(currency, sliders.monthlyExpenses)}/mo</b>.
                   Guaranteed income from {sliders.retirementAge}:{" "}
@@ -649,9 +656,8 @@ function IndependenceDebug(): React.ReactElement {
                   localPct={local?.firePct}
                   metaParts={
                     <>
-                      Gap to FI:{" "}
-                      <b>{fmtMoney(currency, fiMetrics?.gapToFi)}</b>. Locked
-                      pension assets ignored.
+                      Gap to FI: <b>{fmtMoney(currency, fiMetrics?.gapToFi)}</b>
+                      . Locked pension assets ignored.
                     </>
                   }
                 />
@@ -893,9 +899,7 @@ function IndependenceDebug(): React.ReactElement {
                     </div>
                     <div>
                       netMonthlyExpenses (local):{" "}
-                      <b>
-                        {fmtMoney(currency, local?.netMonthlyExpenses)}
-                      </b>
+                      <b>{fmtMoney(currency, local?.netMonthlyExpenses)}</b>
                     </div>
                     <div>
                       totalMonthlyIncome (backend):{" "}
@@ -942,9 +946,9 @@ function IndependenceDebug(): React.ReactElement {
                     Note: local compute treats pension+ss+other as guaranteed
                     income; backend may add derived pension income from policy
                     assets. Backend rental income is excluded from local pension
-                    PV (it&apos;s continuous illiquid income, not pension-shaped).
-                    Local realReturn uses equity slider only; backend blends
-                    equity/cash/housing weighted by allocation.
+                    PV (it&apos;s continuous illiquid income, not
+                    pension-shaped). Local realReturn uses equity slider only;
+                    backend blends equity/cash/housing weighted by allocation.
                   </p>
                 </div>
               </main>

--- a/src/pages/independence/index.tsx
+++ b/src/pages/independence/index.tsx
@@ -313,14 +313,12 @@ function RetirementPlanning(): React.ReactElement {
   // from inside the page where the shared plan will land — without this the
   // SharesBadge counts INDEPENDENCE_PLAN invites but has no accept surface
   // (ManagedPortfolios only renders PORTFOLIO shares).
-  const {
-    data: pendingResourceShares,
-    mutate: mutatePendingResourceShares,
-  } = useSwr<PendingResourceSharesResponse>(resourceSharesPendingKey, fetcher, {
-    refreshInterval: 300000,
-    revalidateOnFocus: false,
-    dedupingInterval: 60000,
-  })
+  const { data: pendingResourceShares, mutate: mutatePendingResourceShares } =
+    useSwr<PendingResourceSharesResponse>(resourceSharesPendingKey, fetcher, {
+      refreshInterval: 300000,
+      revalidateOnFocus: false,
+      dedupingInterval: 60000,
+    })
 
   const handlePendingResourceSharesAction = (): void => {
     mutatePendingResourceShares()
@@ -331,9 +329,8 @@ function RetirementPlanning(): React.ReactElement {
   // their own access via DELETE /resource-shares/{shareId}. The owner has
   // a separate "active shares" surface elsewhere; this hook is purely for
   // viewer-side leave actions.
-  const managedIndependencePlanKey = resourceSharesManagedKey(
-    "INDEPENDENCE_PLAN",
-  )
+  const managedIndependencePlanKey =
+    resourceSharesManagedKey("INDEPENDENCE_PLAN")
   const {
     data: managedIndependencePlans,
     mutate: mutateManagedIndependencePlans,

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -498,13 +498,16 @@ function PlanView(): React.ReactElement {
   // (60)" marker on someone else's plan. Owned plans keep the existing
   // settings-driven path so pre-projection rendering still works.
   const planInputsAges = (
-    adjustedProjection as unknown as {
-      planInputs?: {
-        currentAge?: number
-        retirementAge?: number
-        lifeExpectancy?: number
-      }
-    } | null | undefined
+    adjustedProjection as unknown as
+      | {
+          planInputs?: {
+            currentAge?: number
+            retirementAge?: number
+            lifeExpectancy?: number
+          }
+        }
+      | null
+      | undefined
   )?.planInputs
   const displayCurrentAge = isSharedPlan
     ? (planInputsAges?.currentAge ?? currentAge)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -146,7 +146,7 @@ export default function Home(): React.ReactElement {
             <p className="text-gray-600 mb-6 text-center">
               {"No portfolios yet"}
             </p>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {/* Guided Setup - for novice users */}
               <Link
                 href="/onboarding"
@@ -160,6 +160,21 @@ export default function Home(): React.ReactElement {
                 </h3>
                 <p className="text-gray-500 text-sm">
                   {"Guided setup for bank accounts, property, and pensions"}
+                </p>
+              </Link>
+              {/* Open Brokerage - for users who already have a broker account */}
+              <Link
+                href="/tools/open-brokerage"
+                className="border border-gray-200 rounded-xl p-5 text-center hover:border-purple-300 hover:shadow-md transition-all"
+              >
+                <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                  <i className="fas fa-building-columns text-xl text-purple-500"></i>
+                </div>
+                <h3 className="font-semibold text-gray-900 mb-1">
+                  {"Open Brokerage"}
+                </h3>
+                <p className="text-gray-500 text-sm">
+                  {"Add a broker, a brokerage portfolio and your opening cash"}
                 </p>
               </Link>
               {/* Direct Add - for professional users */}

--- a/src/pages/learn/wealth.tsx
+++ b/src/pages/learn/wealth.tsx
@@ -18,6 +18,25 @@ export default function LearnWealth(): React.ReactElement {
             }
           </p>
         </div>
+
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-10">
+          <h2 className="font-semibold text-gray-900 mb-2">
+            {"Curious what fees actually cost you?"}
+          </h2>
+          <p className="text-gray-600 text-sm mb-4">
+            {
+              "Try our interactive fee-impact calculator. Compare bank UTs, robos, brokerage + DIY and ILPs over 30 years."
+            }
+          </p>
+          <Link
+            href="/tools/cost-stack"
+            className="inline-flex items-center text-sm font-medium text-blue-600 hover:text-blue-700"
+          >
+            {"Open Cost Stack"}
+            <i className="fas fa-arrow-right ml-2"></i>
+          </Link>
+        </div>
+
         <div className="text-center">
           <Link href="/auth/login" className="btn-primary">
             {"Sign In"}

--- a/src/pages/portfolios/index.tsx
+++ b/src/pages/portfolios/index.tsx
@@ -4,6 +4,7 @@ import type { User } from "@auth0/nextjs-auth0/types"
 import { Portfolio } from "types/beancounter"
 import { errorOut } from "@components/errors/ErrorOut"
 import { useRouter } from "next/router"
+import useSwr from "swr"
 import { rootLoader } from "@components/ui/PageLoader"
 import PortfolioCorporateActionsPopup from "@components/features/portfolios/PortfolioCorporateActionsPopup"
 import ManagedPortfolios from "@components/features/portfolios/ManagedPortfolios"
@@ -12,6 +13,7 @@ import PortfolioImportDialog from "@components/features/portfolios/PortfolioImpo
 import PortfoliosList from "@components/features/portfolios/PortfoliosList"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
 import { usePortfolios } from "@hooks/usePortfolios"
+import { sharesManagedKey, simpleFetcher } from "@utils/api/fetchHelper"
 
 export default withPageAuthRequired(function Portfolios({
   user,
@@ -71,6 +73,26 @@ export default withPageAuthRequired(function Portfolios({
 
   const activePortfolios = portfolios.filter((p) => p.active !== false)
   const inactivePortfolios = portfolios.filter((p) => p.active === false)
+
+  // Hide the Managed tab when the user has nothing shared with them.
+  // Cheap GET — same endpoint ManagedPortfolios uses; SWR will dedupe.
+  const { data: managedSharesData } = useSwr<{ data: unknown[] }>(
+    sharesManagedKey,
+    simpleFetcher(sharesManagedKey),
+  )
+  const hasManagedShares = (managedSharesData?.data?.length ?? 0) > 0
+  // If the user lands on /portfolios?tab=managed but has nothing managed
+  // (e.g. a share was revoked), bounce them back to "my" so they don't
+  // see an empty tab with no way to switch.
+  React.useEffect(() => {
+    if (
+      activeTab === "managed" &&
+      managedSharesData !== undefined &&
+      !hasManagedShares
+    ) {
+      setActiveTab("my")
+    }
+  }, [activeTab, managedSharesData, hasManagedShares, setActiveTab])
 
   const handleCorporateActionsClose = useCallback(() => {
     setCorporateActionsPortfolio(null)
@@ -147,17 +169,19 @@ export default withPageAuthRequired(function Portfolios({
               </span>
             )}
           </button>
-          <button
-            className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
-              activeTab === "managed"
-                ? "border-wealth-500 text-wealth-600"
-                : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
-            }`}
-            onClick={() => setActiveTab("managed")}
-          >
-            <i className="fas fa-users mr-2"></i>
-            {"Managed"}
-          </button>
+          {hasManagedShares && (
+            <button
+              className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === "managed"
+                  ? "border-wealth-500 text-wealth-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+              }`}
+              onClick={() => setActiveTab("managed")}
+            >
+              <i className="fas fa-users mr-2"></i>
+              {"Managed"}
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -723,8 +723,23 @@ function ExecuteRebalancePage(): React.ReactElement {
             </button>
             <button
               onClick={async () => {
+                // Warn (but don't block) when the user has >1 brokers
+                // and didn't tag the orders — saves a "where's the
+                // broker on these trns?" follow-up later.
+                if (brokers.length > 1 && !selectedBrokerId) {
+                  const ok = window.confirm(
+                    "No broker selected. Your proposed transactions won't be tagged with a broker. Continue?",
+                  )
+                  if (!ok) return
+                }
                 const result = await handlers.commit()
-                if (result) {
+                if (!result) return
+                // Only land on /trns/proposed when the orders are
+                // actually unsettled. Settled commits go straight to
+                // the portfolio holdings.
+                if (result.transactionStatus === "PROPOSED") {
+                  router.push("/trns/proposed")
+                } else {
                   router.push(`/trns?portfolioId=${result.portfolioId}`)
                 }
               }}

--- a/src/pages/shares.tsx
+++ b/src/pages/shares.tsx
@@ -1,0 +1,254 @@
+import React, { useState } from "react"
+import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
+import Head from "next/head"
+import useSwr from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+import type {
+  PortfolioShare,
+  ResourceShare,
+  ShareStatus,
+} from "types/beancounter"
+
+function statusBadge(status: ShareStatus): React.ReactElement {
+  const styles: Record<ShareStatus, string> = {
+    ACTIVE: "bg-green-100 text-green-700",
+    PENDING_CLIENT_INVITE: "bg-amber-100 text-amber-700",
+    PENDING_ADVISER_REQUEST: "bg-amber-100 text-amber-700",
+    REVOKED: "bg-gray-200 text-gray-600",
+  }
+  const labels: Record<ShareStatus, string> = {
+    ACTIVE: "Active",
+    PENDING_CLIENT_INVITE: "Invite sent",
+    PENDING_ADVISER_REQUEST: "Pending",
+    REVOKED: "Revoked",
+  }
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${styles[status]}`}
+    >
+      {labels[status]}
+    </span>
+  )
+}
+
+function SharesPage(): React.ReactElement {
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const portfolios = useSwr<{ data: PortfolioShare[] }>(
+    "/api/shares/granted",
+    simpleFetcher("/api/shares/granted"),
+  )
+  const plans = useSwr<{ data: ResourceShare[] }>(
+    "/api/resource-shares/granted/INDEPENDENCE_PLAN",
+    simpleFetcher("/api/resource-shares/granted/INDEPENDENCE_PLAN"),
+  )
+  const models = useSwr<{ data: ResourceShare[] }>(
+    "/api/resource-shares/granted/REBALANCE_MODEL",
+    simpleFetcher("/api/resource-shares/granted/REBALANCE_MODEL"),
+  )
+
+  const revokePortfolioShare = async (id: string): Promise<void> => {
+    if (!window.confirm("Revoke this share? The recipient loses access immediately.")) return
+    setBusyId(id)
+    setError(null)
+    try {
+      const res = await fetch(`/api/shares/${id}`, { method: "DELETE" })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body?.error || `Revoke failed (${res.status})`)
+      }
+      await portfolios.mutate()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const revokeResourceShare = async (
+    id: string,
+    refetch: () => Promise<unknown>,
+  ): Promise<void> => {
+    if (!window.confirm("Revoke this share? The recipient loses access immediately.")) return
+    setBusyId(id)
+    setError(null)
+    try {
+      const res = await fetch(`/api/resource-shares/${id}`, {
+        method: "DELETE",
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body?.error || `Revoke failed (${res.status})`)
+      }
+      await refetch()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const portfolioShares = portfolios.data?.data ?? []
+  const planShares = plans.data?.data ?? []
+  const modelShares = models.data?.data ?? []
+
+  return (
+    <>
+      <Head>
+        <title>Shares | Holdsworth</title>
+      </Head>
+      <div className="max-w-4xl mx-auto py-6 px-4">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 mb-1">
+            {"Shares I've granted"}
+          </h1>
+          <p className="text-sm text-gray-600">
+            {
+              "Review and revoke access you've shared with advisers or other users. Revoking is immediate — the recipient loses access on their next request."
+            }
+          </p>
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="mb-4 px-4 py-2 rounded bg-red-50 border border-red-200 text-sm text-red-700"
+          >
+            {error}
+          </div>
+        )}
+
+        <Section
+          title="Portfolios"
+          icon="fa-briefcase"
+          loading={portfolios.isLoading}
+          shares={portfolioShares.map((s) => ({
+            id: s.id,
+            label: s.portfolio?.name ?? s.portfolio?.code ?? "(unknown)",
+            sub: s.portfolio?.code,
+            recipient: s.sharedWith?.email ?? s.targetUser?.email ?? "(pending)",
+            accessLevel: s.accessLevel,
+            status: s.status,
+          }))}
+          busyId={busyId}
+          onRevoke={revokePortfolioShare}
+        />
+
+        <Section
+          title="Independence Plans"
+          icon="fa-chart-line"
+          loading={plans.isLoading}
+          shares={planShares.map((s) => ({
+            id: s.id,
+            label: s.resourceName ?? "(unnamed plan)",
+            sub: undefined,
+            recipient: s.sharedWith?.email ?? s.targetUser?.email ?? "(pending)",
+            accessLevel: s.accessLevel,
+            status: s.status,
+          }))}
+          busyId={busyId}
+          onRevoke={(id) => revokeResourceShare(id, plans.mutate)}
+        />
+
+        <Section
+          title="Rebalance Models"
+          icon="fa-balance-scale"
+          loading={models.isLoading}
+          shares={modelShares.map((s) => ({
+            id: s.id,
+            label: s.resourceName ?? "(unnamed model)",
+            sub: undefined,
+            recipient: s.sharedWith?.email ?? s.targetUser?.email ?? "(pending)",
+            accessLevel: s.accessLevel,
+            status: s.status,
+          }))}
+          busyId={busyId}
+          onRevoke={(id) => revokeResourceShare(id, models.mutate)}
+        />
+      </div>
+    </>
+  )
+}
+
+interface SectionRow {
+  id: string
+  label: string
+  sub?: string
+  recipient: string
+  accessLevel: string
+  status: ShareStatus
+}
+
+function Section({
+  title,
+  icon,
+  loading,
+  shares,
+  busyId,
+  onRevoke,
+}: {
+  title: string
+  icon: string
+  loading: boolean
+  shares: SectionRow[]
+  busyId: string | null
+  onRevoke: (id: string) => void | Promise<void>
+}): React.ReactElement {
+  return (
+    <section className="mb-6 bg-white border border-gray-200 rounded-lg overflow-hidden">
+      <header className="px-4 py-3 border-b border-gray-200 flex items-center gap-2 bg-gray-50">
+        <i className={`fas ${icon} text-gray-500`}></i>
+        <h2 className="text-sm font-semibold text-gray-900">{title}</h2>
+        <span className="ml-auto text-xs text-gray-500">
+          {loading ? "…" : `${shares.length} share${shares.length === 1 ? "" : "s"}`}
+        </span>
+      </header>
+      {!loading && shares.length === 0 && (
+        <p className="px-4 py-6 text-sm text-gray-500 text-center">
+          {`No ${title.toLowerCase()} shared.`}
+        </p>
+      )}
+      {shares.length > 0 && (
+        <table className="w-full text-sm">
+          <thead className="text-xs text-gray-500 uppercase tracking-wider bg-gray-50">
+            <tr>
+              <th className="text-left px-4 py-2">Resource</th>
+              <th className="text-left px-4 py-2">Recipient</th>
+              <th className="text-left px-4 py-2">Access</th>
+              <th className="text-left px-4 py-2">Status</th>
+              <th className="text-right px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {shares.map((s) => (
+              <tr key={s.id} className="border-t border-gray-100">
+                <td className="px-4 py-2">
+                  <div className="text-gray-900">{s.label}</div>
+                  {s.sub && (
+                    <div className="text-xs text-gray-500">{s.sub}</div>
+                  )}
+                </td>
+                <td className="px-4 py-2 text-gray-700">{s.recipient}</td>
+                <td className="px-4 py-2 text-gray-700">{s.accessLevel}</td>
+                <td className="px-4 py-2">{statusBadge(s.status)}</td>
+                <td className="px-4 py-2 text-right">
+                  <button
+                    type="button"
+                    onClick={() => onRevoke(s.id)}
+                    disabled={busyId === s.id}
+                    className="px-3 py-1 text-xs font-medium text-red-600 hover:text-red-700 disabled:text-gray-400"
+                  >
+                    {busyId === s.id ? "Revoking…" : "Revoke"}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  )
+}
+
+export default withPageAuthRequired(SharesPage)

--- a/src/pages/tools/cost-stack.tsx
+++ b/src/pages/tools/cost-stack.tsx
@@ -1,0 +1,56 @@
+import Head from "next/head"
+import Link from "next/link"
+import React from "react"
+
+export default function CostStackPage(): React.ReactElement {
+  return (
+    <>
+      <Head>
+        <title>Cost Stack — long-term fee impact | Holdsworth</title>
+        <meta
+          name="description"
+          content="Compare investment fee structures side by side. See how a 1% TER, a 3% front-load, or an ILP wrapper drag on a 30-year compounding portfolio."
+        />
+      </Head>
+      <div className="min-h-screen bg-gray-50">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-4">
+          <div className="text-center mb-6">
+            <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
+              {"Cost Stack"}
+            </h1>
+            <p className="text-gray-600 text-base">
+              {
+                "Compare investment fee structures side by side. Tweak the inputs — see what a 1% TER or a 3% front-load costs you over 30 years."
+              }
+            </p>
+          </div>
+        </div>
+
+        <div className="max-w-7xl mx-auto px-2 sm:px-4 pb-8">
+          <iframe
+            src="/tools/cost-stack.html"
+            title="Cost Stack interactive fee comparison"
+            className="w-full h-[1600px] rounded-lg border border-gray-200 shadow-sm bg-[#0f1217]"
+            loading="lazy"
+          />
+        </div>
+
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
+          <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 text-center">
+            <h2 className="text-xl font-bold text-gray-900 mb-3">
+              {"Track the real numbers, not the brochure."}
+            </h2>
+            <p className="text-gray-600 mb-6">
+              {
+                "Holdsworth tracks your portfolio across brokers and currencies so you can measure actual drag against the model above — and act on it."
+              }
+            </p>
+            <Link href="/auth/login" className="btn-primary">
+              {"Sign In"}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/pages/tools/open-brokerage.tsx
+++ b/src/pages/tools/open-brokerage.tsx
@@ -1,0 +1,23 @@
+import Head from "next/head"
+import React from "react"
+import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
+import OpenBrokerageWizard from "@components/features/openBrokerage/OpenBrokerageWizard"
+
+function OpenBrokeragePage(): React.ReactElement {
+  return (
+    <>
+      <Head>
+        <title>Open Brokerage | Holdsworth</title>
+        <meta
+          name="description"
+          content="Guided wizard to create a broker, a brokerage portfolio, and an optional opening cash deposit (with a paired withdrawal from a source portfolio if you supply one)."
+        />
+      </Head>
+      <div className="min-h-screen bg-gray-50">
+        <OpenBrokerageWizard />
+      </div>
+    </>
+  )
+}
+
+export default withPageAuthRequired(OpenBrokeragePage)

--- a/src/pages/trns/cash-ladder/[...params].tsx
+++ b/src/pages/trns/cash-ladder/[...params].tsx
@@ -127,15 +127,17 @@ export default withPageAuthRequired(function CashLadder(): React.ReactElement {
     [],
   )
 
-  // Calculate running balances
-  // Transactions are sorted desc (newest first)
-  // Sum all cashAmounts to get current balance, then work backwards to show balance after each trn
+  // Calculate running balances.
+  //
+  // Trust the backend's order — svc-data sorts the cash-ladder query
+  // by `tradeDate desc, createdAt desc` (V26 migration added the
+  // `created_at` column for chronological tie-break). The algorithm
+  // walks newest→oldest starting from the current total and subtracts
+  // each trn to expose "balance immediately after this trn".
   const transactionsWithBalance = useMemo((): TrnWithBalance[] => {
     const trns = cashLadderData.data?.data || []
     if (trns.length === 0 || !cashAssetId) return []
 
-    // Calculate total balance from all transactions with enforced signs
-    // Work backwards from total to show balance after each transaction
     let balance = trns.reduce(
       (sum, trn) => sum + getSignedCashAmount(trn, cashAssetId),
       0,

--- a/src/pages/trns/proposed.tsx
+++ b/src/pages/trns/proposed.tsx
@@ -322,6 +322,16 @@ export default function ProposedTransactions(): React.JSX.Element {
     )
   }
 
+  // Bulk-apply a single broker to every row in the preview. Useful when
+  // the user opened a batch of orders that should all settle through the
+  // same broker — saves clicking the dropdown per row.
+  const handleApplyBrokerToAll = (value: string): void => {
+    if (!value) return
+    setTransactions((prev) =>
+      prev.map((trn) => ({ ...trn, editedBrokerId: value })),
+    )
+  }
+
   // Handlers for aggregated transaction edits
   const handleAggregatedPriceChange = (
     aggregateKey: string,
@@ -718,6 +728,32 @@ export default function ProposedTransactions(): React.JSX.Element {
             />
             <span className="text-gray-700">Aggregate by Broker + Asset</span>
           </label>
+
+          {brokers.length > 0 && transactions.length > 0 && (
+            <>
+              <div className="hidden sm:block border-l border-gray-300 h-6" />
+              <label className="flex items-center gap-2 text-sm">
+                <span className="text-gray-700">Apply broker to all:</span>
+                <select
+                  value=""
+                  onChange={(e) => {
+                    handleApplyBrokerToAll(e.target.value)
+                    // Reset so the same broker can be re-applied later.
+                    e.currentTarget.selectedIndex = 0
+                  }}
+                  className="px-2 py-1 border border-gray-300 rounded text-sm bg-white"
+                >
+                  <option value="">— Pick a broker —</option>
+                  {brokers.map((b) => (
+                    <option key={b.id} value={b.id}>
+                      {b.name}
+                      {b.accountNumber ? ` (${b.accountNumber})` : ""}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </>
+          )}
         </div>
 
         {fetchError && (

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -908,6 +908,7 @@ export interface OffboardingSummary {
   portfolioCount: number
   assetCount: number
   taxRateCount: number
+  brokerCount: number
 }
 
 /**


### PR DESCRIPTION
## Summary

- `AddAssetToModelDialog` called `/api/assets/resolve?code={symbol}` without the market the user picked in the search dropdown. `resolve.ts` defaults to `US` when no market is supplied, so a LON / ASX / NZX pick always resolved to (or auto-created) the **US-market** row.
- Result: a plan asset added via search for, e.g., EXUS on LON (a USD-priced UCITS ETF tradeable via IBKR) carried `US:EXUS` instead of `LON:EXUS`. Subsequent **Fetch Prices** then routed through US providers, hit `/eod/EXUS.US`, got nothing, and the plan UI showed empty prices with no error.

## Fix

- Pass `selectedAsset.market` into `resolveAsset(...)`.
- `resolveAsset` builds the query string with `URLSearchParams` so the `market` is propagated to `/api/assets/resolve` (which already supports it).
- Hardened `console.warn` calls to keep the dynamic `code` out of the format string (semgrep CWE-134).

## Existing-data note

Plans created before this fix have plan_assets pointing at the wrong-market asset row. Easiest cleanup: delete the affected weights and re-add them after this lands.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn prettier`
- [ ] Manual: add a LON-listed asset (e.g. EXUS / VUAA) to a draft plan, click Fetch Prices, confirm a non-zero USD/GBP price appears.

@coderabbitai ignore