### PR TITLE
fix(rebalance): pass selected market when resolving an added asset

### DIFF
--- a/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
+++ b/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
@@ -50,8 +50,16 @@ const AddAssetToModelDialog: React.FC<AddAssetToModelDialogProps> = ({
     setError(null)
     try {
       // Resolve the asset to get a real UUID from svc-data
-      // This also creates the asset if it doesn't exist and fetches its price
-      const resolvedAsset = await resolveAsset(selectedAsset.symbol)
+      // This also creates the asset if it doesn't exist and fetches its price.
+      // Pass the selected market so a non-US listing (e.g. LON-listed UCITS
+      // ETF traded via IBKR in USD) resolves to the right asset row instead
+      // of silently falling back to /api/assets/US/{code} — the previous
+      // behaviour was the root cause of "Fetch Prices" returning nothing
+      // for LON / ASX / NZX picks.
+      const resolvedAsset = await resolveAsset(
+        selectedAsset.symbol,
+        selectedAsset.market,
+      )
 
       if (!resolvedAsset?.id) {
         setError("Could not resolve asset. Please try again.")
@@ -91,6 +99,7 @@ const AddAssetToModelDialog: React.FC<AddAssetToModelDialogProps> = ({
    */
   const resolveAsset = async (
     code: string,
+    market?: string,
   ): Promise<{
     id: string
     code: string
@@ -98,15 +107,17 @@ const AddAssetToModelDialog: React.FC<AddAssetToModelDialogProps> = ({
     market: { code: string }
   } | null> => {
     try {
-      const response = await fetch(`/api/assets/resolve?code=${code}`)
+      const params = new URLSearchParams({ code })
+      if (market) params.set("market", market)
+      const response = await fetch(`/api/assets/resolve?${params.toString()}`)
       if (!response.ok) {
-        console.warn(`Failed to resolve asset ${code}:`, response.status)
+        console.warn("Failed to resolve asset:", code, response.status)
         return null
       }
       const data = await response.json()
       return data.data
     } catch (error) {
-      console.warn(`Error resolving asset ${code}:`, error)
+      console.warn("Error resolving asset:", code, error)
       return null
     }
   }


### PR DESCRIPTION
## Summary

- `AddAssetToModelDialog` called `/api/assets/resolve?code={symbol}` without the market the user picked in the search dropdown. `resolve.ts` defaults to `US` when no market is supplied, so a LON / ASX / NZX pick always resolved to (or auto-created) the **US-market** row.
- Result: a plan asset added via search for, e.g., EXUS on LON (a USD-priced UCITS ETF tradeable via IBKR) carried `US:EXUS` instead of `LON:EXUS`. Subsequent **Fetch Prices** then routed through US providers, hit `/eod/EXUS.US`, got nothing, and the plan UI showed empty prices with no error.

## Fix

- Pass `selectedAsset.market` into `resolveAsset(...)`.
- `resolveAsset` builds the query string with `URLSearchParams` so the `market` is propagated to `/api/assets/resolve` (which already supports it).
- Hardened `console.warn` calls to keep the dynamic `code` out of the format string (semgrep CWE-134).

## Existing-data note

Plans created before this fix have plan_assets pointing at the wrong-market asset row. Easiest cleanup: delete the affected weights and re-add them after this lands.

@coderabbitai ignore