### PR TITLE
fix(rebalance): stop forwarding click event into handleFetchPrices

### DIFF
--- a/src/components/features/rebalance/models/ModelWeightsEditor.tsx
+++ b/src/components/features/rebalance/models/ModelWeightsEditor.tsx
@@ -90,7 +90,12 @@ const ModelWeightsEditor: React.FC<ModelWeightsEditorProps> = ({
               {showPrice && onFetchPrices && weights.length > 0 && (
                 <button
                   type="button"
-                  onClick={onFetchPrices}
+                  // Wrap so the React SyntheticEvent isn't forwarded as the
+                  // first arg — handleFetchPrices treats arg[0] as
+                  // `weightsOverride?: AssetWeightWithDetails[]` and would
+                  // call .filter() on the event, throw TypeError, and the
+                  // caller's try/catch would swallow it (no network fired).
+                  onClick={() => onFetchPrices()}
                   disabled={fetchingPrices}
                   className="text-sm text-gray-700 bg-gray-100 px-3 py-1.5 rounded hover:bg-gray-200 transition-colors flex items-center disabled:opacity-50"
                 >

--- a/src/components/features/rebalance/models/__tests__/ModelWeightsEditor.test.tsx
+++ b/src/components/features/rebalance/models/__tests__/ModelWeightsEditor.test.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import ModelWeightsEditor from "../ModelWeightsEditor"
+import { AssetWeightWithDetails } from "types/rebalance"
+
+void React
+
+function sampleWeight(
+  overrides: Partial<AssetWeightWithDetails> = {},
+): AssetWeightWithDetails {
+  return {
+    assetId: "PuEcMsbjRnalL6GBs4O6YA",
+    assetCode: "US:VOO",
+    assetName: "VANGUARD 500 INDEX FUND ETF SHARES",
+    weight: 100,
+    sortOrder: 0,
+    ...overrides,
+  }
+}
+
+describe("ModelWeightsEditor — Fetch Prices click", () => {
+  it("invokes onFetchPrices with NO arguments (does not forward the click event)", () => {
+    // Regression: the button used to render as `onClick={onFetchPrices}` which
+    // forwarded the React SyntheticEvent as `weightsOverride` to the consumer's
+    // handler. The handler then called .filter() on the event, threw TypeError,
+    // and the surrounding try/catch swallowed it — no /prices request was fired.
+    const onFetchPrices = jest.fn<void, []>()
+
+    render(
+      <ModelWeightsEditor
+        weights={[sampleWeight()]}
+        onChange={() => {}}
+        onFetchPrices={onFetchPrices}
+        showPrice
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /fetch prices/i }))
+
+    expect(onFetchPrices).toHaveBeenCalledTimes(1)
+    expect(onFetchPrices).toHaveBeenCalledWith()
+    // Defensive: ensure the first call argument is undefined (not an event).
+    expect(onFetchPrices.mock.calls[0]).toEqual([])
+  })
+
+  it("hides the Fetch Prices button while a fetch is in flight (disabled state)", () => {
+    const onFetchPrices = jest.fn()
+
+    render(
+      <ModelWeightsEditor
+        weights={[sampleWeight()]}
+        onChange={() => {}}
+        onFetchPrices={onFetchPrices}
+        fetchingPrices
+        showPrice
+      />,
+    )
+
+    const button = screen.getByRole("button", { name: /fetch prices/i })
+    expect(button).toBeDisabled()
+    fireEvent.click(button)
+    expect(onFetchPrices).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

\`ModelWeightsEditor\`'s Fetch Prices button rendered as \`onClick={onFetchPrices}\`. React forwards the SyntheticEvent as the handler's first arg. The parent \`handleFetchPrices(weightsOverride?: AssetWeightWithDetails[])\` treated the event as \`weightsOverride\`, called \`.filter()\` on it, threw \`TypeError\`, and the surrounding \`try/catch\` swallowed the failure into \`console.error\`.

Result: no \`GET /plans/{planId}/prices\` request fired. Visible symptom: prices on a v2 plan (created from v1) stayed at whatever was copied from v1. Zero \`/prices\` spans in Sentry despite the user clicking the button.

## Fix

\`onClick={() => onFetchPrices()}\` — wrapper drops the event so the handler runs with \`weightsOverride === undefined\` and falls back to React state's \`weights\`.

## Test plan

- [x] New regression test asserts \`onFetchPrices\` is invoked with zero arguments (\`mock.calls[0]\` is \`[]\`).
- [x] Test asserts the button is \`disabled\` when \`fetchingPrices\` is truthy and clicking it is a no-op.
- [x] \`yarn typecheck\`
- [x] \`yarn lint\`
- [ ] Manual on kauri once deployed: open a draft plan, click Fetch Prices, observe a \`GET /api/rebalance/models/.../plans/.../prices\` request in Network and updated price values in the table.

@coderabbitai ignore