### PR TITLE
feat(assets): admin Delete button on Asset Lookup

### DIFF
--- a/src/pages/api/assets/admin/[id].ts
+++ b/src/pages/api/assets/admin/[id].ts
@@ -6,5 +6,5 @@ export default createApiHandler({
     const { id } = req.query
     return getDataUrl(`/assets/admin/${id}`)
   },
-  methods: ["PATCH"],
+  methods: ["PATCH", "DELETE"],
 })

--- a/src/pages/assets/lookup.tsx
+++ b/src/pages/assets/lookup.tsx
@@ -80,8 +80,10 @@ function AssetLookupPage(): React.ReactElement {
   const [resolvingChart, setResolvingChart] = useState(false)
   const [resolveError, setResolveError] = useState<string | null>(null)
   const { popup: reviewPopup, showReview } = useAssetReview()
-  const { ai: canRunAi, preview: canPreview } = usePermissions()
+  const { ai: canRunAi, preview: canPreview, admin: isAdmin } = usePermissions()
   const canReviewAsset = canRunAi || canPreview
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   // Hydrate selected asset from query string (header search deep-link).
   useEffect(() => {
@@ -185,6 +187,39 @@ function AssetLookupPage(): React.ReactElement {
   // Navigate to transactions on double-click
   const handleRowDoubleClick = (portfolioId: string, assetId: string): void => {
     router.push(`/trns/trades/${portfolioId}/${assetId}`)
+  }
+
+  const handleDeleteAsset = async (): Promise<void> => {
+    if (!selectedAsset?.assetId) return
+    const label = selectedAsset.symbol || selectedAsset.assetId
+    if (
+      !window.confirm(
+        `Delete asset "${label}"? This cannot be undone. The asset must not be held in any portfolio.`,
+      )
+    ) {
+      return
+    }
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      const response = await fetch(
+        `/api/assets/admin/${encodeURIComponent(selectedAsset.assetId)}`,
+        { method: "DELETE" },
+      )
+      if (!response.ok) {
+        const body = await response.text()
+        setDeleteError(
+          body || `Delete failed (${response.status} ${response.statusText})`,
+        )
+        return
+      }
+      setSelectedAsset(null)
+      setChartAsset(null)
+    } catch (e) {
+      setDeleteError(e instanceof Error ? e.message : "Failed to delete asset")
+    } finally {
+      setDeleting(false)
+    }
   }
 
   // Format currency value
@@ -302,8 +337,32 @@ function AssetLookupPage(): React.ReactElement {
                   <span>AI Review</span>
                 </button>
               )}
+              {isAdmin && selectedAsset.assetId && (
+                <button
+                  type="button"
+                  onClick={handleDeleteAsset}
+                  disabled={
+                    deleting || loadingPositions || positions.length > 0
+                  }
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-red-600 text-white text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 disabled:opacity-60 disabled:cursor-not-allowed"
+                  aria-label={`Delete asset ${selectedAsset.symbol || selectedAsset.assetId}`}
+                  title={
+                    positions.length > 0
+                      ? "Cannot delete — asset is held in one or more portfolios"
+                      : "Delete asset (admin)"
+                  }
+                >
+                  <i className="fas fa-trash"></i>
+                  <span>{deleting ? "Deleting..." : "Delete"}</span>
+                </button>
+              )}
             </div>
           </div>
+          {deleteError && (
+            <div className="mt-3 px-3 py-2 rounded-md bg-red-50 border border-red-200 text-sm text-red-700">
+              {deleteError}
+            </div>
+          )}
         </div>
       )}
       {reviewPopup}

--- a/src/pages/assets/lookup.tsx
+++ b/src/pages/assets/lookup.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import { useRouter } from "next/router"
 import useSWR from "swr"
@@ -84,6 +84,13 @@ function AssetLookupPage(): React.ReactElement {
   const canReviewAsset = canRunAi || canPreview
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
+  // Mirror selectedAsset into a ref so the in-flight delete handler can
+  // identity-check against the LATEST selection at the time the response
+  // resolves, not the value it closed over when invoked.
+  const selectedAssetRef = useRef<AssetOption | null>(null)
+  useEffect(() => {
+    selectedAssetRef.current = selectedAsset
+  }, [selectedAsset])
 
   // Hydrate selected asset from query string (header search deep-link).
   useEffect(() => {
@@ -191,6 +198,10 @@ function AssetLookupPage(): React.ReactElement {
 
   const handleDeleteAsset = async (): Promise<void> => {
     if (!selectedAsset?.assetId) return
+    // Snapshot the target identity so a late response can't clear or
+    // overwrite state for a different asset the user picked while the
+    // delete was in flight.
+    const targetAssetId = selectedAsset.assetId
     const label = selectedAsset.symbol || selectedAsset.assetId
     if (
       !window.confirm(
@@ -201,22 +212,49 @@ function AssetLookupPage(): React.ReactElement {
     }
     setDeleting(true)
     setDeleteError(null)
+    const isStillSelected = (): boolean =>
+      selectedAssetRef.current?.assetId === targetAssetId
     try {
       const response = await fetch(
-        `/api/assets/admin/${encodeURIComponent(selectedAsset.assetId)}`,
+        `/api/assets/admin/${encodeURIComponent(targetAssetId)}`,
         { method: "DELETE" },
       )
       if (!response.ok) {
-        const body = await response.text()
-        setDeleteError(
-          body || `Delete failed (${response.status} ${response.statusText})`,
-        )
+        // API proxy writes JSON `{ error, message, ... }` on failures —
+        // surface that message rather than the raw envelope.
+        let errorMessage: string | null = null
+        const raw = await response.text()
+        if (raw) {
+          try {
+            const parsed = JSON.parse(raw) as {
+              message?: string
+              error?: string
+              detail?: string
+            }
+            errorMessage =
+              parsed.message || parsed.error || parsed.detail || null
+          } catch {
+            errorMessage = raw
+          }
+        }
+        if (isStillSelected()) {
+          setDeleteError(
+            errorMessage ||
+              `Delete failed (${response.status} ${response.statusText})`,
+          )
+        }
         return
       }
-      setSelectedAsset(null)
-      setChartAsset(null)
+      if (isStillSelected()) {
+        setSelectedAsset(null)
+        setChartAsset(null)
+      }
     } catch (e) {
-      setDeleteError(e instanceof Error ? e.message : "Failed to delete asset")
+      if (isStillSelected()) {
+        setDeleteError(
+          e instanceof Error ? e.message : "Failed to delete asset",
+        )
+      }
     } finally {
       setDeleting(false)
     }
@@ -347,9 +385,11 @@ function AssetLookupPage(): React.ReactElement {
                   className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-red-600 text-white text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 disabled:opacity-60 disabled:cursor-not-allowed"
                   aria-label={`Delete asset ${selectedAsset.symbol || selectedAsset.assetId}`}
                   title={
-                    positions.length > 0
-                      ? "Cannot delete — asset is held in one or more portfolios"
-                      : "Delete asset (admin)"
+                    loadingPositions
+                      ? "Checking whether this asset is held in any portfolio…"
+                      : positions.length > 0
+                        ? "Cannot delete — asset is held in one or more portfolios"
+                        : "Delete asset (admin)"
                   }
                 >
                   <i className="fas fa-trash"></i>


### PR DESCRIPTION
## Summary
- Adds a Delete button to the Asset Lookup action bar. Visible only to admin callers and only when the selected asset has a real assetId. Disabled while positions are loading or whenever `positions.length > 0` (tooltip explains why).
- On confirm → `DELETE /api/assets/admin/{id}`. Success clears the selection; failure surfaces the server message (e.g. "Cannot delete asset … held in one or more transactions") so the user can act.
- Forwards DELETE through the existing `/api/assets/admin/[id]` proxy.

Pairs with monowai/beancounter PR #920 which adds the server-side `DELETE /assets/admin/{id}` endpoint with the transaction-reference guard.

## Test plan
- [x] `yarn test` green (124 suites / 1373 tests)
- [x] `yarn prettier && yarn typecheck` clean
- [ ] After deploy: as admin on kauri, search an asset not held anywhere → click Delete → confirm → asset gone; re-search resolves a fresh row
- [ ] As admin on an asset held in a portfolio → button disabled with tooltip; if invoked directly (race) → server 400 surfaced inline
- [ ] As non-admin → button not rendered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin users can delete assets from the asset lookup interface. A confirmation prompt is required; assets held in portfolios cannot be deleted. The delete button is disabled while deletion is in progress or when positions exist.
* **Bug Fixes / UX**
  * Deletion errors from the server are surfaced as a visible error banner beneath the header actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

@coderabbitai ignore