### PR TITLE
feat(proposed): 'Due up to' date filter, default today

### DIFF
--- a/src/pages/api/trns/proposed/index.ts
+++ b/src/pages/api/trns/proposed/index.ts
@@ -3,6 +3,7 @@ import { getDataUrl } from "@utils/api/bcConfig"
 import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 const ALLOWED_SCOPES = new Set(["OWNED", "MANAGED", "ALL"])
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
 
 function resolveScope(raw: unknown): string {
   const value = Array.isArray(raw) ? raw[0] : raw
@@ -10,10 +11,18 @@ function resolveScope(raw: unknown): string {
   return ALLOWED_SCOPES.has(normalised) ? normalised : "ALL"
 }
 
+// Only forward a well-formed ISO date; svc-data defaults asAt to today when absent.
+function resolveAsAt(raw: unknown): string | null {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return typeof value === "string" && ISO_DATE.test(value) ? value : null
+}
+
 export default createApiHandler({
   url: (req) => {
     const scope = resolveScope(req.query.scope)
-    return getDataUrl(`/trns/proposed?scope=${scope}`)
+    const asAt = resolveAsAt(req.query.asAt)
+    const query = asAt ? `scope=${scope}&asAt=${asAt}` : `scope=${scope}`
+    return getDataUrl(`/trns/proposed?${query}`)
   },
   transformJson: transformTrnEnvelopeJson,
 })

--- a/src/pages/trns/proposed.tsx
+++ b/src/pages/trns/proposed.tsx
@@ -21,6 +21,7 @@ const SESSION_KEY_INCLUDE_SETTLED = "proposed-include-settled"
 const SESSION_KEY_SETTLED_DATE = "proposed-settled-date"
 const SESSION_KEY_AGGREGATE_VIEW = "proposed-aggregate-view"
 const SESSION_KEY_SCOPE = "proposed-scope"
+const SESSION_KEY_AS_AT = "proposed-as-at"
 
 type ProposedScope = "OWNED" | "MANAGED" | "ALL"
 
@@ -38,6 +39,9 @@ export default function ProposedTransactions(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [includeSettled, setIncludeSettled] = useState(false)
   const [settledDate, setSettledDate] = useState(getToday())
+  // Proposed transactions due on or before this date are shown; defaults to today so
+  // future-dated rows (e.g. dividends with a forward pay date) stay hidden until due.
+  const [asAtDate, setAsAtDate] = useState(getToday())
   const [settledTransactions, setSettledTransactions] = useState<Transaction[]>(
     [],
   )
@@ -59,6 +63,7 @@ export default function ProposedTransactions(): React.JSX.Element {
   useEffect(() => {
     setIncludeSettled(getSessionValue(SESSION_KEY_INCLUDE_SETTLED, false))
     setSettledDate(getSessionValue(SESSION_KEY_SETTLED_DATE, getToday()))
+    setAsAtDate(getSessionValue(SESSION_KEY_AS_AT, getToday()))
     setAggregateView(getSessionValue(SESSION_KEY_AGGREGATE_VIEW, false))
     const storedScope = getSessionValue<ProposedScope>(SESSION_KEY_SCOPE, "ALL")
     if (
@@ -92,6 +97,12 @@ export default function ProposedTransactions(): React.JSX.Element {
 
   useEffect(() => {
     if (sessionInitialized) {
+      setSessionValue(SESSION_KEY_AS_AT, asAtDate)
+    }
+  }, [asAtDate, sessionInitialized])
+
+  useEffect(() => {
+    if (sessionInitialized) {
       setSessionValue(SESSION_KEY_AGGREGATE_VIEW, aggregateView)
     }
   }, [aggregateView, sessionInitialized])
@@ -99,8 +110,10 @@ export default function ProposedTransactions(): React.JSX.Element {
     AggregatedTransaction[]
   >([])
 
-  // Fetch proposed transactions across all portfolios
-  const proposedKey = user ? `/api/trns/proposed?scope=${scope}` : null
+  // Fetch proposed transactions across all portfolios, bounded to those due on or before asAtDate.
+  const proposedKey = user
+    ? `/api/trns/proposed?scope=${scope}&asAt=${asAtDate}`
+    : null
   const { data: proposedData, error: fetchError } = useSwr<{
     data: Transaction[]
   }>(proposedKey, fetcher, { refreshInterval: 0 })
@@ -674,6 +687,15 @@ export default function ProposedTransactions(): React.JSX.Element {
               </button>
             ))}
           </div>
+          <div className="hidden sm:block border-l border-gray-300 h-6" />
+          <label className="flex items-center gap-2 text-sm">
+            <span className="text-gray-700">Due up to</span>
+            <DateInput
+              value={asAtDate}
+              onChange={setAsAtDate}
+              className="px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </label>
           <div className="hidden sm:block border-l border-gray-300 h-6" />
           <label className="flex items-center gap-2 text-sm">
             <span className="text-gray-700">Type:</span>


### PR DESCRIPTION
## Why

The Proposed Transactions review listed every PROPOSED row, including future-dated dividends (pay date 14–15/06 when today is 06/06). They aren't actionable (settling a future tradeDate is blocked), so they clutter review.

## What

- The proposed list now sends `asAt` (default today) to `/api/trns/proposed`; svc-data filters `tradeDate <= asAt`, hiding not-yet-due rows.
- New **"Due up to"** date control (defaults to today, session-persisted) lets the user widen the window to preview upcoming proposed transactions.
- API route validates and forwards `asAt` (ISO date only).

Requires the svc-data `asAt` support (monowai/beancounter#922). Backward-safe: the backend defaults `asAt` to today, so this is purely additive.

## Validation

typecheck ✅, lint ✅ (only a pre-existing unrelated warning), prettier ✅, semgrep ✅. No existing proposed-page test in repo; behavior is covered by the svc-data integration test.

@coderabbitai ignore