### PR TITLE
fix(assets): default CPF LIFE plan to STANDARD

### DIFF
--- a/src/components/features/assets/CompositeAssetEditor.tsx
+++ b/src/components/features/assets/CompositeAssetEditor.tsx
@@ -134,8 +134,14 @@ export default function CompositeAssetEditor({
   const handleApplyTemplate = useCallback(
     (template: SubAccountRequest[]) => {
       onSubAccountsChange(template.map((t) => ({ ...t })))
+      // Belt-and-braces: if someone reaches the CPF template button with
+      // the plan still unset (e.g. policyType was already CPF from a
+      // prior session), seed STANDARD here too.
+      if (policyType === "CPF" && !cpfLifePlan) {
+        onCpfLifePlanChange?.("STANDARD")
+      }
     },
-    [onSubAccountsChange],
+    [onSubAccountsChange, policyType, cpfLifePlan, onCpfLifePlanChange],
   )
 
   const isComposite = policyType !== undefined
@@ -155,6 +161,13 @@ export default function CompositeAssetEditor({
               onPolicyTypeChange(val === "" ? undefined : val)
               if (val === "" && subAccounts.length > 0) {
                 onSubAccountsChange([])
+              }
+              // Default CPF LIFE plan to Standard the moment policy turns
+              // CPF — otherwise projections silently report zero pension
+              // income (svc-retire's enrichCpfConfigs gates on the plan
+              // being set). User can switch to Basic/Escalating after.
+              if (val === "CPF" && !cpfLifePlan) {
+                onCpfLifePlanChange?.("STANDARD")
               }
             }}
             className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-indigo-500 focus:border-indigo-500"

--- a/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
+++ b/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import CompositeAssetEditor from "../CompositeAssetEditor"
+
+/**
+ * Regression: a fresh CPF asset must default to the STANDARD CPF LIFE plan
+ * because svc-retire's pension enrichment only emits a non-zero monthly
+ * payout when the plan is set. An unset plan silently zeroes the projection.
+ */
+describe("CompositeAssetEditor — CPF LIFE plan default", () => {
+  it("seeds STANDARD when policy turns CPF and the plan is empty", () => {
+    const onPolicyTypeChange = jest.fn()
+    const onCpfLifePlanChange = jest.fn()
+    render(
+      <CompositeAssetEditor
+        policyType={undefined}
+        lockedUntilDate=""
+        subAccounts={[]}
+        cpfLifePlan={undefined}
+        onPolicyTypeChange={onPolicyTypeChange}
+        onLockedUntilDateChange={jest.fn()}
+        onSubAccountsChange={jest.fn()}
+        onCpfLifePlanChange={onCpfLifePlanChange}
+        onCpfPayoutStartAgeChange={jest.fn()}
+      />,
+    )
+    // Policy-type select is the first <select> in the editor. The label
+    // is a sibling <label> without htmlFor, so we target by role + order.
+    const policySelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement
+    fireEvent.change(policySelect, { target: { value: "CPF" } })
+    expect(onPolicyTypeChange).toHaveBeenCalledWith("CPF")
+    expect(onCpfLifePlanChange).toHaveBeenCalledWith("STANDARD")
+  })
+
+  it("does NOT overwrite an existing CPF LIFE plan when policy changes to CPF", () => {
+    const onCpfLifePlanChange = jest.fn()
+    render(
+      <CompositeAssetEditor
+        policyType={undefined}
+        lockedUntilDate=""
+        subAccounts={[]}
+        cpfLifePlan="BASIC"
+        onPolicyTypeChange={jest.fn()}
+        onLockedUntilDateChange={jest.fn()}
+        onSubAccountsChange={jest.fn()}
+        onCpfLifePlanChange={onCpfLifePlanChange}
+        onCpfPayoutStartAgeChange={jest.fn()}
+      />,
+    )
+    // Policy-type select is the first <select> in the editor. The label
+    // is a sibling <label> without htmlFor, so we target by role + order.
+    const policySelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement
+    fireEvent.change(policySelect, { target: { value: "CPF" } })
+    expect(onCpfLifePlanChange).not.toHaveBeenCalled()
+  })
+
+  it("seeds STANDARD when Apply CPF Template is clicked with no plan set", () => {
+    const onCpfLifePlanChange = jest.fn()
+    const onSubAccountsChange = jest.fn()
+    render(
+      <CompositeAssetEditor
+        policyType="CPF"
+        lockedUntilDate=""
+        subAccounts={[]}
+        cpfLifePlan={undefined}
+        onPolicyTypeChange={jest.fn()}
+        onLockedUntilDateChange={jest.fn()}
+        onSubAccountsChange={onSubAccountsChange}
+        onCpfLifePlanChange={onCpfLifePlanChange}
+        onCpfPayoutStartAgeChange={jest.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: /Apply CPF Template/i }))
+    expect(onSubAccountsChange).toHaveBeenCalled()
+    expect(onCpfLifePlanChange).toHaveBeenCalledWith("STANDARD")
+  })
+})


### PR DESCRIPTION
## Summary

- New CPF assets always opened with the CPF LIFE plan unset, so svc-retire's pension enrichment returned zero monthly payout and the independence projection silently showed no CPF income.
- Auto-seed STANDARD when the composite policy changes to CPF (or when Apply CPF Template is clicked) with no plan already chosen.
- Users keep full control to switch to Basic/Escalating before save.

## Why STANDARD as the default

STANDARD is the default CPF LIFE option for the vast majority of Singaporeans — level monthly payouts for life. Picking it as the on-by-default is overwhelmingly the right answer; the existing amber warning explicitly told users that an unset plan zeroes the projection, but that warning is easy to miss.

## Tests

3 new unit tests in `CompositeAssetEditor.test.tsx`:
- seeds STANDARD when policy turns CPF and plan is empty
- does NOT overwrite an existing plan (BASIC/ESCALATING preserved)
- seeds STANDARD when Apply CPF Template is clicked with no plan set

## Test plan

- [ ] `yarn jest src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx` green
- [ ] After deploy: new pension → switch to CPF policy → the CPF LIFE Plan dropdown shows "Standard" and the inline amber warning disappears
- [ ] Existing CPF assets with a chosen plan keep that plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CPF Life Plan now automatically defaults to "STANDARD" when you switch the policy type to CPF or apply the CPF template, eliminating manual configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->