### PR TITLE
fix(onboarding): persist cpfLifePlan from Save Pension

### DIFF
--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -3,7 +3,12 @@ import { useRouter } from "next/router"
 import useSwr from "swr"
 import { useUser } from "@auth0/nextjs-auth0/client"
 import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
-import { Currency, PolicyType, Portfolio, SubAccountRequest } from "types/beancounter"
+import {
+  Currency,
+  PolicyType,
+  Portfolio,
+  SubAccountRequest,
+} from "types/beancounter"
 import OnboardingProgress from "./OnboardingProgress"
 import WelcomeStep from "./steps/WelcomeStep"
 import CurrencyStep from "./steps/CurrencyStep"
@@ -42,6 +47,7 @@ export interface Pension {
   lumpSum?: boolean // If true, pays out in full rather than monthly
   monthlyContribution?: number // Regular contribution amount
   policyType?: PolicyType // Composite policy type (CPF, ILP, GENERIC)
+  cpfLifePlan?: "STANDARD" | "BASIC" | "ESCALATING" // CPF LIFE payout plan
   lockedUntilDate?: string // Date when asset can be liquidated
   subAccounts?: SubAccountRequest[] // Sub-accounts for composite policies
 }
@@ -458,6 +464,7 @@ const OnboardingWizard: React.FC = () => {
             monthlyContribution: pension.monthlyContribution,
             rentalCurrency: pension.currency,
             policyType: pension.policyType,
+            cpfLifePlan: pension.cpfLifePlan,
             lockedUntilDate: pension.lockedUntilDate || null,
             subAccounts: pension.subAccounts,
           }),
@@ -719,9 +726,7 @@ const OnboardingWizard: React.FC = () => {
                         "portfolio:".length,
                       )
                     } else if (brokerageSource.startsWith("bankAccount:")) {
-                      const name = brokerageSource.slice(
-                        "bankAccount:".length,
-                      )
+                      const name = brokerageSource.slice("bankAccount:".length)
                       const assetId = bankAccountAssetIds[name]
                       if (assetId) {
                         fund.sourceAssetId = assetId

--- a/src/components/features/onboarding/steps/AssetsStep.tsx
+++ b/src/components/features/onboarding/steps/AssetsStep.tsx
@@ -707,10 +707,14 @@ const AssetsStep: React.FC<AssetsStepProps> = ({
             {/* Composite Policy Type */}
             <CompositeAssetEditor
               policyType={newPension.policyType}
+              cpfLifePlan={newPension.cpfLifePlan}
               lockedUntilDate={newPension.lockedUntilDate || ""}
               subAccounts={newPension.subAccounts || []}
               onPolicyTypeChange={(value: PolicyType | undefined) =>
                 setNewPension({ ...newPension, policyType: value })
+              }
+              onCpfLifePlanChange={(value) =>
+                setNewPension({ ...newPension, cpfLifePlan: value })
               }
               onLockedUntilDateChange={(value: string) =>
                 setNewPension({ ...newPension, lockedUntilDate: value })


### PR DESCRIPTION
## Symptom

Onboarding → add a pension → pick a CPF LIFE plan → **Save Pension** silently dropped `cpfLifePlan`. Edit Asset → Planning tab persists it correctly.

## Root cause (3 drop points, all frontend)

The onboarding pension flow rendered the shared `CompositeAssetEditor` (which has the CPF LIFE selector) but never carried the value through:

1. `Pension` interface (`OnboardingWizard`) had no `cpfLifePlan` field.
2. `AssetsStep`'s `CompositeAssetEditor` usage omitted `cpfLifePlan` + `onCpfLifePlanChange`, so the selection was never captured into `newPension`.
3. The finalize POST to `/api/assets/config/{id}` sent `policyType`/`lockedUntilDate`/`subAccounts` but not `cpfLifePlan`.

The Edit Asset → Planning path wires the editor fully, which is why it worked. Backend already accepts `cpfLifePlan` — no backend change.

## Fix

Wire `cpfLifePlan` end-to-end in onboarding: add it to the `Pension` type, bind the editor's value + `onCpfLifePlanChange`, and include it in the finalize payload.

## Validation

typecheck ✅, lint ✅ (pre-existing unrelated warning only), prettier ✅, semgrep ✅.

@coderabbitai ignore