### PR TITLE
fix(wealth): include custom-asset balances in Net Worth tile

### DIFF
--- a/src/components/features/wealth/__tests__/useWealthSummary.test.ts
+++ b/src/components/features/wealth/__tests__/useWealthSummary.test.ts
@@ -1,0 +1,137 @@
+import { renderHook } from "@testing-library/react"
+import { useWealthSummary } from "../useWealthSummary"
+import { Portfolio, HoldingContract } from "types/beancounter"
+
+const SGD = { code: "SGD" } as Portfolio["base"]
+const USD = { code: "USD" } as Portfolio["base"]
+
+function portfolio(
+  overrides: Partial<Portfolio> & {
+    code: string
+    marketValue: number
+  },
+): Portfolio {
+  return {
+    id: overrides.code,
+    name: overrides.code,
+    base: SGD,
+    currency: SGD,
+    irr: 0,
+    ...overrides,
+  } as Portfolio
+}
+
+const NO_SORT = { key: null as string | null, direction: "asc" as const }
+const NO_HOLDINGS = undefined as HoldingContract | undefined
+
+describe("useWealthSummary", () => {
+  it("returns zeros when there are no portfolios and no custom assets", () => {
+    const { result } = renderHook(() =>
+      useWealthSummary([], { SGD: 1 }, NO_SORT, NO_HOLDINGS),
+    )
+    expect(result.current.totalValue).toBe(0)
+    expect(result.current.portfolioCount).toBe(0)
+  })
+
+  it("sums portfolio market values converted via fxRates", () => {
+    const portfolios = [
+      portfolio({
+        code: "P-SGD",
+        marketValue: 37000,
+        base: SGD,
+        currency: SGD,
+      }),
+      portfolio({
+        code: "P-USD",
+        marketValue: 40000,
+        base: USD,
+        currency: USD,
+      }),
+    ]
+    const fxRates = { SGD: 1, USD: 1.28 }
+    const { result } = renderHook(() =>
+      useWealthSummary(portfolios, fxRates, NO_SORT, NO_HOLDINGS),
+    )
+    expect(result.current.totalValue).toBeCloseTo(37000 + 40000 * 1.28, 2)
+  })
+
+  it("includes custom-asset balances (e.g. CPF composite) in the net-worth total", () => {
+    // Repro: Mary has DBS+UOB+IBKR portfolios totalling SGD 88,200 and a
+    // CPF composite asset worth SGD 281,000 sitting outside any portfolio.
+    // Pre-fix the Net Worth tile reported SGD 88,200 — CPF was dropped.
+    const portfolios = [
+      portfolio({
+        code: "P-SGD",
+        marketValue: 37000,
+        base: SGD,
+        currency: SGD,
+      }),
+      portfolio({
+        code: "P-USD",
+        marketValue: 40000,
+        base: USD,
+        currency: USD,
+      }),
+    ]
+    const fxRates = { SGD: 1, USD: 1.28 }
+    const customAssetTotals = { SGD: 281000 }
+
+    const { result } = renderHook(() =>
+      useWealthSummary(
+        portfolios,
+        fxRates,
+        NO_SORT,
+        NO_HOLDINGS,
+        customAssetTotals,
+      ),
+    )
+    expect(result.current.totalValue).toBeCloseTo(
+      37000 + 40000 * 1.28 + 281000,
+      2,
+    )
+  })
+
+  it("converts custom-asset balances using their currency's fxRate", () => {
+    const fxRates = { USD: 1.28 }
+    const customAssetTotals = { USD: 1000 }
+    const { result } = renderHook(() =>
+      useWealthSummary(
+        [
+          portfolio({
+            code: "P-USD",
+            marketValue: 0,
+            base: USD,
+            currency: USD,
+          }),
+        ],
+        fxRates,
+        NO_SORT,
+        NO_HOLDINGS,
+        customAssetTotals,
+      ),
+    )
+    expect(result.current.totalValue).toBeCloseTo(1280, 2)
+  })
+
+  it("falls back to rate 1 when a custom-asset currency has no fxRate", () => {
+    const fxRates = { SGD: 1 }
+    const customAssetTotals = { THB: 500 }
+    const { result } = renderHook(() =>
+      useWealthSummary(
+        [
+          portfolio({
+            code: "P-SGD",
+            marketValue: 0,
+            base: SGD,
+            currency: SGD,
+          }),
+        ],
+        fxRates,
+        NO_SORT,
+        NO_HOLDINGS,
+        customAssetTotals,
+      ),
+    )
+    expect(result.current.totalValue).toBe(500)
+  })
+})

--- a/src/components/features/wealth/useWealthSummary.ts
+++ b/src/components/features/wealth/useWealthSummary.ts
@@ -12,9 +12,18 @@ export function useWealthSummary(
   fxRates: Record<string, number>,
   sortConfig: SortConfig,
   holdingsData: HoldingContract | undefined,
+  // Per-currency sum of custom-asset balances that live outside any
+  // portfolio (e.g. CPF composite sub-account balances stored on
+  // PrivateAssetConfig). Each entry's value is in its currency key; the
+  // hook applies the same fxRates table used for portfolios.
+  customAssetTotals: Record<string, number> = {},
 ): WealthSummary {
   return useMemo(() => {
-    if (portfolios.length === 0 || Object.keys(fxRates).length === 0) {
+    const hasCustomAssets = Object.keys(customAssetTotals).length > 0
+    if (
+      (portfolios.length === 0 && !hasCustomAssets) ||
+      Object.keys(fxRates).length === 0
+    ) {
       return {
         totalValue: 0,
         totalGainOnDay: 0,
@@ -46,6 +55,11 @@ export function useWealthSummary(
         value: convertedValue,
         irr: portfolio.irr || 0,
       })
+    })
+
+    Object.entries(customAssetTotals).forEach(([currency, balance]) => {
+      const rate = fxRates[currency] || 1
+      totalValue += balance * rate
     })
 
     // Calculate liquidity breakdown and total gain on day from holdings
@@ -129,5 +143,5 @@ export function useWealthSummary(
       classificationBreakdown,
       portfolioBreakdown,
     }
-  }, [portfolios, fxRates, sortConfig, holdingsData])
+  }, [portfolios, fxRates, sortConfig, holdingsData, customAssetTotals])
 }

--- a/src/pages/wealth.tsx
+++ b/src/pages/wealth.tsx
@@ -27,6 +27,7 @@ import QuickActionCards from "@components/features/wealth/QuickActionCards"
 import WealthPerformanceChart from "@components/features/wealth/WealthPerformanceChart"
 import { useWealthSummary } from "@components/features/wealth/useWealthSummary"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
+import { usePrivateAssetConfigs } from "@utils/assets/usePrivateAssetConfigs"
 
 type SortConfig = {
   key: string | null
@@ -101,13 +102,35 @@ function WealthDashboard(): React.ReactElement {
     [portfolioData?.data],
   )
 
+  // Custom assets (composite pensions etc.) — sit outside any portfolio,
+  // so the portfolio.marketValue sum below misses them. Net Worth needs
+  // their balances added in so the headline tile matches what the user
+  // actually has. See DEMO-ISSUES #13.
+  const { configs: privateAssetConfigs } = usePrivateAssetConfigs()
+  const customAssetTotals = useMemo(() => {
+    const totals: Record<string, number> = {}
+    privateAssetConfigs.forEach((config) => {
+      const subAccounts = config.subAccounts ?? []
+      if (subAccounts.length === 0) return
+      const subTotal = subAccounts.reduce(
+        (sum, sa) => sum + (sa.balance || 0),
+        0,
+      )
+      if (subTotal === 0) return
+      const currency = config.rentalCurrency || "USD"
+      totals[currency] = (totals[currency] || 0) + subTotal
+    })
+    return totals
+  }, [privateAssetConfigs])
+
   // FX rates for converting portfolio values to display currency
   const sourceCurrencyCodes = useMemo(
     () => [
       ...portfolios.map((p) => p.base.code),
       ...portfolios.map((p) => p.currency.code),
+      ...Object.keys(customAssetTotals),
     ],
-    [portfolios],
+    [portfolios, customAssetTotals],
   )
   const { displayCurrency, setDisplayCurrency, fxRates, fxReady } = useFxRates(
     currencies,
@@ -143,6 +166,7 @@ function WealthDashboard(): React.ReactElement {
     fxRates,
     sortConfig,
     holdingsData,
+    customAssetTotals,
   )
 
   // Calculate asset breakdown from holdings
@@ -165,7 +189,7 @@ function WealthDashboard(): React.ReactElement {
     return rootLoader("Loading...")
   }
 
-  if (portfolios.length === 0) {
+  if (portfolios.length === 0 && Object.keys(customAssetTotals).length === 0) {
     return (
       <>
         <Head>


### PR DESCRIPTION
## Summary

- `/wealth` Net Worth tile was aggregating only `portfolio.marketValue`, so composite custom assets (e.g. a CPF pension held outside any portfolio) were silently dropped — a clean Mary onboard with CPF SGD 281,000 + DBS/UOB SGD 37,000 + IBKR USD 40,000 saw Net Worth = SGD 88,200 instead of ~SGD 369,000. See [DEMO-ISSUES.md #13](https://github.com/monowai/bc-claude/blob/main/DEMO-ISSUES.md).
- `useWealthSummary` now accepts a per-currency `customAssetTotals` map and folds the balances in using the existing `fxRates` table.
- `wealth.tsx` reads `PrivateAssetConfig.subAccounts` (where composite balances live) via the existing `usePrivateAssetConfigs` hook and groups by `rentalCurrency` (the field the onboarding pension save uses for the asset currency).
- The "no portfolios" empty state now also accounts for users who only have custom assets — a CPF-only user lands on the populated dashboard instead of the setup prompts.

## Test plan

- [x] `npx jest src/components/features/wealth` — 23 tests pass (5 new for `useWealthSummary`).
- [x] `yarn test` — 1381/1381 pass.
- [x] `yarn typecheck` — clean.
- [x] `npx eslint` (touched files, `--max-warnings=0`) — clean.
- [x] `semgrep_scan` — no findings on touched files.
- [ ] Manual verify on kauri once merged: `/wealth` Net Worth ≈ SGD 369k for Mary's persona instead of SGD 88,200.

@coderabbitai ignore