### PR TITLE
fix(scenario): invoke simpleFetcher with key in ScenarioContributions

### DIFF
--- a/src/components/features/independence/scenarios/ScenarioContributions.tsx
+++ b/src/components/features/independence/scenarios/ScenarioContributions.tsx
@@ -93,17 +93,17 @@ export default function ScenarioContributions({
       : null
   const { data: previewResp } = useSWR<CpfPreviewResponse>(
     previewKey,
-    simpleFetcher,
+    previewKey ? simpleFetcher(previewKey) : null,
   )
   const salaryAnnual = previewResp?.data?.annualContribution
 
   const { data: configsResp } = useSWR<PrivateAssetConfigsResponse>(
     configsKey,
-    simpleFetcher,
+    simpleFetcher(configsKey),
   )
   const { data: contribsResp, mutate: refreshContribs } = useSWR<{
     data: PlanContribution[]
-  }>(contributionsKey, simpleFetcher)
+  }>(contributionsKey, simpleFetcher(contributionsKey))
 
   const pensionAssets: PensionAsset[] = (configsResp?.data || [])
     .filter((c) => c.isPension)

--- a/src/components/features/independence/scenarios/__tests__/ScenarioContributions.fetcher.test.tsx
+++ b/src/components/features/independence/scenarios/__tests__/ScenarioContributions.fetcher.test.tsx
@@ -1,0 +1,112 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { SWRConfig } from "swr"
+import ScenarioContributions from "@components/features/independence/scenarios/ScenarioContributions"
+
+// Regression for DEMO-ISSUES #4 — "No pension or policy assets configured"
+// even though the user has a CPF asset with isPension=true. Root cause was
+// that ScenarioContributions passed the simpleFetcher *factory* to useSWR
+// instead of invoking it with the key (`simpleFetcher(url)`). SWR then
+// treated the factory function as the resolved data, the component read
+// `configsResp?.data || []` (undefined → []), and the empty-state path
+// was the only one ever rendered.
+//
+// We do NOT mock `swr` here — we want the real SWR runtime to resolve the
+// fetcher exactly as it does in production. `simpleFetcher` is mocked to
+// return a key-driven async result, and we assert that the rendered output
+// contains the pension assets. A regressed wiring (passing the factory)
+// would render the "No pension or policy assets configured" message.
+
+const previewResponse = {
+  data: {
+    annualContribution: 12000,
+    monthlyContribution: 1000,
+    annualOa: 0,
+    annualSa: 0,
+    annualMa: 0,
+    employeeRate: 0,
+    employerRate: 0,
+    cappedSalary: 0,
+    wageCeiling: 0,
+  },
+}
+
+const configsResponse = {
+  data: [
+    {
+      assetId: "cpf-1",
+      isPension: true,
+      contributionFrequency: "MONTHLY",
+      policyType: "CPF",
+    },
+  ],
+  assetNames: { "cpf-1": "Mary's CPF" },
+}
+
+const contributionsResponse = { data: [] }
+
+jest.mock("@utils/api/fetchHelper", () => {
+  const simpleFetcher = jest.fn((url: string) => () => {
+    if (url === "/api/assets/config")
+      return Promise.resolve(configsResponse)
+    if (url.startsWith("/api/independence/work-scenarios/"))
+      return Promise.resolve(contributionsResponse)
+    if (url.startsWith("/api/independence/cpf/contribution-preview"))
+      return Promise.resolve(previewResponse)
+    return Promise.resolve({ data: [] })
+  })
+  return {
+    __esModule: true,
+    simpleFetcher,
+    ccyKey: "/api/currencies",
+    holdingKey: () => "",
+    portfoliosKey: "/api/portfolios",
+  }
+})
+
+import { simpleFetcher } from "@utils/api/fetchHelper"
+
+function renderInFreshSwrCache(): void {
+  render(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <ScenarioContributions
+        scenarioId="scn-1"
+        currency="SGD"
+        monthlySalary={6250}
+        currentAge={45}
+      />
+    </SWRConfig>,
+  )
+}
+
+describe("ScenarioContributions — SWR fetcher wiring", () => {
+  beforeEach(() => {
+    ;(simpleFetcher as jest.Mock).mockClear()
+  })
+
+  it("invokes simpleFetcher with each SWR key (not the factory itself)", async () => {
+    renderInFreshSwrCache()
+    await waitFor(() => {
+      expect(
+        (simpleFetcher as jest.Mock).mock.calls.map((c) => c[0]),
+      ).toEqual(
+        expect.arrayContaining([
+          "/api/assets/config",
+          "/api/independence/work-scenarios/scn-1/contributions",
+          expect.stringContaining("/api/independence/cpf/contribution-preview"),
+        ]),
+      )
+    })
+  })
+
+  it("renders the pension asset when the configs SWR resolves with isPension=true", async () => {
+    renderInFreshSwrCache()
+    await waitFor(() => {
+      expect(screen.getByText("Mary's CPF")).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByText(/No pension or policy assets configured/i),
+    ).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- `ScenarioContributions` was passing the `simpleFetcher` factory **directly** to `useSWR` for three keys (preview / configs / contributions). Every other caller in the codebase invokes it with the URL (`simpleFetcher(key)`). SWR stored the unresolved factory function as the resolved value, so `configsResp?.data || []` collapsed to `[]` and the Edit Work Scenario dialog always read "No pension or policy assets configured" — even after onboarding a CPF asset with `isPension: true`.
- Fix matches the codebase-wide pattern: `simpleFetcher(configsKey)`, `simpleFetcher(contributionsKey)`, `previewKey ? simpleFetcher(previewKey) : null`.
- Adds `ScenarioContributions.fetcher.test.tsx`: uses the real SWR runtime (not the existing file's full-SWR mock, which masked the bug). Two assertions — `simpleFetcher` is invoked with each key, and the rendered output contains the pension asset name. The pre-fix code fails the second test with the "No pension..." empty state.

See [DEMO-ISSUES.md #4](https://github.com/monowai/bc-claude/blob/main/DEMO-ISSUES.md).

## Test plan

- [x] `npx jest src/components/features/independence/scenarios/__tests__/ScenarioContributions.fetcher.test.tsx` — 2 pass.
- [x] `yarn test` — 1383/1383 pass (including 3 existing ScenarioContributions tests).
- [x] `yarn typecheck` — clean.
- [x] `npx eslint --max-warnings=0` (touched files) — clean.
- [x] `semgrep_scan` — no findings.
- [ ] Verify on kauri once deployed: open `/independence` → Work → Edit Scenario; "Pension contributions" lists Mary's CPF instead of the empty message.

@coderabbitai ignore