### PR TITLE
feat(onboarding): persist targetIndependenceAge to svc-data UserPreferences

### DIFF
--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -23,6 +23,7 @@ import { openBrokerage } from "@lib/openBrokerage/orchestrate"
 import { useRegistration } from "@contexts/RegistrationContext"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import Spinner from "@components/ui/Spinner"
+import { buildMePatchBody } from "./buildMePatchBody"
 
 export interface BankAccount {
   name: string
@@ -561,21 +562,26 @@ const OnboardingWizard: React.FC = () => {
 
     try {
       // Save user preferences with currency settings. When the user filled
-      // in the independence step, also persist their date of birth on the
-      // SystemUser preferences (svc-data) so age-driven projections don't
-      // fall back to the currentYear-55 default.
+      // in the independence step, also persist their date of birth AND
+      // target independence age on the SystemUser preferences (svc-data)
+      // so age-driven projections don't fall back to the currentYear-55
+      // / target-65 defaults. svc-retire's UserIndependenceSettings reads
+      // these as its fallback when its own row has null demographic
+      // fields — see bc-claude/USER_PROFILE.md.
       await fetch("/api/me", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          preferredName: preferredName || undefined,
-          baseCurrencyCode: baseCurrency,
-          reportingCurrencyCode: reportingCurrency,
-          ...(independencePlanEnabled && {
-            yearOfBirth: independenceYearOfBirth,
-            monthOfBirth: independenceMonthOfBirth,
+        body: JSON.stringify(
+          buildMePatchBody({
+            preferredName,
+            baseCurrency,
+            reportingCurrency,
+            independencePlanEnabled,
+            independenceYearOfBirth,
+            independenceMonthOfBirth,
+            independenceTargetAge,
           }),
-        }),
+        ),
       })
 
       // Create portfolio with reporting currency as display currency

--- a/src/components/features/onboarding/__tests__/buildMePatchBody.test.ts
+++ b/src/components/features/onboarding/__tests__/buildMePatchBody.test.ts
@@ -1,0 +1,51 @@
+import { buildMePatchBody } from "../buildMePatchBody"
+
+const baseInput = {
+  preferredName: "Mary",
+  baseCurrency: "SGD",
+  reportingCurrency: "SGD",
+  independencePlanEnabled: true,
+  independenceYearOfBirth: 1981,
+  independenceMonthOfBirth: 1,
+  independenceTargetAge: 60,
+}
+
+describe("buildMePatchBody", () => {
+  it("includes targetIndependenceAge when the user filled in the independence step", () => {
+    // Regression for DEMO-ISSUES #14 — Plan Profile read defaults (Target
+    // 65) until the user re-saved because targetIndependenceAge never made
+    // it onto the PATCH /api/me body, and svc-data UserPreferences didn't
+    // hold the value either. With the field now plumbed (alongside the
+    // svc-data column + svc-retire fallback in companion PRs), a freshly
+    // onboarded user's Plan Profile picks up their entered values without
+    // a manual save.
+    const body = buildMePatchBody(baseInput)
+
+    expect(body).toEqual({
+      preferredName: "Mary",
+      baseCurrencyCode: "SGD",
+      reportingCurrencyCode: "SGD",
+      yearOfBirth: 1981,
+      monthOfBirth: 1,
+      targetIndependenceAge: 60,
+    })
+  })
+
+  it("omits the demographic fields when the independence step was skipped", () => {
+    const body = buildMePatchBody({
+      ...baseInput,
+      independencePlanEnabled: false,
+    })
+
+    expect(body.yearOfBirth).toBeUndefined()
+    expect(body.monthOfBirth).toBeUndefined()
+    expect(body.targetIndependenceAge).toBeUndefined()
+    expect(body.baseCurrencyCode).toBe("SGD")
+  })
+
+  it("collapses an empty preferredName to undefined so the field is omitted", () => {
+    const body = buildMePatchBody({ ...baseInput, preferredName: "" })
+
+    expect(body.preferredName).toBeUndefined()
+  })
+})

--- a/src/components/features/onboarding/buildMePatchBody.ts
+++ b/src/components/features/onboarding/buildMePatchBody.ts
@@ -1,0 +1,42 @@
+/**
+ * Build the PATCH body for `/api/me` on onboarding completion.
+ *
+ * When `independencePlanEnabled` is true, the user filled in their date
+ * of birth and target independence age on the Independence step; mirror
+ * those onto the svc-data master `UserPreferences` so age-driven
+ * projections (svc-retire) resolve real values instead of the defaults
+ * (currentYear-55 / target 65). See bc-claude/USER_PROFILE.md.
+ */
+export interface OnboardingMePatchInput {
+  preferredName: string
+  baseCurrency: string
+  reportingCurrency: string
+  independencePlanEnabled: boolean
+  independenceYearOfBirth: number
+  independenceMonthOfBirth: number
+  independenceTargetAge: number
+}
+
+export interface OnboardingMePatchBody {
+  preferredName?: string
+  baseCurrencyCode: string
+  reportingCurrencyCode: string
+  yearOfBirth?: number
+  monthOfBirth?: number
+  targetIndependenceAge?: number
+}
+
+export function buildMePatchBody(
+  input: OnboardingMePatchInput,
+): OnboardingMePatchBody {
+  return {
+    preferredName: input.preferredName || undefined,
+    baseCurrencyCode: input.baseCurrency,
+    reportingCurrencyCode: input.reportingCurrency,
+    ...(input.independencePlanEnabled && {
+      yearOfBirth: input.independenceYearOfBirth,
+      monthOfBirth: input.independenceMonthOfBirth,
+      targetIndependenceAge: input.independenceTargetAge,
+    }),
+  }
+}


### PR DESCRIPTION
## Summary

- The Independence step collects target retirement age but the wizard's Complete-Setup `PATCH /api/me` never sent it; the value lived only in component state and was lost on submit. With svc-data adding the column and svc-retire reading svc-data as fallback ([companion PRs](#related)), the wizard now plumbs the field through.
- Extracts the PATCH body into a small pure helper `buildMePatchBody` so the new field — alongside `yearOfBirth` + `monthOfBirth` — can be unit-tested without spinning up the 1000-line wizard.

Closes the last leg of [DEMO-ISSUES #14](https://github.com/monowai/bc-claude/blob/main/DEMO-ISSUES.md). With all three PRs deployed, a freshly-onboarded user's Plan Profile reads YoB / month / target age from the first projection load — no manual re-save needed.

## Related

- beancounter [#926](https://github.com/monowai/beancounter/pull/926) — adds `target_independence_age` to svc-data UserPreferences.
- svc-retire [#49](https://github.com/monowai/svc-retire/pull/49) — falls back to svc-data UserPreferences when local demographic fields are null.
- [USER_PROFILE.md](https://github.com/monowai/bc-claude/blob/main/USER_PROFILE.md) — broader migration plan (per-Plan UserProfile entity is a follow-up).

## Test plan

- [x] `npx jest src/components/features/onboarding` — 3 new tests for `buildMePatchBody` pass.
- [x] `yarn test` — 1386/1386 pass.
- [x] `yarn typecheck` — clean.
- [x] `eslint --max-warnings=0` (touched files) — clean.
- [x] `semgrep_scan` — no findings.
- [ ] After all three deploy: fresh Mary onboarding → `/independence` Profile reads YoB 1981 / Month January / Target 60 without re-save; "Spendable at Independence" projects to age 60, not age 90.

@coderabbitai ignore