### PR TITLE
feat(assets): route composite assets to svc-position synthesised position

### DIFF
--- a/__tests__/pages/assets/positions/composite.route.test.ts
+++ b/__tests__/pages/assets/positions/composite.route.test.ts
@@ -1,0 +1,151 @@
+import positionsHandler from "@pages/api/assets/[id]/positions"
+
+jest.mock("@lib/auth0", () => ({
+  auth0: {
+    getSession: jest.fn().mockResolvedValue({ user: { sub: "test-user" } }),
+    getAccessToken: jest.fn().mockResolvedValue({ token: "test-token" }),
+  },
+}))
+
+jest.mock("@utils/api/fetchHelper", () => ({
+  requestInit: jest.fn(
+    (token: string, method: string) =>
+      ({
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+      }) as unknown,
+  ),
+}))
+
+jest.mock("@utils/api/responseWriter", () => ({
+  __esModule: true,
+  default: jest.fn(),
+  handleResponse: jest.fn(),
+  fetchError: jest.fn(
+    (
+      _req: unknown,
+      res: { status: jest.Mock; json: jest.Mock },
+      error: { message: string },
+    ) => {
+      res.status(500).json({ error: error.message })
+    },
+  ),
+}))
+
+jest.mock("@utils/api/bcConfig", () => ({
+  getDataUrl: (path: string = "") => `http://data.test${path}`,
+  getPositionsUrl: (path: string = "") => `http://positions.test${path}`,
+}))
+
+interface Req {
+  method: string
+  query: Record<string, string>
+  headers: Record<string, string>
+}
+
+interface Res {
+  status: jest.Mock
+  setHeader: jest.Mock
+  json: jest.Mock
+}
+
+function makeReq(id: string): Req {
+  return { method: "GET", query: { id }, headers: {} }
+}
+
+function makeRes(): Res {
+  return {
+    status: jest.fn().mockReturnThis(),
+    setHeader: jest.fn(),
+    json: jest.fn(),
+  }
+}
+
+const COMPOSITE_ASSET_ID = "cpf-asset-id"
+
+function mockResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("/api/assets/[id]/positions composite branch", () => {
+  it("synthesises a position for a composite asset when whereHeld is empty", async () => {
+    const routes: Record<string, () => Response> = {
+      [`http://data.test/assets/${COMPOSITE_ASSET_ID}`]: () =>
+        mockResponse({ data: { id: COMPOSITE_ASSET_ID } }),
+      [`http://data.test/portfolios/asset/${COMPOSITE_ASSET_ID}?asAt=today`]:
+        () => mockResponse({ data: [] }),
+      [`http://positions.test/positions/composite/${COMPOSITE_ASSET_ID}?asAt=today`]:
+        () =>
+          mockResponse({
+            data: {
+              asset: { id: COMPOSITE_ASSET_ID },
+              subAccounts: { OA: 145000, SA: 78000, MA: 58000, RA: 0 },
+              quantityValues: { total: 281000 },
+            },
+          }),
+    }
+    global.fetch = jest.fn((input: RequestInfo) => {
+      const url = String(input)
+      const responder = routes[url]
+      if (!responder) {
+        return Promise.reject(new Error(`unexpected fetch: ${url}`))
+      }
+      return Promise.resolve(responder())
+    }) as unknown as typeof fetch
+
+    const req = makeReq(COMPOSITE_ASSET_ID)
+    const res = makeRes()
+
+    await positionsHandler(
+      req as unknown as Parameters<typeof positionsHandler>[0],
+      res as unknown as Parameters<typeof positionsHandler>[1],
+    )
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    const payload = res.json.mock.calls[0][0] as {
+      data: Array<{ portfolio: unknown; balance: number }>
+    }
+    expect(payload.data).toHaveLength(1)
+    expect(payload.data[0].portfolio).toBeNull()
+    expect(payload.data[0].balance).toBe(281000)
+  })
+
+  it("falls back to portfolio scan when composite endpoint returns null", async () => {
+    const routes: Record<string, () => Response> = {
+      [`http://data.test/assets/${COMPOSITE_ASSET_ID}`]: () =>
+        mockResponse({ data: { id: COMPOSITE_ASSET_ID } }),
+      [`http://data.test/portfolios/asset/${COMPOSITE_ASSET_ID}?asAt=today`]:
+        () => mockResponse({ data: [] }),
+      [`http://positions.test/positions/composite/${COMPOSITE_ASSET_ID}?asAt=today`]:
+        () => mockResponse({ data: null }),
+      "http://data.test/portfolios": () => mockResponse({ data: [] }),
+    }
+    global.fetch = jest.fn((input: RequestInfo) => {
+      const url = String(input)
+      const responder = routes[url]
+      if (!responder) {
+        return Promise.reject(new Error(`unexpected fetch: ${url}`))
+      }
+      return Promise.resolve(responder())
+    }) as unknown as typeof fetch
+
+    const req = makeReq(COMPOSITE_ASSET_ID)
+    const res = makeRes()
+
+    await positionsHandler(
+      req as unknown as Parameters<typeof positionsHandler>[0],
+      res as unknown as Parameters<typeof positionsHandler>[1],
+    )
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json.mock.calls[0][0]).toEqual({ data: [] })
+  })
+})

--- a/src/pages/api/assets/[id]/positions.ts
+++ b/src/pages/api/assets/[id]/positions.ts
@@ -9,9 +9,41 @@ const dataUrl = getDataUrl()
 const positionUrl = getPositionsUrl()
 
 interface AssetPosition {
-  portfolio: Portfolio
+  portfolio: Portfolio | null
   position: Position | null
   balance: number
+}
+
+// Response from svc-position /positions/composite/{assetId}
+interface CompositePositionResponse {
+  data: Position | null
+}
+
+async function fetchCompositeBalance(
+  assetId: string,
+  accessToken: string,
+  req: NextApiRequest,
+  date: string,
+): Promise<{ position: Position; balance: number } | null> {
+  try {
+    const response = await fetch(
+      `${positionUrl}/positions/composite/${assetId}?asAt=${date}`,
+      requestInit(accessToken, "GET", req),
+    )
+    if (!response.ok) return null
+    const body: CompositePositionResponse = await response.json()
+    const position = body.data
+    if (!position) return null
+    const subAccountTotal = Object.values(position.subAccounts ?? {}).reduce(
+      (sum: number, raw) => sum + Number(raw ?? 0),
+      0,
+    )
+    const balance =
+      Number(position.quantityValues?.total ?? 0) || subAccountTotal
+    return { position, balance }
+  } catch {
+    return null
+  }
 }
 
 interface AssetPositionsResponse {
@@ -99,9 +131,28 @@ export default async function getAssetPositions(
       portfolios = whereHeldData.data || []
     }
 
-    // If whereHeld returns empty (can happen for ACCOUNT assets where asset.id == cashAsset.id),
-    // fall back to scanning all portfolios for positions
+    // Composite assets (CPF, ILP, ...) hold their balance in svc-data's
+    // PrivateAssetConfig sub-accounts, not as svc-position positions. Ask
+    // svc-position to synthesise one before falling back to portfolio scan.
     if (portfolios.length === 0) {
+      const compositeBalance = await fetchCompositeBalance(
+        resolvedAssetId,
+        accessToken,
+        req,
+        date,
+      )
+      if (compositeBalance !== null) {
+        res.status(200).json({
+          data: [
+            {
+              portfolio: null,
+              position: compositeBalance.position,
+              balance: compositeBalance.balance,
+            },
+          ],
+        })
+        return
+      }
       const allPortfoliosResponse = await fetch(
         `${dataUrl}/portfolios`,
         requestInit(accessToken, "GET", req),
@@ -143,7 +194,7 @@ export default async function getAssetPositions(
               })
             }
           } catch (error) {
-            console.error(`Error scanning portfolio ${portfolio.code}:`, error)
+            console.error("Error scanning portfolio %s:", portfolio.code, error)
           }
         }),
       )
@@ -183,7 +234,11 @@ export default async function getAssetPositions(
             balance: position?.quantityValues?.total || 0,
           }
         } catch (error) {
-          console.error(`Error fetching holdings for ${portfolio.code}:`, error)
+          console.error(
+            "Error fetching holdings for %s:",
+            portfolio.code,
+            error,
+          )
           return {
             portfolio,
             position: null,

--- a/src/pages/api/assets/[id]/positions.ts
+++ b/src/pages/api/assets/[id]/positions.ts
@@ -39,7 +39,9 @@ async function fetchCompositeBalance(
       0,
     )
     const balance =
-      Number(position.quantityValues?.total ?? 0) || subAccountTotal
+      position.quantityValues?.total != null
+        ? Number(position.quantityValues.total)
+        : subAccountTotal
     return { position, balance }
   } catch {
     return null

--- a/src/pages/assets/lookup.tsx
+++ b/src/pages/assets/lookup.tsx
@@ -20,7 +20,10 @@ import Spinner from "@components/ui/Spinner"
 import { usePermissions } from "@hooks/usePermissions"
 
 interface AssetPosition {
-  portfolio: Portfolio
+  // Composite assets (CPF, ILP, ...) don't belong to a portfolio — svc-position
+  // synthesises a position from the asset config and the API returns
+  // portfolio: null on that path.
+  portfolio: Portfolio | null
   position: Position | null
   balance: number
 }
@@ -461,7 +464,7 @@ function AssetLookupPage(): React.ReactElement {
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
-                {positions.map((ap) => {
+                {positions.map((ap, idx) => {
                   const moneyValues = ap.position?.moneyValues?.PORTFOLIO
                   const gain = moneyValues
                     ? (moneyValues.marketValue || 0) -
@@ -471,14 +474,49 @@ function AssetLookupPage(): React.ReactElement {
                     moneyValues && moneyValues.costValue
                       ? (gain / moneyValues.costValue) * 100
                       : 0
+                  const portfolio = ap.portfolio
+                  const currencyCode =
+                    portfolio?.currency.code ??
+                    ap.position?.asset?.market?.currency?.code ??
+                    ""
+                  const rowKey = portfolio?.id ?? `composite-${idx}`
+
+                  if (!portfolio) {
+                    return (
+                      <tr key={rowKey} className="bg-gray-50">
+                        <td className="px-4 py-3">
+                          <span className="font-medium text-gray-700">
+                            Composite
+                          </span>
+                          <div className="text-xs text-gray-500">
+                            Sub-account roll-up (no portfolio)
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-right text-gray-900">
+                          {formatQuantity(ap.balance)}
+                        </td>
+                        <td className="px-4 py-3 text-right text-gray-500 hidden sm:table-cell">
+                          -
+                        </td>
+                        <td className="px-4 py-3 text-right text-gray-900 font-medium">
+                          {currencyCode
+                            ? formatValue(ap.balance, currencyCode)
+                            : formatQuantity(ap.balance)}
+                        </td>
+                        <td className="px-4 py-3 text-right text-gray-500 hidden md:table-cell">
+                          -
+                        </td>
+                      </tr>
+                    )
+                  }
 
                   return (
                     <tr
-                      key={ap.portfolio.id}
+                      key={rowKey}
                       className="hover:bg-gray-50 cursor-pointer transition-colors"
                       onDoubleClick={() =>
                         handleRowDoubleClick(
-                          ap.portfolio.id,
+                          portfolio.id,
                           selectedAsset.assetId || selectedAsset.value,
                         )
                       }
@@ -492,16 +530,16 @@ function AssetLookupPage(): React.ReactElement {
                             const assetId =
                               selectedAsset.assetId || selectedAsset.value
                             router.push(
-                              `/holdings/${ap.portfolio.code}#asset-${encodeURIComponent(assetId)}`,
+                              `/holdings/${portfolio.code}#asset-${encodeURIComponent(assetId)}`,
                             )
                           }}
                           className="font-medium text-blue-600 hover:text-blue-800 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-                          title={`View holdings for ${ap.portfolio.code}`}
+                          title={`View holdings for ${portfolio.code}`}
                         >
-                          {ap.portfolio.code}
+                          {portfolio.code}
                         </button>
                         <div className="text-xs text-gray-500">
-                          {ap.portfolio.name}
+                          {portfolio.name}
                         </div>
                       </td>
                       <td className="px-4 py-3 text-right text-gray-900">
@@ -511,7 +549,7 @@ function AssetLookupPage(): React.ReactElement {
                         {moneyValues
                           ? formatValue(
                               moneyValues.costValue || 0,
-                              ap.portfolio.currency.code,
+                              portfolio.currency.code,
                             )
                           : "-"}
                       </td>
@@ -519,7 +557,7 @@ function AssetLookupPage(): React.ReactElement {
                         {moneyValues
                           ? formatValue(
                               moneyValues.marketValue || 0,
-                              ap.portfolio.currency.code,
+                              portfolio.currency.code,
                             )
                           : "-"}
                       </td>
@@ -531,7 +569,7 @@ function AssetLookupPage(): React.ReactElement {
                             }
                           >
                             <div>
-                              {formatValue(gain, ap.portfolio.currency.code)}
+                              {formatValue(gain, portfolio.currency.code)}
                             </div>
                             <div className="text-xs">
                               ({gainPercent >= 0 ? "+" : ""}


### PR DESCRIPTION
## Summary

- `/api/assets/[id]/positions` now calls `svc-position` `GET /positions/composite/{assetId}` when whereHeld is empty. Composite policies (CPF, ILP, ...) get a synthesised `AssetPosition` with `portfolio: null` and a `balance` summed from sub-accounts.
- Falls through to the existing portfolio-scan path when svc-position reports the asset is not composite.
- `console.error` calls in the route swapped to constant format-string + args (semgrep CWE-134).

## Why

Plan "Policies Need Balances" warning, Plan Total Assets, Onboarding "Assets added" tile and Review row all hit this endpoint. Today it returns `data: []` for composite assets because no portfolio holds them and svc-position has no position. After this change all those surfaces see CPF's 281k without each one re-implementing sub-account summation.

Companion backend PR: monowai/beancounter#927

## Test plan

- [x] `__tests__/pages/assets/positions/composite.route.test.ts` — synthesised-position happy path + fallback to portfolio scan
- [x] `yarn test` (1388 tests)
- [x] `yarn typecheck`
- [x] `yarn prettier --check` + `yarn lint` on changed files
- [ ] Deploy to kauri, verify Mary's CPF 281k surfaces in Plan + Net Worth tile unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for composite asset positions: when portfolio data is missing the system synthesizes a single composite/sub-account roll-up row, shows quantity, uses currency fallback, and displays dashes for cost/value/gain; view/navigation and money formatting handle missing portfolio gracefully.

* **Tests**
  * Added tests covering composite position synthesis and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->