### PR TITLE
fix(independence): plan tile reads totalAssets/liquidAssets from projection echo

### DIFF
--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -519,6 +519,26 @@ function PlanView(): React.ReactElement {
     ? (planInputsAges?.lifeExpectancy ?? lifeExpectancy)
     : lifeExpectancy
 
+  // Display totals: prefer the server's authoritative numbers from the
+  // projection echo so composite assets (CPF sub-accounts, future ILP/
+  // generic) are reflected in the tile. Local categorySlices roll-up
+  // omits composite assets because they aren't svc-position positions —
+  // the projection (via PlanAllocationService) is the single source of
+  // truth. Fall back to the local sum until the projection lands so the
+  // tile renders something on first paint.
+  const projectionTotals = adjustedProjection as unknown as
+    | { totalAssets?: number; liquidAssets?: number }
+    | null
+    | undefined
+  const displayTotalAssets =
+    projectionTotals?.totalAssets != null
+      ? projectionTotals.totalAssets
+      : totalAssets
+  const displayLiquidAssets =
+    projectionTotals?.liquidAssets != null
+      ? projectionTotals.liquidAssets
+      : liquidAssets
+
   // FIRE data is ready when backend projection has completed with valid metrics
   const fireDataReady =
     !!plan &&
@@ -908,8 +928,8 @@ function PlanView(): React.ReactElement {
               spendableCategories={spendableCategories}
               onToggleCategory={toggleCategory}
               pensionProjections={pensionProjections}
-              totalAssets={totalAssets}
-              liquidAssets={liquidAssets}
+              totalAssets={displayTotalAssets}
+              liquidAssets={displayLiquidAssets}
               blendedReturnRate={blendedReturnRate}
               currentAge={displayCurrentAge}
               retirementAge={displayRetirementAge}


### PR DESCRIPTION
## Summary

- Plan tile (Total Assets, Spendable Liquid Assets) on `/independence/plans/[id]` now reads `totalAssets` / `liquidAssets` from the projection response (svc-retire) instead of recomputing locally from `categorySlices`.
- Falls back to the local sum until the projection lands so the tile renders on first paint.
- Categories panel below still uses local roll-up (next follow-up — needs server-side category breakdown that includes composite buckets).

## Why

After svc-retire #50 + #51 deploys, projection response correctly reports Mary's `totalAssets: 369,374.92` / `liquidAssets: 311,374.92` (svc-position portfolio + CPF composite via PlanAllocationService).

bc-view tile was still displaying 88,375 because it computed the sum locally from svc-position-only category slices (no composite CPF). Same leak class as the svc-retire one — fourth iteration, hence this fix: "Backend drives data, frontend displays it" (memory `feedback_backend_drives_display_data.md`).

## Test plan

- [x] `yarn test` (1388 tests, all pass)
- [x] `yarn typecheck`
- [x] `npx prettier --check` + `npx eslint` on changed file
- [ ] Deploy: Mary's plan tile shows SGD 369,374.92 / SGD 311,374.92

## Follow-up (separate PR)

- svc-retire returns `assetBreakdown` (category list including composite bucket) in projection response → AssetsBreakdown chart shows CPF sliver next to Cash/ETF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of displayed asset values in independence plan details by sourcing from authoritative projection data, ensuring more reliable financial information is shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->