### PR TITLE
feat(independence): chart slices come from projection.assetBreakdown

### DIFF
--- a/src/components/features/independence/useAssetBreakdown.ts
+++ b/src/components/features/independence/useAssetBreakdown.ts
@@ -13,7 +13,7 @@ export const DEFAULT_NON_SPENDABLE_CATEGORIES = ["Property", "Real Estate"]
  * ones that exclude them from the spendable pool so the value isn't
  * double-counted against the income column.
  */
-export const INCOME_STREAM_CATEGORIES = ["Policies"]
+export const INCOME_STREAM_CATEGORIES = ["Policies", "Pension"]
 
 export interface AssetBreakdown {
   /** Liquid/spendable assets (everything except property) */

--- a/src/lib/utils/allocation/aggregateHoldings.ts
+++ b/src/lib/utils/allocation/aggregateHoldings.ts
@@ -22,6 +22,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   "Mutual Fund": "#8B5CF6", // purple
   Cash: "#6B7280", // gray
   Property: "#F59E0B", // amber
+  Pension: "#0EA5E9", // sky — composite assets (CPF / ILP / generic)
 }
 
 // Fallback colors for dynamic values
@@ -148,6 +149,35 @@ export function transformToAllocationSlices(
   // Sort by value descending
   slices.sort((a, b) => b.value - a.value)
 
+  return slices
+}
+
+/**
+ * Build chart slices from svc-retire's server-side asset breakdown. Used by
+ * the Independence plan page so composite assets (CPF / ILP / generic
+ * pensions) appear alongside portfolio categories without bc-view having to
+ * re-derive them from svc-position holdings (which never see composite
+ * balances). See `feedback_backend_drives_display_data`.
+ */
+export function serverBreakdownToAllocationSlices(
+  breakdown: Array<{ category: string; value: number }>,
+): AllocationSlice[] {
+  if (!breakdown || breakdown.length === 0) return []
+  const total = breakdown.reduce((sum, b) => sum + Number(b.value || 0), 0)
+  if (total <= 0) return []
+  const slices: AllocationSlice[] = breakdown.map((b, index) => {
+    const value = Number(b.value || 0)
+    return {
+      key: b.category,
+      label: b.category,
+      value,
+      percentage: (value / total) * 100,
+      color: getColor(b.category, index),
+      gainOnDay: 0,
+      irr: 0,
+    }
+  })
+  slices.sort((a, b) => b.value - a.value)
   return slices
 }
 

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -4,7 +4,10 @@ import Head from "next/head"
 import Link from "next/link"
 import { useRouter } from "next/router"
 import { Position } from "types/beancounter"
-import { transformToAllocationSlices } from "@lib/allocation/aggregateHoldings"
+import {
+  serverBreakdownToAllocationSlices,
+  transformToAllocationSlices,
+} from "@lib/allocation/aggregateHoldings"
 import { ValueIn } from "@components/features/holdings/GroupByOptions"
 import {
   TabId,
@@ -539,6 +542,25 @@ function PlanView(): React.ReactElement {
       ? projectionTotals.liquidAssets
       : liquidAssets
 
+  // Server-side asset breakdown (projection echo) drives the headline
+  // category chart so composite policies (CPF / ILP / generic) appear
+  // alongside Cash / ETF without bc-view re-deriving from svc-position
+  // holdings (which don't see composite balances). Falls back to the
+  // local roll-up until the projection lands so the chart renders on
+  // first paint.
+  const projectionAssetBreakdown = (
+    adjustedProjection as unknown as
+      | { assetBreakdown?: Array<{ category: string; value: number }> }
+      | null
+      | undefined
+  )?.assetBreakdown
+  const displayCategorySlices = useMemo(() => {
+    if (projectionAssetBreakdown && projectionAssetBreakdown.length > 0) {
+      return serverBreakdownToAllocationSlices(projectionAssetBreakdown)
+    }
+    return categorySlices
+  }, [projectionAssetBreakdown, categorySlices])
+
   // FIRE data is ready when backend projection has completed with valid metrics
   const fireDataReady =
     !!plan &&
@@ -924,7 +946,7 @@ function PlanView(): React.ReactElement {
               effectiveCurrency={effectiveCurrency}
               planCurrency={planCurrency}
               onEditDetails={() => setShowEditDetailsModal(true)}
-              categorySlices={categorySlices}
+              categorySlices={displayCategorySlices}
               spendableCategories={spendableCategories}
               onToggleCategory={toggleCategory}
               pensionProjections={pensionProjections}


### PR DESCRIPTION
## Summary

Follow-up to monowai/bc-view#797. Plan chart panel slices now read svc-retire's `projection.assetBreakdown` so composite policies (CPF / ILP / generic) appear as a `Pension` slice alongside Cash / ETF. Falls back to local roll-up until the projection lands.

Companion svc-retire PR already deployed: monowai/svc-retire#52 — projection response includes `assetBreakdown` with `Pension: 281,000` for Mary's case.

## Why

PR #797 fixed the headline tile (Total / Spendable totals) but the Assets-by-Category panel still ran the local `transformToAllocationSlices(holdings, ...)` path which omits composite. This PR plugs the chart into the server breakdown so CPF surfaces visually.

## Test plan

- [x] `yarn test` (1388 tests)
- [x] `yarn typecheck`
- [ ] Deploy: Mary's chart shows Pension slice ~281k SGD next to Cash + ETF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Pension as an income stream category alongside existing categories.
  * Enhanced asset breakdown visualization to display pension allocations with improved color-coded display and percentage calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->