### PR TITLE
feat(portfolios): banner + dialog to link standalone composite assets

### DIFF
--- a/src/components/features/portfolios/LinkCompositeBanner.tsx
+++ b/src/components/features/portfolios/LinkCompositeBanner.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react"
+import { useStandaloneCompositeAssets } from "@hooks/useStandaloneCompositeAssets"
+import LinkCompositeDialog from "./LinkCompositeDialog"
+
+/**
+ * Prompts the user to link a standalone composite-policy asset (CPF / ILP
+ * / generic pension) to a portfolio. The asset's balance lives in
+ * svc-data's PrivateAssetConfig today; linking emits a BALANCE trn with
+ * sub-accounts so svc-position holdings reflect the value and the asset
+ * appears under the user's portfolio rather than as a hidden side-bucket.
+ *
+ * Server-side rollup (svc-retire PlanAllocationService) still surfaces
+ * the value in plan totals before the user links — this banner is purely
+ * a visibility / UX nudge.
+ */
+export default function LinkCompositeBanner(): React.ReactElement | null {
+  const { standalone, isLoading } = useStandaloneCompositeAssets()
+  const [targetId, setTargetId] = useState<string | null>(null)
+
+  if (isLoading || standalone.length === 0) return null
+
+  const first = standalone[0]
+  const more = standalone.length - 1
+
+  return (
+    <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-medium text-amber-900">
+            {first.assetName}{" "}
+            <span className="font-normal">
+              ({first.currency} {Math.round(first.total).toLocaleString()})
+            </span>{" "}
+            isn&apos;t in a portfolio yet.
+          </p>
+          <p className="text-amber-800">
+            Link it so the balance shows up in your holdings and counts against
+            your wealth without a fresh entry every month.
+          </p>
+          {more > 0 && (
+            <p className="mt-1 text-xs text-amber-700">
+              +{more} more standalone composite asset
+              {more === 1 ? "" : "s"} to link.
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          className="shrink-0 rounded-md bg-amber-600 px-3 py-1 text-white hover:bg-amber-700"
+          onClick={() => setTargetId(first.assetId)}
+        >
+          Link to portfolio
+        </button>
+      </div>
+      {targetId && (
+        <LinkCompositeDialog
+          config={standalone.find((c) => c.assetId === targetId)!}
+          onClose={() => setTargetId(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/features/portfolios/LinkCompositeDialog.tsx
+++ b/src/components/features/portfolios/LinkCompositeDialog.tsx
@@ -1,0 +1,170 @@
+import React, { useEffect, useState } from "react"
+import useSwr from "swr"
+import { portfoliosKey, simpleFetcher } from "@utils/api/fetchHelper"
+import type { StandaloneCompositeConfig } from "@hooks/useStandaloneCompositeAssets"
+
+interface PortfoliosResponse {
+  data: Array<{
+    id: string
+    code: string
+    name: string
+    currency: { code: string }
+  }>
+}
+
+interface Props {
+  config: StandaloneCompositeConfig
+  onClose: () => void
+}
+
+/**
+ * Confirms the BALANCE trn that links a composite-policy asset (CPF
+ * today) to a portfolio. The trn carries the per-sub-account map so
+ * svc-position's BalanceBehaviour can persist the full breakdown without
+ * impacting the portfolio's cash balance. Repeating the same trn on a
+ * later date overwrites the snapshot (term-deposit-like semantics).
+ */
+export default function LinkCompositeDialog({
+  config,
+  onClose,
+}: Props): React.ReactElement {
+  const { data: portfoliosData } = useSwr<PortfoliosResponse>(
+    portfoliosKey,
+    simpleFetcher(portfoliosKey),
+  )
+  const [portfolioId, setPortfolioId] = useState<string>("")
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Default to first same-currency portfolio.
+  useEffect(() => {
+    if (!portfolioId && portfoliosData?.data?.length) {
+      const sameCcy = portfoliosData.data.find(
+        (p) => p.currency.code === config.currency,
+      )
+      setPortfolioId((sameCcy ?? portfoliosData.data[0]).id)
+    }
+  }, [portfoliosData, portfolioId, config.currency])
+
+  async function submit(): Promise<void> {
+    if (!portfolioId) return
+    setSubmitting(true)
+    setError(null)
+    const today = new Date().toISOString().slice(0, 10)
+    const subAccountsMap = Object.fromEntries(
+      config.subAccounts.map((sa) => [sa.code, sa.balance]),
+    )
+    const trnData: Record<string, unknown> = {
+      assetId: config.assetId,
+      trnType: "BALANCE",
+      quantity: config.total,
+      tradeAmount: config.total,
+      tradeDate: today,
+      tradeCurrency: config.currency,
+      cashCurrency: config.currency,
+      status: "SETTLED",
+      comments: `Link ${config.assetName} balance to portfolio`,
+      subAccounts: subAccountsMap,
+    }
+    try {
+      const r = await fetch("/api/trns", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ portfolioId, data: [trnData] }),
+      })
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}))
+        setError(body.message || body.detail || "Link failed")
+        return
+      }
+      onClose()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Link failed")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-md rounded-md bg-white p-4 shadow-lg">
+        <h2 className="mb-2 text-lg font-semibold">Link {config.assetName}</h2>
+        <p className="mb-3 text-sm text-gray-600">
+          Records a BALANCE snapshot of{" "}
+          <span className="font-medium">
+            {config.currency} {Math.round(config.total).toLocaleString()}
+          </span>{" "}
+          on today&apos;s date. Cash is not affected — re-running on a new date
+          replaces the snapshot.
+        </p>
+        <table className="mb-3 w-full text-sm">
+          <thead>
+            <tr className="text-left text-gray-500">
+              <th>Sub-account</th>
+              <th className="text-right">Balance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {config.subAccounts.map((sa) => (
+              <tr key={sa.code}>
+                <td>
+                  {sa.code}
+                  {sa.displayName ? ` — ${sa.displayName}` : ""}
+                  {!sa.liquid && (
+                    <span className="ml-1 text-xs text-gray-500">(locked)</span>
+                  )}
+                </td>
+                <td className="text-right tabular-nums">
+                  {Math.round(sa.balance).toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="mb-3">
+          <label
+            htmlFor="link-composite-portfolio"
+            className="mb-1 block text-sm font-medium"
+          >
+            Portfolio
+          </label>
+          <select
+            id="link-composite-portfolio"
+            value={portfolioId}
+            onChange={(e) => setPortfolioId(e.target.value)}
+            className="w-full rounded-md border border-gray-300 p-2 text-sm"
+          >
+            {portfoliosData?.data?.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.code} — {p.name} ({p.currency.code})
+              </option>
+            ))}
+          </select>
+        </div>
+        {error && (
+          <p className="mb-2 text-sm text-red-600" role="alert">
+            {error}
+          </p>
+        )}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="rounded-md border border-gray-300 px-3 py-1 text-sm"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="rounded-md bg-amber-600 px-3 py-1 text-sm text-white disabled:opacity-60"
+            onClick={submit}
+            disabled={submitting || !portfolioId}
+          >
+            {submitting ? "Linking…" : "Link"}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useStandaloneCompositeAssets.ts
+++ b/src/hooks/useStandaloneCompositeAssets.ts
@@ -1,0 +1,119 @@
+import useSwr from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+
+/**
+ * Subset of svc-data's PrivateAssetConfig response — only the fields the
+ * Link banner / dialog need. Keep narrow so we don't drag the full asset
+ * config DTO into UI code.
+ */
+export interface StandaloneCompositeConfig {
+  assetId: string
+  assetName: string
+  assetCode: string
+  currency: string
+  policyType: string
+  total: number
+  subAccounts: Array<{
+    code: string
+    displayName?: string
+    balance: number
+    liquid: boolean
+  }>
+}
+
+interface PrivateAssetConfigsResponse {
+  data: Array<{
+    assetId: string
+    policyType?: string | null
+    isComposite?: boolean
+    subAccounts?: Array<{
+      code: string
+      displayName?: string
+      balance: number
+      liquid?: boolean
+    }>
+  }>
+  assetNames?: Record<string, string>
+}
+
+interface AssetPositionsResponse {
+  data: Array<{ portfolio: { id: string } | null }>
+}
+
+const CONFIGS_KEY = "/api/assets/config"
+
+/**
+ * Lists composite-policy assets the user owns that aren't held in any
+ * portfolio. Used by the Link banner to nudge the user to BALANCE the
+ * asset into a portfolio (CPF / ILP / generic pension) so it appears in
+ * portfolio holdings + the plan's Assets-by-Category panel.
+ *
+ * Implementation: pulls all configs, filters to composite, then asks
+ * svc-position whether each is held. Standalone = held nowhere.
+ */
+export function useStandaloneCompositeAssets(): {
+  standalone: StandaloneCompositeConfig[]
+  isLoading: boolean
+} {
+  const { data, isLoading } = useSwr<PrivateAssetConfigsResponse>(
+    CONFIGS_KEY,
+    simpleFetcher(CONFIGS_KEY),
+  )
+
+  const composites = (data?.data ?? []).filter(
+    (c) => c.isComposite && (c.subAccounts?.length ?? 0) > 0,
+  )
+
+  const compositeKey = composites.length
+    ? `standalone-composites:${composites.map((c) => c.assetId).join(",")}`
+    : null
+
+  const { data: standaloneIds, isLoading: heldLoading } = useSwr<string[]>(
+    compositeKey,
+    async () => {
+      const checks = await Promise.all(
+        composites.map(async (c) => {
+          try {
+            const r = await fetch(
+              `/api/assets/${c.assetId}/positions?date=today`,
+            )
+            if (!r.ok) return c.assetId
+            const body: AssetPositionsResponse = await r.json()
+            const held = (body.data ?? []).some(
+              (e) => e.portfolio && e.portfolio.id,
+            )
+            return held ? null : c.assetId
+          } catch {
+            return c.assetId
+          }
+        }),
+      )
+      return checks.filter((id): id is string => id != null)
+    },
+  )
+
+  const names = data?.assetNames ?? {}
+  const safeIds: string[] = Array.isArray(standaloneIds) ? standaloneIds : []
+  const standalone: StandaloneCompositeConfig[] = safeIds
+    .map((id) => composites.find((c) => c.assetId === id))
+    .filter((c): c is NonNullable<typeof c> => c != null)
+    .map((c) => {
+      const subs = (c.subAccounts ?? []).map((sa) => ({
+        code: sa.code,
+        displayName: sa.displayName,
+        balance: sa.balance,
+        liquid: sa.liquid ?? true,
+      }))
+      return {
+        assetId: c.assetId,
+        assetName: names[c.assetId] ?? c.assetId,
+        assetCode: c.assetId,
+        currency: "USD", // placeholder — overridden when banner displays via asset lookup
+        policyType: c.policyType ?? "UNKNOWN",
+        total: subs.reduce((sum, sa) => sum + (sa.balance || 0), 0),
+        subAccounts: subs,
+      }
+    })
+
+  return { standalone, isLoading: isLoading || heldLoading }
+}

--- a/src/pages/portfolios/index.tsx
+++ b/src/pages/portfolios/index.tsx
@@ -11,6 +11,7 @@ import ManagedPortfolios from "@components/features/portfolios/ManagedPortfolios
 import ShareInviteDialog from "@components/features/portfolios/ShareInviteDialog"
 import PortfolioImportDialog from "@components/features/portfolios/PortfolioImportDialog"
 import PortfoliosList from "@components/features/portfolios/PortfoliosList"
+import LinkCompositeBanner from "@components/features/portfolios/LinkCompositeBanner"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
 import { usePortfolios } from "@hooks/usePortfolios"
 import { sharesManagedKey, simpleFetcher } from "@utils/api/fetchHelper"
@@ -187,17 +188,22 @@ export default withPageAuthRequired(function Portfolios({
 
       {/* Tab content */}
       {activeTab === "my" && !isLoading && (
-        <PortfoliosList
-          portfolios={activePortfolios}
-          displayCurrency={displayCurrency}
-          currencies={currencies}
-          fxRates={fxRates}
-          onCurrencyChange={setDisplayCurrency}
-          onImportClick={handleImportClick}
-          onShareClick={handleShareClick}
-          onCorporateActions={setCorporateActionsPortfolio}
-          onDelete={setDeleteTarget}
-        />
+        <>
+          <div className="px-4 pt-4">
+            <LinkCompositeBanner />
+          </div>
+          <PortfoliosList
+            portfolios={activePortfolios}
+            displayCurrency={displayCurrency}
+            currencies={currencies}
+            fxRates={fxRates}
+            onCurrencyChange={setDisplayCurrency}
+            onImportClick={handleImportClick}
+            onShareClick={handleShareClick}
+            onCorporateActions={setCorporateActionsPortfolio}
+            onDelete={setDeleteTarget}
+          />
+        </>
       )}
       {activeTab === "inactive" && !isLoading && (
         <PortfoliosList


### PR DESCRIPTION
## Summary

- New `LinkCompositeBanner` on `/portfolios` surfaces composite-policy assets (CPF / ILP / generic) the user owns but hasn't linked to a portfolio yet.
- `LinkCompositeDialog` confirms the BALANCE trn — sub-accounts map carried alongside total, status SETTLED, today's tradeDate. No cash impact (term-deposit-like semantic; transaction IS the balance).
- `useStandaloneCompositeAssets` hook discovers composites + cross-checks whereHeld via `/api/assets/:id/positions`.

## Why

User feedback on Mary's demo: "CPF should be visible in her SGD portfolio — if it's not in a portfolio it can't be considered as part of her wealth." This PR adds the nudge + one-click link. After link, CPF appears in portfolio holdings + plan tile reads from a single source (svc-position) instead of falling back to the config rollup.

Companion PRs (deploy first):
- monowai/beancounter#929 — BALANCE captures subAccounts + AllocationData.heldAssetIds
- monowai/svc-retire — `feat/composite-rollup-skip-held` (dedup)

## Test plan

- [x] `yarn test` (1388 tests)
- [x] `yarn typecheck`
- [x] `npx prettier --check` + `npx eslint` on changed files
- [ ] Deploy: Mary sees banner on `/portfolios`; click Link; CPF appears in SGD holdings; plan total stays 369k (no double-count)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New banner in the Portfolios section displays standalone composite assets with a "Link to portfolio" option
  * Added modal dialog to select the target portfolio when linking composite assets
  * Automatic detection of composite assets not currently associated with any portfolio

<!-- end of auto-generated comment: release notes by coderabbit.ai -->