### PR TITLE
fix(hooks): resolve composite asset currency from policy type

### DIFF
--- a/src/hooks/__tests__/useStandaloneCompositeAssets.test.ts
+++ b/src/hooks/__tests__/useStandaloneCompositeAssets.test.ts
@@ -1,0 +1,53 @@
+import { buildStandaloneConfigs } from "../useStandaloneCompositeAssets"
+
+describe("buildStandaloneConfigs", () => {
+  const cpfConfig = {
+    assetId: "asset-cpf",
+    policyType: "CPF",
+    isComposite: true,
+    subAccounts: [
+      { code: "OA", balance: 145000, liquid: true },
+      { code: "SA", balance: 78000, liquid: true },
+      { code: "MA", balance: 58000, liquid: false },
+    ],
+  }
+
+  it("returns SGD for CPF policies (never USD placeholder)", () => {
+    const result = buildStandaloneConfigs(["asset-cpf"], [cpfConfig], {
+      "asset-cpf": "CPF",
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].currency).toBe("SGD")
+    expect(result[0].policyType).toBe("CPF")
+    expect(result[0].total).toBe(281000)
+  })
+
+  it("preserves sub-account liquid flags", () => {
+    const result = buildStandaloneConfigs(["asset-cpf"], [cpfConfig], {})
+
+    const ma = result[0].subAccounts.find((s) => s.code === "MA")
+    expect(ma?.liquid).toBe(false)
+    const oa = result[0].subAccounts.find((s) => s.code === "OA")
+    expect(oa?.liquid).toBe(true)
+  })
+
+  it("skips ids not in composites map", () => {
+    const result = buildStandaloneConfigs(["asset-missing"], [cpfConfig], {})
+
+    expect(result).toEqual([])
+  })
+
+  it("falls back to UNKNOWN currency for unknown policy types (forces server lookup later)", () => {
+    const ilpConfig = {
+      assetId: "asset-ilp",
+      policyType: "ILP",
+      isComposite: true,
+      subAccounts: [{ code: "FUND-A", balance: 50000, liquid: true }],
+    }
+    const result = buildStandaloneConfigs(["asset-ilp"], [ilpConfig], {})
+
+    expect(result[0].currency).toBe("")
+    expect(result[0].policyType).toBe("ILP")
+  })
+})

--- a/src/hooks/useStandaloneCompositeAssets.ts
+++ b/src/hooks/useStandaloneCompositeAssets.ts
@@ -21,18 +21,20 @@ export interface StandaloneCompositeConfig {
   }>
 }
 
-interface PrivateAssetConfigsResponse {
-  data: Array<{
-    assetId: string
-    policyType?: string | null
-    isComposite?: boolean
-    subAccounts?: Array<{
-      code: string
-      displayName?: string
-      balance: number
-      liquid?: boolean
-    }>
+interface CompositeConfigSource {
+  assetId: string
+  policyType?: string | null
+  isComposite?: boolean
+  subAccounts?: Array<{
+    code: string
+    displayName?: string
+    balance: number
+    liquid?: boolean
   }>
+}
+
+interface PrivateAssetConfigsResponse {
+  data: CompositeConfigSource[]
   assetNames?: Record<string, string>
 }
 
@@ -41,6 +43,49 @@ interface AssetPositionsResponse {
 }
 
 const CONFIGS_KEY = "/api/assets/config"
+
+// Composite policies are denominated in a fixed currency dictated by the
+// scheme rules. CPF is statutory SGD; ILP / generic policies vary and need
+// a server-side lookup (deferred — empty string forces the caller to handle).
+const POLICY_CURRENCY: Record<string, string> = {
+  CPF: "SGD",
+}
+
+/**
+ * Pure mapping step extracted for unit testing. Given the list of
+ * standalone asset ids, the composite configs and the asset-name map,
+ * return the [StandaloneCompositeConfig] shape consumed by the Link
+ * banner / dialog. `currency` is resolved from the policy type — never
+ * a placeholder — so the downstream BALANCE trn carries the correct
+ * statutory currency instead of defaulting to USD.
+ */
+export function buildStandaloneConfigs(
+  standaloneIds: string[],
+  composites: CompositeConfigSource[],
+  assetNames: Record<string, string>,
+): StandaloneCompositeConfig[] {
+  return standaloneIds
+    .map((id) => composites.find((c) => c.assetId === id))
+    .filter((c): c is NonNullable<typeof c> => c != null)
+    .map((c) => {
+      const subs = (c.subAccounts ?? []).map((sa) => ({
+        code: sa.code,
+        displayName: sa.displayName,
+        balance: sa.balance,
+        liquid: sa.liquid ?? true,
+      }))
+      const policyType = c.policyType ?? "UNKNOWN"
+      return {
+        assetId: c.assetId,
+        assetName: assetNames[c.assetId] ?? c.assetId,
+        assetCode: c.assetId,
+        currency: POLICY_CURRENCY[policyType] ?? "",
+        policyType,
+        total: subs.reduce((sum, sa) => sum + (sa.balance || 0), 0),
+        subAccounts: subs,
+      }
+    })
+}
 
 /**
  * Lists composite-policy assets the user owns that aren't held in any
@@ -92,28 +137,12 @@ export function useStandaloneCompositeAssets(): {
     },
   )
 
-  const names = data?.assetNames ?? {}
   const safeIds: string[] = Array.isArray(standaloneIds) ? standaloneIds : []
-  const standalone: StandaloneCompositeConfig[] = safeIds
-    .map((id) => composites.find((c) => c.assetId === id))
-    .filter((c): c is NonNullable<typeof c> => c != null)
-    .map((c) => {
-      const subs = (c.subAccounts ?? []).map((sa) => ({
-        code: sa.code,
-        displayName: sa.displayName,
-        balance: sa.balance,
-        liquid: sa.liquid ?? true,
-      }))
-      return {
-        assetId: c.assetId,
-        assetName: names[c.assetId] ?? c.assetId,
-        assetCode: c.assetId,
-        currency: "USD", // placeholder — overridden when banner displays via asset lookup
-        policyType: c.policyType ?? "UNKNOWN",
-        total: subs.reduce((sum, sa) => sum + (sa.balance || 0), 0),
-        subAccounts: subs,
-      }
-    })
+  const standalone = buildStandaloneConfigs(
+    safeIds,
+    composites,
+    data?.assetNames ?? {},
+  )
 
   return { standalone, isLoading: isLoading || heldLoading }
 }


### PR DESCRIPTION
## Summary

- `useStandaloneCompositeAssets` hardcoded `currency: "USD"` as a placeholder
- That value propagated into `LinkCompositeDialog`'s BALANCE trn (`tradeCurrency`)
- svc-data stored USD-denominated trn for SGD CPF balances
- svc-position then applied USD→SGD FX (~1.28) on the PORTFOLIO bucket, inflating CPF market value by ~28% in `/wealth` and the plan projection `liquidAssets`

## Fix

- Extract pure `buildStandaloneConfigs` helper, drive currency from `POLICY_CURRENCY` (`CPF → SGD`)
- Unknown policy types return `""` so the dialog can decline to submit a bad trn (defer ILP / generic to server lookup)

## Companion PRs (in flight)

- svc-data: enforce `tradeCurrency = asset.accountingType.currency` server-side for POLICY BALANCE trns
- svc-position: PORTFOLIO bucket falls back to `getTradeCurrency(asset)` rather than `asset.market.currency`
- Flyway: backfill existing POLICY BALANCE trns where `trade_currency_code` is wrong

## Test plan

- [x] Unit: `buildStandaloneConfigs` returns SGD for CPF, preserves liquid flags, skips missing ids, empty currency for unknown policy
- [ ] Manual: link a CPF on kauri; verify `/api/trns` payload has `tradeCurrency: "SGD"`; verify `/wealth` shows correct CPF total (281k, not 360k for Mary persona)

@coderabbitai ignore