### PR TITLE
feat(independence): stacked-layer wealth journey chart

### DIFF
--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from "react"
 import {
   ComposedChart,
   Line,
+  Area,
   Bar,
   XAxis,
   YAxis,
@@ -92,7 +93,10 @@ export default function TimelineTabContent({
   // adjusted projection. Used to gate the "compared to baseline" UI.
   const hasActiveWhatIf = baselineProjection !== null
 
-  // Combine accumulation and drawdown for chart
+  // Combine accumulation and drawdown for chart. Sub-bucket fields drive
+  // the stacked-area visualisation (Liquid + Housing + CPF MA + CPF Annuity).
+  // Locked layers grow even after liquid depletes, so the chart needs to
+  // show each separately instead of lumping into a single Total Wealth line.
   const fullJourneyData = useMemo(() => {
     if (!projection) return []
 
@@ -103,6 +107,10 @@ export default function TimelineTabContent({
         accumulationBalance: year.endingBalance,
         retirementBalance: null as number | null,
         totalWealth: year.totalWealth,
+        liquidValue: year.endingBalance,
+        housingValue: year.housingValue ?? 0,
+        cpfNonLiquidValue: year.cpfNonLiquidValue ?? 0,
+        annuitizedValue: year.annuitizedValue ?? 0,
         contribution: year.contribution,
         investmentGrowth: year.investmentGrowth,
         phase: "accumulation" as const,
@@ -116,8 +124,13 @@ export default function TimelineTabContent({
         index === 0 ? year.endingBalance : (null as number | null),
       retirementBalance: year.endingBalance,
       totalWealth: year.totalWealth,
+      liquidValue: year.endingBalance,
+      housingValue: year.housingValue ?? 0,
+      cpfNonLiquidValue: year.cpfNonLiquidValue ?? 0,
+      annuitizedValue: year.annuitizedValue ?? 0,
       withdrawals: year.withdrawals,
       investment: year.investment,
+      unfundedExpense: year.unfundedExpense ?? 0,
       phase: "retirement" as const,
     }))
 
@@ -276,11 +289,14 @@ export default function TimelineTabContent({
                   const formatted = hideValues
                     ? HIDDEN_VALUE
                     : `$${Number(value || 0).toLocaleString()}`
-                  if (name === "totalWealth") return [formatted, "Total Wealth"]
-                  if (name === "accumulationBalance")
-                    return [formatted, "Working Years"]
-                  if (name === "retirementBalance")
-                    return [formatted, "Independence Years"]
+                  if (name === "liquidValue")
+                    return [formatted, "Liquid (spendable)"]
+                  if (name === "housingValue")
+                    return [formatted, "Housing (locked)"]
+                  if (name === "cpfNonLiquidValue")
+                    return [formatted, "CPF MA (locked)"]
+                  if (name === "annuitizedValue")
+                    return [formatted, "CPF LIFE principal (locked)"]
                   if (name === "fireBalance") return [formatted, "FIRE Path"]
                   if (name === "baselineBalance") return [formatted, "Baseline"]
                   return [formatted, name]
@@ -291,17 +307,19 @@ export default function TimelineTabContent({
                 verticalAlign="top"
                 height={36}
                 formatter={(value) =>
-                  value === "totalWealth"
-                    ? "Total Wealth"
-                    : value === "accumulationBalance"
-                      ? "Working Years"
-                      : value === "retirementBalance"
-                        ? "Independence Years"
-                        : value === "fireBalance"
-                          ? "FIRE Path"
-                          : value === "baselineBalance"
-                            ? "Baseline"
-                            : value
+                  value === "liquidValue"
+                    ? "Liquid (spendable)"
+                    : value === "housingValue"
+                      ? "Housing (locked)"
+                      : value === "cpfNonLiquidValue"
+                        ? "CPF MA (locked)"
+                        : value === "annuitizedValue"
+                          ? "CPF LIFE principal (locked)"
+                          : value === "fireBalance"
+                            ? "FIRE Path"
+                            : value === "baselineBalance"
+                              ? "Baseline"
+                              : value
                 }
               />
               <ReferenceLine y={0} stroke="#ef4444" strokeWidth={2} />
@@ -378,41 +396,54 @@ export default function TimelineTabContent({
                   }}
                 />
               )}
-              {/* Total Wealth line - show in traditional view when non-spendable assets exist */}
-              {timelineViewMode === "traditional" &&
-                projection.nonSpendableAtRetirement > 0 && (
-                  <Line
+              {/* Stacked wealth journey — bottom-up: Liquid (spendable),
+                  Housing, CPF MA, CPF LIFE principal. Top of the stack
+                  equals total wealth at each age. Stack tells the user
+                  which slice of their wealth is actually spendable: as
+                  Liquid shrinks, the locked layers continue rising. */}
+              {timelineViewMode === "traditional" && (
+                <>
+                  <Area
                     type="monotone"
-                    dataKey="totalWealth"
-                    stroke="#22c55e"
+                    dataKey="liquidValue"
+                    stackId="wealth"
+                    stroke="#2563eb"
+                    fill="#3b82f6"
+                    fillOpacity={0.6}
                     strokeWidth={2}
-                    dot={{ r: 2, fill: "#22c55e" }}
-                    name="totalWealth"
+                    name="liquidValue"
                   />
-                )}
-              {/* Traditional path - Working years (blue) */}
-              {timelineViewMode === "traditional" && (
-                <Line
-                  type="monotone"
-                  dataKey="accumulationBalance"
-                  stroke="#3b82f6"
-                  strokeWidth={3}
-                  dot={{ r: 3, fill: "#3b82f6" }}
-                  name="accumulationBalance"
-                  connectNulls={false}
-                />
-              )}
-              {/* Traditional path - Independence years (purple) */}
-              {timelineViewMode === "traditional" && (
-                <Line
-                  type="monotone"
-                  dataKey="retirementBalance"
-                  stroke="#f97316"
-                  strokeWidth={3}
-                  dot={{ r: 3, fill: "#f97316" }}
-                  name="retirementBalance"
-                  connectNulls={false}
-                />
+                  <Area
+                    type="monotone"
+                    dataKey="housingValue"
+                    stackId="wealth"
+                    stroke="#a16207"
+                    fill="#eab308"
+                    fillOpacity={0.35}
+                    strokeWidth={1}
+                    name="housingValue"
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="cpfNonLiquidValue"
+                    stackId="wealth"
+                    stroke="#0d9488"
+                    fill="#14b8a6"
+                    fillOpacity={0.35}
+                    strokeWidth={1}
+                    name="cpfNonLiquidValue"
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="annuitizedValue"
+                    stackId="wealth"
+                    stroke="#16a34a"
+                    fill="#22c55e"
+                    fillOpacity={0.35}
+                    strokeWidth={1}
+                    name="annuitizedValue"
+                  />
+                </>
               )}
               {/* FIRE path */}
               {timelineViewMode === "fire" &&

--- a/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
+++ b/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import {
   ComposedChart,
   Area,
-  Line,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -55,10 +54,17 @@ export default function WealthJourneyTab(): React.ReactElement | null {
     return null
   }
 
+  // Stacked-area data — bottom-up: Liquid (spendable) + Housing + CPF MA
+  // + CPF Annuity. Top of stack = totalWealth. Locked layers signal what
+  // share of net worth isn't actually drawdownable in retirement.
   const chartData = projection.yearlyProjections.map((row) => ({
     age: row.age,
     endingBalance: row.endingBalance,
     totalWealth: row.totalWealth,
+    liquidValue: row.endingBalance,
+    housingValue: row.housingValue ?? 0,
+    cpfNonLiquidValue: row.cpfNonLiquidValue ?? 0,
+    annuitizedValue: row.annuitizedValue ?? 0,
     income: row.income,
     expenses: row.expenses,
     planId: row.planId,
@@ -130,9 +136,14 @@ export default function WealthJourneyTab(): React.ReactElement | null {
                 const formatted = hideValues
                   ? HIDDEN_VALUE
                   : `${displayCurrency} ${Number(value || 0).toLocaleString()}`
-                if (name === "totalWealth") return [formatted, "Total Wealth"]
-                if (name === "endingBalance")
-                  return [formatted, "Liquid Assets"]
+                if (name === "liquidValue")
+                  return [formatted, "Liquid (spendable)"]
+                if (name === "housingValue")
+                  return [formatted, "Housing (locked)"]
+                if (name === "cpfNonLiquidValue")
+                  return [formatted, "CPF MA (locked)"]
+                if (name === "annuitizedValue")
+                  return [formatted, "CPF LIFE principal (locked)"]
                 return [formatted, String(name)]
               }}
               labelFormatter={(label) => {
@@ -146,11 +157,15 @@ export default function WealthJourneyTab(): React.ReactElement | null {
               verticalAlign="top"
               height={36}
               formatter={(value: string) =>
-                value === "totalWealth"
-                  ? "Total Wealth"
-                  : value === "endingBalance"
-                    ? "Liquid Assets"
-                    : value
+                value === "liquidValue"
+                  ? "Liquid (spendable)"
+                  : value === "housingValue"
+                    ? "Housing (locked)"
+                    : value === "cpfNonLiquidValue"
+                      ? "CPF MA (locked)"
+                      : value === "annuitizedValue"
+                        ? "CPF LIFE principal (locked)"
+                        : value
               }
             />
 
@@ -187,27 +202,49 @@ export default function WealthJourneyTab(): React.ReactElement | null {
               ) : null,
             )}
 
-            {/* Total Wealth area (liquid + property) */}
+            {/* Stacked-area wealth journey: Liquid (bottom) + Housing
+                + CPF MA + CPF LIFE principal. Top of stack = total
+                wealth. Layers tell the user which slice of net worth
+                is spendable as Liquid shrinks. */}
             <Area
               type="monotone"
-              dataKey="totalWealth"
-              fill="#22c55e"
-              fillOpacity={0.15}
-              stroke="#22c55e"
-              strokeWidth={1}
-              strokeDasharray="4 2"
-              dot={false}
-              name="totalWealth"
+              dataKey="liquidValue"
+              stackId="wealth"
+              stroke="#2563eb"
+              fill="#3b82f6"
+              fillOpacity={0.6}
+              strokeWidth={2}
+              name="liquidValue"
             />
-
-            {/* Liquid assets line */}
-            <Line
+            <Area
               type="monotone"
-              dataKey="endingBalance"
-              stroke="#3b82f6"
-              strokeWidth={2.5}
-              dot={false}
-              name="endingBalance"
+              dataKey="housingValue"
+              stackId="wealth"
+              stroke="#a16207"
+              fill="#eab308"
+              fillOpacity={0.35}
+              strokeWidth={1}
+              name="housingValue"
+            />
+            <Area
+              type="monotone"
+              dataKey="cpfNonLiquidValue"
+              stackId="wealth"
+              stroke="#0d9488"
+              fill="#14b8a6"
+              fillOpacity={0.35}
+              strokeWidth={1}
+              name="cpfNonLiquidValue"
+            />
+            <Area
+              type="monotone"
+              dataKey="annuitizedValue"
+              stackId="wealth"
+              stroke="#16a34a"
+              fill="#22c55e"
+              fillOpacity={0.35}
+              strokeWidth={1}
+              name="annuitizedValue"
             />
           </ComposedChart>
         </ResponsiveContainer>

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -431,8 +431,14 @@ export interface YearlyAccumulation {
   lumpSumPayout?: number
   /** Balance at end of year */
   endingBalance: number
-  /** Non-spendable asset value for this year */
+  /** Non-spendable asset value (housing + CPF MA + CPF Annuity) for this year */
   nonSpendableValue: number
+  /** Real-estate / housing portion of nonSpendableValue. */
+  housingValue?: number
+  /** CPF MA (and future composite non-liquid) portion of nonSpendableValue. */
+  cpfNonLiquidValue?: number
+  /** CPF LIFE annuity principal portion of nonSpendableValue. */
+  annuitizedValue?: number
   /** Total wealth = endingBalance + nonSpendableValue */
   totalWealth: number
   /** Currency code */
@@ -472,14 +478,26 @@ export interface YearlyProjection {
   endingBalance: number
   inflationAdjustedExpenses: number
   currency: string
-  /** Non-spendable asset value (e.g., property) for this year */
+  /** Non-spendable asset value (housing + CPF MA + CPF Annuity) for this year */
   nonSpendableValue: number
+  /** Real-estate / housing portion of nonSpendableValue. Liquidatable. */
+  housingValue?: number
+  /** CPF MA (and future composite non-liquid) portion of nonSpendableValue. Locked. */
+  cpfNonLiquidValue?: number
+  /** CPF LIFE annuity principal portion of nonSpendableValue. Locked. */
+  annuitizedValue?: number
   /** Total wealth = endingBalance + nonSpendableValue */
   totalWealth: number
   /** True if property was liquidated this year (when liquid assets fell below 10%) */
   propertyLiquidated?: boolean
   /** Net life event amount (income - expense) for this year */
   lifeEventAmount?: number
+  /**
+   * Portion of `withdrawals` that couldn't be funded from this year's
+   * available cash. Zero on sustainable years; positive when the plan
+   * is insolvent.
+   */
+  unfundedExpense?: number
   /** Breakdown of income sources for this year */
   incomeBreakdown?: IncomeBreakdown
 }
@@ -1074,6 +1092,12 @@ export interface CompositeYearlyProjection {
   expenses: number
   endingBalance: number
   nonSpendableValue: number
+  /** Real-estate / housing portion of nonSpendableValue. */
+  housingValue?: number
+  /** CPF MA portion of nonSpendableValue. Locked. */
+  cpfNonLiquidValue?: number
+  /** CPF LIFE annuity principal portion of nonSpendableValue. Locked. */
+  annuitizedValue?: number
   totalWealth: number
   currency: string
   incomeBreakdown?: IncomeBreakdown


### PR DESCRIPTION
## Summary

Wealth journey charts (single-plan `TimelineTabContent` + composite `WealthJourneyTab`) showed a single Total Wealth line rising through retirement even as the user's liquid pool depleted. Lumped spendable cash with locked CPF + housing balances.

Forensic review of Mary's projection traced the rising green line to locked layers (CPF MA + CPF LIFE annuity principal) growing at 4% statutory while liquid drained. Chart couldn't tell user honestly 'you're going broke for general spending' because locked wealth kept compounding into the same line.

## Fix

Replace single Line with stacked Area, bottom-up:

| Layer | Color | Opacity | Meaning |
|---|---|---:|---|
| Liquid (spendable) | blue | 0.6 | endingBalance |
| Housing | amber | 0.35 | housingValue (liquidatable last resort) |
| CPF MA | teal | 0.35 | cpfNonLiquidValue (locked) |
| CPF LIFE principal | green | 0.35 | annuitizedValue (locked) |

Top of stack = totalWealth (implicit). Liquid shrinking visible as the bright blue band collapses; muted locked layers continue rising. Tooltip + legend updated with explicit spendable/locked tags.

## Data source

Backend (svc-retire PR #62, deployed) surfaces `housingValue`, `cpfNonLiquidValue`, `annuitizedValue` on `YearlyProjection` + `YearlyAccumulation` + `CompositeYearlyProjection`.

## Test plan

- [x] Existing TimelineTab + CompositeTab tests pass
- [x] typecheck + lint clean
- [ ] After deploy: open Mary's `/independence/plans/<id>` — wealth journey shows stacked layers, Liquid (blue) visibly shrinks from age 60 → 90 while CPF Annuity (green) + CPF MA (teal) grow
- [ ] Composite multi-plan view: same stacked layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the Wealth Journey chart to display assets as stacked-area visualization, clearly separating spendable (liquid) vs locked portions (housing, CPF accounts)
  * Added tracking of unfunded expenses during the retirement phase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->