### PR TITLE
fix(independence): liquidity-gradient palette on wealth chart

### DIFF
--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -398,18 +398,21 @@ export default function TimelineTabContent({
               )}
               {/* Stacked wealth journey — bottom-up: Liquid (spendable),
                   Housing, CPF MA, CPF LIFE principal. Top of the stack
-                  equals total wealth at each age. Stack tells the user
-                  which slice of their wealth is actually spendable: as
-                  Liquid shrinks, the locked layers continue rising. */}
+                  equals total wealth at each age. Liquidity gradient
+                  palette: Liquid pops in bright blue; locked layers
+                  drop into muted oranges/greys so the user reads
+                  brightness as 'spendable' at a glance. Green is
+                  deliberately avoided on locked layers — it carries a
+                  'wealth growing' connotation that undoes the message. */}
               {timelineViewMode === "traditional" && (
                 <>
                   <Area
                     type="monotone"
                     dataKey="liquidValue"
                     stackId="wealth"
-                    stroke="#2563eb"
-                    fill="#3b82f6"
-                    fillOpacity={0.6}
+                    stroke="#1d4ed8"
+                    fill="#2563eb"
+                    fillOpacity={0.7}
                     strokeWidth={2}
                     name="liquidValue"
                   />
@@ -417,9 +420,9 @@ export default function TimelineTabContent({
                     type="monotone"
                     dataKey="housingValue"
                     stackId="wealth"
-                    stroke="#a16207"
-                    fill="#eab308"
-                    fillOpacity={0.35}
+                    stroke="#c2410c"
+                    fill="#f97316"
+                    fillOpacity={0.3}
                     strokeWidth={1}
                     name="housingValue"
                   />
@@ -427,9 +430,9 @@ export default function TimelineTabContent({
                     type="monotone"
                     dataKey="cpfNonLiquidValue"
                     stackId="wealth"
-                    stroke="#0d9488"
-                    fill="#14b8a6"
-                    fillOpacity={0.35}
+                    stroke="#737373"
+                    fill="#a3a3a3"
+                    fillOpacity={0.3}
                     strokeWidth={1}
                     name="cpfNonLiquidValue"
                   />
@@ -437,9 +440,9 @@ export default function TimelineTabContent({
                     type="monotone"
                     dataKey="annuitizedValue"
                     stackId="wealth"
-                    stroke="#16a34a"
-                    fill="#22c55e"
-                    fillOpacity={0.35}
+                    stroke="#64748b"
+                    fill="#94a3b8"
+                    fillOpacity={0.3}
                     strokeWidth={1}
                     name="annuitizedValue"
                   />

--- a/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
+++ b/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
@@ -204,15 +204,17 @@ export default function WealthJourneyTab(): React.ReactElement | null {
 
             {/* Stacked-area wealth journey: Liquid (bottom) + Housing
                 + CPF MA + CPF LIFE principal. Top of stack = total
-                wealth. Layers tell the user which slice of net worth
-                is spendable as Liquid shrinks. */}
+                wealth. Liquidity gradient palette — bright blue Liquid
+                pops, muted orange/grey locked layers recede. Green
+                deliberately avoided on locked layers; it would imply
+                "wealth growing" and undo the spendable-vs-locked story. */}
             <Area
               type="monotone"
               dataKey="liquidValue"
               stackId="wealth"
-              stroke="#2563eb"
-              fill="#3b82f6"
-              fillOpacity={0.6}
+              stroke="#1d4ed8"
+              fill="#2563eb"
+              fillOpacity={0.7}
               strokeWidth={2}
               name="liquidValue"
             />
@@ -220,9 +222,9 @@ export default function WealthJourneyTab(): React.ReactElement | null {
               type="monotone"
               dataKey="housingValue"
               stackId="wealth"
-              stroke="#a16207"
-              fill="#eab308"
-              fillOpacity={0.35}
+              stroke="#c2410c"
+              fill="#f97316"
+              fillOpacity={0.3}
               strokeWidth={1}
               name="housingValue"
             />
@@ -230,9 +232,9 @@ export default function WealthJourneyTab(): React.ReactElement | null {
               type="monotone"
               dataKey="cpfNonLiquidValue"
               stackId="wealth"
-              stroke="#0d9488"
-              fill="#14b8a6"
-              fillOpacity={0.35}
+              stroke="#737373"
+              fill="#a3a3a3"
+              fillOpacity={0.3}
               strokeWidth={1}
               name="cpfNonLiquidValue"
             />
@@ -240,9 +242,9 @@ export default function WealthJourneyTab(): React.ReactElement | null {
               type="monotone"
               dataKey="annuitizedValue"
               stackId="wealth"
-              stroke="#16a34a"
-              fill="#22c55e"
-              fillOpacity={0.35}
+              stroke="#64748b"
+              fill="#94a3b8"
+              fillOpacity={0.3}
               strokeWidth={1}
               name="annuitizedValue"
             />


### PR DESCRIPTION
## Summary

PR #802 stacked the wealth chart but used **green** for the CPF LIFE principal band. Green signals "wealth growing" — exactly the confusing read the stack was meant to dispel. Locked layers also ran at opacity 0.35 which muddied them into a single haze.

## Fix — liquidity gradient palette

Brightness signals spendability. Locked layers recede; Liquid pops.

| Layer | Color | Opacity | Stroke |
|---|---|---:|---|
| Liquid (spendable) | bright blue `#2563eb` | 0.7 | 2 |
| Housing (locked, sellable) | muted orange `#f97316` | 0.3 | 1 |
| CPF MA (locked) | warm grey `#a3a3a3` | 0.3 | 1 |
| CPF LIFE principal (locked) | cool slate `#94a3b8` | 0.3 | 1 |

No green = no "rising wealth" miscue. User reads brightness as "spendable at a glance" without needing tooltip.

## Verified by screenshot

Pre-fix screenshot showed the green CPF LIFE band dominating ages 65-90 and undoing the depletion signal.

## Test plan

- [x] yarn typecheck clean
- [x] Existing TimelineTab + WealthJourneyTab tests pass
- [ ] After deploy: Mary's chart — bright blue Liquid band visibly collapses age 60→90 while muted grey/slate locked layers recede. Visual story 'spendable shrinks while locked recedes' reads at a glance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the Wealth Journey chart visualization with an updated liquidity gradient color palette, improving visual distinction and clarity across different asset categories displayed in the wealth composition view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->