### PR TITLE
feat(independence): CPF sub-account breakdown with locked tags

### DIFF
--- a/src/components/features/independence/AssetsBreakdown.tsx
+++ b/src/components/features/independence/AssetsBreakdown.tsx
@@ -2,11 +2,13 @@ import React from "react"
 import { RetirementProjection } from "types/independence"
 import { AllocationSlice } from "@lib/allocation/aggregateHoldings"
 import { HIDDEN_VALUE, PensionProjection } from "@lib/independence/planHelpers"
+import { CpfSubAccountRow } from "@lib/independence/cpfSubAccountTags"
 import {
   DEFAULT_NON_SPENDABLE_CATEGORIES,
   INCOME_STREAM_CATEGORIES,
 } from "@components/features/independence"
 import Spinner from "@components/ui/Spinner"
+import InfoTooltip from "@components/ui/Tooltip"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
 
 interface AssetsBreakdownProps {
@@ -29,6 +31,11 @@ interface AssetsBreakdownProps {
   onRefreshHoldings: () => void
   excludedPensionFV: number
   includedPensionFvDifferential: number
+  /**
+   * Per-sub-account display rows for CPF policies. Empty array (or undefined)
+   * hides the breakdown panel — used to suppress for non-CPF plans.
+   */
+  cpfSubAccountRows?: CpfSubAccountRow[]
 }
 
 /**
@@ -56,6 +63,7 @@ export default function AssetsBreakdown({
   onRefreshHoldings,
   excludedPensionFV,
   includedPensionFvDifferential,
+  cpfSubAccountRows,
 }: AssetsBreakdownProps): React.ReactElement {
   const { hideValues } = usePrivacyMode()
 
@@ -207,6 +215,56 @@ export default function AssetsBreakdown({
                 )
               })}
           </div>
+
+          {cpfSubAccountRows && cpfSubAccountRows.length > 0 && (
+            <div className="mt-4 border-t pt-4">
+              <h3 className="text-sm font-medium text-gray-700 mb-3">
+                <i className="fas fa-layer-group mr-2 text-teal-500"></i>
+                CPF Sub-Accounts
+              </h3>
+              <p className="text-xs text-gray-500 mb-2">
+                {
+                  "Liquid totals above include CPF OA + SA + RA. Each sub-account has different access rules — only OA is reachable today, and SA/RA flow into CPF LIFE at age 55."
+                }
+              </p>
+              <div className="space-y-2">
+                {cpfSubAccountRows.map((row) => {
+                  const toneClasses =
+                    row.tagTone === "amber"
+                      ? "bg-amber-100 text-amber-800"
+                      : "bg-gray-200 text-gray-700"
+                  return (
+                    <div
+                      key={`${row.parentAssetId}-${row.code}`}
+                      className="p-3 rounded-lg border border-teal-200 bg-teal-50"
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3 min-w-0">
+                          <span className="font-medium text-gray-800 truncate">
+                            {row.displayName}
+                          </span>
+                          <InfoTooltip text={row.tooltip}>
+                            <span
+                              className={`text-xs px-2 py-0.5 rounded ${toneClasses}`}
+                            >
+                              {row.tagLabel}
+                            </span>
+                          </InfoTooltip>
+                        </div>
+                        <span
+                          className={`font-medium ${hideValues ? "text-gray-400" : "text-gray-800"}`}
+                        >
+                          {hideValues
+                            ? HIDDEN_VALUE
+                            : `${effectiveCurrency}${Math.round(row.balance * effectiveFxRate).toLocaleString()}`}
+                        </span>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
 
           {pensionProjections.length > 0 && (
             <div className="mt-4 border-t pt-4">

--- a/src/components/features/independence/DetailsTabContent.tsx
+++ b/src/components/features/independence/DetailsTabContent.tsx
@@ -3,6 +3,7 @@ import InfoTooltip from "@components/ui/Tooltip"
 import { RetirementPlan, RetirementProjection } from "types/independence"
 import { AllocationSlice } from "@lib/allocation/aggregateHoldings"
 import { HIDDEN_VALUE, PensionProjection } from "@lib/independence/planHelpers"
+import { CpfSubAccountRow } from "@lib/independence/cpfSubAccountTags"
 import {
   RentalIncomeData,
   AssetsBreakdown,
@@ -39,6 +40,11 @@ interface DetailsTabContentProps {
   excludedPensionFV: number
   includedPensionFvDifferential: number
   /**
+   * Per-CPF-sub-account display rows. Empty when the user has no CPF
+   * policy — the breakdown panel hides entirely in that case.
+   */
+  cpfSubAccountRows?: CpfSubAccountRow[]
+  /**
    * Caller doesn't own the plan. Per-category holdings can't be resolved
    * server-side under the M2M path today, so the breakdown panel hides
    * (showing the viewer's caller-scoped categories would be the same leak
@@ -73,6 +79,7 @@ export default function DetailsTabContent({
   onRefreshHoldings,
   excludedPensionFV,
   includedPensionFvDifferential,
+  cpfSubAccountRows,
   isSharedPlan = false,
 }: DetailsTabContentProps): React.ReactElement {
   const { hideValues } = usePrivacyMode()
@@ -308,6 +315,7 @@ export default function DetailsTabContent({
           onRefreshHoldings={onRefreshHoldings}
           excludedPensionFV={excludedPensionFV}
           includedPensionFvDifferential={includedPensionFvDifferential}
+          cpfSubAccountRows={cpfSubAccountRows}
         />
       )}
     </div>

--- a/src/lib/utils/independence/cpfSubAccountTags.test.ts
+++ b/src/lib/utils/independence/cpfSubAccountTags.test.ts
@@ -1,0 +1,126 @@
+import { buildCpfSubAccountRows } from "./cpfSubAccountTags"
+import { PrivateAssetConfig } from "types/beancounter"
+
+const baseCpf: PrivateAssetConfig = {
+  assetId: "cpf-asset",
+  monthlyRentalIncome: 0,
+  rentalCurrency: "SGD",
+  countryCode: "SG",
+  monthlyManagementFee: 0,
+  managementFeePercent: 0,
+  monthlyBodyCorporateFee: 0,
+  annualPropertyTax: 0,
+  annualInsurance: 0,
+  monthlyOtherExpenses: 0,
+  deductIncomeTax: false,
+  isPrimaryResidence: false,
+  liquidationPriority: 99,
+  transactionDayOfMonth: 1,
+  autoGenerateTransactions: false,
+  isPension: true,
+  policyType: "CPF",
+  subAccounts: [
+    {
+      id: "1",
+      assetId: "cpf-asset",
+      code: "OA",
+      balance: 145000,
+      liquid: true,
+    },
+    {
+      id: "2",
+      assetId: "cpf-asset",
+      code: "SA",
+      balance: 78000,
+      liquid: true,
+    },
+    {
+      id: "3",
+      assetId: "cpf-asset",
+      code: "MA",
+      balance: 58000,
+      liquid: false,
+    },
+    { id: "4", assetId: "cpf-asset", code: "RA", balance: 0, liquid: true },
+  ],
+  createdDate: "2024-01-01",
+  updatedDate: "2024-01-01",
+}
+
+describe("buildCpfSubAccountRows", () => {
+  it("returns empty array when no configs", () => {
+    expect(buildCpfSubAccountRows(undefined, {})).toEqual([])
+    expect(buildCpfSubAccountRows([], {})).toEqual([])
+  })
+
+  it("returns empty array when no CPF configs", () => {
+    const ilp: PrivateAssetConfig = {
+      ...baseCpf,
+      assetId: "ilp",
+      policyType: "ILP",
+      subAccounts: [
+        {
+          id: "f1",
+          assetId: "ilp",
+          code: "FUND-A",
+          balance: 50000,
+          liquid: true,
+        },
+      ],
+    }
+    expect(buildCpfSubAccountRows([ilp], { ilp: "MyILP" })).toEqual([])
+  })
+
+  it("ignores CPF configs without sub-accounts", () => {
+    const noSubs: PrivateAssetConfig = { ...baseCpf, subAccounts: [] }
+    expect(buildCpfSubAccountRows([noSubs], {})).toEqual([])
+  })
+
+  it("flattens all CPF sub-accounts with correct tags", () => {
+    const rows = buildCpfSubAccountRows([baseCpf], { "cpf-asset": "Mary CPF" })
+    expect(rows).toHaveLength(4)
+    const oa = rows.find((r) => r.code === "OA")
+    const sa = rows.find((r) => r.code === "SA")
+    const ma = rows.find((r) => r.code === "MA")
+    const ra = rows.find((r) => r.code === "RA")
+    expect(oa).toMatchObject({
+      balance: 145000,
+      liquid: true,
+      tagTone: "amber",
+      parentAssetName: "Mary CPF",
+    })
+    expect(sa?.tagLabel).toContain("merges to RA")
+    expect(ma?.tagLabel).toBe("Medical only")
+    expect(ra?.tagLabel).toContain("CPF LIFE")
+    expect(ma?.liquid).toBe(false)
+  })
+
+  it("sub-account balances sum to parent total", () => {
+    const rows = buildCpfSubAccountRows([baseCpf], {})
+    const total = rows.reduce((s, r) => s + r.balance, 0)
+    expect(total).toBe(281000)
+  })
+
+  it("falls back to assetId when assetNames map missing entry", () => {
+    const rows = buildCpfSubAccountRows([baseCpf], {})
+    expect(rows[0]?.parentAssetName).toBe("cpf-asset")
+  })
+
+  it("uses displayName when provided on sub-account", () => {
+    const custom: PrivateAssetConfig = {
+      ...baseCpf,
+      subAccounts: [
+        {
+          id: "1",
+          assetId: "cpf-asset",
+          code: "OA",
+          displayName: "Ordinary",
+          balance: 100,
+          liquid: true,
+        },
+      ],
+    }
+    const rows = buildCpfSubAccountRows([custom], {})
+    expect(rows[0].displayName).toBe("Ordinary")
+  })
+})

--- a/src/lib/utils/independence/cpfSubAccountTags.ts
+++ b/src/lib/utils/independence/cpfSubAccountTags.ts
@@ -1,0 +1,90 @@
+import { PrivateAssetConfig, SubAccount } from "types/beancounter"
+
+export interface CpfSubAccountRow {
+  parentAssetId: string
+  parentAssetName: string
+  code: string
+  displayName: string
+  balance: number
+  liquid: boolean
+  tagLabel: string
+  tagTone: "amber" | "gray"
+  tooltip: string
+}
+
+const TAGS: Record<
+  string,
+  { label: string; tone: "amber" | "gray"; tooltip: string }
+> = {
+  OA: {
+    label: "Restricted — housing / edu pre-55",
+    tone: "amber",
+    tooltip:
+      "Ordinary Account. Withdrawable for approved uses (housing, education, top-ups). At age 55 the balance flows into the Retirement Account up to the FRS cap to fund CPF LIFE.",
+  },
+  SA: {
+    label: "Locked — merges to RA at 55",
+    tone: "gray",
+    tooltip:
+      "Special Account. Statutorily locked until 55, then absorbed into the Retirement Account to fund CPF LIFE annuity. Not spendable as a lump sum.",
+  },
+  MA: {
+    label: "Medical only",
+    tone: "gray",
+    tooltip:
+      "MediSave Account. Locked for approved healthcare expenses and MediShield premiums. Never enters the spendable pool.",
+  },
+  RA: {
+    label: "CPF LIFE annuity source",
+    tone: "gray",
+    tooltip:
+      "Retirement Account. Created at age 55 from OA/SA balances; pays out as the CPF LIFE annuity from the payout-start age.",
+  },
+}
+
+function tagFor(code: string): {
+  label: string
+  tone: "amber" | "gray"
+  tooltip: string
+} {
+  return (
+    TAGS[code.toUpperCase()] ?? {
+      label: "Locked",
+      tone: "gray",
+      tooltip: "Composite sub-account.",
+    }
+  )
+}
+
+/**
+ * Flatten CPF configs into per-sub-account display rows. Returns empty array
+ * for users without any CPF policy. Caller sums to verify against the
+ * composite parent balance.
+ */
+export function buildCpfSubAccountRows(
+  configs: PrivateAssetConfig[] | undefined,
+  assetNames: Record<string, string>,
+): CpfSubAccountRow[] {
+  if (!configs || configs.length === 0) return []
+  const rows: CpfSubAccountRow[] = []
+  for (const cfg of configs) {
+    if (cfg.policyType !== "CPF") continue
+    if (!cfg.subAccounts || cfg.subAccounts.length === 0) continue
+    const parentName = assetNames[cfg.assetId] ?? cfg.assetId
+    for (const sa of cfg.subAccounts as SubAccount[]) {
+      const tag = tagFor(sa.code)
+      rows.push({
+        parentAssetId: cfg.assetId,
+        parentAssetName: parentName,
+        code: sa.code,
+        displayName: sa.displayName || `CPF ${sa.code.toUpperCase()}`,
+        balance: sa.balance,
+        liquid: sa.liquid,
+        tagLabel: tag.label,
+        tagTone: tag.tone,
+        tooltip: tag.tooltip,
+      })
+    }
+  }
+  return rows
+}

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -54,6 +54,7 @@ import {
   hasManualAssets,
   manualAssetsToSlices,
 } from "@lib/independence/planHelpers"
+import { buildCpfSubAccountRows } from "@lib/independence/cpfSubAccountTags"
 
 function PlanView(): React.ReactElement {
   const router = useRouter()
@@ -151,8 +152,18 @@ function PlanView(): React.ReactElement {
   const planCurrency = plan?.expensesCurrency || "NZD"
 
   // Fetch rental income from RE asset configs
-  const { configs: assetConfigs, getNetRentalByCurrency } =
-    usePrivateAssetConfigs()
+  const {
+    configs: assetConfigs,
+    assetNames: assetConfigNames,
+    getNetRentalByCurrency,
+  } = usePrivateAssetConfigs()
+
+  // CPF sub-account breakdown rows — empty when the user has no CPF policy,
+  // so the panel hides for non-Singaporean plans.
+  const cpfSubAccountRows = useMemo(
+    () => buildCpfSubAccountRows(assetConfigs, assetConfigNames),
+    [assetConfigs, assetConfigNames],
+  )
 
   // Resolve asset IDs belonging to excluded portfolios (for rental income filtering)
   const excludedAssetIds = useExcludedAssetIds(
@@ -963,6 +974,7 @@ function PlanView(): React.ReactElement {
               onRefreshHoldings={() => refreshHoldings()}
               excludedPensionFV={excludedPensionFV}
               includedPensionFvDifferential={includedPensionFvDifferential}
+              cpfSubAccountRows={cpfSubAccountRows}
               isSharedPlan={isSharedPlan}
             />
           )}


### PR DESCRIPTION
## Summary
- New panel under Assets by Category lists CPF sub-accounts (OA / SA / MA / RA) with a tag explaining each one's access rule (e.g. OA "Restricted — housing / edu pre-55", SA "Locked — merges to RA at 55", MA "Medical only", RA "CPF LIFE annuity source").
- Renders only when the user owns a CPF policy (`policyType === \"CPF\"` with sub-accounts present). Hidden entirely for non-CPF plans.
- Numbers are unchanged — same balances, clearer labels. Closes the UX gap where the "Liquid 311,718" sum lumped CPF OA + SA + RA in with bank + ETF without explaining their actual access rules.

## Test plan
- [x] `yarn test --testPathPatterns=cpfSubAccountTags` — 7 unit tests pass
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean for touched files (pre-existing errors unchanged)
- [x] Empty-state: confirmed the panel hides when `assetConfigs` has no CPF policy
- [ ] Manual verification on kauri once deployed — Mary's plan should show 4 OA/SA/MA/RA rows summing to 281,000 SGD

@coderabbitai ignore