### PR TITLE
refactor(independence): inline CPF expander + drop empty wealth layers

### DIFF
--- a/src/components/features/independence/AssetsBreakdown.tsx
+++ b/src/components/features/independence/AssetsBreakdown.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { RetirementProjection } from "types/independence"
 import { AllocationSlice } from "@lib/allocation/aggregateHoldings"
 import { HIDDEN_VALUE, PensionProjection } from "@lib/independence/planHelpers"
@@ -8,7 +8,6 @@ import {
   INCOME_STREAM_CATEGORIES,
 } from "@components/features/independence"
 import Spinner from "@components/ui/Spinner"
-import InfoTooltip from "@components/ui/Tooltip"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
 
 interface AssetsBreakdownProps {
@@ -32,10 +31,11 @@ interface AssetsBreakdownProps {
   excludedPensionFV: number
   includedPensionFvDifferential: number
   /**
-   * Per-sub-account display rows for CPF policies. Empty array (or undefined)
-   * hides the breakdown panel — used to suppress for non-CPF plans.
+   * Sub-account rows grouped by the category-slice key their CPF parent
+   * resolves to. Slices listed here render with a chevron expander showing
+   * indented child rows. Missing or empty → no expander.
    */
-  cpfSubAccountRows?: CpfSubAccountRow[]
+  cpfSubAccountsByCategoryKey?: Record<string, CpfSubAccountRow[]>
 }
 
 /**
@@ -63,8 +63,19 @@ export default function AssetsBreakdown({
   onRefreshHoldings,
   excludedPensionFV,
   includedPensionFvDifferential,
-  cpfSubAccountRows,
+  cpfSubAccountsByCategoryKey,
 }: AssetsBreakdownProps): React.ReactElement {
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set())
+  const toggleExpand = (key: string): void => {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+  const subAccountsFor = (key: string): CpfSubAccountRow[] =>
+    cpfSubAccountsByCategoryKey?.[key] ?? []
   const { hideValues } = usePrivacyMode()
 
   return (
@@ -125,6 +136,9 @@ export default function AssetsBreakdown({
               )
               .map((slice) => {
                 const isSpendable = spendableCategories.includes(slice.key)
+                const subRows = subAccountsFor(slice.key)
+                const isExpandable = subRows.length > 0
+                const isExpanded = expandedKeys.has(slice.key)
                 return (
                   <div
                     key={slice.key}
@@ -134,8 +148,8 @@ export default function AssetsBreakdown({
                         : "border-gray-200 bg-gray-50"
                     }`}
                   >
-                    <label className="flex items-center justify-between cursor-pointer">
-                      <div className="flex items-center gap-3">
+                    <div className="flex items-center justify-between">
+                      <label className="flex items-center gap-3 cursor-pointer flex-1 min-w-0">
                         <input
                           type="checkbox"
                           checked={isSpendable}
@@ -153,21 +167,73 @@ export default function AssetsBreakdown({
                         >
                           {slice.label}
                         </span>
+                      </label>
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`font-medium ${
+                            hideValues
+                              ? "text-gray-400"
+                              : isSpendable
+                                ? "text-gray-900"
+                                : "text-gray-400"
+                          }`}
+                        >
+                          {hideValues
+                            ? HIDDEN_VALUE
+                            : `${effectiveCurrency}${Math.round(slice.value * effectiveFxRate).toLocaleString()}`}
+                        </span>
+                        {isExpandable && (
+                          <button
+                            type="button"
+                            onClick={() => toggleExpand(slice.key)}
+                            className="text-gray-500 hover:text-gray-700 px-1"
+                            aria-expanded={isExpanded}
+                            aria-label={
+                              isExpanded ? "Hide breakdown" : "Show breakdown"
+                            }
+                          >
+                            <i
+                              className={`fas fa-chevron-${isExpanded ? "up" : "down"}`}
+                            ></i>
+                          </button>
+                        )}
                       </div>
-                      <span
-                        className={`font-medium ${
-                          hideValues
-                            ? "text-gray-400"
-                            : isSpendable
-                              ? "text-gray-900"
-                              : "text-gray-400"
-                        }`}
-                      >
-                        {hideValues
-                          ? HIDDEN_VALUE
-                          : `${effectiveCurrency}${Math.round(slice.value * effectiveFxRate).toLocaleString()}`}
-                      </span>
-                    </label>
+                    </div>
+                    {isExpandable && isExpanded && (
+                      <div className="mt-2 ml-7 pl-3 border-l-2 border-teal-300 space-y-1.5">
+                        {subRows.map((row) => {
+                          const toneClasses =
+                            row.tagTone === "amber"
+                              ? "bg-amber-100 text-amber-800"
+                              : "bg-gray-200 text-gray-700"
+                          return (
+                            <div
+                              key={`${row.parentAssetId}-${row.code}`}
+                              className="flex items-center justify-between gap-2 text-sm"
+                            >
+                              <div className="flex items-center gap-2 min-w-0">
+                                <span className="font-medium text-gray-800 truncate">
+                                  {row.displayName}
+                                </span>
+                                <span
+                                  className={`text-xs px-2 py-0.5 rounded ${toneClasses}`}
+                                  title={row.tooltip}
+                                >
+                                  {row.tagLabel}
+                                </span>
+                              </div>
+                              <span
+                                className={`font-medium ${hideValues ? "text-gray-400" : "text-gray-800"}`}
+                              >
+                                {hideValues
+                                  ? HIDDEN_VALUE
+                                  : `${effectiveCurrency}${Math.round(row.balance * effectiveFxRate).toLocaleString()}`}
+                              </span>
+                            </div>
+                          )
+                        })}
+                      </div>
+                    )}
                   </div>
                 )
               })}
@@ -215,56 +281,6 @@ export default function AssetsBreakdown({
                 )
               })}
           </div>
-
-          {cpfSubAccountRows && cpfSubAccountRows.length > 0 && (
-            <div className="mt-4 border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-3">
-                <i className="fas fa-layer-group mr-2 text-teal-500"></i>
-                CPF Sub-Accounts
-              </h3>
-              <p className="text-xs text-gray-500 mb-2">
-                {
-                  "Liquid totals above include CPF OA + SA + RA. Each sub-account has different access rules — only OA is reachable today, and SA/RA flow into CPF LIFE at age 55."
-                }
-              </p>
-              <div className="space-y-2">
-                {cpfSubAccountRows.map((row) => {
-                  const toneClasses =
-                    row.tagTone === "amber"
-                      ? "bg-amber-100 text-amber-800"
-                      : "bg-gray-200 text-gray-700"
-                  return (
-                    <div
-                      key={`${row.parentAssetId}-${row.code}`}
-                      className="p-3 rounded-lg border border-teal-200 bg-teal-50"
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-3 min-w-0">
-                          <span className="font-medium text-gray-800 truncate">
-                            {row.displayName}
-                          </span>
-                          <InfoTooltip text={row.tooltip}>
-                            <span
-                              className={`text-xs px-2 py-0.5 rounded ${toneClasses}`}
-                            >
-                              {row.tagLabel}
-                            </span>
-                          </InfoTooltip>
-                        </div>
-                        <span
-                          className={`font-medium ${hideValues ? "text-gray-400" : "text-gray-800"}`}
-                        >
-                          {hideValues
-                            ? HIDDEN_VALUE
-                            : `${effectiveCurrency}${Math.round(row.balance * effectiveFxRate).toLocaleString()}`}
-                        </span>
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
-            </div>
-          )}
 
           {pensionProjections.length > 0 && (
             <div className="mt-4 border-t pt-4">

--- a/src/components/features/independence/DetailsTabContent.tsx
+++ b/src/components/features/independence/DetailsTabContent.tsx
@@ -40,10 +40,11 @@ interface DetailsTabContentProps {
   excludedPensionFV: number
   includedPensionFvDifferential: number
   /**
-   * Per-CPF-sub-account display rows. Empty when the user has no CPF
-   * policy — the breakdown panel hides entirely in that case.
+   * Sub-account rows grouped by the category-slice key their CPF parent
+   * resolves to (e.g. "Retirement Fund"). Empty when the user has no CPF
+   * policy — the parent slice then renders without a chevron expander.
    */
-  cpfSubAccountRows?: CpfSubAccountRow[]
+  cpfSubAccountsByCategoryKey?: Record<string, CpfSubAccountRow[]>
   /**
    * Caller doesn't own the plan. Per-category holdings can't be resolved
    * server-side under the M2M path today, so the breakdown panel hides
@@ -79,7 +80,7 @@ export default function DetailsTabContent({
   onRefreshHoldings,
   excludedPensionFV,
   includedPensionFvDifferential,
-  cpfSubAccountRows,
+  cpfSubAccountsByCategoryKey,
   isSharedPlan = false,
 }: DetailsTabContentProps): React.ReactElement {
   const { hideValues } = usePrivacyMode()
@@ -315,7 +316,7 @@ export default function DetailsTabContent({
           onRefreshHoldings={onRefreshHoldings}
           excludedPensionFV={excludedPensionFV}
           includedPensionFvDifferential={includedPensionFvDifferential}
-          cpfSubAccountRows={cpfSubAccountRows}
+          cpfSubAccountsByCategoryKey={cpfSubAccountsByCategoryKey}
         />
       )}
     </div>

--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -137,6 +137,22 @@ export default function TimelineTabContent({
     return [...accumulationData, ...retirementData]
   }, [projection])
 
+  // Hide stacked layers (and their legend entries) when the user has none
+  // of that asset class. Mary has no housing → drop the Housing band.
+  // Mike has no CPF → drop CPF MA + CPF LIFE bands.
+  const hasHousingLayer = useMemo(
+    () => fullJourneyData.some((p) => (p.housingValue ?? 0) > 0),
+    [fullJourneyData],
+  )
+  const hasCpfNonLiquidLayer = useMemo(
+    () => fullJourneyData.some((p) => (p.cpfNonLiquidValue ?? 0) > 0),
+    [fullJourneyData],
+  )
+  const hasAnnuitizedLayer = useMemo(
+    () => fullJourneyData.some((p) => (p.annuitizedValue ?? 0) > 0),
+    [fullJourneyData],
+  )
+
   // Merge FIRE path projections into chart data
   const chartDataWithFirePath = useMemo(() => {
     const firePathProjections = projection?.firePathProjections
@@ -416,36 +432,42 @@ export default function TimelineTabContent({
                     strokeWidth={2}
                     name="liquidValue"
                   />
-                  <Area
-                    type="monotone"
-                    dataKey="housingValue"
-                    stackId="wealth"
-                    stroke="#c2410c"
-                    fill="#f97316"
-                    fillOpacity={0.3}
-                    strokeWidth={1}
-                    name="housingValue"
-                  />
-                  <Area
-                    type="monotone"
-                    dataKey="cpfNonLiquidValue"
-                    stackId="wealth"
-                    stroke="#737373"
-                    fill="#a3a3a3"
-                    fillOpacity={0.3}
-                    strokeWidth={1}
-                    name="cpfNonLiquidValue"
-                  />
-                  <Area
-                    type="monotone"
-                    dataKey="annuitizedValue"
-                    stackId="wealth"
-                    stroke="#64748b"
-                    fill="#94a3b8"
-                    fillOpacity={0.3}
-                    strokeWidth={1}
-                    name="annuitizedValue"
-                  />
+                  {hasHousingLayer && (
+                    <Area
+                      type="monotone"
+                      dataKey="housingValue"
+                      stackId="wealth"
+                      stroke="#c2410c"
+                      fill="#f97316"
+                      fillOpacity={0.3}
+                      strokeWidth={1}
+                      name="housingValue"
+                    />
+                  )}
+                  {hasCpfNonLiquidLayer && (
+                    <Area
+                      type="monotone"
+                      dataKey="cpfNonLiquidValue"
+                      stackId="wealth"
+                      stroke="#737373"
+                      fill="#a3a3a3"
+                      fillOpacity={0.3}
+                      strokeWidth={1}
+                      name="cpfNonLiquidValue"
+                    />
+                  )}
+                  {hasAnnuitizedLayer && (
+                    <Area
+                      type="monotone"
+                      dataKey="annuitizedValue"
+                      stackId="wealth"
+                      stroke="#64748b"
+                      fill="#94a3b8"
+                      fillOpacity={0.3}
+                      strokeWidth={1}
+                      name="annuitizedValue"
+                    />
+                  )}
                 </>
               )}
               {/* FIRE path */}

--- a/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
+++ b/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
@@ -75,6 +75,13 @@ export default function WealthJourneyTab(): React.ReactElement | null {
     return null
   }
 
+  // Drop stacked layers (and their legend entries) when the user holds none
+  // of that asset class. Plans without housing or CPF skip those bands so
+  // the legend stays focused on layers that actually appear in the chart.
+  const hasHousingLayer = chartData.some((p) => p.housingValue > 0)
+  const hasCpfNonLiquidLayer = chartData.some((p) => p.cpfNonLiquidValue > 0)
+  const hasAnnuitizedLayer = chartData.some((p) => p.annuitizedValue > 0)
+
   const phaseBoundaries = projection.phases.map((phase, idx) => ({
     ...phase,
     color: PHASE_COLORS[idx % PHASE_COLORS.length],
@@ -218,36 +225,42 @@ export default function WealthJourneyTab(): React.ReactElement | null {
               strokeWidth={2}
               name="liquidValue"
             />
-            <Area
-              type="monotone"
-              dataKey="housingValue"
-              stackId="wealth"
-              stroke="#c2410c"
-              fill="#f97316"
-              fillOpacity={0.3}
-              strokeWidth={1}
-              name="housingValue"
-            />
-            <Area
-              type="monotone"
-              dataKey="cpfNonLiquidValue"
-              stackId="wealth"
-              stroke="#737373"
-              fill="#a3a3a3"
-              fillOpacity={0.3}
-              strokeWidth={1}
-              name="cpfNonLiquidValue"
-            />
-            <Area
-              type="monotone"
-              dataKey="annuitizedValue"
-              stackId="wealth"
-              stroke="#64748b"
-              fill="#94a3b8"
-              fillOpacity={0.3}
-              strokeWidth={1}
-              name="annuitizedValue"
-            />
+            {hasHousingLayer && (
+              <Area
+                type="monotone"
+                dataKey="housingValue"
+                stackId="wealth"
+                stroke="#c2410c"
+                fill="#f97316"
+                fillOpacity={0.3}
+                strokeWidth={1}
+                name="housingValue"
+              />
+            )}
+            {hasCpfNonLiquidLayer && (
+              <Area
+                type="monotone"
+                dataKey="cpfNonLiquidValue"
+                stackId="wealth"
+                stroke="#737373"
+                fill="#a3a3a3"
+                fillOpacity={0.3}
+                strokeWidth={1}
+                name="cpfNonLiquidValue"
+              />
+            )}
+            {hasAnnuitizedLayer && (
+              <Area
+                type="monotone"
+                dataKey="annuitizedValue"
+                stackId="wealth"
+                stroke="#64748b"
+                fill="#94a3b8"
+                fillOpacity={0.3}
+                strokeWidth={1}
+                name="annuitizedValue"
+              />
+            )}
           </ComposedChart>
         </ResponsiveContainer>
       </div>

--- a/src/lib/utils/independence/cpfSubAccountTags.test.ts
+++ b/src/lib/utils/independence/cpfSubAccountTags.test.ts
@@ -89,9 +89,9 @@ describe("buildCpfSubAccountRows", () => {
       tagTone: "amber",
       parentAssetName: "Mary CPF",
     })
-    expect(sa?.tagLabel).toContain("merges to RA")
+    expect(sa?.tagLabel).toContain("rolls into RA")
     expect(ma?.tagLabel).toBe("Medical only")
-    expect(ra?.tagLabel).toContain("CPF LIFE")
+    expect(ra?.tagLabel).toContain("Pays out")
     expect(ma?.liquid).toBe(false)
   })
 

--- a/src/lib/utils/independence/cpfSubAccountTags.ts
+++ b/src/lib/utils/independence/cpfSubAccountTags.ts
@@ -17,28 +17,28 @@ const TAGS: Record<
   { label: string; tone: "amber" | "gray"; tooltip: string }
 > = {
   OA: {
-    label: "Restricted — housing / edu pre-55",
+    label: "Accumulates, rolls into RA at retirement",
     tone: "amber",
     tooltip:
-      "Ordinary Account. Withdrawable for approved uses (housing, education, top-ups). At age 55 the balance flows into the Retirement Account up to the FRS cap to fund CPF LIFE.",
+      "Ordinary Account. Accumulates until the retirement age, then rolls into the Retirement Account to fund payouts.",
   },
   SA: {
-    label: "Locked — merges to RA at 55",
+    label: "Accumulates, rolls into RA at retirement",
     tone: "gray",
     tooltip:
-      "Special Account. Statutorily locked until 55, then absorbed into the Retirement Account to fund CPF LIFE annuity. Not spendable as a lump sum.",
+      "Special Account. Accumulates until the retirement age, then rolls into the Retirement Account to fund payouts.",
   },
   MA: {
     label: "Medical only",
     tone: "gray",
     tooltip:
-      "MediSave Account. Locked for approved healthcare expenses and MediShield premiums. Never enters the spendable pool.",
+      "MediSave Account. Reserved for approved healthcare expenses and insurance premiums. Not part of the spendable pool.",
   },
   RA: {
-    label: "CPF LIFE annuity source",
-    tone: "gray",
+    label: "Pays out from retirement age",
+    tone: "amber",
     tooltip:
-      "Retirement Account. Created at age 55 from OA/SA balances; pays out as the CPF LIFE annuity from the payout-start age.",
+      "Retirement Account. Holds OA + SA balances at retirement age and pays them out across retirement.",
   },
 }
 

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -8,6 +8,7 @@ import {
   serverBreakdownToAllocationSlices,
   transformToAllocationSlices,
 } from "@lib/allocation/aggregateHoldings"
+import { getReportCategory } from "@lib/categoryMapping"
 import { ValueIn } from "@components/features/holdings/GroupByOptions"
 import {
   TabId,
@@ -164,6 +165,31 @@ function PlanView(): React.ReactElement {
     () => buildCpfSubAccountRows(assetConfigs, assetConfigNames),
     [assetConfigs, assetConfigNames],
   )
+
+  // Group sub-account rows under the category-slice key their CPF parent
+  // resolves to via getReportCategory. Lets AssetsBreakdown expand the
+  // parent slice (e.g. "Retirement Fund") with indented child rows.
+  const cpfSubAccountsByCategoryKey = useMemo<
+    Record<string, typeof cpfSubAccountRows>
+  >(() => {
+    if (cpfSubAccountRows.length === 0) return {}
+    if (!holdingsData?.positions) return {}
+    const parentIds = new Set(cpfSubAccountRows.map((r) => r.parentAssetId))
+    const assetCategoryKey: Record<string, string> = {}
+    for (const p of Object.values(holdingsData.positions) as Position[]) {
+      if (parentIds.has(p.asset.id)) {
+        assetCategoryKey[p.asset.id] = getReportCategory(p.asset)
+      }
+    }
+    const grouped: Record<string, typeof cpfSubAccountRows> = {}
+    for (const row of cpfSubAccountRows) {
+      const key = assetCategoryKey[row.parentAssetId]
+      if (!key) continue
+      if (!grouped[key]) grouped[key] = []
+      grouped[key].push(row)
+    }
+    return grouped
+  }, [cpfSubAccountRows, holdingsData])
 
   // Resolve asset IDs belonging to excluded portfolios (for rental income filtering)
   const excludedAssetIds = useExcludedAssetIds(
@@ -974,7 +1000,7 @@ function PlanView(): React.ReactElement {
               onRefreshHoldings={() => refreshHoldings()}
               excludedPensionFV={excludedPensionFV}
               includedPensionFvDifferential={includedPensionFvDifferential}
-              cpfSubAccountRows={cpfSubAccountRows}
+              cpfSubAccountsByCategoryKey={cpfSubAccountsByCategoryKey}
               isSharedPlan={isSharedPlan}
             />
           )}


### PR DESCRIPTION
## Summary
Follow-up to #804 with two refinements driven by user feedback.

- **Inline CPF expander.** Standalone "CPF Sub-Accounts" panel removed. The parent category slice (e.g. "Retirement Fund") now has a chevron — click to reveal indented OA / SA / MA / RA rows underneath, each with a single tag and amount. No CPF preamble copy. Tag wording reflects the standard Singaporean retirement model (OA + SA accumulate to retirement age then roll into RA, which pays out); CPF LIFE / age-55 language dropped. Panel hides entirely when the user holds no CPF policy.
- **Wealth Journey legend filter.** Both `TimelineTabContent` and the composite `WealthJourneyTab` skip the Housing / CPF MA / CPF LIFE stacked layers when every projected value is zero. Mary's chart drops Housing; Mike's drops both CPF rows. Legend tracks what actually renders.

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn test --testPathPatterns=cpfSubAccountTags` — 7 unit tests pass (updated tag-text assertions)
- [ ] Manual verification on kauri once deployed
  - [ ] Mary: Retirement Fund row shows chevron, expand → OA/SA/MA/RA rows; Wealth Journey legend shows Liquid + CPF MA + CPF LIFE (no Housing)
  - [ ] Mike: Assets-by-Category has no CPF expander; Wealth Journey legend shows only Liquid (no Housing, no CPF rows)

@coderabbitai ignore