### PR TITLE
refactor(independence): treat CPF MA as healthcare reserve, drop from wealth chart

### DIFF
--- a/src/components/features/independence/AssetsBreakdown.tsx
+++ b/src/components/features/independence/AssetsBreakdown.tsx
@@ -65,6 +65,22 @@ export default function AssetsBreakdown({
   includedPensionFvDifferential,
   cpfSubAccountsByCategoryKey,
 }: AssetsBreakdownProps): React.ReactElement {
+  // Healthcare reserve — sum of CPF MA balances across every CPF parent.
+  // Surfaced as its own line in the totals block (and never on the wealth
+  // chart) so users see it for what it is: an earmarked pool that funds
+  // MediShield / CareShield premiums and approved medical, not retirement
+  // spending. Zero (or missing) → no line rendered.
+  const healthcareReserve = React.useMemo(() => {
+    if (!cpfSubAccountsByCategoryKey) return 0
+    let total = 0
+    for (const rows of Object.values(cpfSubAccountsByCategoryKey)) {
+      for (const row of rows) {
+        if (row.code.toUpperCase() === "MA") total += row.balance
+      }
+    }
+    return total
+  }, [cpfSubAccountsByCategoryKey])
+
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set())
   const toggleExpand = (key: string): void => {
     setExpandedKeys((prev) => {
@@ -378,6 +394,24 @@ export default function AssetsBreakdown({
                   security.
                 </p>
               </>
+            )}
+            {healthcareReserve > 0 && (
+              <div className="flex justify-between text-sm">
+                <span
+                  className="text-gray-500"
+                  title="CPF MediSave Account. Reserved for MediShield Life / CareShield premiums and approved medical expenses. Not drawdownable for retirement spending."
+                >
+                  <i className="fas fa-heart-pulse text-xs mr-1 text-rose-400"></i>
+                  Healthcare Reserve (CPF MA)
+                </span>
+                <span
+                  className={`font-medium ${hideValues ? "text-gray-400" : "text-rose-500"}`}
+                >
+                  {hideValues
+                    ? HIDDEN_VALUE
+                    : `${effectiveCurrency}${Math.round(healthcareReserve * effectiveFxRate).toLocaleString()}`}
+                </span>
+              </div>
             )}
             <div className="flex justify-between text-sm">
               <span className="text-gray-500">Blended Return Rate</span>

--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -94,9 +94,10 @@ export default function TimelineTabContent({
   const hasActiveWhatIf = baselineProjection !== null
 
   // Combine accumulation and drawdown for chart. Sub-bucket fields drive
-  // the stacked-area visualisation (Liquid + Housing + CPF MA + CPF Annuity).
-  // Locked layers grow even after liquid depletes, so the chart needs to
-  // show each separately instead of lumping into a single Total Wealth line.
+  // the stacked-area visualisation (Liquid + Housing + CPF LIFE principal).
+  // Locked layers grow even after liquid depletes, so the chart shows
+  // each separately instead of lumping into a single Total Wealth line.
+  // CPF MA is excluded — see comment on hasAnnuitizedLayer.
   const fullJourneyData = useMemo(() => {
     if (!projection) return []
 
@@ -109,7 +110,6 @@ export default function TimelineTabContent({
         totalWealth: year.totalWealth,
         liquidValue: year.endingBalance,
         housingValue: year.housingValue ?? 0,
-        cpfNonLiquidValue: year.cpfNonLiquidValue ?? 0,
         annuitizedValue: year.annuitizedValue ?? 0,
         contribution: year.contribution,
         investmentGrowth: year.investmentGrowth,
@@ -126,7 +126,6 @@ export default function TimelineTabContent({
       totalWealth: year.totalWealth,
       liquidValue: year.endingBalance,
       housingValue: year.housingValue ?? 0,
-      cpfNonLiquidValue: year.cpfNonLiquidValue ?? 0,
       annuitizedValue: year.annuitizedValue ?? 0,
       withdrawals: year.withdrawals,
       investment: year.investment,
@@ -139,13 +138,11 @@ export default function TimelineTabContent({
 
   // Hide stacked layers (and their legend entries) when the user has none
   // of that asset class. Mary has no housing → drop the Housing band.
-  // Mike has no CPF → drop CPF MA + CPF LIFE bands.
+  // Mike has no CPF → drop the CPF LIFE band. CPF MA is never stacked here
+  // — it's an earmarked healthcare reserve, not drawdownable wealth — so
+  // the layer doesn't exist regardless of who's viewing.
   const hasHousingLayer = useMemo(
     () => fullJourneyData.some((p) => (p.housingValue ?? 0) > 0),
-    [fullJourneyData],
-  )
-  const hasCpfNonLiquidLayer = useMemo(
-    () => fullJourneyData.some((p) => (p.cpfNonLiquidValue ?? 0) > 0),
     [fullJourneyData],
   )
   const hasAnnuitizedLayer = useMemo(
@@ -309,8 +306,6 @@ export default function TimelineTabContent({
                     return [formatted, "Liquid (spendable)"]
                   if (name === "housingValue")
                     return [formatted, "Housing (locked)"]
-                  if (name === "cpfNonLiquidValue")
-                    return [formatted, "CPF MA (locked)"]
                   if (name === "annuitizedValue")
                     return [formatted, "CPF LIFE principal (locked)"]
                   if (name === "fireBalance") return [formatted, "FIRE Path"]
@@ -327,15 +322,13 @@ export default function TimelineTabContent({
                     ? "Liquid (spendable)"
                     : value === "housingValue"
                       ? "Housing (locked)"
-                      : value === "cpfNonLiquidValue"
-                        ? "CPF MA (locked)"
-                        : value === "annuitizedValue"
-                          ? "CPF LIFE principal (locked)"
-                          : value === "fireBalance"
-                            ? "FIRE Path"
-                            : value === "baselineBalance"
-                              ? "Baseline"
-                              : value
+                      : value === "annuitizedValue"
+                        ? "CPF LIFE principal (locked)"
+                        : value === "fireBalance"
+                          ? "FIRE Path"
+                          : value === "baselineBalance"
+                            ? "Baseline"
+                            : value
                 }
               />
               <ReferenceLine y={0} stroke="#ef4444" strokeWidth={2} />
@@ -413,11 +406,15 @@ export default function TimelineTabContent({
                 />
               )}
               {/* Stacked wealth journey — bottom-up: Liquid (spendable),
-                  Housing, CPF MA, CPF LIFE principal. Top of the stack
-                  equals total wealth at each age. Liquidity gradient
-                  palette: Liquid pops in bright blue; locked layers
-                  drop into muted oranges/greys so the user reads
-                  brightness as 'spendable' at a glance. Green is
+                  Housing, CPF LIFE principal. Top of the stack equals
+                  drawdownable + locked principal at each age. CPF MA is
+                  intentionally excluded — it's an earmarked healthcare
+                  reserve (MediShield / CareShield premiums + approved
+                  medical), not wealth available for retirement spending.
+                  Surface MA via the Assets-by-Category panel instead.
+                  Liquidity gradient palette: Liquid pops in bright blue;
+                  locked layers drop into muted oranges/greys so the user
+                  reads brightness as 'spendable' at a glance. Green is
                   deliberately avoided on locked layers — it carries a
                   'wealth growing' connotation that undoes the message. */}
               {timelineViewMode === "traditional" && (
@@ -442,18 +439,6 @@ export default function TimelineTabContent({
                       fillOpacity={0.3}
                       strokeWidth={1}
                       name="housingValue"
-                    />
-                  )}
-                  {hasCpfNonLiquidLayer && (
-                    <Area
-                      type="monotone"
-                      dataKey="cpfNonLiquidValue"
-                      stackId="wealth"
-                      stroke="#737373"
-                      fill="#a3a3a3"
-                      fillOpacity={0.3}
-                      strokeWidth={1}
-                      name="cpfNonLiquidValue"
                     />
                   )}
                   {hasAnnuitizedLayer && (

--- a/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
+++ b/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
@@ -54,16 +54,19 @@ export default function WealthJourneyTab(): React.ReactElement | null {
     return null
   }
 
-  // Stacked-area data — bottom-up: Liquid (spendable) + Housing + CPF MA
-  // + CPF Annuity. Top of stack = totalWealth. Locked layers signal what
-  // share of net worth isn't actually drawdownable in retirement.
+  // Stacked-area data — bottom-up: Liquid (spendable) + Housing + CPF
+  // Annuity. Top of stack = totalWealth. Locked layers signal the share
+  // of net worth that isn't drawdownable in retirement. CPF MA is
+  // deliberately excluded — it's an earmarked healthcare reserve
+  // (MediShield / CareShield premiums + approved medical), not part of
+  // wealth available for spending. The MA balance is surfaced
+  // separately on the Assets-by-Category panel ("Medical only" tag).
   const chartData = projection.yearlyProjections.map((row) => ({
     age: row.age,
     endingBalance: row.endingBalance,
     totalWealth: row.totalWealth,
     liquidValue: row.endingBalance,
     housingValue: row.housingValue ?? 0,
-    cpfNonLiquidValue: row.cpfNonLiquidValue ?? 0,
     annuitizedValue: row.annuitizedValue ?? 0,
     income: row.income,
     expenses: row.expenses,
@@ -79,7 +82,6 @@ export default function WealthJourneyTab(): React.ReactElement | null {
   // of that asset class. Plans without housing or CPF skip those bands so
   // the legend stays focused on layers that actually appear in the chart.
   const hasHousingLayer = chartData.some((p) => p.housingValue > 0)
-  const hasCpfNonLiquidLayer = chartData.some((p) => p.cpfNonLiquidValue > 0)
   const hasAnnuitizedLayer = chartData.some((p) => p.annuitizedValue > 0)
 
   const phaseBoundaries = projection.phases.map((phase, idx) => ({
@@ -147,8 +149,6 @@ export default function WealthJourneyTab(): React.ReactElement | null {
                   return [formatted, "Liquid (spendable)"]
                 if (name === "housingValue")
                   return [formatted, "Housing (locked)"]
-                if (name === "cpfNonLiquidValue")
-                  return [formatted, "CPF MA (locked)"]
                 if (name === "annuitizedValue")
                   return [formatted, "CPF LIFE principal (locked)"]
                 return [formatted, String(name)]
@@ -168,11 +168,9 @@ export default function WealthJourneyTab(): React.ReactElement | null {
                   ? "Liquid (spendable)"
                   : value === "housingValue"
                     ? "Housing (locked)"
-                    : value === "cpfNonLiquidValue"
-                      ? "CPF MA (locked)"
-                      : value === "annuitizedValue"
-                        ? "CPF LIFE principal (locked)"
-                        : value
+                    : value === "annuitizedValue"
+                      ? "CPF LIFE principal (locked)"
+                      : value
               }
             />
 
@@ -210,11 +208,16 @@ export default function WealthJourneyTab(): React.ReactElement | null {
             )}
 
             {/* Stacked-area wealth journey: Liquid (bottom) + Housing
-                + CPF MA + CPF LIFE principal. Top of stack = total
-                wealth. Liquidity gradient palette — bright blue Liquid
-                pops, muted orange/grey locked layers recede. Green
-                deliberately avoided on locked layers; it would imply
-                "wealth growing" and undo the spendable-vs-locked story. */}
+                + CPF LIFE principal. Top of stack = drawdownable + locked
+                principal at each age. CPF MA is intentionally excluded —
+                it's an earmarked healthcare reserve (MediShield /
+                CareShield premiums + approved medical), not wealth
+                available for retirement spending. Surface MA via the
+                Assets-by-Category panel instead.
+                Liquidity gradient palette — bright blue Liquid pops,
+                muted orange/grey locked layers recede. Green deliberately
+                avoided on locked layers; it would imply "wealth growing"
+                and undo the spendable-vs-locked story. */}
             <Area
               type="monotone"
               dataKey="liquidValue"
@@ -235,18 +238,6 @@ export default function WealthJourneyTab(): React.ReactElement | null {
                 fillOpacity={0.3}
                 strokeWidth={1}
                 name="housingValue"
-              />
-            )}
-            {hasCpfNonLiquidLayer && (
-              <Area
-                type="monotone"
-                dataKey="cpfNonLiquidValue"
-                stackId="wealth"
-                stroke="#737373"
-                fill="#a3a3a3"
-                fillOpacity={0.3}
-                strokeWidth={1}
-                name="cpfNonLiquidValue"
               />
             )}
             {hasAnnuitizedLayer && (


### PR DESCRIPTION
## Summary
CPF MediSave Account is statutorily reserved for MediShield Life / CareShield premiums and approved medical expenses. It grows at the 4% statutory rate and is never drawdownable for retirement spending. Stacking it inside the wealth journey alongside Liquid / Housing / CPF LIFE principal implied it was usable wealth — the opposite of how every Singapore retirement projector (CPF RES, DBS NAV, Moneysense, OCBC, MoneyOwl, Endowus) treats it.

### Changes
- **Wealth chart (Timeline + composite Wealth Journey)** — drop the CPF MA stacked-area layer. Tooltip + legend formatter + has-layer guard removed.
- **Assets-by-Category panel** — new "Healthcare Reserve (CPF MA)" line in the totals block aggregating MA balances across CPF parents. Renders only when the user holds CPF; absent for non-Singaporean plans. Tooltip explains the earmarking.
- The CPF expander inside the Retirement Fund slice already labels the MA sub-account "Medical only", so the per-sub-account balance is still discoverable.

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn test --testPathPatterns=cpfSubAccountTags` — 7 tests pass
- [ ] Manual verification on kauri once deployed
  - [ ] Mary's wealth chart shows only Liquid + CPF LIFE principal (no Housing, no MA)
  - [ ] Assets-by-Category totals block shows "Healthcare Reserve (CPF MA): SGD 58,000"
  - [ ] Mike's view: no healthcare reserve line, no MA / Housing layers on the chart (just Liquid)

@coderabbitai ignore