### PR TITLE
feat(independence): Cash → Investments scenario slider

### DIFF
--- a/src/components/features/independence/ScenarioBar.tsx
+++ b/src/components/features/independence/ScenarioBar.tsx
@@ -262,6 +262,25 @@ export default function ScenarioBar({
               unit=""
               formatValue={PCT}
             />
+            {/* Wealth Transfer — cash → equities. Surfaces a Singapore-flavoured
+                question: "what if I moved part of my bank cash into
+                investments?" Slider stays at 0 (no shift) by default; moving
+                it changes plan.cashAllocation / equityAllocation via
+                scenarioToPayload. Future siblings (OA → SA, ETF → CPF VC)
+                will live alongside this once we generalise to
+                wealthTransfers[]. */}
+            <WhatIfSlider
+              label="Cash → Investments"
+              value={scenario.cashToInvestPercent}
+              onChange={(cashToInvestPercent) =>
+                onScenarioChange({ cashToInvestPercent })
+              }
+              min={0}
+              max={100}
+              step={5}
+              unit="%"
+              formatValue={(v) => `${Math.round(v)}%`}
+            />
           </div>
         )}
       </div>

--- a/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
+++ b/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
@@ -47,6 +47,7 @@ const scenario: ScenarioState = {
   otherIncomeMonthly: 100,
   realReturn: null,
   inflation: 0.025,
+  cashToInvestPercent: 0,
 }
 
 const ctx: ScenarioPayloadCtx = {
@@ -168,6 +169,51 @@ describe("scenarioToPayload", () => {
       },
     })
     expect("rentalIncomeMonthly" in payload).toBe(false)
+  })
+
+  describe("cashToInvestPercent slider", () => {
+    it("omits allocation overrides when the slider is at zero", () => {
+      const payload = scenarioToPayload(scenario, ctx)
+      expect("cashAllocation" in payload).toBe(false)
+      expect("equityAllocation" in payload).toBe(false)
+    })
+
+    it("shifts half the cash into equity at 50%", () => {
+      // Plan: cash 0.3, equity 0.7. Slider 50 → move 0.15 of cash into equity.
+      // New cash 0.15, new equity 0.85.
+      const payload = scenarioToPayload(
+        { ...scenario, cashToInvestPercent: 50 },
+        ctx,
+      )
+      expect(payload.cashAllocation).toBeCloseTo(0.15, 5)
+      expect(payload.equityAllocation).toBeCloseTo(0.85, 5)
+    })
+
+    it("zeros the cash allocation at 100%", () => {
+      const payload = scenarioToPayload(
+        { ...scenario, cashToInvestPercent: 100 },
+        ctx,
+      )
+      expect(payload.cashAllocation).toBeCloseTo(0, 5)
+      expect(payload.equityAllocation).toBeCloseTo(1, 5)
+    })
+
+    it("clamps negative slider values to no shift", () => {
+      const payload = scenarioToPayload(
+        { ...scenario, cashToInvestPercent: -10 },
+        ctx,
+      )
+      expect("cashAllocation" in payload).toBe(false)
+    })
+
+    it("clamps above 100 to a full shift", () => {
+      const payload = scenarioToPayload(
+        { ...scenario, cashToInvestPercent: 250 },
+        ctx,
+      )
+      expect(payload.cashAllocation).toBeCloseTo(0, 5)
+      expect(payload.equityAllocation).toBeCloseTo(1, 5)
+    })
   })
 })
 

--- a/src/components/features/independence/scenario/scenarioToPayload.ts
+++ b/src/components/features/independence/scenario/scenarioToPayload.ts
@@ -58,6 +58,20 @@ export function scenarioToPayload(
     targetBalance: ctx.plan.targetBalance,
   }
 
+  // Wealth Transfer: cash → investments. Translate the 0–100 slider into
+  // explicit allocation overrides so svc-retire's blended-return calc
+  // (and the FI gauges that read off it) react immediately. Slider at 0
+  // means "don't send the overrides at all" — keeps the projection
+  // request shape stable for the default case and lets a plan with no
+  // cashAllocation set fall through to plan defaults.
+  const shift =
+    Math.max(0, Math.min(100, scenario.cashToInvestPercent ?? 0)) / 100
+  if (shift > 0) {
+    const movedCash = ctx.plan.cashAllocation * shift
+    payload.cashAllocation = ctx.plan.cashAllocation - movedCash
+    payload.equityAllocation = ctx.plan.equityAllocation + movedCash
+  }
+
   // `portfolioIds` and `monthlyContribution` come from the viewer's own
   // holdings + contributions. On a shared plan svc-retire resolves the
   // OWNER's portfolios + contributions via the M2M path — sending the

--- a/src/components/features/independence/scenario/seedFromPlan.ts
+++ b/src/components/features/independence/scenario/seedFromPlan.ts
@@ -34,6 +34,7 @@ export function seedFromPlan(
     otherIncomeMonthly: plan.otherIncomeMonthly ?? 0,
     realReturn: null,
     inflation: plan.inflationRate,
+    cashToInvestPercent: 0,
   }
 }
 
@@ -59,6 +60,7 @@ export function isScenarioDirty(
     scenario.socialSecurityMonthly !== seed.socialSecurityMonthly ||
     scenario.otherIncomeMonthly !== seed.otherIncomeMonthly ||
     scenario.realReturn !== null ||
-    scenario.inflation !== seed.inflation
+    scenario.inflation !== seed.inflation ||
+    scenario.cashToInvestPercent !== seed.cashToInvestPercent
   )
 }

--- a/src/components/features/independence/scenario/types.ts
+++ b/src/components/features/independence/scenario/types.ts
@@ -43,6 +43,17 @@ export interface ScenarioState {
   realReturn: number | null
   /** Absolute inflation rate as a decimal (e.g. 0.025 for 2.5%). */
   inflation: number
+  /**
+   * Wealth Transfer slider: how much of the plan's CASH allocation gets
+   * shifted into EQUITY for this scenario. 0 = leave allocations at the
+   * saved plan values; 100 = move every dollar of cash into equities.
+   * Drives a single (cashAllocation / equityAllocation) override pair on
+   * the projection request — backend recomputes the blended return and
+   * the headline FI gauges from there. Housing is untouched. Future
+   * siblings (OA → SA, ETF → CPF VC, etc.) will live alongside this
+   * field once we generalise into a `wealthTransfers[]` shape.
+   */
+  cashToInvestPercent: number
 }
 
 export const DEFAULT_SCENARIO_STATE: ScenarioState = {
@@ -56,4 +67,5 @@ export const DEFAULT_SCENARIO_STATE: ScenarioState = {
   otherIncomeMonthly: 0,
   realReturn: null,
   inflation: 0.025,
+  cashToInvestPercent: 0,
 }


### PR DESCRIPTION
## Summary
Adds a "Cash → Investments" slider to the ScenarioBar. Slider value is the percentage of the plan's cash allocation to shift into equity for this scenario only. Saved plan untouched.

Companion to svc-retire #65 which adds the matching backend overrides. Without that PR the slider sends overrides that the backend ignores.

### Changes
- `ScenarioState.cashToInvestPercent` (0–100, default 0).
- `scenarioToPayload` translates the slider into explicit `cashAllocation` / `equityAllocation` overrides. Slider at 0 omits the overrides so the default request shape is unchanged.
- `seedFromPlan` defaults to 0 and `isScenarioDirty` tracks it.
- `ScenarioBar` adds the slider next to Inflation, 0–100% step 5%.

### Behaviour on Mary

| Slider | Cash alloc | Equity alloc | Effect |
|---|---|---|---|
| 0% | 0.20 (plan) | 0.80 (plan) | baseline |
| 50% | 0.10 | 0.90 | half the bank cash into ETFs |
| 100% | 0.00 | 1.00 | all bank cash into ETFs |

Backend's blended-return calc reacts immediately → wealth chart + FI gauges diverge from baseline. Real-time visual answer to "should Mary stop sitting on cash?".

### Out of scope (future)
- General `wealthTransfers[]` model for OA → SA, ETF → CPF VC, etc.
- Emergency-buffer warnings when slider goes above a threshold.
- Sequence-of-returns risk disclosure (covered by the existing Monte Carlo tab).

## Test plan
- [x] `yarn test --testPathPatterns='(scenarioToPayload|seedFromPlan|ScenarioBar)'` — 41 tests pass (5 new on the slider)
- [x] `yarn typecheck` — clean
- [ ] Manual on kauri after svc-retire #65 ships
  - [ ] Drag slider 0 → 100% on Mary's plan; wealth chart + FI gauges visibly improve
  - [ ] Drop back to 0 → projection matches saved-plan baseline

@coderabbitai ignore