### PR TITLE
fix(independence): hide phantom Housing layer + rename Bridge → Self-funded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,7 @@ Output is `standalone` mode for containerized deployment.
    fails if not.
 
 Critical configuration:
+
 - `actions/upload-artifact@v6+`: `include-hidden-files: true` is **required**.
   Without it the action silently drops dot-prefixed paths like `.next/`. This
   is the trap PRs #762–#766 chased: artifact appeared to upload but `.next/`

--- a/e2e/tests/tools/open-brokerage.spec.ts
+++ b/e2e/tests/tools/open-brokerage.spec.ts
@@ -4,9 +4,7 @@ import { createTestHelpers, generateTestId } from "../../fixtures/test-data"
 test.describe("/tools/open-brokerage", () => {
   test("renders wizard at the Broker step", async ({ page }) => {
     await page.goto("/tools/open-brokerage")
-    await expect(
-      page.getByRole("heading", { name: /^Broker$/i }),
-    ).toBeVisible()
+    await expect(page.getByRole("heading", { name: /^Broker$/i })).toBeVisible()
     await expect(page.getByText(/Step 1 of 4/i)).toBeVisible()
   })
 
@@ -80,9 +78,8 @@ test.describe("/tools/open-brokerage", () => {
         if (!r.ok) return null
         const j = await r.json()
         return (
-          j.data?.find(
-            (p: { code: string; id: string }) => p.code === code,
-          ) ?? null
+          j.data?.find((p: { code: string; id: string }) => p.code === code) ??
+          null
         )
       }, portfolioCode)
       expect(result).not.toBeNull()
@@ -173,7 +170,9 @@ test.describe("/tools/open-brokerage", () => {
       // Select by portfolio id (option `value`) to avoid building a runtime
       // regex from test data (ReDoS lint) and to be resilient to label
       // formatting changes.
-      await page.getByLabel(/Source portfolio/i).selectOption(sourcePortfolio.id)
+      await page
+        .getByLabel(/Source portfolio/i)
+        .selectOption(sourcePortfolio.id)
       await page.getByRole("button", { name: "Next →" }).click()
 
       // Step 4 — Review + submit

--- a/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
@@ -12,7 +12,12 @@ jest.mock("swr", () => ({
 }))
 const mockUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
 
-const mockUsePermissions = jest.fn(() => ({ ai: false, preview: false, admin: false, isLoading: false }))
+const mockUsePermissions = jest.fn(() => ({
+  ai: false,
+  preview: false,
+  admin: false,
+  isLoading: false,
+}))
 jest.mock("@hooks/usePermissions", () => ({
   __esModule: true,
   usePermissions: () => mockUsePermissions(),
@@ -105,7 +110,12 @@ function renderPopup(
 describe("PriceChartPopup", () => {
   beforeEach(() => {
     mockUseSwr.mockReset()
-    mockUsePermissions.mockReturnValue({ ai: false, preview: false, admin: false, isLoading: false })
+    mockUsePermissions.mockReturnValue({
+      ai: false,
+      preview: false,
+      admin: false,
+      isLoading: false,
+    })
   })
 
   it("renders the chart with the asset name and close price", () => {
@@ -314,7 +324,12 @@ describe("PriceChartPopup", () => {
     })
 
     it("posts to the repair endpoint and surfaces the response when admin clicks", async () => {
-      mockUsePermissions.mockReturnValue({ ai: false, preview: false, admin: true, isLoading: false })
+      mockUsePermissions.mockReturnValue({
+        ai: false,
+        preview: false,
+        admin: true,
+        isLoading: false,
+      })
       mockUseSwr.mockImplementation(makeRouter({}) as typeof useSwr)
 
       const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
@@ -348,7 +363,12 @@ describe("PriceChartPopup", () => {
     })
 
     it("surfaces a forbidden error if the server rejects the admin gate", async () => {
-      mockUsePermissions.mockReturnValue({ ai: false, preview: false, admin: true, isLoading: false })
+      mockUsePermissions.mockReturnValue({
+        ai: false,
+        preview: false,
+        admin: true,
+        isLoading: false,
+      })
       mockUseSwr.mockImplementation(makeRouter({}) as typeof useSwr)
 
       const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({

--- a/src/components/features/independence/FiMetrics.tsx
+++ b/src/components/features/independence/FiMetrics.tsx
@@ -62,7 +62,7 @@ interface FiMetricsProps {
   effectiveStrategy?: "FIRE" | "PENSION" | "HYBRID"
   /**
    * Strategy view chosen at the page level. Drives which sections render —
-   * FIRE / Pension / Bridge focus on one; ALL shows every section.
+   * FIRE / Pension / Self-funded focus on one; ALL shows every section.
    */
   view?: StrategyView
   /** Current inflation rate from plan (as decimal) */
@@ -192,7 +192,7 @@ export default function FiMetrics({
 
   // Section visibility derived from the page-level view selection. ALL shows
   // every section; FIRE / PENSION / HYBRID focus on one — but only render
-  // Pension or Bridge when their backend data is actually present.
+  // Pension or Self-funded when their backend data is actually present.
   const showFire = view === "ALL" || view === "FIRE"
   const showPension =
     view === "PENSION" || (view === "ALL" && autoPensionEligible)
@@ -209,7 +209,7 @@ export default function FiMetrics({
       <div className="flex items-center mb-4 gap-3 flex-wrap">
         <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
           Retirement Strategies
-          <InfoTooltip text="Each user pursues one or more of three paths: FIRE (live off liquid investments), Pension (rely on guaranteed income), or Bridge (use liquid to cover the gap until pensions start). Pick a view at the top of the page to focus on one.">
+          <InfoTooltip text="Each user pursues one or more of three paths: FIRE (live off liquid investments), Pension (rely on guaranteed income), or Self-funded (use liquid to cover the years until pensions start). Pick a view at the top of the page to focus on one.">
             <span></span>
           </InfoTooltip>
         </h2>
@@ -713,7 +713,7 @@ interface BridgeStrategySectionProps {
 }
 
 /**
- * Bridge Strategy: liquid runway covering the gap between today and pension
+ * Self-funded Years: liquid runway covering the gap between today and pension
  * payout age. Shown only when the user has both guaranteed income (a pension
  * to bridge to) and working-years remaining.
  */
@@ -728,16 +728,16 @@ function BridgeStrategySection({
   return (
     <div className="pt-4 border-t border-gray-100 space-y-3">
       <StrategyHeader
-        title="Bridge Strategy"
-        tooltip="For savers whose pension covers retirement but who want to stop working before pensions start. Measures how many years of expenses your liquid pot can carry until the pension kicks in."
+        title="Self-funded Years"
+        tooltip="For savers whose pension covers retirement but who want to stop working before pensions start. Measures how many years of expenses your liquid pot can self-fund until the pension kicks in."
         iconClass="fas fa-bridge text-blue-500"
         active={active}
       />
 
       {hasData ? (
         <PensionGauge
-          label="Bridge to Pension"
-          tooltip={`Years of full expenses your liquid pot covers, capped at the ${bridgeYearsNeeded}-year gap to your pension payout age. 100% means you could stop working today and ride the bridge to your pension.`}
+          label="Self-funded years"
+          tooltip={`Years of full expenses your liquid pot covers, capped at the ${bridgeYearsNeeded}-year gap to your pension payout age. 100% means you could stop working today and self-fund every year until your pension starts.`}
           value={bridgeProgress}
           hideValues={hideValues}
           format={() =>
@@ -746,8 +746,8 @@ function BridgeStrategySection({
         />
       ) : (
         <p className="text-sm text-gray-500 italic">
-          No pension to bridge to, or no working-years gap. Configure pension
-          income on the plan to enable this view.
+          No pension payout configured, or no working-years gap. Configure
+          pension income on the plan to enable this view.
         </p>
       )}
     </div>

--- a/src/components/features/independence/StrategyGaugesStrip.tsx
+++ b/src/components/features/independence/StrategyGaugesStrip.tsx
@@ -10,7 +10,7 @@ export interface StrategyGaugesStripProps {
   /**
    * When true, lays out the gauges in a 2-column grid (suitable for the
    * sticky ScenarioBar). When false, stacks them vertically (suitable for
-   * the Metrics tab Pension/Bridge sections).
+   * the Metrics tab Pension/Self-funded sections).
    */
   compact?: boolean
   /**
@@ -27,7 +27,7 @@ export interface StrategyGaugesStripProps {
 
 /**
  * Inline strip of the four pension-saver gauges: FIRE Progress,
- * Retirement-Age FI, Income Coverage, Bridge to Pension.
+ * Retirement-Age FI, Income Coverage, Self-funded years.
  *
  * Renders a placeholder when fiMetrics is undefined so the strip keeps its
  * layout slot during projection recalculations — avoids layout shift.
@@ -147,7 +147,7 @@ function buildGauges(
     const needed = fi.bridgeYearsNeeded
     out.push({
       key: "bridge",
-      label: "Bridge to Pension",
+      label: "Self-funded years",
       tooltip:
         "Years of full expenses your liquid pot covers vs years to your pension payout age.",
       value: fi.bridgeProgress,

--- a/src/components/features/independence/__tests__/FiMetrics.test.tsx
+++ b/src/components/features/independence/__tests__/FiMetrics.test.tsx
@@ -442,16 +442,16 @@ describe("FiMetrics", () => {
     it("renders Pension + Bridge sections for a pension saver", () => {
       render(<FiMetrics {...rubyPensionProps} />)
       expect(screen.getByText("Pension Strategy")).toBeInTheDocument()
-      expect(screen.getByText("Bridge Strategy")).toBeInTheDocument()
+      expect(screen.getByText("Self-funded Years")).toBeInTheDocument()
       expect(screen.getByText("Retirement-Age FI")).toBeInTheDocument()
       expect(screen.getByText("Income Coverage")).toBeInTheDocument()
-      expect(screen.getByText("Bridge to Pension")).toBeInTheDocument()
+      expect(screen.getByText("Self-funded years")).toBeInTheDocument()
     })
 
     it("hides Pension + Bridge when no guaranteed income configured", () => {
       render(<FiMetrics {...defaultProps} />)
       expect(screen.queryByText("Pension Strategy")).not.toBeInTheDocument()
-      expect(screen.queryByText("Bridge Strategy")).not.toBeInTheDocument()
+      expect(screen.queryByText("Self-funded Years")).not.toBeInTheDocument()
     })
 
     it("shows Pension but not Bridge when no years-to-retirement gap", () => {
@@ -464,7 +464,7 @@ describe("FiMetrics", () => {
       )
       expect(screen.getByText("Pension Strategy")).toBeInTheDocument()
       expect(screen.getByText("Income Coverage")).toBeInTheDocument()
-      expect(screen.queryByText("Bridge Strategy")).not.toBeInTheDocument()
+      expect(screen.queryByText("Self-funded Years")).not.toBeInTheDocument()
     })
 
     it("formats Retirement-Age FI as a percentage", () => {
@@ -475,10 +475,10 @@ describe("FiMetrics", () => {
       expect(row?.textContent).toContain("54.0%")
     })
 
-    it("formats Bridge to Pension as years out of needed", () => {
+    it("formats Self-funded years as years out of needed", () => {
       render(<FiMetrics {...rubyPensionProps} />)
       const row = screen
-        .getByText("Bridge to Pension")
+        .getByText("Self-funded years")
         .closest("div")?.parentElement
       expect(row?.textContent).toContain("3.3 / 13 years")
     })
@@ -623,9 +623,9 @@ describe("FiMetrics", () => {
       expect(row?.textContent).toContain("Active")
     })
 
-    it("shows Active badge on Bridge Strategy when effective strategy is HYBRID", () => {
+    it("shows Active badge on Self-funded Years when effective strategy is HYBRID", () => {
       render(<FiMetrics {...rubyPensionProps} effectiveStrategy="HYBRID" />)
-      const header = screen.getByText("Bridge Strategy")
+      const header = screen.getByText("Self-funded Years")
       const row = header.closest(".justify-between")
       expect(row?.textContent).toContain("Active")
     })
@@ -639,28 +639,28 @@ describe("FiMetrics", () => {
       render(<FiMetrics {...rubyPensionProps} view="ALL" />)
       expect(screen.getByText("FIRE Strategy")).toBeInTheDocument()
       expect(screen.getByText("Pension Strategy")).toBeInTheDocument()
-      expect(screen.getByText("Bridge Strategy")).toBeInTheDocument()
+      expect(screen.getByText("Self-funded Years")).toBeInTheDocument()
     })
 
     it("view=FIRE hides Pension + Bridge for Ruby", () => {
       render(<FiMetrics {...rubyPensionProps} view="FIRE" />)
       expect(screen.getByText("FIRE Strategy")).toBeInTheDocument()
       expect(screen.queryByText("Pension Strategy")).not.toBeInTheDocument()
-      expect(screen.queryByText("Bridge Strategy")).not.toBeInTheDocument()
+      expect(screen.queryByText("Self-funded Years")).not.toBeInTheDocument()
     })
 
     it("view=PENSION hides FIRE + Bridge for Ruby", () => {
       render(<FiMetrics {...rubyPensionProps} view="PENSION" />)
       expect(screen.queryByText("FIRE Strategy")).not.toBeInTheDocument()
       expect(screen.getByText("Pension Strategy")).toBeInTheDocument()
-      expect(screen.queryByText("Bridge Strategy")).not.toBeInTheDocument()
+      expect(screen.queryByText("Self-funded Years")).not.toBeInTheDocument()
     })
 
     it("view=HYBRID hides FIRE + Pension for Ruby", () => {
       render(<FiMetrics {...rubyPensionProps} view="HYBRID" />)
       expect(screen.queryByText("FIRE Strategy")).not.toBeInTheDocument()
       expect(screen.queryByText("Pension Strategy")).not.toBeInTheDocument()
-      expect(screen.getByText("Bridge Strategy")).toBeInTheDocument()
+      expect(screen.getByText("Self-funded Years")).toBeInTheDocument()
     })
 
     it("view defaults to ALL when omitted (plain FIRE user shows FIRE only)", () => {
@@ -668,7 +668,7 @@ describe("FiMetrics", () => {
       expect(screen.getByText("FIRE Strategy")).toBeInTheDocument()
       // No backend pension/bridge data → those sections still hidden.
       expect(screen.queryByText("Pension Strategy")).not.toBeInTheDocument()
-      expect(screen.queryByText("Bridge Strategy")).not.toBeInTheDocument()
+      expect(screen.queryByText("Self-funded Years")).not.toBeInTheDocument()
     })
 
     it("hides funded banner when classic FI already achieved", () => {

--- a/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
+++ b/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
@@ -14,6 +14,7 @@ import {
 import Spinner from "@components/ui/Spinner"
 import Alert from "@components/ui/Alert"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
+import { buildWealthJourneyChartData } from "@lib/independence/wealthJourneyChartData"
 import { useCompositeProjectionContext } from "../CompositeProjectionContext"
 
 const HIDDEN_VALUE = "****"
@@ -61,28 +62,15 @@ export default function WealthJourneyTab(): React.ReactElement | null {
   // (MediShield / CareShield premiums + approved medical), not part of
   // wealth available for spending. The MA balance is surfaced
   // separately on the Assets-by-Category panel ("Medical only" tag).
-  const chartData = projection.yearlyProjections.map((row) => ({
-    age: row.age,
-    endingBalance: row.endingBalance,
-    totalWealth: row.totalWealth,
-    liquidValue: row.endingBalance,
-    housingValue: row.housingValue ?? 0,
-    annuitizedValue: row.annuitizedValue ?? 0,
-    income: row.income,
-    expenses: row.expenses,
-    planId: row.planId,
-    planName: row.planName,
-  }))
+  // buildWealthJourneyChartData also nets cpfNonLiquidValue out of
+  // housingValue so users with no real estate don't see a phantom
+  // Housing legend entry from the upstream svc-retire MA bleed.
+  const { chartData, hasHousingLayer, hasAnnuitizedLayer } =
+    buildWealthJourneyChartData(projection.yearlyProjections)
 
   if (chartData.length === 0) {
     return null
   }
-
-  // Drop stacked layers (and their legend entries) when the user holds none
-  // of that asset class. Plans without housing or CPF skip those bands so
-  // the legend stays focused on layers that actually appear in the chart.
-  const hasHousingLayer = chartData.some((p) => p.housingValue > 0)
-  const hasAnnuitizedLayer = chartData.some((p) => p.annuitizedValue > 0)
 
   const phaseBoundaries = projection.phases.map((phase, idx) => ({
     ...phase,

--- a/src/components/features/independence/scenarios/__tests__/ScenarioContributions.fetcher.test.tsx
+++ b/src/components/features/independence/scenarios/__tests__/ScenarioContributions.fetcher.test.tsx
@@ -48,8 +48,7 @@ const contributionsResponse = { data: [] }
 
 jest.mock("@utils/api/fetchHelper", () => {
   const simpleFetcher = jest.fn((url: string) => () => {
-    if (url === "/api/assets/config")
-      return Promise.resolve(configsResponse)
+    if (url === "/api/assets/config") return Promise.resolve(configsResponse)
     if (url.startsWith("/api/independence/work-scenarios/"))
       return Promise.resolve(contributionsResponse)
     if (url.startsWith("/api/independence/cpf/contribution-preview"))
@@ -88,9 +87,7 @@ describe("ScenarioContributions — SWR fetcher wiring", () => {
   it("invokes simpleFetcher with each SWR key (not the factory itself)", async () => {
     renderInFreshSwrCache()
     await waitFor(() => {
-      expect(
-        (simpleFetcher as jest.Mock).mock.calls.map((c) => c[0]),
-      ).toEqual(
+      expect((simpleFetcher as jest.Mock).mock.calls.map((c) => c[0])).toEqual(
         expect.arrayContaining([
           "/api/assets/config",
           "/api/independence/work-scenarios/scn-1/contributions",

--- a/src/components/features/independence/strategyView.ts
+++ b/src/components/features/independence/strategyView.ts
@@ -15,7 +15,7 @@ export type StrategyView = PrimaryStrategy | "ALL"
 export const STRATEGY_VIEW_LABELS: Record<StrategyView, string> = {
   FIRE: "FIRE",
   PENSION: "Pension",
-  HYBRID: "Bridge",
+  HYBRID: "Self-funded",
   ALL: "All",
 }
 

--- a/src/components/features/offboarding/OffboardingWizard.tsx
+++ b/src/components/features/offboarding/OffboardingWizard.tsx
@@ -61,9 +61,7 @@ export default function OffboardingWizard(): React.ReactElement {
         const modelsData = (await modelsRes.json()) as {
           data?: Array<{ isOwner?: boolean }>
         }
-        const owned = (modelsData.data ?? []).filter(
-          (m) => m.isOwner !== false,
-        )
+        const owned = (modelsData.data ?? []).filter((m) => m.isOwner !== false)
         setModelCount(owned.length)
       }
     } catch (error) {

--- a/src/components/features/onboarding/steps/BrokerageStep.tsx
+++ b/src/components/features/onboarding/steps/BrokerageStep.tsx
@@ -179,15 +179,15 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
                 {`You have bank accounts in ${otherCurrencyBankAccounts
                   .map((b) => b.currency)
                   .filter((c, i, a) => a.indexOf(c) === i)
-                  .join(", ")} but the brokerage currency is ${currency}. Cross-currency funding (FX) isn't supported yet — the opening deposit will be recorded as a standalone cash injection on the new portfolio with no matching withdrawal.`}
+                  .join(
+                    ", ",
+                  )} but the brokerage currency is ${currency}. Cross-currency funding (FX) isn't supported yet — the opening deposit will be recorded as a standalone cash injection on the new portfolio with no matching withdrawal.`}
               </div>
             )}
             <select
               id="ob-source"
               value={source}
-              onChange={(e) =>
-                onSourceChange(e.target.value as SourceValue)
-              }
+              onChange={(e) => onSourceChange(e.target.value as SourceValue)}
               className="w-full px-3 py-2 border border-gray-300 rounded-md"
             >
               <option value="">— None (standalone deposit) —</option>

--- a/src/components/features/onboarding/steps/CompleteStep.tsx
+++ b/src/components/features/onboarding/steps/CompleteStep.tsx
@@ -77,9 +77,7 @@ const CompleteStep: React.FC<CompleteStepProps> = ({
         <i className="fas fa-check-circle text-green-500"></i>
         {"You're all set!"}
       </h2>
-      <p className="text-sm text-gray-600 mb-3">
-        {"Created:"}
-      </p>
+      <p className="text-sm text-gray-600 mb-3">{"Created:"}</p>
 
       {/* Horizontal summary chips */}
       <div className="flex flex-wrap gap-2 mb-4">
@@ -125,7 +123,9 @@ const CompleteStep: React.FC<CompleteStepProps> = ({
           <p className="text-xs text-gray-600">
             {"Use the "}
             <strong>Wealth</strong>
-            {" menu to record assets BC doesn't natively support — collectibles, alt-investments, anything off-market."}
+            {
+              " menu to record assets BC doesn't natively support — collectibles, alt-investments, anything off-market."
+            }
           </p>
         </div>
       </div>

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -34,7 +34,16 @@ interface FundingState {
 // Fallback list — used only if /api/currencies hasn't returned yet so the
 // dropdown isn't empty on first paint. Replaced by backend response as soon
 // as SWR resolves.
-const FALLBACK_CURRENCIES = ["USD", "SGD", "EUR", "GBP", "AUD", "NZD", "HKD", "JPY"]
+const FALLBACK_CURRENCIES = [
+  "USD",
+  "SGD",
+  "EUR",
+  "GBP",
+  "AUD",
+  "NZD",
+  "HKD",
+  "JPY",
+]
 
 const STEP_TITLES: Record<Exclude<Step, "done">, string> = {
   broker: "Broker",
@@ -50,7 +59,11 @@ const STEP_ORDER: Exclude<Step, "done">[] = [
   "review",
 ]
 
-function StepHeader({ step }: { step: Exclude<Step, "done"> }): React.ReactElement {
+function StepHeader({
+  step,
+}: {
+  step: Exclude<Step, "done">
+}): React.ReactElement {
   const idx = STEP_ORDER.indexOf(step) + 1
   return (
     <div className="mb-6">
@@ -98,10 +111,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     simpleFetcher(ccyKey),
   )
   const brokers = useMemo(() => brokersData?.data ?? [], [brokersData])
-  const portfolios = useMemo(
-    () => portfoliosData?.data ?? [],
-    [portfoliosData],
-  )
+  const portfolios = useMemo(() => portfoliosData?.data ?? [], [portfoliosData])
   const currencyCodes = useMemo(() => {
     const codes = currenciesData?.data?.map((c) => c.code)
     return codes && codes.length > 0 ? codes : FALLBACK_CURRENCIES
@@ -242,8 +252,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                 disabled={brokers.length === 0}
               />
               <span>
-                Use an existing broker{" "}
-                {brokers.length === 0 && "(none yet)"}
+                Use an existing broker {brokers.length === 0 && "(none yet)"}
               </span>
             </label>
           </fieldset>
@@ -251,7 +260,10 @@ export default function OpenBrokerageWizard(): React.ReactElement {
           {broker.mode === "new" ? (
             <div className="space-y-3">
               <div>
-                <label htmlFor="broker-name" className="block text-sm font-medium text-gray-700 mb-1">
+                <label
+                  htmlFor="broker-name"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
                   {"Broker name"}
                 </label>
                 <input
@@ -266,7 +278,10 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                 />
               </div>
               <div>
-                <label htmlFor="broker-acct" className="block text-sm font-medium text-gray-700 mb-1">
+                <label
+                  htmlFor="broker-acct"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
                   {"Account number (optional)"}
                 </label>
                 <input
@@ -282,7 +297,10 @@ export default function OpenBrokerageWizard(): React.ReactElement {
             </div>
           ) : (
             <div>
-              <label htmlFor="broker-select" className="block text-sm font-medium text-gray-700 mb-1">
+              <label
+                htmlFor="broker-select"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
                 {"Existing broker"}
               </label>
               <select
@@ -370,7 +388,10 @@ export default function OpenBrokerageWizard(): React.ReactElement {
           ) : (
             <>
               <div>
-                <label htmlFor="pf-code" className="block text-sm font-medium text-gray-700 mb-1">
+                <label
+                  htmlFor="pf-code"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
                   {"Portfolio code"}
                 </label>
                 <input
@@ -385,7 +406,10 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                 />
               </div>
               <div>
-                <label htmlFor="pf-name" className="block text-sm font-medium text-gray-700 mb-1">
+                <label
+                  htmlFor="pf-name"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
                   {"Portfolio name"}
                 </label>
                 <input
@@ -434,7 +458,10 @@ export default function OpenBrokerageWizard(): React.ReactElement {
             {`Optional — fund the new portfolio in ${portfolio.currency}. Pick a source portfolio (must be in ${portfolio.currency}) to record a matching withdrawal, or leave blank for a standalone deposit.`}
           </p>
           <div>
-            <label htmlFor="fund-amount" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="fund-amount"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               {"Amount"}
             </label>
             <input
@@ -451,7 +478,10 @@ export default function OpenBrokerageWizard(): React.ReactElement {
             />
           </div>
           <div>
-            <label htmlFor="fund-source" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="fund-source"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               {"Source portfolio (optional)"}
             </label>
             <select
@@ -481,7 +511,8 @@ export default function OpenBrokerageWizard(): React.ReactElement {
               <dd className="col-span-2 text-gray-900">
                 {broker.mode === "new"
                   ? `${broker.newName} (new)`
-                  : brokers.find((b) => b.id === broker.existingId)?.name ?? ""}
+                  : (brokers.find((b) => b.id === broker.existingId)?.name ??
+                    "")}
               </dd>
               <dt className="text-gray-500">Portfolio</dt>
               <dd className="col-span-2 text-gray-900">

--- a/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
@@ -12,78 +12,80 @@ const existingBrokers: Broker[] = [
   { id: "broker-dbs", name: "DBS Vickers" },
 ]
 
-const existingPortfolios: Pick<Portfolio, "id" | "code" | "name" | "currency">[] =
-  [
-    {
-      id: "src-pf",
-      code: "SAVINGS",
-      name: "Savings",
-      currency: { code: "USD", name: "US Dollar", symbol: "$" },
-    },
-  ]
+const existingPortfolios: Pick<
+  Portfolio,
+  "id" | "code" | "name" | "currency"
+>[] = [
+  {
+    id: "src-pf",
+    code: "SAVINGS",
+    name: "Savings",
+    currency: { code: "USD", name: "US Dollar", symbol: "$" },
+  },
+]
 
 function mockEndpoints(): void {
   fetchMock.mockResponse((req) => handleMock(req))
 }
 
 function handleMock(req: Request): Promise<string> {
-    const url = req.url
-    if (url.includes("/api/brokers") && req.method === "GET") {
-      return Promise.resolve(JSON.stringify({ data: existingBrokers }))
-    }
-    if (url.includes("/api/portfolios") && req.method === "GET") {
-      return Promise.resolve(JSON.stringify({ data: existingPortfolios }))
-    }
-    if (url.includes("/api/brokers") && req.method === "POST") {
-      // Echo the requested name so downstream broker-cash-asset codes
-      // (e.g. `IBRK-USD`) match the broker the wizard just created.
-      return req
-        .clone()
-        .json()
-        .then((body: { name?: string }) =>
-          JSON.stringify({
-            data: { id: "broker-new", name: body.name ?? "New Broker" },
-          }),
-        )
-    }
-    if (url.includes("/api/portfolios") && req.method === "POST") {
-      return Promise.resolve(
+  const url = req.url
+  if (url.includes("/api/brokers") && req.method === "GET") {
+    return Promise.resolve(JSON.stringify({ data: existingBrokers }))
+  }
+  if (url.includes("/api/portfolios") && req.method === "GET") {
+    return Promise.resolve(JSON.stringify({ data: existingPortfolios }))
+  }
+  if (url.includes("/api/brokers") && req.method === "POST") {
+    // Echo the requested name so downstream broker-cash-asset codes
+    // (e.g. `IBRK-USD`) match the broker the wizard just created.
+    return req
+      .clone()
+      .json()
+      .then((body: { name?: string }) =>
         JSON.stringify({
-          data: [
-            {
-              id: "pf-new",
-              code: "IBKR",
-              name: "IBKR USD",
-              currency: { code: "USD" },
-              base: { code: "USD" },
-            },
-          ],
+          data: { id: "broker-new", name: body.name ?? "New Broker" },
         }),
       )
-    }
-    if (url.includes("/api/assets") && req.method === "POST") {
-      // Echo the requested asset key + market so tests can assert on the
-      // exact code (e.g. broker-cash `IBRK-USD`, market: "PRIVATE").
-      return req
-        .clone()
-        .json()
-        .then(
-          (body: {
-            data?: Record<string, { market?: string; code?: string }>
-          }) => {
-            const code = Object.keys(body.data ?? {})[0] ?? "USD"
-            return JSON.stringify({
-              data: { [code]: { id: `asset-${code}`, code } },
-            })
+  }
+  if (url.includes("/api/portfolios") && req.method === "POST") {
+    return Promise.resolve(
+      JSON.stringify({
+        data: [
+          {
+            id: "pf-new",
+            code: "IBKR",
+            name: "IBKR USD",
+            currency: { code: "USD" },
+            base: { code: "USD" },
           },
-        )
-    }
-    if (url.includes("/api/trns") && req.method === "POST") {
-      return Promise.resolve(
-        JSON.stringify({ data: { trns: [{ id: "trn-1" }] } }),
+        ],
+      }),
+    )
+  }
+  if (url.includes("/api/assets") && req.method === "POST") {
+    // Echo the requested asset key + market so tests can assert on the
+    // exact code (e.g. broker-cash `IBRK-USD`, market: "PRIVATE").
+    return req
+      .clone()
+      .json()
+      .then(
+        (body: {
+          data?: Record<string, { market?: string; code?: string }>
+        }) => {
+          const code = Object.keys(body.data ?? {})[0] ?? "USD"
+          return JSON.stringify({
+            data: { [code]: { id: `asset-${code}`, code } },
+          })
+        },
       )
-    }
-    return Promise.resolve(JSON.stringify({}))
+  }
+  if (url.includes("/api/trns") && req.method === "POST") {
+    return Promise.resolve(
+      JSON.stringify({ data: { trns: [{ id: "trn-1" }] } }),
+    )
+  }
+  return Promise.resolve(JSON.stringify({}))
 }
 
 describe("<OpenBrokerageWizard />", () => {
@@ -106,11 +108,10 @@ describe("<OpenBrokerageWizard />", () => {
     // Step 1 — broker: create new. Use a name not in the existing list so
     // ensureBroker takes the POST branch (reuse-by-name is covered below).
     await screen.findByRole("heading", { name: /Broker/i })
-    await user.click(screen.getByRole("radio", { name: /Create a new broker/i }))
-    await user.type(
-      screen.getByLabelText(/Broker name/i),
-      "Brand New Broker",
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new broker/i }),
     )
+    await user.type(screen.getByLabelText(/Broker name/i), "Brand New Broker")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 2 — portfolio: fill code + currency
@@ -190,7 +191,9 @@ describe("<OpenBrokerageWizard />", () => {
     const bodies = trnPosts.map((c) =>
       JSON.parse((c[1] as RequestInit).body as string),
     )
-    const types = bodies.flatMap((b) => b.data.map((d: { trnType: string }) => d.trnType))
+    const types = bodies.flatMap((b) =>
+      b.data.map((d: { trnType: string }) => d.trnType),
+    )
     expect(types).toContain("DEPOSIT")
     expect(types).toContain("WITHDRAWAL")
   })
@@ -201,7 +204,9 @@ describe("<OpenBrokerageWizard />", () => {
 
     // Step 1 — broker: create new, but type a name that already exists
     await screen.findByRole("heading", { name: /Broker/i })
-    await user.click(screen.getByRole("radio", { name: /Create a new broker/i }))
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new broker/i }),
+    )
     await user.type(
       screen.getByLabelText(/Broker name/i),
       "Interactive Brokers",
@@ -304,7 +309,9 @@ describe("<OpenBrokerageWizard />", () => {
     const user = userEvent.setup()
     render(<OpenBrokerageWizard />)
     await screen.findByRole("heading", { name: /Broker/i })
-    await user.click(screen.getByRole("radio", { name: /Create a new broker/i }))
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new broker/i }),
+    )
     await user.type(screen.getByLabelText(/Broker name/i), "Test Broker")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 

--- a/src/contexts/RegistrationContext.tsx
+++ b/src/contexts/RegistrationContext.tsx
@@ -43,7 +43,10 @@ function writeCachedRegistration(sub: string, since?: string): void {
   try {
     localStorage.setItem(
       registeredKey(sub),
-      JSON.stringify({ since, checkedAt: Date.now() } satisfies CachedRegistration),
+      JSON.stringify({
+        since,
+        checkedAt: Date.now(),
+      } satisfies CachedRegistration),
     )
   } catch {
     // localStorage may be unavailable (private mode, quota); just skip caching.
@@ -92,7 +95,7 @@ export function RegistrationProvider({
     }
 
     if (!user?.sub) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- terminal state when no auth user
+       
       setIsChecking(false)
       return
     }

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -403,7 +403,8 @@ export function useRebalanceExecution(
 
   // Commit execution - create transactions
   const handleCommit = useCallback(async (): Promise<
-    { portfolioId: string; transactionStatus: "PROPOSED" | "SETTLED" } | undefined
+    | { portfolioId: string; transactionStatus: "PROPOSED" | "SETTLED" }
+    | undefined
   > => {
     if (!execution || execution.portfolioIds.length === 0) return undefined
 

--- a/src/lib/utils/auth0.ts
+++ b/src/lib/utils/auth0.ts
@@ -36,9 +36,7 @@ export const auth0 = new Auth0Client({
   // eslint-disable-next-line require-await -- OnCallbackHook signature returns Promise<NextResponse>; async keyword keeps the implementation consistent with that contract.
   onCallback: async (error, ctx, session) => {
     const appBaseUrl =
-      ctx.appBaseUrl ||
-      process.env.APP_BASE_URL ||
-      "https://kauri.monowai.com"
+      ctx.appBaseUrl || process.env.APP_BASE_URL || "https://kauri.monowai.com"
     const target = new URL(ctx.returnTo || "/", appBaseUrl)
 
     if (error && !session) {

--- a/src/lib/utils/independence/headlineGauge.ts
+++ b/src/lib/utils/independence/headlineGauge.ts
@@ -55,7 +55,7 @@ export function pickHeadlineGauge(
     fi.bridgeYearsNeeded != null
   ) {
     return {
-      label: "Bridge to Pension",
+      label: "Self-funded years",
       value: fi.bridgeProgress,
       display: `${fi.bridgeYears.toFixed(1)} / ${fi.bridgeYearsNeeded}y`,
       fillPercent: clamp(fi.bridgeProgress),

--- a/src/lib/utils/independence/wealthJourneyChartData.test.ts
+++ b/src/lib/utils/independence/wealthJourneyChartData.test.ts
@@ -1,0 +1,102 @@
+import { buildWealthJourneyChartData } from "./wealthJourneyChartData"
+import type { CompositeYearlyProjection } from "types/independence"
+
+const makeYear = (
+  overrides: Partial<CompositeYearlyProjection> = {},
+): CompositeYearlyProjection => ({
+  year: 2026,
+  age: 45,
+  planId: "p1",
+  planName: "My Independence Plan",
+  startingBalance: 100_000,
+  investmentReturns: 3_000,
+  income: 0,
+  expenses: 0,
+  endingBalance: 103_000,
+  nonSpendableValue: 0,
+  totalWealth: 103_000,
+  currency: "SGD",
+  ...overrides,
+})
+
+describe("buildWealthJourneyChartData", () => {
+  it("hides Housing layer when reported housingValue is purely CPF MA bleed", () => {
+    // Mary persona: no real estate. svc-retire still folds CPF MA into
+    // housingValue upstream (PlanAllocationService:117). After netting MA
+    // out, the pure housing share is zero — the Housing legend entry must
+    // disappear so the user isn't told they own property they don't have.
+    const years: CompositeYearlyProjection[] = [
+      makeYear({
+        housingValue: 58_000,
+        cpfNonLiquidValue: 58_000,
+        annuitizedValue: 0,
+      }),
+      makeYear({
+        age: 46,
+        housingValue: 60_320,
+        cpfNonLiquidValue: 60_320,
+        annuitizedValue: 0,
+      }),
+    ]
+
+    const { hasHousingLayer, chartData } = buildWealthJourneyChartData(years)
+
+    expect(hasHousingLayer).toBe(false)
+    expect(chartData.every((d) => d.housingValue === 0)).toBe(true)
+  })
+
+  it("keeps Housing layer when real property exists on top of CPF MA", () => {
+    const years: CompositeYearlyProjection[] = [
+      makeYear({
+        housingValue: 558_000,
+        cpfNonLiquidValue: 58_000,
+        annuitizedValue: 0,
+      }),
+    ]
+
+    const { hasHousingLayer, chartData } = buildWealthJourneyChartData(years)
+
+    expect(hasHousingLayer).toBe(true)
+    expect(chartData[0].housingValue).toBe(500_000)
+  })
+
+  it("hides Annuitized layer when never present", () => {
+    const years: CompositeYearlyProjection[] = [
+      makeYear({ annuitizedValue: 0 }),
+      makeYear({ age: 46, annuitizedValue: 0 }),
+    ]
+
+    const { hasAnnuitizedLayer } = buildWealthJourneyChartData(years)
+
+    expect(hasAnnuitizedLayer).toBe(false)
+  })
+
+  it("keeps Annuitized layer when any year has positive value", () => {
+    const years: CompositeYearlyProjection[] = [
+      makeYear({ annuitizedValue: 0 }),
+      makeYear({ age: 65, annuitizedValue: 220_000 }),
+    ]
+
+    const { hasAnnuitizedLayer } = buildWealthJourneyChartData(years)
+
+    expect(hasAnnuitizedLayer).toBe(true)
+  })
+
+  it("treats missing optional fields as zero", () => {
+    const years: CompositeYearlyProjection[] = [
+      makeYear({
+        housingValue: undefined,
+        cpfNonLiquidValue: undefined,
+        annuitizedValue: undefined,
+      }),
+    ]
+
+    const { hasHousingLayer, hasAnnuitizedLayer, chartData } =
+      buildWealthJourneyChartData(years)
+
+    expect(hasHousingLayer).toBe(false)
+    expect(hasAnnuitizedLayer).toBe(false)
+    expect(chartData[0].housingValue).toBe(0)
+    expect(chartData[0].annuitizedValue).toBe(0)
+  })
+})

--- a/src/lib/utils/independence/wealthJourneyChartData.ts
+++ b/src/lib/utils/independence/wealthJourneyChartData.ts
@@ -1,0 +1,53 @@
+import type { CompositeYearlyProjection } from "types/independence"
+
+export interface WealthJourneyChartRow {
+  age: number
+  endingBalance: number
+  totalWealth: number
+  liquidValue: number
+  housingValue: number
+  annuitizedValue: number
+  income: number
+  expenses: number
+  planId: string
+  planName: string
+}
+
+export interface WealthJourneyChartData {
+  chartData: WealthJourneyChartRow[]
+  hasHousingLayer: boolean
+  hasAnnuitizedLayer: boolean
+}
+
+// svc-retire's PlanAllocationService folds CPF MA (composite non-liquid) into
+// `housingValue` upstream. For users with no real estate but a CPF MA balance,
+// the raw `housingValue` is non-zero even though the chart's Housing layer is
+// supposed to mean Property only. Subtracting `cpfNonLiquidValue` recovers the
+// pure property share; if that's zero, the Housing legend entry is dropped so
+// the user isn't told they own real estate they don't have.
+export function buildWealthJourneyChartData(
+  yearlyProjections: CompositeYearlyProjection[],
+): WealthJourneyChartData {
+  const chartData: WealthJourneyChartRow[] = yearlyProjections.map((row) => {
+    const cpfNonLiquid = row.cpfNonLiquidValue ?? 0
+    const rawHousing = row.housingValue ?? 0
+    const pureHousing = Math.max(0, rawHousing - cpfNonLiquid)
+    return {
+      age: row.age,
+      endingBalance: row.endingBalance,
+      totalWealth: row.totalWealth,
+      liquidValue: row.endingBalance,
+      housingValue: pureHousing,
+      annuitizedValue: row.annuitizedValue ?? 0,
+      income: row.income,
+      expenses: row.expenses,
+      planId: row.planId,
+      planName: row.planName,
+    }
+  })
+
+  const hasHousingLayer = chartData.some((p) => p.housingValue > 0)
+  const hasAnnuitizedLayer = chartData.some((p) => p.annuitizedValue > 0)
+
+  return { chartData, hasHousingLayer, hasAnnuitizedLayer }
+}

--- a/src/lib/utils/openBrokerage/orchestrate.ts
+++ b/src/lib/utils/openBrokerage/orchestrate.ts
@@ -136,7 +136,8 @@ async function ensureAsset(payload: {
     data: { [payload.code]: payload },
   })
   const asset = Object.values(resp.data)[0]
-  if (!asset?.id) throw new Error(`Asset lookup returned no id (${payload.code})`)
+  if (!asset?.id)
+    throw new Error(`Asset lookup returned no id (${payload.code})`)
   return asset.id
 }
 

--- a/src/pages/shares.tsx
+++ b/src/pages/shares.tsx
@@ -49,7 +49,12 @@ function SharesPage(): React.ReactElement {
   )
 
   const revokePortfolioShare = async (id: string): Promise<void> => {
-    if (!window.confirm("Revoke this share? The recipient loses access immediately.")) return
+    if (
+      !window.confirm(
+        "Revoke this share? The recipient loses access immediately.",
+      )
+    )
+      return
     setBusyId(id)
     setError(null)
     try {
@@ -70,7 +75,12 @@ function SharesPage(): React.ReactElement {
     id: string,
     refetch: () => Promise<unknown>,
   ): Promise<void> => {
-    if (!window.confirm("Revoke this share? The recipient loses access immediately.")) return
+    if (
+      !window.confirm(
+        "Revoke this share? The recipient loses access immediately.",
+      )
+    )
+      return
     setBusyId(id)
     setError(null)
     try {
@@ -127,7 +137,8 @@ function SharesPage(): React.ReactElement {
             id: s.id,
             label: s.portfolio?.name ?? s.portfolio?.code ?? "(unknown)",
             sub: s.portfolio?.code,
-            recipient: s.sharedWith?.email ?? s.targetUser?.email ?? "(pending)",
+            recipient:
+              s.sharedWith?.email ?? s.targetUser?.email ?? "(pending)",
             accessLevel: s.accessLevel,
             status: s.status,
           }))}
@@ -143,7 +154,8 @@ function SharesPage(): React.ReactElement {
             id: s.id,
             label: s.resourceName ?? "(unnamed plan)",
             sub: undefined,
-            recipient: s.sharedWith?.email ?? s.targetUser?.email ?? "(pending)",
+            recipient:
+              s.sharedWith?.email ?? s.targetUser?.email ?? "(pending)",
             accessLevel: s.accessLevel,
             status: s.status,
           }))}
@@ -159,7 +171,8 @@ function SharesPage(): React.ReactElement {
             id: s.id,
             label: s.resourceName ?? "(unnamed model)",
             sub: undefined,
-            recipient: s.sharedWith?.email ?? s.targetUser?.email ?? "(pending)",
+            recipient:
+              s.sharedWith?.email ?? s.targetUser?.email ?? "(pending)",
             accessLevel: s.accessLevel,
             status: s.status,
           }))}
@@ -201,7 +214,9 @@ function Section({
         <i className={`fas ${icon} text-gray-500`}></i>
         <h2 className="text-sm font-semibold text-gray-900">{title}</h2>
         <span className="ml-auto text-xs text-gray-500">
-          {loading ? "…" : `${shares.length} share${shares.length === 1 ? "" : "s"}`}
+          {loading
+            ? "…"
+            : `${shares.length} share${shares.length === 1 ? "" : "s"}`}
         </span>
       </header>
       {!loading && shares.length === 0 && (


### PR DESCRIPTION
## Summary

- **Housing fix (defensive UI)**: net `cpfNonLiquidValue` out of `housingValue` in the Wealth Journey chart and gate the Housing area on the pure residue. Users with no real estate (Mary persona — CPF + cash only) no longer see a phantom "Housing (locked)" legend entry caused by an upstream svc-retire bleed where CPF MA gets folded into `housingValue`. New pure helper `wealthJourneyChartData.ts` with 5 unit tests.
- **Rename "Bridge to Pension" → "Self-funded years"** in UI labels: gauge label, tooltip, strategy section header, headline gauge, HYBRID strategy view label. Internal field names (`bridgeYears`, `HYBRID` enum) unchanged so the API surface is untouched.
- **Prettier drift cleanup**: includes line-wrap formatting drift across `openBrokerage`, `shares`, `RegistrationContext`, `auth0`, onboarding/offboarding wizards. No semantic changes.

> **Follow-up**: svc-retire root fix at https://github.com/monowai/svc-retire/pull/... (separate PR — splits CPF MA out of `housingValue` at the allocation layer). Once that lands and deploys, the defensive net-out here becomes redundant and can be reverted.

## Test plan

- [ ] `yarn test && yarn prettier && yarn lint && yarn typecheck` (all green locally)
- [ ] Visit `/independence/plans/<id>` on kauri with the Mary persona and confirm Wealth Journey legend shows only Liquid + CPF LIFE (no Housing entry)
- [ ] Confirm legend keeps Housing entry for a persona with real property
- [ ] Confirm "Self-funded years" appears in the gauge label / Pension-Saver view
- [ ] Confirm the strategy-view dropdown shows "Self-funded" (not "Bridge")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added enhanced wealth journey chart data functionality for improved financial projections visualization.

* **Refactor**
  * Consolidated chart data building logic into a shared utility module for better code maintainability.
  * Terminology updates: "Bridge" strategy references updated to "Self-funded" across Financial Independence UI elements for improved clarity.

* **Tests**
  * Added comprehensive test coverage for wealth journey chart data transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->