### PR TITLE
fix(independence): net CPF MA out of housingValue in My Path chart too

### DIFF
--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -16,6 +16,7 @@ import {
 import CollapsibleSection from "@components/ui/CollapsibleSection"
 import { RetirementProjection } from "types/independence"
 import { HIDDEN_VALUE } from "@lib/independence/planHelpers"
+import { netHousingValue } from "@lib/independence/wealthJourneyChartData"
 import { IncomeBreakdownTable } from "@components/features/independence"
 import Spinner from "@components/ui/Spinner"
 
@@ -109,7 +110,7 @@ export default function TimelineTabContent({
         retirementBalance: null as number | null,
         totalWealth: year.totalWealth,
         liquidValue: year.endingBalance,
-        housingValue: year.housingValue ?? 0,
+        housingValue: netHousingValue(year),
         annuitizedValue: year.annuitizedValue ?? 0,
         contribution: year.contribution,
         investmentGrowth: year.investmentGrowth,
@@ -125,7 +126,7 @@ export default function TimelineTabContent({
       retirementBalance: year.endingBalance,
       totalWealth: year.totalWealth,
       liquidValue: year.endingBalance,
-      housingValue: year.housingValue ?? 0,
+      housingValue: netHousingValue(year),
       annuitizedValue: year.annuitizedValue ?? 0,
       withdrawals: year.withdrawals,
       investment: year.investment,

--- a/src/lib/utils/independence/wealthJourneyChartData.test.ts
+++ b/src/lib/utils/independence/wealthJourneyChartData.test.ts
@@ -1,4 +1,7 @@
-import { buildWealthJourneyChartData } from "./wealthJourneyChartData"
+import {
+  buildWealthJourneyChartData,
+  netHousingValue,
+} from "./wealthJourneyChartData"
 import type { CompositeYearlyProjection } from "types/independence"
 
 const makeYear = (
@@ -82,6 +85,28 @@ describe("buildWealthJourneyChartData", () => {
     expect(hasAnnuitizedLayer).toBe(true)
   })
 
+  it("collapses sub-cent housingValue residue from svc-retire rounding", () => {
+    // Real-world Mary case observed on kauri after the svc-retire fix:
+    // RetirementPhaseProjector leaves a 0.01–0.03 sub-cent BigDecimal
+    // residue in housingValue across all retirement years. cpfMA is
+    // large (~127k+), so netting collapses it to 0 and the Housing
+    // legend disappears.
+    const years: CompositeYearlyProjection[] = Array.from({ length: 25 }).map(
+      (_, i): CompositeYearlyProjection =>
+        makeYear({
+          age: 66 + i,
+          housingValue: 0.01 + i * 0.001,
+          cpfNonLiquidValue: 127_000 + i * 5_000,
+          annuitizedValue: 0,
+        }),
+    )
+
+    const { hasHousingLayer, chartData } = buildWealthJourneyChartData(years)
+
+    expect(hasHousingLayer).toBe(false)
+    expect(chartData.every((d) => d.housingValue === 0)).toBe(true)
+  })
+
   it("treats missing optional fields as zero", () => {
     const years: CompositeYearlyProjection[] = [
       makeYear({
@@ -98,5 +123,27 @@ describe("buildWealthJourneyChartData", () => {
     expect(hasAnnuitizedLayer).toBe(false)
     expect(chartData[0].housingValue).toBe(0)
     expect(chartData[0].annuitizedValue).toBe(0)
+  })
+
+  describe("netHousingValue", () => {
+    it("returns raw housing when no CPF MA exists", () => {
+      expect(netHousingValue({ housingValue: 500_000 })).toBe(500_000)
+    })
+
+    it("subtracts CPF MA from housing for the pure property share", () => {
+      expect(
+        netHousingValue({ housingValue: 558_000, cpfNonLiquidValue: 58_000 }),
+      ).toBe(500_000)
+    })
+
+    it("clamps to zero when CPF MA exceeds housing (residue case)", () => {
+      expect(
+        netHousingValue({ housingValue: 0.01, cpfNonLiquidValue: 127_000 }),
+      ).toBe(0)
+    })
+
+    it("returns zero when both fields are missing", () => {
+      expect(netHousingValue({})).toBe(0)
+    })
   })
 })

--- a/src/lib/utils/independence/wealthJourneyChartData.ts
+++ b/src/lib/utils/independence/wealthJourneyChartData.ts
@@ -1,5 +1,21 @@
 import type { CompositeYearlyProjection } from "types/independence"
 
+interface RowWithLockedBuckets {
+  housingValue?: number
+  cpfNonLiquidValue?: number
+}
+
+// svc-retire's RetirementPhaseProjector can leave a sub-cent housingValue
+// residue (BigDecimal scale artefacts) even for users with no real estate,
+// which makes a `housingValue > 0` gate render a phantom Housing legend
+// entry. Netting cpfNonLiquidValue out + max(0, ...) collapses that
+// residue to zero while leaving real-property scenarios untouched.
+export function netHousingValue(row: RowWithLockedBuckets): number {
+  const cpfNonLiquid = row.cpfNonLiquidValue ?? 0
+  const rawHousing = row.housingValue ?? 0
+  return Math.max(0, rawHousing - cpfNonLiquid)
+}
+
 export interface WealthJourneyChartRow {
   age: number
   endingBalance: number
@@ -22,29 +38,24 @@ export interface WealthJourneyChartData {
 // svc-retire's PlanAllocationService folds CPF MA (composite non-liquid) into
 // `housingValue` upstream. For users with no real estate but a CPF MA balance,
 // the raw `housingValue` is non-zero even though the chart's Housing layer is
-// supposed to mean Property only. Subtracting `cpfNonLiquidValue` recovers the
-// pure property share; if that's zero, the Housing legend entry is dropped so
-// the user isn't told they own real estate they don't have.
+// supposed to mean Property only. [netHousingValue] recovers the pure property
+// share; if it's zero, the Housing legend entry is dropped so the user isn't
+// told they own real estate they don't have.
 export function buildWealthJourneyChartData(
   yearlyProjections: CompositeYearlyProjection[],
 ): WealthJourneyChartData {
-  const chartData: WealthJourneyChartRow[] = yearlyProjections.map((row) => {
-    const cpfNonLiquid = row.cpfNonLiquidValue ?? 0
-    const rawHousing = row.housingValue ?? 0
-    const pureHousing = Math.max(0, rawHousing - cpfNonLiquid)
-    return {
-      age: row.age,
-      endingBalance: row.endingBalance,
-      totalWealth: row.totalWealth,
-      liquidValue: row.endingBalance,
-      housingValue: pureHousing,
-      annuitizedValue: row.annuitizedValue ?? 0,
-      income: row.income,
-      expenses: row.expenses,
-      planId: row.planId,
-      planName: row.planName,
-    }
-  })
+  const chartData: WealthJourneyChartRow[] = yearlyProjections.map((row) => ({
+    age: row.age,
+    endingBalance: row.endingBalance,
+    totalWealth: row.totalWealth,
+    liquidValue: row.endingBalance,
+    housingValue: netHousingValue(row),
+    annuitizedValue: row.annuitizedValue ?? 0,
+    income: row.income,
+    expenses: row.expenses,
+    planId: row.planId,
+    planName: row.planName,
+  }))
 
   const hasHousingLayer = chartData.some((p) => p.housingValue > 0)
   const hasAnnuitizedLayer = chartData.some((p) => p.annuitizedValue > 0)


### PR DESCRIPTION
## Summary

Follow-up to #809. PR #809 added defensive netting of `cpfNonLiquidValue` out of `housingValue` for the Composite Wealth Journey, but missed the single-plan **My Path** tab (`TimelineTabContent`).

After svc-retire #66 deployed, Mary's projection on kauri still rendered a "Housing (locked)" stack layer on the My Path chart. Network response confirmed `RetirementPhaseProjector` leaves a sub-cent BigDecimal residue (0.01–0.03 across all retirement years) in `housingValue` even though Mary owns no real estate. The `housingValue > 0` gate then renders the phantom Housing layer.

- Extract netting math into a shared `netHousingValue()` helper exported from `wealthJourneyChartData.ts`.
- Apply to **both** charts: `WealthJourneyTab` (via existing `buildWealthJourneyChartData`) and `TimelineTabContent` (both accumulation and retirement rows).
- Unit coverage: direct tests for `netHousingValue` + a new `buildWealthJourneyChartData` case using the kauri-observed sub-cent residue pattern.

> svc-retire follow-up still worth doing: collapse the sub-cent residue at source (cleaner than relying on a downstream net-out).

## Test plan

- [ ] `yarn test && yarn prettier && yarn lint && yarn typecheck` (all green locally)
- [ ] Open Mary's "My Independence Plan" on kauri after deploy → My Path tab → confirm "Housing (locked)" no longer appears in the legend
- [ ] Persona with real property still shows the Housing band on both Composite Wealth Journey and My Path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved housing value calculations to eliminate phantom Housing legend entries caused by minimal rounding residues in wealth journey charts.

* **Tests**
  * Added comprehensive tests verifying housing value calculation edge cases and legend layer visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->