### PR TITLE
feat(auth0): surface OAuth2Error root cause in onCallback Sentry capture

### DIFF
--- a/src/lib/utils/auth0.ts
+++ b/src/lib/utils/auth0.ts
@@ -1,6 +1,7 @@
 import { Auth0Client } from "@auth0/nextjs-auth0/server"
 import { NextResponse } from "next/server"
 import * as Sentry from "@sentry/nextjs"
+import { extractAuth0Detail } from "./auth0Errors"
 
 // Scope and audience are configured here rather than via env vars because
 // Auth0 v4 removed AUTH0_SCOPE/AUTH0_AUDIENCE env var support.
@@ -39,11 +40,20 @@ export const auth0 = new Auth0Client({
       ctx.appBaseUrl || process.env.APP_BASE_URL || "https://kauri.monowai.com"
     const target = new URL(ctx.returnTo || "/", appBaseUrl)
 
+    // The SDK wraps the underlying OAuth2 error in an AuthorizationError
+    // with a generic message ("An error occurred during the authorization
+    // flow."). The real signal — invalid_grant / invalid_client / access_denied
+    // (e.g. an Action that threw post-login) — lives on `error.code` and
+    // `error.cause`. Surface them as Sentry extras so future occurrences
+    // identify the root cause without an Auth0 dashboard dive.
+    const auth0Detail = extractAuth0Detail(error)
+
     if (error && !session) {
       Sentry.captureException(error, {
         tags: { component: "auth0", phase: "callback", recovered: "false" },
+        extra: auth0Detail,
       })
-      console.error("[Auth0] callback failed (no session):", error)
+      console.error("[Auth0] callback failed (no session):", error, auth0Detail)
       return NextResponse.redirect(new URL("/auth/login", appBaseUrl))
     }
 
@@ -51,10 +61,12 @@ export const auth0 = new Auth0Client({
       Sentry.captureException(error, {
         level: "warning",
         tags: { component: "auth0", phase: "callback", recovered: "true" },
+        extra: auth0Detail,
       })
       console.warn(
         "[Auth0] post-callback non-fatal error (session persisted):",
         error,
+        auth0Detail,
       )
       return NextResponse.redirect(target)
     }

--- a/src/lib/utils/auth0Errors.test.ts
+++ b/src/lib/utils/auth0Errors.test.ts
@@ -1,0 +1,55 @@
+import { extractAuth0Detail } from "./auth0Errors"
+
+describe("extractAuth0Detail", () => {
+  it("returns undefined for nullish or non-object errors", () => {
+    expect(extractAuth0Detail(null)).toBeUndefined()
+    expect(extractAuth0Detail(undefined)).toBeUndefined()
+    expect(extractAuth0Detail("string")).toBeUndefined()
+    expect(extractAuth0Detail(42)).toBeUndefined()
+  })
+
+  it("returns undefined when no diagnostic fields are present", () => {
+    expect(extractAuth0Detail({})).toBeUndefined()
+  })
+
+  it("captures default Error.name when no other detail is available", () => {
+    expect(extractAuth0Detail(new Error())).toEqual({ errorName: "Error" })
+  })
+
+  it("captures top-level name and code", () => {
+    const err = Object.assign(new Error("wrapper"), {
+      name: "AuthorizationError",
+      code: "authorization_error",
+    })
+    expect(extractAuth0Detail(err)).toEqual({
+      errorName: "AuthorizationError",
+      errorCode: "authorization_error",
+    })
+  })
+
+  it("captures cause name, code, and message (OAuth2Error inside AuthorizationError)", () => {
+    const cause = Object.assign(new Error("Action threw post-login"), {
+      name: "OAuth2Error",
+      code: "access_denied",
+    })
+    const err = Object.assign(
+      new Error("An error occurred during the authorization flow."),
+      {
+        name: "AuthorizationError",
+        cause,
+      },
+    )
+    expect(extractAuth0Detail(err)).toEqual({
+      errorName: "AuthorizationError",
+      causeName: "OAuth2Error",
+      causeCode: "access_denied",
+      causeMessage: "Action threw post-login",
+    })
+  })
+
+  it("ignores empty string fields", () => {
+    expect(
+      extractAuth0Detail({ name: "", code: "", cause: { message: "" } }),
+    ).toBeUndefined()
+  })
+})

--- a/src/lib/utils/auth0Errors.ts
+++ b/src/lib/utils/auth0Errors.ts
@@ -1,0 +1,42 @@
+// Diagnostic helper for the Auth0 nextjs-auth0 SDK callback hook.
+//
+// The SDK wraps the underlying OAuth2 error in a generic AuthorizationError
+// ("An error occurred during the authorization flow."). The real reason —
+// invalid_grant / invalid_client / access_denied (e.g. an Action that threw
+// post-login) — lives on `error.code` and `error.cause`. We surface it as
+// Sentry `extra` so a callback failure identifies the root cause without
+// digging through Auth0 dashboard logs.
+
+export type Auth0ErrorDetail = {
+  errorName?: string
+  errorCode?: string
+  causeName?: string
+  causeCode?: string
+  causeMessage?: string
+}
+
+const stringIfPresent = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined
+
+export const extractAuth0Detail = (
+  error: unknown,
+): Auth0ErrorDetail | undefined => {
+  if (!error || typeof error !== "object") return undefined
+  const err = error as { name?: unknown; code?: unknown; cause?: unknown }
+  const cause =
+    err.cause && typeof err.cause === "object"
+      ? (err.cause as {
+          name?: unknown
+          code?: unknown
+          message?: unknown
+        })
+      : undefined
+  const detail: Auth0ErrorDetail = {
+    errorName: stringIfPresent(err.name),
+    errorCode: stringIfPresent(err.code),
+    causeName: stringIfPresent(cause?.name),
+    causeCode: stringIfPresent(cause?.code),
+    causeMessage: stringIfPresent(cause?.message),
+  }
+  return Object.values(detail).some((v) => v !== undefined) ? detail : undefined
+}


### PR DESCRIPTION
## Summary
- BC-VIEW-3S surfaces 4 callback failures (Jun 6–10) as the SDK's generic AuthorizationError — actual reason hidden in the wrapper.
- `onCallback` now extracts `error.name`, `error.code`, plus the cause's `name`, `code`, and `message`, attaching them as Sentry `extra` on both branches.
- Helper extracted to `auth0Errors.ts` so unit tests can run without next/server polyfills.

## Test plan
- [x] `auth0Errors.test.ts` (6 cases) covers nullish, generic Error, top-level fields, OAuth2Error-inside-AuthorizationError, empty strings.
- [x] `yarn typecheck && yarn lint && yarn prettier` clean.
- [ ] After deploy, next BC-VIEW-3S event in Sentry exposes the real Auth0 error code (e.g. `access_denied` if the post-login Action is throwing — current suspect per `[[project_auth0_action_secret_rotation]]`).

Refs BC-VIEW-3S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging during authentication callbacks with enhanced error diagnostics.
  * Fixed session-aware redirect behavior when authentication failures occur, ensuring users are directed to the appropriate page based on their current session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->