### PR TITLE
fix(wealth): de-dup CPF composite + net Healthcare Reserve out of Net Worth

### DIFF
--- a/src/components/features/wealth/WealthHeroSection.tsx
+++ b/src/components/features/wealth/WealthHeroSection.tsx
@@ -90,6 +90,18 @@ const WealthHeroSection: React.FC<WealthHeroSectionProps> = ({
           Across {summary.portfolioCount} portfolio
           {summary.portfolioCount !== 1 ? "s" : ""}
         </p>
+        {summary.healthcareReserve > 0 && (
+          <p
+            className="text-white/70 text-sm mt-1"
+            title="CPF MA / Medisave is a statutory healthcare reserve, not spendable wealth — excluded from Net Worth."
+          >
+            + Healthcare Reserve{" "}
+            <span className="font-semibold text-white tabular-nums">
+              {displayCurrency?.symbol}
+              <FormatValue value={summary.healthcareReserve} />
+            </span>
+          </p>
+        )}
       </div>
 
       {/* Liquidity bar — inline in hero */}

--- a/src/components/features/wealth/__tests__/WealthHeroSection.test.tsx
+++ b/src/components/features/wealth/__tests__/WealthHeroSection.test.tsx
@@ -14,6 +14,7 @@ function makeSummary(overrides: Partial<WealthSummary> = {}): WealthSummary {
     totalValue: 100_000,
     totalGainOnDay: 0,
     portfolioCount: 1,
+    healthcareReserve: 0,
     classificationBreakdown: [],
     portfolioBreakdown: [],
     ...overrides,
@@ -68,5 +69,17 @@ describe("WealthHeroSection — today's gain percent", () => {
     renderHero(makeSummary({ totalValue: 500, totalGainOnDay: 500 }))
     expect(screen.queryByText(/%/)).not.toBeInTheDocument()
     expect(screen.getByText(/today/)).toBeInTheDocument()
+  })
+})
+
+describe("WealthHeroSection — Healthcare Reserve", () => {
+  it("renders the Healthcare Reserve line when summary.healthcareReserve > 0", () => {
+    renderHero(makeSummary({ healthcareReserve: 58_000 }))
+    expect(screen.getByText(/Healthcare Reserve/)).toBeInTheDocument()
+  })
+
+  it("hides the Healthcare Reserve line when summary.healthcareReserve is zero", () => {
+    renderHero(makeSummary({ healthcareReserve: 0 }))
+    expect(screen.queryByText(/Healthcare Reserve/)).not.toBeInTheDocument()
   })
 })

--- a/src/components/features/wealth/__tests__/useWealthSummary.test.ts
+++ b/src/components/features/wealth/__tests__/useWealthSummary.test.ts
@@ -31,6 +31,7 @@ describe("useWealthSummary", () => {
     )
     expect(result.current.totalValue).toBe(0)
     expect(result.current.portfolioCount).toBe(0)
+    expect(result.current.healthcareReserve).toBe(0)
   })
 
   it("sums portfolio market values converted via fxRates", () => {
@@ -55,10 +56,9 @@ describe("useWealthSummary", () => {
     expect(result.current.totalValue).toBeCloseTo(37000 + 40000 * 1.28, 2)
   })
 
-  it("includes custom-asset balances (e.g. CPF composite) in the net-worth total", () => {
-    // Repro: Mary has DBS+UOB+IBKR portfolios totalling SGD 88,200 and a
-    // CPF composite asset worth SGD 281,000 sitting outside any portfolio.
-    // Pre-fix the Net Worth tile reported SGD 88,200 — CPF was dropped.
+  it("adds standalone composite-asset balances (no parent portfolio trn) to net worth", () => {
+    // Caller pre-filters customAssetTotals to assets whose parent is NOT
+    // in any portfolio (i.e. config-only). The hook just adds them.
     const portfolios = [
       portfolio({
         code: "P-SGD",
@@ -66,15 +66,9 @@ describe("useWealthSummary", () => {
         base: SGD,
         currency: SGD,
       }),
-      portfolio({
-        code: "P-USD",
-        marketValue: 40000,
-        base: USD,
-        currency: USD,
-      }),
     ]
-    const fxRates = { SGD: 1, USD: 1.28 }
-    const customAssetTotals = { SGD: 281000 }
+    const fxRates = { SGD: 1 }
+    const customAssetTotals = { SGD: 100000 }
 
     const { result } = renderHook(() =>
       useWealthSummary(
@@ -85,10 +79,37 @@ describe("useWealthSummary", () => {
         customAssetTotals,
       ),
     )
-    expect(result.current.totalValue).toBeCloseTo(
-      37000 + 40000 * 1.28 + 281000,
-      2,
+    expect(result.current.totalValue).toBeCloseTo(37000 + 100000, 2)
+  })
+
+  it("nets Healthcare Reserve (CPF MA) out of totalValue and surfaces it separately", () => {
+    // Mary's case after the fix: SGD portfolio holds the CPF parent
+    // (276k incl. MA 58k) plus DBS 75k + UOB 12k → portfolio mv 363k.
+    // customAssetTotals is empty (CPF is in-portfolio), MA is the only
+    // composite contribution and is subtracted from Net Worth.
+    const portfolios = [
+      portfolio({
+        code: "SGD",
+        marketValue: 363000,
+        base: SGD,
+        currency: SGD,
+      }),
+    ]
+    const fxRates = { SGD: 1 }
+    const healthcareReserveTotals = { SGD: 58000 }
+
+    const { result } = renderHook(() =>
+      useWealthSummary(
+        portfolios,
+        fxRates,
+        NO_SORT,
+        NO_HOLDINGS,
+        {},
+        healthcareReserveTotals,
+      ),
     )
+    expect(result.current.totalValue).toBeCloseTo(363000 - 58000, 2)
+    expect(result.current.healthcareReserve).toBeCloseTo(58000, 2)
   })
 
   it("converts custom-asset balances using their currency's fxRate", () => {
@@ -133,5 +154,32 @@ describe("useWealthSummary", () => {
       ),
     )
     expect(result.current.totalValue).toBe(500)
+  })
+
+  it("converts Healthcare Reserve using its currency's fxRate when display ccy differs", () => {
+    const fxRates = { SGD: 0.78, USD: 1 }
+    const portfolios = [
+      portfolio({
+        code: "P-USD",
+        marketValue: 100000,
+        base: USD,
+        currency: USD,
+      }),
+    ]
+    const healthcareReserveTotals = { SGD: 58000 }
+
+    const { result } = renderHook(() =>
+      useWealthSummary(
+        portfolios,
+        fxRates,
+        NO_SORT,
+        NO_HOLDINGS,
+        {},
+        healthcareReserveTotals,
+      ),
+    )
+    const reserveInDisplay = 58000 * 0.78
+    expect(result.current.healthcareReserve).toBeCloseTo(reserveInDisplay, 2)
+    expect(result.current.totalValue).toBeCloseTo(100000 - reserveInDisplay, 2)
   })
 })

--- a/src/components/features/wealth/useWealthSummary.ts
+++ b/src/components/features/wealth/useWealthSummary.ts
@@ -12,22 +12,28 @@ export function useWealthSummary(
   fxRates: Record<string, number>,
   sortConfig: SortConfig,
   holdingsData: HoldingContract | undefined,
-  // Per-currency sum of custom-asset balances that live outside any
-  // portfolio (e.g. CPF composite sub-account balances stored on
-  // PrivateAssetConfig). Each entry's value is in its currency key; the
-  // hook applies the same fxRates table used for portfolios.
+  // Sub-account balances for composite assets that DO NOT have a parent
+  // trn in any portfolio (e.g. a CPF the user added as a config-only
+  // pension). Excludes MA (healthcare reserve). Added to totalValue.
   customAssetTotals: Record<string, number> = {},
+  // CPF MA / Healthcare Reserve balances per currency. Subtracted from
+  // totalValue (parent CPF already includes MA via the portfolio BALANCE
+  // trn), and reported separately on WealthSummary.healthcareReserve so
+  // the UI can surface it as its own tile.
+  healthcareReserveTotals: Record<string, number> = {},
 ): WealthSummary {
   return useMemo(() => {
     const hasCustomAssets = Object.keys(customAssetTotals).length > 0
+    const hasReserve = Object.keys(healthcareReserveTotals).length > 0
     if (
-      (portfolios.length === 0 && !hasCustomAssets) ||
+      (portfolios.length === 0 && !hasCustomAssets && !hasReserve) ||
       Object.keys(fxRates).length === 0
     ) {
       return {
         totalValue: 0,
         totalGainOnDay: 0,
         portfolioCount: 0,
+        healthcareReserve: 0,
         classificationBreakdown: [],
         portfolioBreakdown: [],
       }
@@ -60,6 +66,19 @@ export function useWealthSummary(
     Object.entries(customAssetTotals).forEach(([currency, balance]) => {
       const rate = fxRates[currency] || 1
       totalValue += balance * rate
+    })
+
+    let healthcareReserve = 0
+    Object.entries(healthcareReserveTotals).forEach(([currency, balance]) => {
+      const rate = fxRates[currency] || 1
+      const converted = balance * rate
+      healthcareReserve += converted
+      // Net out of Net Worth — MA is statutory healthcare reserve, not
+      // spendable wealth. The parent composite asset's portfolio balance
+      // already includes MA, so this subtraction removes it from
+      // totalValue without double-debiting in the standalone case
+      // (where MA would not have been added by customAssetTotals).
+      totalValue -= converted
     })
 
     // Calculate liquidity breakdown and total gain on day from holdings
@@ -140,8 +159,16 @@ export function useWealthSummary(
       totalValue,
       totalGainOnDay,
       portfolioCount: portfolios.length,
+      healthcareReserve,
       classificationBreakdown,
       portfolioBreakdown,
     }
-  }, [portfolios, fxRates, sortConfig, holdingsData, customAssetTotals])
+  }, [
+    portfolios,
+    fxRates,
+    sortConfig,
+    holdingsData,
+    customAssetTotals,
+    healthcareReserveTotals,
+  ])
 }

--- a/src/lib/utils/wealth/liquidityGroups.ts
+++ b/src/lib/utils/wealth/liquidityGroups.ts
@@ -64,6 +64,11 @@ export interface WealthSummary {
   totalValue: number
   totalGainOnDay: number
   portfolioCount: number
+  // Healthcare Reserve (e.g. CPF Medisave Account) — statutory, not
+  // spendable wealth. Reported separately so the UI can surface it as a
+  // sibling tile rather than rolling it into Net Worth. Already excluded
+  // from `totalValue`.
+  healthcareReserve: number
   classificationBreakdown: {
     classification: string
     value: number

--- a/src/pages/wealth.tsx
+++ b/src/pages/wealth.tsx
@@ -102,26 +102,64 @@ function WealthDashboard(): React.ReactElement {
     [portfolioData?.data],
   )
 
-  // Custom assets (composite pensions etc.) — sit outside any portfolio,
-  // so the portfolio.marketValue sum below misses them. Net Worth needs
-  // their balances added in so the headline tile matches what the user
-  // actually has. See DEMO-ISSUES #13.
+  // Composite assets (CPF / pensions) have two cases:
+  //   1. Parent trn lives in a portfolio (CompositeValuation already rolls
+  //      sub-account balances into portfolio.marketValue) — adding them
+  //      again here would double-count, which is exactly the bug Mary's
+  //      account exposed (wealth 644k vs portfolio 363k).
+  //   2. Standalone — config exists but no parent trn → portfolios miss
+  //      the value, so we top it up via customAssetTotals.
+  // CPF MA (Medisave) is statutory healthcare reserve, NOT spendable
+  // wealth: it's always tracked separately under healthcareReserveTotals,
+  // surfaced as its own tile, and netted out of Net Worth.
   const { configs: privateAssetConfigs } = usePrivateAssetConfigs()
-  const customAssetTotals = useMemo(() => {
-    const totals: Record<string, number> = {}
+  const portfolioAssetIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (holdingsData?.positions) {
+      Object.values(holdingsData.positions).forEach((position) => {
+        const id = position.asset?.id
+        if (id) ids.add(id)
+      })
+    }
+    return ids
+  }, [holdingsData])
+
+  const { customAssetTotals, healthcareReserveTotals } = useMemo(() => {
+    const customTotals: Record<string, number> = {}
+    const reserveTotals: Record<string, number> = {}
     privateAssetConfigs.forEach((config) => {
       const subAccounts = config.subAccounts ?? []
       if (subAccounts.length === 0) return
-      const subTotal = subAccounts.reduce(
-        (sum, sa) => sum + (sa.balance || 0),
-        0,
-      )
-      if (subTotal === 0) return
       const currency = config.rentalCurrency || "USD"
-      totals[currency] = (totals[currency] || 0) + subTotal
+      const parentInPortfolio = portfolioAssetIds.has(config.assetId)
+
+      let nonReserve = 0
+      let reserve = 0
+      subAccounts.forEach((sa) => {
+        const balance = sa.balance || 0
+        if (balance === 0) return
+        if (sa.code === "MA") {
+          reserve += balance
+        } else {
+          nonReserve += balance
+        }
+      })
+
+      if (reserve > 0) {
+        reserveTotals[currency] = (reserveTotals[currency] || 0) + reserve
+      }
+      // Only add non-reserve sub-account balances when the parent
+      // composite asset has NO trn in any portfolio — otherwise the
+      // parent BALANCE trn already includes them via composite valuation.
+      if (!parentInPortfolio && nonReserve > 0) {
+        customTotals[currency] = (customTotals[currency] || 0) + nonReserve
+      }
     })
-    return totals
-  }, [privateAssetConfigs])
+    return {
+      customAssetTotals: customTotals,
+      healthcareReserveTotals: reserveTotals,
+    }
+  }, [privateAssetConfigs, portfolioAssetIds])
 
   // FX rates for converting portfolio values to display currency
   const sourceCurrencyCodes = useMemo(
@@ -129,8 +167,9 @@ function WealthDashboard(): React.ReactElement {
       ...portfolios.map((p) => p.base.code),
       ...portfolios.map((p) => p.currency.code),
       ...Object.keys(customAssetTotals),
+      ...Object.keys(healthcareReserveTotals),
     ],
-    [portfolios, customAssetTotals],
+    [portfolios, customAssetTotals, healthcareReserveTotals],
   )
   const { displayCurrency, setDisplayCurrency, fxRates, fxReady } = useFxRates(
     currencies,
@@ -167,6 +206,7 @@ function WealthDashboard(): React.ReactElement {
     sortConfig,
     holdingsData,
     customAssetTotals,
+    healthcareReserveTotals,
   )
 
   // Calculate asset breakdown from holdings


### PR DESCRIPTION
## Summary
- Net Worth tile was double-counting CPF on accounts where the composite asset has a parent trn in a portfolio. Mary on kauri: wealth tile reported SGD 644k while her single SGD portfolio was SGD 363k.
- Root cause: composite valuation in svc-position already rolls CPF sub-account balances (OA + SA + MA) into the parent CPF asset's portfolio.marketValue. `useWealthSummary` was also summing the same sub-account balances on top via `customAssetTotals` (~281k → close to the 644 − 363 gap).
- Fix 1 (de-dup): `wealth.tsx` only feeds `customAssetTotals` for composite configs whose parent asset has **no** trn in any portfolio (true standalone config-only pensions). Configs whose parent is already in a portfolio are dropped — portfolio.marketValue is now the single source of truth.
- Fix 2 (CPF MA / Healthcare Reserve): MA is statutory and not spendable wealth (per `[[project_cpf_ma_healthcare_reserve]]`). MA sub-account balances are aggregated per currency, subtracted from `totalValue`, and surfaced as `WealthSummary.healthcareReserve`. `WealthHeroSection` adds a "+ Healthcare Reserve \$X" sub-line under the Net Worth headline when non-zero.

Mary, after fix:
- Net Worth = SGD 305k (363k portfolio mv − 58k CPF MA)
- Healthcare Reserve = SGD 58k

## Test plan
- [x] `useWealthSummary.test.ts` — new cases for standalone customAsset add, in-portfolio MA subtraction, FX conversion of both.
- [x] `WealthHeroSection.test.tsx` — Healthcare Reserve line renders when non-zero, hidden otherwise.
- [x] `yarn typecheck && yarn lint && yarn prettier` clean.
- [ ] After deploy, verify Mary's `/wealth` tile reads SGD 305k Net Worth + SGD 58k Healthcare Reserve sub-line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Healthcare Reserve is now displayed as a separate line item in the wealth overview with its own dedicated tile.
  * Healthcare Reserve is properly excluded from Net Worth calculations and shows currency conversion when applicable.

* **Tests**
  * Added comprehensive test coverage for Healthcare Reserve display and calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->