### PR TITLE
fix(wealth): Net Worth reconciles with sum of portfolios; Healthcare Reserve stays inside

### DIFF
--- a/src/components/features/wealth/WealthHeroSection.tsx
+++ b/src/components/features/wealth/WealthHeroSection.tsx
@@ -93,9 +93,9 @@ const WealthHeroSection: React.FC<WealthHeroSectionProps> = ({
         {summary.healthcareReserve > 0 && (
           <p
             className="text-white/70 text-sm mt-1"
-            title="CPF MA / Medisave is a statutory healthcare reserve, not spendable wealth — excluded from Net Worth."
+            title="CPF MA / Medisave is a statutory healthcare reserve — counted in Net Worth, but not freely spendable."
           >
-            + Healthcare Reserve{" "}
+            Includes Healthcare Reserve{" "}
             <span className="font-semibold text-white tabular-nums">
               {displayCurrency?.symbol}
               <FormatValue value={summary.healthcareReserve} />

--- a/src/components/features/wealth/__tests__/WealthHeroSection.test.tsx
+++ b/src/components/features/wealth/__tests__/WealthHeroSection.test.tsx
@@ -73,9 +73,9 @@ describe("WealthHeroSection — today's gain percent", () => {
 })
 
 describe("WealthHeroSection — Healthcare Reserve", () => {
-  it("renders the Healthcare Reserve line when summary.healthcareReserve > 0", () => {
+  it("renders the 'Includes Healthcare Reserve' line when summary.healthcareReserve > 0", () => {
     renderHero(makeSummary({ healthcareReserve: 58_000 }))
-    expect(screen.getByText(/Healthcare Reserve/)).toBeInTheDocument()
+    expect(screen.getByText(/Includes Healthcare Reserve/)).toBeInTheDocument()
   })
 
   it("hides the Healthcare Reserve line when summary.healthcareReserve is zero", () => {

--- a/src/components/features/wealth/__tests__/useWealthSummary.test.ts
+++ b/src/components/features/wealth/__tests__/useWealthSummary.test.ts
@@ -82,11 +82,11 @@ describe("useWealthSummary", () => {
     expect(result.current.totalValue).toBeCloseTo(37000 + 100000, 2)
   })
 
-  it("nets Healthcare Reserve (CPF MA) out of totalValue and surfaces it separately", () => {
-    // Mary's case after the fix: SGD portfolio holds the CPF parent
-    // (276k incl. MA 58k) plus DBS 75k + UOB 12k → portfolio mv 363k.
-    // customAssetTotals is empty (CPF is in-portfolio), MA is the only
-    // composite contribution and is subtracted from Net Worth.
+  it("reports Healthcare Reserve (CPF MA) as an informational subset; totalValue still reconciles with portfolios", () => {
+    // Mary's case: SGD portfolio holds the CPF parent (276k incl. MA 58k)
+    // plus DBS 75k + UOB 12k → portfolio mv 363k. Total wealth must equal
+    // the sum of portfolios; the MA is surfaced separately for the UI but
+    // is NOT subtracted from totalValue.
     const portfolios = [
       portfolio({
         code: "SGD",
@@ -108,7 +108,7 @@ describe("useWealthSummary", () => {
         healthcareReserveTotals,
       ),
     )
-    expect(result.current.totalValue).toBeCloseTo(363000 - 58000, 2)
+    expect(result.current.totalValue).toBeCloseTo(363000, 2)
     expect(result.current.healthcareReserve).toBeCloseTo(58000, 2)
   })
 
@@ -156,7 +156,7 @@ describe("useWealthSummary", () => {
     expect(result.current.totalValue).toBe(500)
   })
 
-  it("converts Healthcare Reserve using its currency's fxRate when display ccy differs", () => {
+  it("converts Healthcare Reserve using its currency's fxRate; does not change totalValue", () => {
     const fxRates = { SGD: 0.78, USD: 1 }
     const portfolios = [
       portfolio({
@@ -180,6 +180,6 @@ describe("useWealthSummary", () => {
     )
     const reserveInDisplay = 58000 * 0.78
     expect(result.current.healthcareReserve).toBeCloseTo(reserveInDisplay, 2)
-    expect(result.current.totalValue).toBeCloseTo(100000 - reserveInDisplay, 2)
+    expect(result.current.totalValue).toBeCloseTo(100000, 2)
   })
 })

--- a/src/components/features/wealth/useWealthSummary.ts
+++ b/src/components/features/wealth/useWealthSummary.ts
@@ -16,10 +16,13 @@ export function useWealthSummary(
   // trn in any portfolio (e.g. a CPF the user added as a config-only
   // pension). Excludes MA (healthcare reserve). Added to totalValue.
   customAssetTotals: Record<string, number> = {},
-  // CPF MA / Healthcare Reserve balances per currency. Subtracted from
-  // totalValue (parent CPF already includes MA via the portfolio BALANCE
-  // trn), and reported separately on WealthSummary.healthcareReserve so
-  // the UI can surface it as its own tile.
+  // CPF MA / Healthcare Reserve balances per currency. Reported on
+  // WealthSummary.healthcareReserve as an informational subset of
+  // totalValue — NOT subtracted, so Net Worth still reconciles with the
+  // sum of portfolio market values. The parent composite asset already
+  // counts MA via its BALANCE trn; this number lets the UI annotate
+  // "of which is statutory healthcare reserve" without breaking the
+  // top-line reconciliation.
   healthcareReserveTotals: Record<string, number> = {},
 ): WealthSummary {
   return useMemo(() => {
@@ -71,14 +74,7 @@ export function useWealthSummary(
     let healthcareReserve = 0
     Object.entries(healthcareReserveTotals).forEach(([currency, balance]) => {
       const rate = fxRates[currency] || 1
-      const converted = balance * rate
-      healthcareReserve += converted
-      // Net out of Net Worth — MA is statutory healthcare reserve, not
-      // spendable wealth. The parent composite asset's portfolio balance
-      // already includes MA, so this subtraction removes it from
-      // totalValue without double-debiting in the standalone case
-      // (where MA would not have been added by customAssetTotals).
-      totalValue -= converted
+      healthcareReserve += balance * rate
     })
 
     // Calculate liquidity breakdown and total gain on day from holdings


### PR DESCRIPTION
## Summary
- Follow-up to #813. That PR subtracted CPF MA from Net Worth (305k for Mary vs 363k portfolio sum). The required behaviour is reconciliation: Net Worth must equal the sum of portfolio market values.
- Healthcare Reserve is now purely informational. Still aggregated per currency and surfaced on `WealthSummary.healthcareReserve`, but no longer netted out of `totalValue`.
- Hero sub-line label: `+ Healthcare Reserve` → `Includes Healthcare Reserve` (annotates how much of Net Worth is statutory).
- The composite-asset de-dup from #813 stays — `portfolio.marketValue` is the single source of truth.

Mary, after fix:
- Net Worth = SGD 363,000 (== sum of portfolios)
- Sub-line: Includes Healthcare Reserve SGD 58,000

## Test plan
- [x] `useWealthSummary.test.ts` updated: totalValue stays at portfolio sum even when healthcareReserveTotals is non-zero.
- [x] `WealthHeroSection.test.tsx` updated for the new label.
- [x] `yarn typecheck && yarn lint && yarn prettier` clean.
- [ ] After deploy, Mary's `/wealth` tile reads SGD 363k Net Worth + "Includes Healthcare Reserve SGD 58k" sub-line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Healthcare Reserve (CPF MA/Medisave) is now correctly included in Net Worth calculations but displayed as non-spendable, providing more accurate asset representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->