### PR TITLE
feat(independence): label Today vs projected wealth in AssetsBreakdown

### DIFF
--- a/src/components/features/independence/AssetsBreakdown.tsx
+++ b/src/components/features/independence/AssetsBreakdown.tsx
@@ -369,6 +369,9 @@ export default function AssetsBreakdown({
           )}
 
           <div className="border-t pt-4 space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {"Today"}
+            </p>
             <div className="flex justify-between text-sm">
               <span className="text-gray-500">{"Total Assets"}</span>
               <span
@@ -454,6 +457,9 @@ export default function AssetsBreakdown({
           </div>
 
           <div className="border-t pt-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
+              {"Projected to independence"}
+            </p>
             <div className="flex justify-between font-medium text-lg">
               <span>
                 {"Spendable at Independence"}


### PR DESCRIPTION
F3 from the Mary forensic audit. The AssetsBreakdown wealth summary shows today's `Total Assets` / `Spendable (Liquid)` / `Non-Spendable` immediately above the **future** `Spendable at Independence` value (liquidAssetsAtRetirement, grown to retirement age) with no visual TODAY/FUTURE distinction — the likely source of the reported 'why does it show ~640k when I have 363k' confusion.

Adds two small uppercase eyebrow labels — `Today` over the present-value block and `Projected to independence` over the future block — so the projected figure can't be misread as current wealth. Static labels only; no logic change.

typecheck + eslint + prettier clean on the file; semgrep clean. Not browser-verified (additive labels only — low risk).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Today" subheading to the totals section and "Projected to independence" subheading to the projection value for improved clarity in the assets breakdown view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->