### PR TITLE
fix(trns): drop unsettle cash-leg delete prompt (server cascades)

### DIFF
--- a/src/components/features/transactions/DetailedTransactionsTable.tsx
+++ b/src/components/features/transactions/DetailedTransactionsTable.tsx
@@ -102,7 +102,9 @@ export default function DetailedTransactionsTable({
                   type="checkbox"
                   checked={selectedIds.has(trn.id)}
                   onChange={(e) => onSelectOne(trn.id, e.target.checked)}
-                  disabled={trn.status !== "PROPOSED"}
+                  disabled={
+                    trn.status !== "PROPOSED" && trn.status !== "SETTLED"
+                  }
                   className="rounded border-gray-300 text-green-600 focus:ring-green-500 disabled:opacity-50"
                   title={
                     trn.status === "PROPOSED"

--- a/src/lib/utils/trns/apiHelper.ts
+++ b/src/lib/utils/trns/apiHelper.ts
@@ -6,8 +6,9 @@ export function deleteTrn(trnId: string): Promise<Response> {
 
 /**
  * PATCH /trns/{trnId}/status — Unsettle a SETTLED trn (sets PROPOSED).
- * Response: { updated, siblings: string[] } — siblings are the auto-emitted
- * cash legs (WITHDRAWAL + DEPOSIT) the UI prompts the user to delete.
+ * Response: { updated, siblings: string[] } — the server cascade-deletes the
+ * auto-emitted cash legs (WITHDRAWAL + DEPOSIT) on unsettle; `siblings` reports
+ * the removed ids for reference (no longer a delete prompt).
  */
 export function unsettleTrn(trnId: string): Promise<Response> {
   return fetch(`/api/trns/status/${trnId}`, {

--- a/src/pages/api/trns/portfolio/[portfolioId]/unsettle.ts
+++ b/src/pages/api/trns/portfolio/[portfolioId]/unsettle.ts
@@ -1,0 +1,7 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getDataUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: (req) => getDataUrl(`/trns/portfolio/${req.query.portfolioId}/unsettle`),
+  methods: ["POST"],
+})

--- a/src/pages/trns/proposed.tsx
+++ b/src/pages/trns/proposed.tsx
@@ -51,6 +51,7 @@ export default function ProposedTransactions(): React.JSX.Element {
   const [typeFilter, setTypeFilter] = useState<string>("ALL")
   const [scope, setScope] = useState<ProposedScope>("ALL")
   const [isSettling, setIsSettling] = useState(false)
+  const [isUnsettling, setIsUnsettling] = useState(false)
   const [aggregateView, setAggregateView] = useState(false)
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
   const [editTarget, setEditTarget] = useState<{
@@ -489,6 +490,9 @@ export default function ProposedTransactions(): React.JSX.Element {
   const selectedProposed = proposedTransactions.filter((trn) =>
     selectedIds.has(trn.id),
   )
+  const selectedSettled = transactions.filter(
+    (trn) => trn.status === "SETTLED" && selectedIds.has(trn.id),
+  )
   const allProposedSelected =
     proposedTransactions.length > 0 &&
     proposedTransactions.every((trn) => selectedIds.has(trn.id))
@@ -561,6 +565,54 @@ export default function ProposedTransactions(): React.JSX.Element {
       )
     } finally {
       setIsSettling(false)
+    }
+  }
+
+  const handleUnsettleSelected = async (): Promise<void> => {
+    if (selectedSettled.length === 0) return
+
+    setIsUnsettling(true)
+    setError(null)
+
+    try {
+      // Group selected SETTLED transactions by portfolio
+      const byPortfolio = new Map<string, string[]>()
+      selectedSettled.forEach((trn) => {
+        const ids = byPortfolio.get(trn.portfolio.id) || []
+        ids.push(trn.id)
+        byPortfolio.set(trn.portfolio.id, ids)
+      })
+
+      // Unsettle each portfolio's transactions. The server cascade-deletes each
+      // trade's auto-emitted cash legs.
+      for (const [portfolioId, trnIds] of byPortfolio) {
+        const response = await fetch(
+          `/api/trns/portfolio/${portfolioId}/unsettle`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ trnIds }),
+          },
+        )
+
+        if (!response.ok) {
+          setError(`Failed to unsettle: ${response.statusText}`)
+          setIsUnsettling(false)
+          return
+        }
+      }
+
+      // Refresh and clear selection
+      mutate(proposedKey)
+      mutate("/api/trns/proposed/count")
+      setSelectedIds(new Set())
+    } catch (err) {
+      console.error("Error unsettling transactions:", err)
+      setError(
+        err instanceof Error ? err.message : "Failed to unsettle transactions",
+      )
+    } finally {
+      setIsUnsettling(false)
     }
   }
 
@@ -815,6 +867,17 @@ export default function ProposedTransactions(): React.JSX.Element {
                   ? "Settling..."
                   : `Settle Selected (${selectedProposed.length})`}
               </button>
+              {selectedSettled.length > 0 && (
+                <button
+                  onClick={handleUnsettleSelected}
+                  disabled={isUnsettling}
+                  className="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+                >
+                  {isUnsettling
+                    ? "Unsettling..."
+                    : `Unsettle Selected (${selectedSettled.length})`}
+                </button>
+              )}
               <button
                 onClick={handleSave}
                 disabled={!anyChanges || isSaving}

--- a/src/pages/trns/trades/[...trades].tsx
+++ b/src/pages/trns/trades/[...trades].tsx
@@ -23,9 +23,6 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
   const router = useRouter()
   const [editModalOpen, setEditModalOpen] = useState(true)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-  // After Unsettle, the server returns auto-emitted cash leg ids; we hold
-  // them here and prompt the user to delete via [showSiblingsConfirm].
-  const [siblingsToConfirm, setSiblingsToConfirm] = useState<string[]>([])
   const [unsettleError, setUnsettleError] = useState<string | null>(null)
   const [listDeleteTarget, setListDeleteTarget] = useState<{
     id: string
@@ -252,48 +249,20 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
           )
           return
         }
-        const body = await response.json().catch(() => ({}))
-        const siblings: string[] = body?.siblings ?? []
-        // Invalidate holdings cache so the row reflects the new PROPOSED status.
+        // The server cascade-deletes the auto-emitted cash legs on unsettle, so
+        // there is nothing for the user to confirm. Invalidate holdings so the row
+        // reflects the new PROPOSED status, then close.
         setTimeout(() => {
           mutate(holdingKey(transaction.portfolio.code, "today"))
           mutate("/api/holdings/aggregated?asAt=today")
         }, 1500)
-        if (siblings.length > 0) {
-          setSiblingsToConfirm(siblings)
-        } else {
-          router.back()
-        }
+        router.back()
       } catch (err) {
         console.error("Error unsettling transaction:", err)
         setUnsettleError(
           err instanceof Error ? err.message : "Failed to unsettle",
         )
       }
-    }
-
-    const handleSiblingsDelete = async (): Promise<void> => {
-      const ids = siblingsToConfirm
-      setSiblingsToConfirm([])
-      const failures: string[] = []
-      for (const id of ids) {
-        try {
-          const r = await fetch(`/api/trns/trades/${id}`, { method: "DELETE" })
-          if (!r.ok) failures.push(id)
-        } catch {
-          failures.push(id)
-        }
-      }
-      if (failures.length > 0) {
-        setUnsettleError(
-          `Failed to delete ${failures.length} of ${ids.length} cash legs`,
-        )
-      }
-      setTimeout(() => {
-        mutate(holdingKey(transaction.portfolio.code, "today"))
-        mutate("/api/holdings/aggregated?asAt=today")
-      }, 1500)
-      router.back()
     }
 
     // Use FxEditModal for FX transactions (FX, FX_BUY, FX_SELL)
@@ -334,20 +303,6 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
             variant="red"
             onConfirm={handleDeleteConfirm}
             onCancel={() => setShowDeleteConfirm(false)}
-          />
-        )}
-        {siblingsToConfirm.length > 0 && (
-          <ConfirmDialog
-            title={"Delete auto-settled cash transactions?"}
-            message={`Unsettling this trade leaves ${siblingsToConfirm.length} auto-emitted cash transaction(s). Delete them?`}
-            confirmLabel={"Delete cash legs"}
-            cancelLabel={"Keep"}
-            variant="red"
-            onConfirm={handleSiblingsDelete}
-            onCancel={() => {
-              setSiblingsToConfirm([])
-              router.back()
-            }}
           />
         )}
         {unsettleError && (


### PR DESCRIPTION
Pairs with beancounter #945 (cash auto-settle on settlement; unsettle cascade-deletes the cash legs).

Server now removes the auto-emitted W+D cash legs itself on unsettle, so the client must no longer prompt the user to delete them (it would ask them to delete already-gone legs). `handleUnsettle` now just refreshes holdings and closes; removed the siblings `ConfirmDialog`, the delete loop (`handleSiblingsDelete`), and the `siblingsToConfirm` state. Updated the `unsettleTrn` doc comment.

**Bulk path unaffected:** the "settle many at once" action (`proposed.tsx` → `/settle`) needs no change — the backend emits a cash transfer per settled trade automatically. There is no bulk *unsettle* (unsettle is per-trade via the modal).

typecheck + eslint + import-check clean.

@coderabbitai ignore