### PR TITLE
feat(independence): guided onboarding interview + empty-portfolio spinner fix

### DIFF
--- a/__tests__/pages/independence/setup.test.tsx
+++ b/__tests__/pages/independence/setup.test.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { enableFetchMocks } from "jest-fetch-mock"
+
+enableFetchMocks()
+
+jest.mock("../../../src/contexts/UserPreferencesContext", () => ({
+  useUserPreferences: () => ({
+    preferences: {
+      baseCurrencyCode: "USD",
+      reportingCurrencyCode: "USD",
+      preferredName: "Test User",
+    },
+    isLoading: false,
+    error: null,
+  }),
+  UserPreferencesProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}))
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+describe("/independence/setup", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    fetchMock.mockResponse(JSON.stringify({ data: {} }))
+  })
+
+  test("renders profile, work and objectives sections", async () => {
+    const { default: Setup } =
+      await import("../../../src/pages/independence/setup")
+    render(<Setup />)
+
+    expect(
+      screen.getByText(/set up your independence plan/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/independence settings/i)).toBeInTheDocument()
+    expect(screen.getByText(/my work scenario/i)).toBeInTheDocument()
+  })
+
+  test("shows date of birth and target age inputs", async () => {
+    const { default: Setup } =
+      await import("../../../src/pages/independence/setup")
+    render(<Setup />)
+
+    expect(
+      screen.getByRole("spinbutton", { name: /year of birth/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("spinbutton", { name: /target independence age/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("shows work plan income field", async () => {
+    const { default: Setup } =
+      await import("../../../src/pages/independence/setup")
+    render(<Setup />)
+
+    expect(
+      screen.getByRole("spinbutton", { name: /monthly income/i }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/features/independence/IndependenceSettingsSummary.tsx
+++ b/src/components/features/independence/IndependenceSettingsSummary.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react"
+import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
+import IndependenceSettingsModal from "./IndependenceSettingsModal"
+
+const currentYear = new Date().getFullYear()
+
+export default function IndependenceSettingsSummary(): React.ReactElement {
+  const { settings, isLoading } = useIndependenceSettings()
+  const [showModal, setShowModal] = useState(false)
+
+  const yearOfBirth = settings?.yearOfBirth
+  const currentAge = yearOfBirth ? currentYear - yearOfBirth : undefined
+  const targetIndependenceAge = settings?.targetIndependenceAge ?? 65
+  const lifeExpectancy = settings?.lifeExpectancy ?? 90
+
+  return (
+    <>
+      <div className="mb-6 space-y-3">
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-medium text-gray-700">
+              Your Independence Settings
+            </h3>
+            <button
+              type="button"
+              onClick={() => setShowModal(true)}
+              className="text-sm text-independence-600 hover:text-independence-700 font-medium"
+            >
+              <i className="fas fa-edit mr-1"></i>
+              Edit
+            </button>
+          </div>
+
+          {isLoading ? (
+            <p className="text-sm text-gray-500">Loading settings...</p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <p className="text-xs text-gray-500 mb-1">Year of Birth</p>
+                <p className="text-sm font-medium text-gray-900">
+                  {yearOfBirth ?? "Not set"}
+                </p>
+                {currentAge !== undefined && (
+                  <p className="text-xs text-gray-500">
+                    Currently {currentAge} years old
+                  </p>
+                )}
+              </div>
+              <div>
+                <p className="text-xs text-gray-500 mb-1">
+                  Target Independence Age
+                </p>
+                <p className="text-sm font-medium text-gray-900">
+                  {targetIndependenceAge}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500 mb-1">Life Expectancy</p>
+                <p className="text-sm font-medium text-gray-900">
+                  {lifeExpectancy}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="bg-independence-50 border border-independence-200 rounded-lg p-4">
+          <div className="flex">
+            <i className="fas fa-info-circle text-independence-600 mt-0.5 mr-3"></i>
+            <div className="text-sm text-independence-700">
+              <p className="font-medium">Planning horizon</p>
+              <p className="mt-1">
+                Your planning horizon will be{" "}
+                {lifeExpectancy - targetIndependenceAge} years (from age{" "}
+                {targetIndependenceAge} to {lifeExpectancy}). These settings
+                apply across all your independence plans.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <IndependenceSettingsModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+      />
+    </>
+  )
+}

--- a/src/components/features/independence/WizardContainer.tsx
+++ b/src/components/features/independence/WizardContainer.tsx
@@ -6,6 +6,7 @@ import { mutate } from "swr"
 import WizardProgress from "./WizardProgress"
 import WizardNavigation from "./WizardNavigation"
 import WorkScenarioBanner from "./WorkScenarioBanner"
+import IndependenceSettingsSummary from "./IndependenceSettingsSummary"
 import PersonalInfoStep from "./steps/PersonalInfoStep"
 import AssetsStep from "./steps/AssetsStep"
 import AssumptionsStep from "./steps/AssumptionsStep"
@@ -374,6 +375,8 @@ export default function WizardContainer({
           stepErrors={stepErrors}
           onStepClick={handleStepClick}
         />
+
+        <IndependenceSettingsSummary />
 
         <WorkScenarioBanner />
 

--- a/src/components/features/independence/__tests__/MonteCarloTab.test.tsx
+++ b/src/components/features/independence/__tests__/MonteCarloTab.test.tsx
@@ -73,6 +73,7 @@ const assets: AssetBreakdown = {
   nonSpendableAssets: 250_000,
   totalAssets: 750_000,
   hasAssets: true,
+  isLoaded: true,
 }
 
 import { DEFAULT_SCENARIO_STATE } from "../scenario/types"

--- a/src/components/features/independence/__tests__/PersonalInfoStep.test.tsx
+++ b/src/components/features/independence/__tests__/PersonalInfoStep.test.tsx
@@ -10,24 +10,6 @@ import {
 } from "@lib/independence/schema"
 import { WizardFormData } from "types/independence"
 
-// Mock the independence settings hook
-jest.mock("@hooks/useIndependenceSettings", () => ({
-  useIndependenceSettings: () => ({
-    settings: {
-      id: "test-id",
-      ownerId: "test-owner",
-      yearOfBirth: 1971,
-      targetIndependenceAge: 65,
-      lifeExpectancy: 90,
-      createdDate: "2026-01-01",
-      updatedDate: "2026-01-01",
-    },
-    settingsError: undefined,
-    isLoading: false,
-    updateSettings: jest.fn(),
-    mutateSettings: jest.fn(),
-  }),
-}))
 
 const TestWrapper: React.FC<{ children: React.ReactNode }> = () => {
   const methods = useForm<WizardFormData>({
@@ -48,8 +30,6 @@ const TestWrapper: React.FC<{ children: React.ReactNode }> = () => {
   )
 }
 
-const currentYear = new Date().getFullYear()
-
 describe("PersonalInfoStep", () => {
   it("renders plan name and currency fields", () => {
     render(
@@ -62,31 +42,6 @@ describe("PersonalInfoStep", () => {
     expect(screen.getByLabelText(/currency/i)).toBeInTheDocument()
   })
 
-  it("shows read-only settings values from user settings", () => {
-    render(
-      <TestWrapper>
-        <div />
-      </TestWrapper>,
-    )
-
-    // Settings are displayed as read-only text, not form inputs
-    expect(screen.getByText("1971")).toBeInTheDocument()
-    expect(screen.getByText("65")).toBeInTheDocument()
-    expect(screen.getByText("90")).toBeInTheDocument()
-    expect(
-      screen.getByText(`Currently ${currentYear - 1971} years old`),
-    ).toBeInTheDocument()
-  })
-
-  it("shows edit button to open settings modal", () => {
-    render(
-      <TestWrapper>
-        <div />
-      </TestWrapper>,
-    )
-
-    expect(screen.getByText(/edit/i)).toBeInTheDocument()
-  })
 
   it("shows validation error for empty plan name", async () => {
     render(
@@ -117,15 +72,4 @@ describe("PersonalInfoStep", () => {
     expect(input).toHaveValue("My Retirement Plan")
   })
 
-  it("shows info box about planning horizon", () => {
-    render(
-      <TestWrapper>
-        <div />
-      </TestWrapper>,
-    )
-
-    expect(
-      screen.getByText(/these settings apply across all/i),
-    ).toBeInTheDocument()
-  })
 })

--- a/src/components/features/independence/steps/PersonalInfoStep.tsx
+++ b/src/components/features/independence/steps/PersonalInfoStep.tsx
@@ -1,15 +1,11 @@
-import React, { useState } from "react"
+import React from "react"
 import { Control, Controller, FieldErrors } from "react-hook-form"
 import { WizardFormData } from "types/independence"
-import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
-import IndependenceSettingsModal from "../IndependenceSettingsModal"
 
 interface PersonalInfoStepProps {
   control: Control<WizardFormData>
   errors: FieldErrors<WizardFormData>
 }
-
-const currentYear = new Date().getFullYear()
 
 const CURRENCIES = [
   { code: "NZD", name: "New Zealand Dollar", symbol: "NZ$" },
@@ -26,14 +22,6 @@ export default function PersonalInfoStep({
   control,
   errors,
 }: PersonalInfoStepProps): React.ReactElement {
-  const { settings, isLoading: settingsLoading } = useIndependenceSettings()
-  const [showSettingsModal, setShowSettingsModal] = useState(false)
-
-  const yearOfBirth = settings?.yearOfBirth
-  const currentAge = yearOfBirth ? currentYear - yearOfBirth : undefined
-  const targetIndependenceAge = settings?.targetIndependenceAge ?? 65
-  const lifeExpectancy = settings?.lifeExpectancy ?? 90
-
   return (
     <div className="space-y-4">
       <div>
@@ -251,75 +239,7 @@ export default function PersonalInfoStep({
           </p>
         </div>
 
-        {/* Read-only settings display */}
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-medium text-gray-700">
-              Your Independence Settings
-            </h3>
-            <button
-              type="button"
-              onClick={() => setShowSettingsModal(true)}
-              className="text-sm text-independence-600 hover:text-independence-700 font-medium"
-            >
-              <i className="fas fa-edit mr-1"></i>
-              Edit
-            </button>
-          </div>
-
-          {settingsLoading ? (
-            <p className="text-sm text-gray-500">Loading settings...</p>
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div>
-                <p className="text-xs text-gray-500 mb-1">Year of Birth</p>
-                <p className="text-sm font-medium text-gray-900">
-                  {yearOfBirth ?? "Not set"}
-                </p>
-                {currentAge !== undefined && (
-                  <p className="text-xs text-gray-500">
-                    Currently {currentAge} years old
-                  </p>
-                )}
-              </div>
-              <div>
-                <p className="text-xs text-gray-500 mb-1">
-                  Target Independence Age
-                </p>
-                <p className="text-sm font-medium text-gray-900">
-                  {targetIndependenceAge}
-                </p>
-              </div>
-              <div>
-                <p className="text-xs text-gray-500 mb-1">Life Expectancy</p>
-                <p className="text-sm font-medium text-gray-900">
-                  {lifeExpectancy}
-                </p>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="bg-independence-50 border border-independence-200 rounded-lg p-4">
-          <div className="flex">
-            <i className="fas fa-info-circle text-independence-600 mt-0.5 mr-3"></i>
-            <div className="text-sm text-independence-700">
-              <p className="font-medium">Planning horizon</p>
-              <p className="mt-1">
-                Your planning horizon will be{" "}
-                {lifeExpectancy - targetIndependenceAge} years (from age{" "}
-                {targetIndependenceAge} to {lifeExpectancy}). These settings
-                apply across all your independence plans.
-              </p>
-            </div>
-          </div>
-        </div>
       </div>
-
-      <IndependenceSettingsModal
-        isOpen={showSettingsModal}
-        onClose={() => setShowSettingsModal(false)}
-      />
     </div>
   )
 }

--- a/src/components/features/independence/useAssetBreakdown.ts
+++ b/src/components/features/independence/useAssetBreakdown.ts
@@ -24,6 +24,8 @@ export interface AssetBreakdown {
   totalAssets: number
   /** Whether holdings data is available */
   hasAssets: boolean
+  /** Whether holdings data has been received (true even when portfolio is empty) */
+  isLoaded: boolean
 }
 
 /**
@@ -61,12 +63,23 @@ export function calculateAssetBreakdown(
   valueIn: ValueInOption = "PORTFOLIO",
   nonSpendableCategories: string[] = DEFAULT_NON_SPENDABLE_CATEGORIES,
 ): AssetBreakdown {
-  if (!holdingsData?.positions) {
+  if (holdingsData == null) {
     return {
       liquidAssets: 0,
       nonSpendableAssets: 0,
       totalAssets: 0,
       hasAssets: false,
+      isLoaded: false,
+    }
+  }
+
+  if (!holdingsData.positions) {
+    return {
+      liquidAssets: 0,
+      nonSpendableAssets: 0,
+      totalAssets: 0,
+      hasAssets: false,
+      isLoaded: true,
     }
   }
 
@@ -89,5 +102,6 @@ export function calculateAssetBreakdown(
     nonSpendableAssets: nonSpendable,
     totalAssets: liquid + nonSpendable,
     hasAssets: liquid > 0 || nonSpendable > 0,
+    isLoaded: true,
   }
 }

--- a/src/components/features/independence/useUnifiedProjection.ts
+++ b/src/components/features/independence/useUnifiedProjection.ts
@@ -364,8 +364,9 @@ export function useFiProjectionSimple({
     ? `/api/independence/projection/${plan.id}`
     : null
 
-  // Track if we're waiting for assets - this is a "loading" state even though SWR isn't fetching
-  const waitingForAssets = !!projectionUrl && !assets.hasAssets
+  // Track if we're waiting for assets — only spin when holdings haven't loaded yet.
+  // An empty portfolio (isLoaded=true, hasAssets=false) should NOT spin indefinitely.
+  const waitingForAssets = !!projectionUrl && !assets.isLoaded
 
   // Fetch projection with asset values
   // Only fetch when we have both a plan and assets

--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -174,6 +174,14 @@ const OnboardingWizard: React.FC = () => {
   const [independenceTargetAge, setIndependenceTargetAge] = useState(65)
   const [independencePlanCreated, setIndependencePlanCreated] = useState(false)
 
+  // Work plan state (collected in the Independence step)
+  const [workingIncomeMonthly, setWorkingIncomeMonthly] = useState(0)
+  const [workingExpensesMonthly, setWorkingExpensesMonthly] = useState(0)
+  const [taxesMonthly, setTaxesMonthly] = useState(0)
+  const [bonusMonthly, setBonusMonthly] = useState(0)
+  const [investmentAllocationPercent, setInvestmentAllocationPercent] =
+    useState(80)
+
   // Brokerage step (optional, post-default-portfolio creation)
   const [brokerageEnabled, setBrokerageEnabled] = useState(false)
   const [brokerageBrokerName, setBrokerageBrokerName] = useState("")
@@ -653,13 +661,18 @@ const OnboardingWizard: React.FC = () => {
       // Create independence plan if enabled
       if (independencePlanEnabled) {
         try {
-          // Create a default work scenario before the plan
+          // Create a work scenario with user-provided income/expense data
           await fetch("/api/independence/work-scenarios", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
               name: "My Work Scenario",
               currency: baseCurrency,
+              workingIncomeMonthly,
+              workingExpensesMonthly,
+              taxesMonthly,
+              bonusMonthly,
+              investmentAllocationPercent: investmentAllocationPercent / 100,
             }),
           })
         } catch (scenarioErr) {
@@ -869,11 +882,21 @@ const OnboardingWizard: React.FC = () => {
             monthOfBirth={independenceMonthOfBirth}
             monthlyExpenses={independenceMonthlyExpenses}
             targetRetirementAge={independenceTargetAge}
+            workingIncomeMonthly={workingIncomeMonthly}
+            workingExpensesMonthly={workingExpensesMonthly}
+            taxesMonthly={taxesMonthly}
+            bonusMonthly={bonusMonthly}
+            investmentAllocationPercent={investmentAllocationPercent}
             onEnabledChange={setIndependencePlanEnabled}
             onYearOfBirthChange={setIndependenceYearOfBirth}
             onMonthOfBirthChange={setIndependenceMonthOfBirth}
             onMonthlyExpensesChange={setIndependenceMonthlyExpenses}
             onTargetRetirementAgeChange={setIndependenceTargetAge}
+            onWorkingIncomeMonthlyChange={setWorkingIncomeMonthly}
+            onWorkingExpensesMonthlyChange={setWorkingExpensesMonthly}
+            onTaxesMonthlyChange={setTaxesMonthly}
+            onBonusMonthlyChange={setBonusMonthly}
+            onInvestmentAllocationPercentChange={setInvestmentAllocationPercent}
             baseCurrency={baseCurrency}
           />
         )

--- a/src/components/features/onboarding/steps/IndependencePlanStep.tsx
+++ b/src/components/features/onboarding/steps/IndependencePlanStep.tsx
@@ -16,115 +16,181 @@ const MONTHS = [
   "December",
 ]
 
-interface IndependencePlanStepProps {
+export interface IndependencePlanStepProps {
   enabled: boolean
+  hideToggle?: boolean
   yearOfBirth: number
   monthOfBirth: number
   monthlyExpenses: number
   targetRetirementAge: number
+  workingIncomeMonthly: number
+  workingExpensesMonthly: number
+  taxesMonthly: number
+  bonusMonthly: number
+  investmentAllocationPercent: number
   onEnabledChange: (enabled: boolean) => void
   onYearOfBirthChange: (year: number) => void
   onMonthOfBirthChange: (month: number) => void
   onMonthlyExpensesChange: (amount: number) => void
   onTargetRetirementAgeChange: (age: number) => void
+  onWorkingIncomeMonthlyChange: (amount: number) => void
+  onWorkingExpensesMonthlyChange: (amount: number) => void
+  onTaxesMonthlyChange: (amount: number) => void
+  onBonusMonthlyChange: (amount: number) => void
+  onInvestmentAllocationPercentChange: (pct: number) => void
   baseCurrency: string
+}
+
+function computeMonthlyContribution(
+  income: number,
+  expenses: number,
+  taxes: number,
+  bonus: number,
+  allocationPct: number,
+): number {
+  const surplus = income + bonus - expenses - taxes
+  return Math.round(Math.max(0, surplus) * (allocationPct / 100))
 }
 
 const IndependencePlanStep: React.FC<IndependencePlanStepProps> = ({
   enabled,
+  hideToggle = false,
   yearOfBirth,
   monthOfBirth,
   monthlyExpenses,
   targetRetirementAge,
+  workingIncomeMonthly,
+  workingExpensesMonthly,
+  taxesMonthly,
+  bonusMonthly,
+  investmentAllocationPercent,
   onEnabledChange,
   onYearOfBirthChange,
   onMonthOfBirthChange,
   onMonthlyExpensesChange,
   onTargetRetirementAgeChange,
+  onWorkingIncomeMonthlyChange,
+  onWorkingExpensesMonthlyChange,
+  onTaxesMonthlyChange,
+  onBonusMonthlyChange,
+  onInvestmentAllocationPercentChange,
   baseCurrency,
 }) => {
+  const monthlyContribution = computeMonthlyContribution(
+    workingIncomeMonthly,
+    workingExpensesMonthly,
+    taxesMonthly,
+    bonusMonthly,
+    investmentAllocationPercent,
+  )
+
   return (
     <div className="space-y-6">
-      {/* Enable/Skip toggle. Tick follows the selected option so the user
-          sees clear feedback when picking either path (previously hardcoded
-          on "Yes" regardless of state — Skip felt unresponsive). */}
-      <div className="flex items-center justify-center gap-4">
-        <button
-          type="button"
-          onClick={() => onEnabledChange(true)}
-          aria-pressed={enabled}
-          className={`px-6 py-3 rounded-lg font-medium transition-colors border-2 ${
-            enabled
-              ? "bg-independence-600 text-white border-independence-600"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200 border-transparent"
-          }`}
-        >
-          {enabled && <i className="fas fa-check mr-2"></i>}
-          {"Yes, let's do it"}
-        </button>
-        <button
-          type="button"
-          onClick={() => onEnabledChange(false)}
-          aria-pressed={!enabled}
-          className={`px-6 py-3 rounded-lg font-medium transition-colors border-2 ${
-            !enabled
-              ? "bg-gray-700 text-white border-gray-700"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200 border-transparent"
-          }`}
-        >
-          {!enabled && <i className="fas fa-check mr-2"></i>}
-          {"Skip for now"}
-        </button>
-      </div>
+      {!hideToggle && (
+        <div className="flex items-center justify-center gap-4">
+          <button
+            type="button"
+            onClick={() => onEnabledChange(true)}
+            aria-pressed={enabled}
+            className={`px-6 py-3 rounded-lg font-medium transition-colors border-2 ${
+              enabled
+                ? "bg-independence-600 text-white border-independence-600"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200 border-transparent"
+            }`}
+          >
+            {enabled && <i className="fas fa-check mr-2"></i>}
+            {"Yes, let's do it"}
+          </button>
+          <button
+            type="button"
+            onClick={() => onEnabledChange(false)}
+            aria-pressed={!enabled}
+            className={`px-6 py-3 rounded-lg font-medium transition-colors border-2 ${
+              !enabled
+                ? "bg-gray-700 text-white border-gray-700"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200 border-transparent"
+            }`}
+          >
+            {!enabled && <i className="fas fa-check mr-2"></i>}
+            {"Skip for now"}
+          </button>
+        </div>
+      )}
 
       {enabled && (
-        <div className="space-y-4 bg-gray-50 rounded-lg p-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              {"Date of Birth"}
-            </label>
-            <div className="grid grid-cols-2 gap-3">
-              <select
-                id="independenceMonthOfBirth"
-                aria-label="Month of birth"
-                value={monthOfBirth}
-                onChange={(e) => onMonthOfBirthChange(Number(e.target.value))}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+        <div className="space-y-6">
+          {/* Section 1: Independence Settings — goal definition first */}
+          <div className="bg-gray-50 rounded-lg p-6 space-y-4">
+            <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+              {"Independence Settings"}
+            </h3>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {"Date of Birth"}
+              </label>
+              <div className="grid grid-cols-2 gap-3">
+                <select
+                  id="independenceMonthOfBirth"
+                  aria-label="Month of birth"
+                  value={monthOfBirth}
+                  onChange={(e) => onMonthOfBirthChange(Number(e.target.value))}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                >
+                  {MONTHS.map((label, i) => (
+                    <option key={label} value={i + 1}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  id="independenceYearOfBirth"
+                  type="number"
+                  aria-label="Year of birth"
+                  value={yearOfBirth}
+                  min={1920}
+                  max={currentYear - 18}
+                  onChange={(e) => onYearOfBirthChange(Number(e.target.value))}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                />
+              </div>
+              <p className="mt-1 text-sm text-gray-500">
+                {`Currently ${currentYear - yearOfBirth} years old`}
+              </p>
+            </div>
+
+            <div>
+              <label
+                htmlFor="independenceTargetAge"
+                className="block text-sm font-medium text-gray-700 mb-1"
               >
-                {MONTHS.map((label, i) => (
-                  <option key={label} value={i + 1}>
-                    {label}
-                  </option>
-                ))}
-              </select>
+                {"Target Independence Age"}
+              </label>
               <input
-                id="independenceYearOfBirth"
+                id="independenceTargetAge"
                 type="number"
-                aria-label="Year of birth"
-                value={yearOfBirth}
-                min={1920}
-                max={currentYear - 18}
-                onChange={(e) => onYearOfBirthChange(Number(e.target.value))}
+                aria-label="Target independence age"
+                value={targetRetirementAge}
+                min={18}
+                max={100}
+                onChange={(e) =>
+                  onTargetRetirementAgeChange(Number(e.target.value))
+                }
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
               />
             </div>
-            <p className="mt-1 text-sm text-gray-500">
-              {`Currently ${currentYear - yearOfBirth} years old`}
-            </p>
-          </div>
 
-          <div>
-            <label
-              htmlFor="independenceMonthlyExpenses"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              {`Estimated Monthly Expenses (${baseCurrency})`}
-            </label>
-            <div className="relative">
-              <span className="absolute left-3 top-2.5 text-gray-500">$</span>
+            <div>
+              <label
+                htmlFor="independenceMonthlyExpenses"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {`Estimated Monthly Expenses in Retirement (${baseCurrency})`}
+              </label>
               <input
                 id="independenceMonthlyExpenses"
                 type="number"
+                aria-label="Monthly retirement expenses"
                 value={monthlyExpenses || ""}
                 min={0}
                 step={100}
@@ -134,45 +200,161 @@ const IndependencePlanStep: React.FC<IndependencePlanStepProps> = ({
                     e.target.value === "" ? 0 : Number(e.target.value),
                   )
                 }
-                className="w-full pl-8 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
               />
             </div>
           </div>
 
-          <div>
-            <label
-              htmlFor="independenceTargetAge"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              {"Target Independence Age"}
-            </label>
-            <input
-              id="independenceTargetAge"
-              type="number"
-              value={targetRetirementAge}
-              min={18}
-              max={100}
-              onChange={(e) =>
-                onTargetRetirementAgeChange(Number(e.target.value))
+          {/* Section 2: My Work Scenario */}
+          <div className="bg-gray-50 rounded-lg p-6 space-y-4">
+            <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+              {"My Work Scenario"}
+            </h3>
+            <p className="text-xs text-gray-500">
+              {
+                "How much do you earn and spend today? Used to project your savings runway."
               }
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
-            />
+            </p>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label
+                  htmlFor="workingIncome"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  {`Monthly Income (${baseCurrency})`}
+                </label>
+                <input
+                  id="workingIncome"
+                  type="number"
+                  aria-label="Monthly income"
+                  value={workingIncomeMonthly || ""}
+                  min={0}
+                  step={100}
+                  placeholder={"e.g. 8000"}
+                  onChange={(e) =>
+                    onWorkingIncomeMonthlyChange(
+                      e.target.value === "" ? 0 : Number(e.target.value),
+                    )
+                  }
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="workingExpenses"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  {`Monthly Expenses (${baseCurrency})`}
+                </label>
+                <input
+                  id="workingExpenses"
+                  type="number"
+                  aria-label="Monthly living expenses"
+                  value={workingExpensesMonthly || ""}
+                  min={0}
+                  step={100}
+                  placeholder={"e.g. 4000"}
+                  onChange={(e) =>
+                    onWorkingExpensesMonthlyChange(
+                      e.target.value === "" ? 0 : Number(e.target.value),
+                    )
+                  }
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="taxesMonthly"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  {`Monthly Taxes (${baseCurrency})`}
+                </label>
+                <input
+                  id="taxesMonthly"
+                  type="number"
+                  aria-label="Monthly taxes"
+                  value={taxesMonthly || ""}
+                  min={0}
+                  step={100}
+                  placeholder={"e.g. 1500"}
+                  onChange={(e) =>
+                    onTaxesMonthlyChange(
+                      e.target.value === "" ? 0 : Number(e.target.value),
+                    )
+                  }
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="bonusMonthly"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  {`Avg Monthly Bonus (${baseCurrency})`}
+                </label>
+                <input
+                  id="bonusMonthly"
+                  type="number"
+                  aria-label="Average monthly bonus"
+                  value={bonusMonthly || ""}
+                  min={0}
+                  step={100}
+                  placeholder={"e.g. 500"}
+                  onChange={(e) =>
+                    onBonusMonthlyChange(
+                      e.target.value === "" ? 0 : Number(e.target.value),
+                    )
+                  }
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label
+                htmlFor="investmentAllocation"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {`Invest ${investmentAllocationPercent}% of surplus`}
+              </label>
+              <input
+                id="investmentAllocation"
+                type="range"
+                aria-label="Investment allocation percent"
+                value={investmentAllocationPercent}
+                min={0}
+                max={100}
+                step={5}
+                onChange={(e) =>
+                  onInvestmentAllocationPercentChange(Number(e.target.value))
+                }
+                className="w-full accent-independence-600"
+              />
+              <div className="flex justify-between text-xs text-gray-400 mt-1">
+                <span>{"0%"}</span>
+                <span>{"50%"}</span>
+                <span>{"100%"}</span>
+              </div>
+            </div>
+
+            {monthlyContribution > 0 && (
+              <div className="bg-independence-50 border border-independence-200 rounded-lg p-3">
+                <p className="text-sm text-independence-700">
+                  <i className="fas fa-piggy-bank mr-2"></i>
+                  {`Estimated monthly investment: ${baseCurrency} ${monthlyContribution.toLocaleString()}`}
+                </p>
+              </div>
+            )}
           </div>
 
-          <div className="bg-independence-50 border border-independence-200 rounded-lg p-3">
-            <div className="flex items-start">
-              <i className="fas fa-info-circle text-independence-600 mt-0.5 mr-2"></i>
-              <p className="text-sm text-independence-700">
-                {
-                  'A plan called "My Independence Plan" will be created with sensible defaults. You can refine it anytime from the Independence page.'
-                }
-              </p>
-            </div>
-          </div>
         </div>
       )}
 
-      {!enabled && (
+      {!enabled && !hideToggle && (
         <div className="text-center text-sm text-gray-500">
           <p>
             {

--- a/src/pages/independence/index.tsx
+++ b/src/pages/independence/index.tsx
@@ -755,7 +755,7 @@ function RetirementPlanning(): React.ReactElement {
 
           {error && <Alert>Failed to load plans. Please try again.</Alert>}
 
-          {!isLoading && !error && plans.length === 0 && (
+          {!isLoading && !error && plans.length === 0 && activeView === "plans" && (
             <div className="bg-white rounded-2xl shadow-lg p-12 text-center">
               <div className="w-20 h-20 bg-independence-100 rounded-full flex items-center justify-center mx-auto mb-6">
                 <i className="fas fa-umbrella-beach text-3xl text-independence-600"></i>
@@ -764,16 +764,25 @@ function RetirementPlanning(): React.ReactElement {
                 No independence plans yet
               </h2>
               <p className="text-gray-600 mb-6 max-w-md mx-auto">
-                Create your first independence plan to start projecting your
-                financial runway and exploring different scenarios.
+                Answer a few quick questions to create your first independence
+                plan and start projecting your financial freedom timeline.
               </p>
-              <Link
-                href="/independence/wizard"
-                className="inline-flex items-center bg-independence-600 text-white px-6 py-3 rounded-lg hover:bg-independence-700 font-medium"
-              >
-                <i className="fas fa-plus mr-2"></i>
-                Create Your First Plan
-              </Link>
+              <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                <Link
+                  href="/independence/setup"
+                  className="inline-flex items-center bg-independence-600 text-white px-6 py-3 rounded-lg hover:bg-independence-700 font-medium"
+                >
+                  <i className="fas fa-magic mr-2"></i>
+                  Get Started
+                </Link>
+                <Link
+                  href="/independence/wizard"
+                  className="inline-flex items-center border border-gray-300 text-gray-700 px-6 py-3 rounded-lg hover:bg-gray-50 font-medium"
+                >
+                  <i className="fas fa-sliders-h mr-2"></i>
+                  Advanced Setup
+                </Link>
+              </div>
             </div>
           )}
 

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -520,6 +520,7 @@ function PlanView(): React.ReactElement {
       nonSpendableAssets,
       totalAssets,
       hasAssets,
+      isLoaded: true,
     },
     selectedPortfolioIds,
     monthlyInvestment,
@@ -1042,6 +1043,7 @@ function PlanView(): React.ReactElement {
                 nonSpendableAssets,
                 totalAssets,
                 hasAssets,
+                isLoaded: true,
               }}
               monthlyInvestment={monthlyInvestment}
               scenario={scenario}

--- a/src/pages/independence/setup.tsx
+++ b/src/pages/independence/setup.tsx
@@ -1,0 +1,227 @@
+import React, { useState, useEffect } from "react"
+import { useRouter } from "next/router"
+import Head from "next/head"
+import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
+import IndependencePlanStep from "@components/features/onboarding/steps/IndependencePlanStep"
+import { useUserPreferences } from "@contexts/UserPreferencesContext"
+import { WorkScenario } from "types/independence"
+
+const currentYear = new Date().getFullYear()
+
+function IndependenceSetupPage(): React.ReactElement {
+  const router = useRouter()
+  const { preferences } = useUserPreferences()
+
+  const [yearOfBirth, setYearOfBirth] = useState(currentYear - 35)
+  const [monthOfBirth, setMonthOfBirth] = useState(1)
+  const [targetRetirementAge, setTargetRetirementAge] = useState(65)
+  const [monthlyExpenses, setMonthlyExpenses] = useState(0)
+  const [workingIncomeMonthly, setWorkingIncomeMonthly] = useState(0)
+  const [workingExpensesMonthly, setWorkingExpensesMonthly] = useState(0)
+  const [taxesMonthly, setTaxesMonthly] = useState(0)
+  const [bonusMonthly, setBonusMonthly] = useState(0)
+  const [investmentAllocationPercent, setInvestmentAllocationPercent] =
+    useState(80)
+  const [existingScenarioId, setExistingScenarioId] = useState<string | null>(
+    null,
+  )
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [initialized, setInitialized] = useState(false)
+
+  useEffect(() => {
+    if (initialized || !preferences) return
+
+    // Pre-fill DOB from user preferences
+    if (preferences.yearOfBirth) setYearOfBirth(preferences.yearOfBirth)
+    if (preferences.monthOfBirth) setMonthOfBirth(preferences.monthOfBirth)
+
+    // Fetch existing work scenarios — pre-fill from current one if present
+    fetch("/api/independence/work-scenarios")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { data?: WorkScenario[] } | null) => {
+        const scenarios: WorkScenario[] = data?.data ?? []
+        const current =
+          scenarios.find((s) => s.isCurrent) ?? scenarios[0] ?? null
+        if (current) {
+          setExistingScenarioId(current.id)
+          setWorkingIncomeMonthly(current.workingIncomeMonthly ?? 0)
+          setWorkingExpensesMonthly(current.workingExpensesMonthly ?? 0)
+          setTaxesMonthly(current.taxesMonthly ?? 0)
+          setBonusMonthly(current.bonusMonthly ?? 0)
+          // API stores allocation as decimal fraction; form uses 0-100
+          setInvestmentAllocationPercent(
+            (current.investmentAllocationPercent ?? 0.8) * 100,
+          )
+        }
+      })
+      .catch(() => undefined)
+
+    setInitialized(true)
+  }, [preferences, initialized])
+
+  const baseCurrency = preferences?.baseCurrencyCode ?? "USD"
+
+  const handleSubmit = async (): Promise<void> => {
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      // Persist profile to user preferences
+      await fetch("/api/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ yearOfBirth, monthOfBirth }),
+      })
+
+      const workPayload = {
+        name: "My Work Scenario",
+        currency: baseCurrency,
+        workingIncomeMonthly,
+        workingExpensesMonthly,
+        taxesMonthly,
+        bonusMonthly,
+        investmentAllocationPercent: investmentAllocationPercent / 100,
+      }
+
+      if (existingScenarioId) {
+        // Update the existing scenario rather than creating a duplicate
+        await fetch(`/api/independence/work-scenarios/${existingScenarioId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(workPayload),
+        })
+      } else {
+        await fetch("/api/independence/work-scenarios", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(workPayload),
+        })
+      }
+
+      // Create the independence plan
+      const planResponse = await fetch("/api/independence/plans", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "My Independence Plan",
+          yearOfBirth,
+          planningHorizonYears: 90 - targetRetirementAge,
+          lifeExpectancy: 90,
+          monthlyExpenses,
+          expensesCurrency: baseCurrency,
+          cashReturnRate: 0.03,
+          equityReturnRate: 0.08,
+          housingReturnRate: 0.04,
+          inflationRate: 0.025,
+          cashAllocation: 0.2,
+          equityAllocation: 0.8,
+          housingAllocation: 0.0,
+          pensionMonthly: 0,
+          socialSecurityMonthly: 0,
+          otherIncomeMonthly: 0,
+          workingIncomeMonthly,
+          workingExpensesMonthly,
+          taxesMonthly,
+          bonusMonthly,
+          investmentAllocationPercent: investmentAllocationPercent / 100,
+        }),
+      })
+
+      if (!planResponse.ok) {
+        throw new Error("Failed to create independence plan")
+      }
+
+      const plan = await planResponse.json()
+      const planId = plan?.data?.id ?? plan?.id
+      if (planId) {
+        await router.push(`/independence/wizard/${planId}`)
+      } else {
+        await router.push("/independence")
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{"Set Up Your Independence Plan"}</title>
+      </Head>
+      <div className="min-h-screen bg-gray-50">
+        <div className="max-w-2xl mx-auto px-4 py-12">
+          <div className="text-center mb-8">
+            <div className="w-16 h-16 bg-independence-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <i className="fas fa-umbrella-beach text-2xl text-independence-600"></i>
+            </div>
+            <h1 className="text-2xl font-bold text-gray-900 mb-2">
+              {"Set Up Your Independence Plan"}
+            </h1>
+            <p className="text-gray-600">
+              {
+                "Answer a few questions to start projecting your financial freedom timeline."
+              }
+            </p>
+          </div>
+
+          <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 space-y-6">
+            <IndependencePlanStep
+              enabled={true}
+              hideToggle={true}
+              yearOfBirth={yearOfBirth}
+              monthOfBirth={monthOfBirth}
+              monthlyExpenses={monthlyExpenses}
+              targetRetirementAge={targetRetirementAge}
+              workingIncomeMonthly={workingIncomeMonthly}
+              workingExpensesMonthly={workingExpensesMonthly}
+              taxesMonthly={taxesMonthly}
+              bonusMonthly={bonusMonthly}
+              investmentAllocationPercent={investmentAllocationPercent}
+              onEnabledChange={() => undefined}
+              onYearOfBirthChange={setYearOfBirth}
+              onMonthOfBirthChange={setMonthOfBirth}
+              onMonthlyExpensesChange={setMonthlyExpenses}
+              onTargetRetirementAgeChange={setTargetRetirementAge}
+              onWorkingIncomeMonthlyChange={setWorkingIncomeMonthly}
+              onWorkingExpensesMonthlyChange={setWorkingExpensesMonthly}
+              onTaxesMonthlyChange={setTaxesMonthly}
+              onBonusMonthlyChange={setBonusMonthly}
+              onInvestmentAllocationPercentChange={
+                setInvestmentAllocationPercent
+              }
+              baseCurrency={baseCurrency}
+            />
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+
+            <div className="flex gap-3 pt-2">
+              <button
+                type="button"
+                onClick={() => router.push("/independence")}
+                className="flex-1 px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 font-medium"
+              >
+                {"Skip for now"}
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+                className="flex-1 px-6 py-3 bg-independence-600 text-white rounded-lg hover:bg-independence-700 font-medium disabled:opacity-60"
+              >
+                {isSubmitting ? "Creating..." : "Create My Plan"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default withPageAuthRequired(IndependenceSetupPage)


### PR DESCRIPTION
## Summary

- New `/independence/setup` page: guided interview (Independence Settings + Work Scenario) that pre-fills from existing work scenario, creates plan then redirects to wizard for full step-through
- `IndependencePlanStep` gains Work Plan section (income/expenses/taxes/bonus/investAlloc%) with live contribution preview; section order is Independence Settings first, Work Scenario second
- `OnboardingWizard` wires work plan state through step 6 so work scenario is created with real values instead of zeros
- Independence empty state links to `/independence/setup` (Get Started) and `/independence/wizard` (Advanced Setup); only shown on Plans tab, not Profile/Shared tabs
- `IndependenceSettingsSummary` extracted from `PersonalInfoStep` and placed at top of `WizardContainer` — visible on all wizard steps, not just step 1
- **Fix:** `AssetBreakdown` gains `isLoaded` flag; empty portfolio no longer spins indefinitely (`waitingForAssets` checks `isLoaded`, not `hasAssets`)

## Test plan

- [ ] New user flow: `/independence` → Get Started → `/independence/setup` → fills in form → Create My Plan → redirects to wizard
- [ ] Existing work scenario pre-fills on setup page; submit PATCHes it rather than creating duplicate
- [ ] Profile tab on `/independence` no longer shows empty-state card
- [ ] Plan wizard shows Independence Settings summary at top of every step
- [ ] Portfolio with zero holdings: plan card shows FI Number fallback, not infinite spinner
- [ ] `yarn test && yarn lint && yarn typecheck` all pass

@coderabbitai ignore