### PR TITLE
polish(ui): invest/rebalance UI polish + plan delete error feedback

### DIFF
--- a/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
+++ b/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
@@ -28,6 +28,7 @@ function PlanDetailPage(): React.ReactElement {
   const [deleting, setDeleting] = useState(false)
   const [saving, setSaving] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
   const [fetchingPrices, setFetchingPrices] = useState(false)
   const [creatingVersion, setCreatingVersion] = useState(false)
   const [showImportDropdown, setShowImportDropdown] = useState(false)
@@ -141,6 +142,7 @@ function PlanDetailPage(): React.ReactElement {
   const handleDelete = async (): Promise<void> => {
     setShowDeleteConfirm(false)
     setDeleting(true)
+    setActionError(null)
     try {
       const response = await fetch(
         `/api/rebalance/models/${modelId}/plans/${planId}`,
@@ -148,9 +150,13 @@ function PlanDetailPage(): React.ReactElement {
       )
       if (response.ok) {
         router.push(`/rebalance/models/${modelId}`)
+      } else {
+        const text = await response.text().catch(() => "")
+        setActionError(`Delete failed (${response.status})${text ? `: ${text}` : ""}`)
       }
     } catch (err) {
       console.error("Failed to delete plan:", err)
+      setActionError("Delete failed — please try again")
     } finally {
       setDeleting(false)
     }
@@ -515,6 +521,22 @@ function PlanDetailPage(): React.ReactElement {
           {"Plan"} v{plan.version}
         </span>
       </nav>
+
+      {/* Action error banner */}
+      {actionError && (
+        <div className="mb-4 max-w-5xl mx-auto bg-red-50 border border-red-200 rounded-lg px-4 py-3 flex items-center justify-between text-sm text-red-700">
+          <span>
+            <i className="fas fa-exclamation-circle mr-2"></i>
+            {actionError}
+          </span>
+          <button
+            onClick={() => setActionError(null)}
+            className="ml-4 text-red-500 hover:text-red-700"
+          >
+            <i className="fas fa-times"></i>
+          </button>
+        </div>
+      )}
 
       {/* Header */}
       <div className="bg-white shadow-sm border border-gray-200 rounded-lg p-6 max-w-5xl mx-auto mb-6">


### PR DESCRIPTION
## Summary
- Independence, wealth, invest, portfolio, font, and rebalance plan pages polished for contrast, icon consistency, and token standardisation
- Rebalance plan detail: wider layout (`max-w-5xl`), cleaner header (status pill inline, New Version as text link), copy-to-CSV clipboard button
- Plan delete now surfaces error banner with HTTP status when backend returns non-2xx

## Test plan
- [ ] Independence / wealth pages render with correct contrast and no gradient cards
- [ ] Invest pages use `invest-*` tokens consistently
- [ ] Rebalance plan detail: wider layout, copy button copies CSV to clipboard, error banner appears on failed delete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan deletion operations now display comprehensive error messages in a dismissible banner when failures occur. Error messages include HTTP status codes and detailed explanations for each failure type. Network-related failures provide helpful retry guidance, enabling users to better understand what went wrong and how to proceed with their next action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->