### PR TITLE
fix(onboarding): auto-link composite CPF pension to default portfolio

### DIFF
--- a/__tests__/components/features/onboarding/buildPensionTrn.test.ts
+++ b/__tests__/components/features/onboarding/buildPensionTrn.test.ts
@@ -1,0 +1,79 @@
+import { buildPensionTrn } from "@components/features/onboarding/buildPensionTrn"
+import type { Pension } from "@components/features/onboarding/OnboardingWizard"
+
+const TODAY = "2026-06-14"
+
+describe("buildPensionTrn", () => {
+  it("links a composite CPF pension (sub-accounts, no top-level balance) as a BALANCE trn", () => {
+    const cpf: Pension = {
+      name: "CPF",
+      currency: "SGD",
+      policyType: "CPF",
+      // No top-level balance: CPF balance lives in sub-accounts.
+      subAccounts: [
+        { code: "OA", balance: 50000, liquid: true },
+        { code: "SA", balance: 30000, liquid: false },
+        { code: "MA", balance: 20000, liquid: false },
+        { code: "RA", balance: 0, liquid: false },
+      ],
+    }
+
+    const row = buildPensionTrn(cpf, "asset-cpf", TODAY)
+
+    expect(row).toEqual({
+      assetId: "asset-cpf",
+      trnType: "BALANCE",
+      quantity: 100000,
+      tradeAmount: 100000,
+      tradeDate: TODAY,
+      tradeCurrency: "SGD",
+      cashCurrency: "SGD",
+      status: "SETTLED",
+      comments: "Link CPF balance to portfolio",
+      subAccounts: { OA: 50000, SA: 30000, MA: 20000, RA: 0 },
+    })
+  })
+
+  it("keeps a plain pension (top-level balance, no sub-accounts) as an ADD trn", () => {
+    const pension: Pension = {
+      name: "Acme Pension",
+      currency: "USD",
+      balance: 12345,
+    }
+
+    const row = buildPensionTrn(pension, "asset-plain", TODAY)
+
+    expect(row).toEqual({
+      assetId: "asset-plain",
+      trnType: "ADD",
+      quantity: 12345,
+      price: 1,
+      tradeCurrency: "USD",
+      tradeDate: TODAY,
+      status: "SETTLED",
+    })
+  })
+
+  it("returns null when there is nothing to link (no sub-accounts, no positive balance)", () => {
+    const empty: Pension = { name: "Empty", currency: "SGD" }
+    expect(buildPensionTrn(empty, "asset-empty", TODAY)).toBeNull()
+
+    const zero: Pension = { name: "Zero", currency: "SGD", balance: 0 }
+    expect(buildPensionTrn(zero, "asset-zero", TODAY)).toBeNull()
+  })
+
+  it("prefers the BALANCE shape when both sub-accounts and a top-level balance are present", () => {
+    const mixed: Pension = {
+      name: "Mixed",
+      currency: "SGD",
+      balance: 999,
+      subAccounts: [{ code: "OA", balance: 200 }],
+    }
+
+    const row = buildPensionTrn(mixed, "asset-mixed", TODAY)
+
+    expect(row?.trnType).toBe("BALANCE")
+    expect(row?.quantity).toBe(200)
+    expect(row?.subAccounts).toEqual({ OA: 200 })
+  })
+})

--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -24,6 +24,7 @@ import { useRegistration } from "@contexts/RegistrationContext"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import Spinner from "@components/ui/Spinner"
 import { buildMePatchBody } from "./buildMePatchBody"
+import { buildPensionTrn } from "./buildPensionTrn"
 
 export interface BankAccount {
   name: string
@@ -488,17 +489,30 @@ const OnboardingWizard: React.FC = () => {
           }),
         })
 
-        // Create ADD transaction for initial balance if provided (doesn't impact cash)
-        if (pension.balance && pension.balance > 0) {
-          await createTransaction(
-            portfolioId,
-            asset.id,
-            "ADD",
-            pension.balance,
-            1,
-            pension.currency,
-            new Date().toISOString().split("T")[0],
-          )
+        // Link the pension to the default portfolio so a freshly
+        // onboarded user never sees the "isn't in a portfolio yet"
+        // banner. Composite pensions (CPF) carry their balance in
+        // sub-accounts, so post a BALANCE trn with the per-sub-account
+        // map exactly as LinkCompositeDialog does; plain pensions keep
+        // the cash-neutral ADD. Both are skipped when there's nothing
+        // to link. See buildPensionTrn for the shape.
+        const trnRow = buildPensionTrn(
+          pension,
+          asset.id,
+          new Date().toISOString().split("T")[0],
+        )
+        if (trnRow) {
+          const response = await fetch("/api/trns", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ portfolioId, data: [trnRow] }),
+          })
+          if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}))
+            throw new Error(
+              errorData.error || `Failed to link ${pension.name} to portfolio`,
+            )
+          }
         }
       }
     }

--- a/src/components/features/onboarding/buildPensionTrn.ts
+++ b/src/components/features/onboarding/buildPensionTrn.ts
@@ -1,0 +1,74 @@
+import type { Pension } from "./OnboardingWizard"
+
+/**
+ * Build the `/api/trns` transaction-data row that links a pension asset
+ * to the default portfolio during onboarding.
+ *
+ * Composite pensions (CPF today) hold their balance in `subAccounts`,
+ * not in the top-level `balance`. Mirror what LinkCompositeDialog posts:
+ * a BALANCE trn carrying the per-sub-account map and a total equal to
+ * the sum of sub-account balances, so svc-position's BalanceBehaviour
+ * persists the breakdown and svc-data's `whereHeld` resolves a portfolio
+ * (no "isn't in a portfolio yet" banner for freshly-onboarded users).
+ * BALANCE does not impact the portfolio's cash.
+ *
+ * Plain pensions keep the prior behaviour: an ADD trn for the top-level
+ * balance (also cash-neutral).
+ *
+ * Returns null when there is nothing to link (no sub-accounts and no
+ * positive top-level balance) so the caller can skip the POST.
+ */
+export interface PensionTrnRow {
+  assetId: string
+  trnType: "BALANCE" | "ADD"
+  quantity: number
+  tradeCurrency: string
+  tradeDate: string
+  status: "SETTLED"
+  price?: number
+  tradeAmount?: number
+  cashCurrency?: string
+  comments?: string
+  subAccounts?: Record<string, number>
+}
+
+export function buildPensionTrn(
+  pension: Pension,
+  assetId: string,
+  tradeDate: string,
+): PensionTrnRow | null {
+  const subAccounts = pension.subAccounts ?? []
+
+  if (subAccounts.length > 0) {
+    const total = subAccounts.reduce((sum, sa) => sum + sa.balance, 0)
+    const subAccountsMap = Object.fromEntries(
+      subAccounts.map((sa) => [sa.code, sa.balance]),
+    )
+    return {
+      assetId,
+      trnType: "BALANCE",
+      quantity: total,
+      tradeAmount: total,
+      tradeDate,
+      tradeCurrency: pension.currency,
+      cashCurrency: pension.currency,
+      status: "SETTLED",
+      comments: `Link ${pension.name} balance to portfolio`,
+      subAccounts: subAccountsMap,
+    }
+  }
+
+  if (pension.balance && pension.balance > 0) {
+    return {
+      assetId,
+      trnType: "ADD",
+      quantity: pension.balance,
+      price: 1,
+      tradeCurrency: pension.currency,
+      tradeDate,
+      status: "SETTLED",
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Problem
A freshly-onboarded user's composite CPF pension (sub-accounts OA/SA/MA/RA) showed the "isn't in a portfolio yet" warning banner with a "Link to portfolio" button, even though onboarding created the CPF with balances.

## Root cause
The onboarding pension loop only created a transaction when the top-level `pension.balance > 0`. CPF balance lives in `pension.subAccounts`, and the top-level `balance` is typically `undefined`, so no trn was created. svc-data's `whereHeld` then found no portfolio and the standalone-asset banner showed.

## Fix
For composite pensions (sub-accounts present), onboarding now posts a `BALANCE` trn to the default portfolio carrying the per-sub-account map and a total equal to the sum of sub-account balances — exactly mirroring `LinkCompositeDialog`. Plain pensions keep the prior cash-neutral `ADD`. Both skip the POST when there's nothing to link.

The trn-building decision is extracted into a pure `buildPensionTrn` helper (same pattern as `buildMePatchBody`) and unit-tested.

## Tests
`__tests__/components/features/onboarding/buildPensionTrn.test.ts` asserts:
- composite CPF (sub-accounts, no top-level balance) -> `BALANCE` trn with correct `subAccounts` map + total
- plain pension -> `ADD`
- nothing-to-link -> null (skip)
- both present -> prefers `BALANCE`

@coderabbitai ignore