### PR TITLE
fix(rebalance): render model allocations on client-side navigation

### DIFF
--- a/__tests__/pages/rebalance/models/[modelId]/plans/planId.test.tsx
+++ b/__tests__/pages/rebalance/models/[modelId]/plans/planId.test.tsx
@@ -1,0 +1,127 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+
+// Controllable router mock — mimics Next.js Pages Router behaviour where, on
+// client-side navigation, router.query is empty until router.isReady flips true.
+const routerState: {
+  isReady: boolean
+  query: Record<string, string>
+  push: jest.Mock
+} = {
+  isReady: false,
+  query: {},
+  push: jest.fn(),
+}
+jest.mock("next/router", () => ({
+  useRouter: () => routerState,
+}))
+
+// Mock SWR so it behaves like the real thing: a null key means "don't fetch"
+// (no data, not loading); a real key resolves to the matching fixture.
+import useSwr from "swr"
+jest.mock("swr")
+const mockUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
+
+const model = {
+  id: "model-1",
+  name: "Aggressive Growth",
+  baseCurrency: "USD",
+}
+
+const plan = {
+  id: "plan-1",
+  modelId: "model-1",
+  modelName: "Aggressive Growth",
+  version: 1,
+  status: "APPROVED",
+  cashWeight: 0,
+  createdAt: "2026-01-01T00:00:00Z",
+  approvedAt: "2026-01-02T00:00:00Z",
+  updatedAt: "2026-01-02T00:00:00Z",
+  assets: [
+    {
+      id: "pa-1",
+      assetId: "asset-voo",
+      assetCode: "NASDAQ:VOO",
+      assetName: "Vanguard S&P 500 ETF",
+      weight: 0.6,
+      sortOrder: 0,
+    },
+    {
+      id: "pa-2",
+      assetId: "asset-qqq",
+      assetCode: "NASDAQ:QQQ",
+      assetName: "Invesco QQQ Trust",
+      weight: 0.4,
+      sortOrder: 1,
+    },
+  ],
+}
+
+const idle = {
+  data: undefined,
+  error: undefined,
+  isLoading: false,
+  isValidating: false,
+  mutate: jest.fn(),
+}
+
+function swrByKey(key: unknown): ReturnType<typeof useSwr> {
+  // Real SWR: null key => disabled (no data, not loading).
+  if (!key) return idle as unknown as ReturnType<typeof useSwr>
+  const k = String(key)
+  if (k.endsWith("/plans/plan-1")) {
+    return { ...idle, data: { data: plan } } as unknown as ReturnType<
+      typeof useSwr
+    >
+  }
+  if (k.endsWith("/models/model-1")) {
+    return { ...idle, data: { data: model } } as unknown as ReturnType<
+      typeof useSwr
+    >
+  }
+  if (k.endsWith("/plans")) {
+    return { ...idle, data: { data: [plan] } } as unknown as ReturnType<
+      typeof useSwr
+    >
+  }
+  return idle as unknown as ReturnType<typeof useSwr>
+}
+
+describe("/rebalance/models/[modelId]/plans/[planId] — Target Allocations", () => {
+  beforeEach(() => {
+    mockUseSwr.mockReset()
+    mockUseSwr.mockImplementation((key: unknown) => swrByKey(key))
+    routerState.isReady = false
+    routerState.query = {}
+  })
+
+  test("does not flash 'Failed to load' before the router is ready", async () => {
+    const { default: PlanDetailPage } =
+      await import("../../../../../../src/pages/rebalance/models/[modelId]/plans/[planId]")
+
+    // First client-side render: router not ready, query empty.
+    render(<PlanDetailPage />)
+
+    // Regression guard: while the route params are unknown we must show a
+    // loading state, never the empty/error state that latches an empty page.
+    expect(screen.queryByText(/Failed to load/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Vanguard S&P 500 ETF/i)).not.toBeInTheDocument()
+  })
+
+  test("renders allocations once the router becomes ready (no manual refresh)", async () => {
+    const { default: PlanDetailPage } =
+      await import("../../../../../../src/pages/rebalance/models/[modelId]/plans/[planId]")
+
+    const { rerender } = render(<PlanDetailPage />)
+
+    // Router resolves the dynamic params on a later tick (client-side nav).
+    routerState.isReady = true
+    routerState.query = { modelId: "model-1", planId: "plan-1" }
+    rerender(<PlanDetailPage />)
+
+    expect(await screen.findByText("Target Allocations")).toBeInTheDocument()
+    expect(screen.getByText("Vanguard S&P 500 ETF")).toBeInTheDocument()
+    expect(screen.getByText("Invesco QQQ Trust")).toBeInTheDocument()
+  })
+})

--- a/__tests__/pages/rebalance/models/modelId.test.tsx
+++ b/__tests__/pages/rebalance/models/modelId.test.tsx
@@ -1,0 +1,87 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+
+const routerState: {
+  isReady: boolean
+  query: Record<string, string>
+  push: jest.Mock
+} = {
+  isReady: false,
+  query: {},
+  push: jest.fn(),
+}
+jest.mock("next/router", () => ({
+  useRouter: () => routerState,
+}))
+
+import useSwr from "swr"
+jest.mock("swr")
+const mockUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
+
+// ModelPlans pulls the plan list through its own SWR call; stub it out so the
+// test focuses on the model detail loading path.
+jest.mock(
+  "../../../../src/components/features/rebalance/models/ModelPlans",
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="model-plans" />,
+  }),
+)
+
+const model = {
+  id: "model-1",
+  name: "Aggressive Growth",
+  baseCurrency: "USD",
+}
+
+const idle = {
+  data: undefined,
+  error: undefined,
+  isLoading: false,
+  isValidating: false,
+  mutate: jest.fn(),
+}
+
+function swrByKey(key: unknown): ReturnType<typeof useSwr> {
+  if (!key) return idle as unknown as ReturnType<typeof useSwr>
+  if (String(key).endsWith("/models/model-1")) {
+    return { ...idle, data: { data: model } } as unknown as ReturnType<
+      typeof useSwr
+    >
+  }
+  return idle as unknown as ReturnType<typeof useSwr>
+}
+
+describe("/rebalance/models/[modelId] — Model detail", () => {
+  beforeEach(() => {
+    mockUseSwr.mockReset()
+    mockUseSwr.mockImplementation((key: unknown) => swrByKey(key))
+    routerState.isReady = false
+    routerState.query = {}
+  })
+
+  test("shows a loading state (not an empty page) before the router is ready", async () => {
+    const { default: ModelDetailPage } =
+      await import("../../../../src/pages/rebalance/models/[modelId]")
+    render(<ModelDetailPage />)
+
+    // Must not commit the empty/error state while the route param is unknown.
+    expect(screen.queryByText(/Failed to load model/i)).not.toBeInTheDocument()
+    expect(screen.queryByText("Aggressive Growth")).not.toBeInTheDocument()
+  })
+
+  test("renders the model once the router becomes ready (no manual refresh)", async () => {
+    const { default: ModelDetailPage } =
+      await import("../../../../src/pages/rebalance/models/[modelId]")
+    const { rerender } = render(<ModelDetailPage />)
+
+    routerState.isReady = true
+    routerState.query = { modelId: "model-1" }
+    rerender(<ModelDetailPage />)
+
+    expect(
+      await screen.findByRole("heading", { name: "Aggressive Growth" }),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("model-plans")).toBeInTheDocument()
+  })
+})

--- a/src/pages/rebalance/models/[modelId].tsx
+++ b/src/pages/rebalance/models/[modelId].tsx
@@ -9,13 +9,33 @@ import { TableSkeletonLoader } from "@components/ui/SkeletonLoader"
 
 function ModelDetailPage(): React.ReactElement {
   const router = useRouter()
-  const { modelId } = router.query
+  // router.query is empty until router.isReady on client-side navigation;
+  // reading modelId before then yields a null SWR key that never refetches,
+  // leaving the page blank until a manual refresh.
+  const modelId = router.isReady ? (router.query.modelId as string) : undefined
 
   const isNew = modelId === "__NEW__"
   const { model, isLoading, error, mutate } = useModel(
-    isNew ? undefined : (modelId as string),
+    isNew ? undefined : modelId,
   )
-  const [isEditing, setIsEditing] = useState(isNew)
+  // Open straight into the editor for a brand-new model. isNew is only known
+  // once the router is ready, so seed the edit state on the render where that
+  // first becomes true (render-phase "store previous value" pattern) rather
+  // than via the state initialiser, which runs before the query is populated.
+  const [isEditing, setIsEditing] = useState(false)
+  const [prevIsNew, setPrevIsNew] = useState(isNew)
+  if (isNew !== prevIsNew) {
+    setPrevIsNew(isNew)
+    if (isNew) setIsEditing(true)
+  }
+
+  if (!router.isReady) {
+    return (
+      <div className="w-full py-4">
+        <TableSkeletonLoader rows={5} />
+      </div>
+    )
+  }
 
   if (!isNew && isLoading) {
     return (

--- a/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
+++ b/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
@@ -18,14 +18,16 @@ import Spinner from "@components/ui/Spinner"
 
 function PlanDetailPage(): React.ReactElement {
   const router = useRouter()
-  const { modelId, planId } = router.query
+  // On client-side navigation router.query is empty until router.isReady flips
+  // true. Reading the params before then yields undefined SWR keys (no fetch),
+  // which would otherwise render the empty/error state and never recover until a
+  // manual refresh. Gate the param reads on readiness so they fetch once known.
+  const modelId = router.isReady ? (router.query.modelId as string) : undefined
+  const planId = router.isReady ? (router.query.planId as string) : undefined
 
-  const { model } = useModel(modelId as string)
-  const { plan, isLoading, error, mutate } = useModelPlan(
-    modelId as string,
-    planId as string,
-  )
-  const { plans } = useModelPlans(modelId as string)
+  const { model } = useModel(modelId)
+  const { plan, isLoading, error, mutate } = useModelPlan(modelId, planId)
+  const { plans } = useModelPlans(modelId)
 
   const [approving, setApproving] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -527,7 +529,7 @@ function PlanDetailPage(): React.ReactElement {
     event.target.value = ""
   }
 
-  if (isLoading) {
+  if (!router.isReady || isLoading) {
     return (
       <div className="w-full py-4">
         <TableSkeletonLoader rows={5} />


### PR DESCRIPTION
## Problem
Opening a rebalance Model / its plan (Target Allocations) via client-side navigation rendered an empty/error state on first paint and never populated until a manual browser refresh. Hard refresh (SSR) worked.

## Root cause
Both `src/pages/rebalance/models/[modelId].tsx` and `src/pages/rebalance/models/[modelId]/plans/[planId].tsx` derived their SWR keys directly from `router.query` without gating on `router.isReady`. On client-side navigation `router.query` is empty until `router.isReady` flips true, so `modelId`/`planId` are `undefined`, the SWR key is `null` (no fetch), `isLoading` stays `false`, and the page falls straight through to the `!plan` / `!model` branch — committing the empty/"Failed to load" state instead of a loading state.

## Fix
- Read the dynamic params only once `router.isReady` is true; treat "not ready" as a loading state (render the skeleton).
- Plan page loading guard now `!router.isReady || isLoading`.
- Model page seeds create-mode editing via the render-phase "store previous value" pattern (the `isNew` flag is only known once the router is ready, so the state initialiser can't see it).

## Tests
Added two page tests reproducing empty-first-render then asserting allocations/model render after the router becomes ready (no manual refresh), plus a regression guard that the empty/error state is never shown while route params are unknown.

@coderabbitai ignore