### PR TITLE
fix(independence): pin chart age axis to current age→life expectancy; clarify Investment column

### DIFF
--- a/src/components/features/independence/IncomeBreakdownTable.tsx
+++ b/src/components/features/independence/IncomeBreakdownTable.tsx
@@ -115,7 +115,12 @@ export default function IncomeBreakdownTable({
               </th>
               {columnVisibility.investment && (
                 <th className="text-right py-2 px-2 font-medium text-gray-600">
-                  <span className="text-green-600">Investment</span>
+                  <span
+                    className="text-green-600 cursor-help"
+                    title="Net-of-fee return your investment portfolio (cash + equities) earns each year. Compounds every year, including in independence — while you also draw down capital (see Withdrawals). CPF, pensions and property grow separately in their own columns."
+                  >
+                    Investment Growth
+                  </span>
                 </th>
               )}
               {columnVisibility.pension && (
@@ -311,8 +316,12 @@ export default function IncomeBreakdownTable({
         <p className="flex flex-wrap gap-x-3">
           {columnVisibility.investment && (
             <span>
-              <span className="font-medium text-green-600">Investment:</span>{" "}
-              Returns on portfolio
+              <span className="font-medium text-green-600">
+                Investment Growth:
+              </span>{" "}
+              Net-of-fee return on your investment portfolio (cash + equities) —
+              compounds each year, including in independence while you also draw
+              down capital. Excludes CPF, pensions &amp; property.
             </span>
           )}
           {columnVisibility.pension && (

--- a/src/components/features/independence/PlanFiOverviewTab.tsx
+++ b/src/components/features/independence/PlanFiOverviewTab.tsx
@@ -11,6 +11,7 @@ import {
   ReferenceArea,
 } from "recharts"
 import ChartFrame from "@components/features/independence/ChartFrame"
+import { ageAxisDomain, ageAxisTicks } from "@lib/independence/ageAxis"
 import Spinner from "@components/ui/Spinner"
 import type { RetirementPlan, RetirementProjection } from "types/independence"
 import type { ScenarioState } from "./scenario/types"
@@ -167,6 +168,24 @@ export default function PlanFiOverviewTab({
     if (fiNumber <= 0 || !chartData.length) return null
     return chartData.find((r) => r.endingBalance >= fiNumber)?.age ?? null
   }, [chartData, fiNumber])
+
+  // Always span current age → life expectancy, even when the trajectory
+  // depletes earlier or runs past it.
+  const ageAxis = useMemo(() => {
+    const [minAge, maxAge] = ageAxisDomain(
+      currentAge,
+      plan.lifeExpectancy,
+      chartData.map((r) => r.age),
+    )
+    return {
+      domain: [minAge, maxAge] as [number, number],
+      ticks: ageAxisTicks(
+        minAge,
+        maxAge,
+        fiCrossingAge != null ? [fiCrossingAge] : [],
+      ),
+    }
+  }, [chartData, currentAge, plan.lifeExpectancy, fiCrossingAge])
 
   const gap = Math.abs(fiMetrics?.gapToFi ?? fiNumber - currentLiquid)
   const fiProgress =
@@ -360,6 +379,11 @@ export default function PlanFiOverviewTab({
             />
             <XAxis
               dataKey="age"
+              type="number"
+              scale="linear"
+              domain={ageAxis.domain}
+              ticks={ageAxis.ticks}
+              allowDataOverflow
               tick={{ fontSize: 11, fill: "#94a3b8" }}
               tickLine={false}
               axisLine={false}

--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -17,6 +17,7 @@ import CollapsibleSection from "@components/ui/CollapsibleSection"
 import { RetirementProjection } from "types/independence"
 import { HIDDEN_VALUE } from "@lib/independence/planHelpers"
 import { netHousingValue } from "@lib/independence/wealthJourneyChartData"
+import { ageAxisDomain, ageAxisTicks } from "@lib/independence/ageAxis"
 import { IncomeBreakdownTable } from "@components/features/independence"
 import Spinner from "@components/ui/Spinner"
 
@@ -151,6 +152,23 @@ export default function TimelineTabContent({
     [fullJourneyData],
   )
 
+  // Age axis pinned to (current age → life expectancy) so both charts share
+  // the same horizon even when the trajectory depletes before life expectancy.
+  const ageAxis = useMemo(() => {
+    const ages = fullJourneyData
+      .map((d) => d.age)
+      .filter((a): a is number => a !== undefined)
+    const [minAge, maxAge] = ageAxisDomain(undefined, lifeExpectancy, ages)
+    return {
+      domain: [minAge, maxAge] as [number, number],
+      ticks: ageAxisTicks(
+        minAge,
+        maxAge,
+        [retirementAge, fiAchievementAge].filter((a): a is number => a != null),
+      ),
+    }
+  }, [fullJourneyData, lifeExpectancy, retirementAge, fiAchievementAge])
+
   // Merge FIRE path projections into chart data
   const chartDataWithFirePath = useMemo(() => {
     const firePathProjections = projection?.firePathProjections
@@ -256,40 +274,11 @@ export default function TimelineTabContent({
                 offset: -10,
               }}
               tick={{ fontSize: 12 }}
-              domain={[
-                (dataMin: number) =>
-                  Math.min(
-                    dataMin,
-                    retirementAge ? retirementAge - 3 : dataMin,
-                  ),
-                "dataMax",
-              ]}
+              type="number"
+              scale="linear"
+              domain={ageAxis.domain}
+              ticks={ageAxis.ticks}
               allowDataOverflow={true}
-              ticks={(() => {
-                const ages = fullJourneyData
-                  .map((d) => d.age)
-                  .filter((a): a is number => a !== undefined)
-                if (ages.length === 0) return undefined
-                const minAge = Math.min(...ages)
-                const maxAge = Math.max(...ages)
-                const range = maxAge - minAge
-                const step = range <= 30 ? 5 : 10
-                const ticks: number[] = []
-                for (
-                  let age = Math.ceil(minAge / step) * step;
-                  age <= maxAge;
-                  age += step
-                ) {
-                  ticks.push(age)
-                }
-                if (retirementAge && !ticks.includes(retirementAge)) {
-                  ticks.push(retirementAge)
-                }
-                if (fiAchievementAge && !ticks.includes(fiAchievementAge)) {
-                  ticks.push(fiAchievementAge)
-                }
-                return ticks.sort((a, b) => a - b)
-              })()}
             />
             <YAxis
               tickFormatter={(value) =>
@@ -525,6 +514,11 @@ export default function TimelineTabContent({
                 offset: -10,
               }}
               tick={{ fontSize: 12 }}
+              type="number"
+              scale="linear"
+              domain={ageAxis.domain}
+              ticks={ageAxis.ticks}
+              allowDataOverflow={true}
             />
             <YAxis
               tickFormatter={(value) =>

--- a/src/components/features/independence/composite/tabs/FiOverviewTab.tsx
+++ b/src/components/features/independence/composite/tabs/FiOverviewTab.tsx
@@ -11,6 +11,7 @@ import {
   ReferenceArea,
 } from "recharts"
 import ChartFrame from "@components/features/independence/ChartFrame"
+import { ageAxisDomain, ageAxisTicks } from "@lib/independence/ageAxis"
 import Spinner from "@components/ui/Spinner"
 import Alert from "@components/ui/Alert"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
@@ -181,6 +182,27 @@ export default function FiOverviewTab(): React.ReactElement | null {
     if (fiNumber <= 0 || !chartData.length) return null
     return chartData.find((r) => r.endingBalance >= fiNumber)?.age ?? null
   }, [chartData, fiNumber])
+
+  // Always span current age → life expectancy (longest plan horizon in the
+  // composite), even when the trajectory depletes earlier or runs past it.
+  const ageAxis = useMemo(() => {
+    const lifeExpectancy = plans.length
+      ? Math.max(...plans.map((p) => p.lifeExpectancy))
+      : undefined
+    const [minAge, maxAge] = ageAxisDomain(
+      currentAge,
+      lifeExpectancy,
+      chartData.map((r) => r.age),
+    )
+    return {
+      domain: [minAge, maxAge] as [number, number],
+      ticks: ageAxisTicks(
+        minAge,
+        maxAge,
+        fiCrossingAge != null ? [fiCrossingAge] : [],
+      ),
+    }
+  }, [chartData, currentAge, plans, fiCrossingAge])
 
   const currentLiquid = projection?.liquidAssets ?? 0
   const isAchieved = fiNumber > 0 && currentLiquid >= fiNumber
@@ -395,6 +417,11 @@ export default function FiOverviewTab(): React.ReactElement | null {
             />
             <XAxis
               dataKey="age"
+              type="number"
+              scale="linear"
+              domain={ageAxis.domain}
+              ticks={ageAxis.ticks}
+              allowDataOverflow
               tick={{ fontSize: 11, fill: "#94a3b8" }}
               tickLine={false}
               axisLine={false}

--- a/src/lib/utils/independence/ageAxis.test.ts
+++ b/src/lib/utils/independence/ageAxis.test.ts
@@ -1,0 +1,45 @@
+import { ageAxisDomain, ageAxisTicks } from "./ageAxis"
+
+describe("ageAxisDomain", () => {
+  it("spans currentAge → lifeExpectancy regardless of data range", () => {
+    // Data depletes at 80, but axis must still reach life expectancy 90.
+    expect(ageAxisDomain(45, 90, [45, 60, 80])).toEqual([45, 90])
+  })
+
+  it("extends to lifeExpectancy even if data runs past it", () => {
+    expect(ageAxisDomain(45, 90, [45, 95, 100])).toEqual([45, 90])
+  })
+
+  it("falls back to data range when age inputs are missing", () => {
+    expect(ageAxisDomain(undefined, undefined, [50, 70])).toEqual([50, 70])
+  })
+
+  it("guards a degenerate range", () => {
+    const [min, max] = ageAxisDomain(90, 90, [90])
+    expect(max).toBeGreaterThan(min)
+  })
+})
+
+describe("ageAxisTicks", () => {
+  it("pins both endpoints", () => {
+    const ticks = ageAxisTicks(45, 90)
+    expect(ticks[0]).toBe(45)
+    expect(ticks[ticks.length - 1]).toBe(90)
+  })
+
+  it("uses 5-year steps for a <=30y span", () => {
+    expect(ageAxisTicks(45, 60)).toEqual([45, 50, 55, 60])
+  })
+
+  it("folds in extra ages inside the range, de-duped and sorted", () => {
+    const ticks = ageAxisTicks(45, 90, [60, 67])
+    expect(ticks).toContain(60)
+    expect(ticks).toContain(67)
+    expect([...ticks]).toEqual([...ticks].sort((a, b) => a - b))
+    expect(new Set(ticks).size).toBe(ticks.length)
+  })
+
+  it("ignores extras outside the range", () => {
+    expect(ageAxisTicks(45, 60, [90])).not.toContain(90)
+  })
+})

--- a/src/lib/utils/independence/ageAxis.ts
+++ b/src/lib/utils/independence/ageAxis.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared X-axis configuration for independence projection charts.
+ *
+ * Product rule: the age axis must ALWAYS span the user's current age through
+ * their life expectancy — even when the projection data stops earlier (e.g. the
+ * portfolio depletes) or runs past it. Pinning the domain keeps every chart on
+ * the same horizon so the "runway vs. shortfall" story reads consistently.
+ */
+
+/**
+ * Domain `[minAge, maxAge]` for the age axis. Prefers the explicit
+ * currentAge / lifeExpectancy; falls back to the data range when either is
+ * missing, and guards against an inverted/degenerate range.
+ */
+export function ageAxisDomain(
+  currentAge: number | undefined,
+  lifeExpectancy: number | undefined,
+  ages: number[] = [],
+): [number, number] {
+  const valid = ages.filter((a) => Number.isFinite(a))
+  const dataMin = valid.length ? Math.min(...valid) : (currentAge ?? 0)
+  const dataMax = valid.length
+    ? Math.max(...valid)
+    : (lifeExpectancy ?? dataMin)
+  const min = currentAge ?? dataMin
+  const max = lifeExpectancy ?? dataMax
+  if (min < max) return [min, max]
+  // Degenerate (missing/equal/inverted) — widen to cover whatever we have.
+  return [Math.min(min, dataMin), Math.max(max, dataMax, min + 1)]
+}
+
+/**
+ * Readable tick array across `[min, max]`. 5-year steps for ≤30y spans,
+ * 10-year otherwise; always pins the endpoints and folds in any `extras`
+ * (e.g. retirement / FI ages) that fall strictly inside the range.
+ */
+export function ageAxisTicks(
+  min: number,
+  max: number,
+  extras: number[] = [],
+): number[] {
+  if (!(max > min)) return [min]
+  const step = max - min <= 30 ? 5 : 10
+  const ticks: number[] = [min]
+  for (let a = Math.ceil(min / step) * step; a <= max; a += step) {
+    if (a > min && a < max) ticks.push(a)
+  }
+  ticks.push(max)
+  for (const e of extras) {
+    if (Number.isFinite(e) && e > min && e < max) ticks.push(e)
+  }
+  return [...new Set(ticks)].sort((a, b) => a - b)
+}


### PR DESCRIPTION
## Axis — always span current age → life expectancy
Projection charts let the age axis auto-fit the data, so when a trajectory depletes before life expectancy (or runs past it) the axis stopped short and charts disagreed on horizon. New shared helper `lib/utils/independence/ageAxis.ts` (`ageAxisDomain` + `ageAxisTicks`) pins the X domain to `[currentAge, lifeExpectancy]` with readable, endpoint-pinned ticks (retirement / FI ages folded in).

Applied to the balance-trajectory charts where truncation showed:
- `PlanFiOverviewTab` (single plan)
- `TimelineTabContent` (both balance + cashflow charts)
- composite `FiOverviewTab` (life expectancy = longest plan horizon)

(WealthJourneyTab plots total-wealth area that already spans the full horizon and reads life expectancy only via context — left as-is.)

## Income Breakdown — clarify the "Investment" column
The column is the net-of-fee blended return on the **liquid investment portfolio only** (cash + equity allocation, minus fees) — it is NOT all-asset growth. CPF, pensions/policies and property grow on their own schedules and surface in their own columns (Pension / Private Pension / Rental / housing value). The old "Investment / Returns on portfolio" label read as spendable income and confused users when it compounded pre-FI then ran down post-FI.

- Header `Investment` → `Investment Growth`, with a tooltip.
- Legend rewritten: net-of-fee return on the investment portfolio; compounds each year incl. in independence while capital is also drawn down (see Withdrawals); excludes CPF, pensions & property.

## Tests
- `ageAxis.test.ts` (8): domain pins to LE regardless of data range, fallbacks, tick stepping/dedupe/extras.
- typecheck + lint clean; existing independence suites green.

> Visual note: axis change is structural (Recharts category → numeric age axis with explicit domain/ticks). Worth a glance post-deploy on a depleting plan (e.g. Mary, cash-only) to confirm the right-hand gap to life expectancy renders.

@coderabbitai ignore