### PR TITLE
feat(independence): on-track verdict under the header FI gauge

### DIFF
--- a/src/components/features/independence/ScenarioBar.tsx
+++ b/src/components/features/independence/ScenarioBar.tsx
@@ -5,6 +5,7 @@ import type { ScenarioState } from "./scenario/types"
 import StrategyGaugesStrip from "./StrategyGaugesStrip"
 import { STRATEGY_VIEW_LABELS, type StrategyView } from "./strategyView"
 import WhatIfSlider from "./WhatIfSlider"
+import type { OnTrackStatus } from "@lib/independence/onTrack"
 
 export interface ScenarioBarProps {
   scenario: ScenarioState
@@ -20,6 +21,12 @@ export interface ScenarioBarProps {
   currency: string
   /** Live FiMetrics from the most recent projection. */
   fiMetrics?: FiMetrics
+  /**
+   * Whether the projected plan covers retirement (funds last to life
+   * expectancy). Distinct from the accumulation gauge — null while
+   * calculating or when life expectancy is unknown.
+   */
+  onTrack?: OnTrackStatus | null
   /** Active strategy view — drives the headline gauge + FiMetrics sections. */
   view: StrategyView
   onViewChange: (next: StrategyView) => void
@@ -56,6 +63,7 @@ export default function ScenarioBar({
   isDirty,
   currency,
   fiMetrics,
+  onTrack,
   view,
   onViewChange,
   derivedLiquidAssets,
@@ -79,7 +87,9 @@ export default function ScenarioBar({
   return (
     <div className="sticky top-0 z-30 bg-white border-b shadow-sm mb-3">
       <div className="px-4 py-2">
-        {/* Headline gauge (horizontal bar) on its own row. */}
+        {/* Headline gauge (horizontal bar) on its own row, with the on-track
+            verdict beneath it — the gauge shows today's progress, the verdict
+            shows whether the projected plan actually lasts to life expectancy. */}
         <div className="mb-2">
           <StrategyGaugesStrip
             fiMetrics={fiMetrics}
@@ -87,6 +97,31 @@ export default function ScenarioBar({
             view={view}
             singleHeadline
           />
+          {onTrack && (
+            <div
+              className={`mt-1.5 flex items-center gap-1.5 text-sm font-medium ${
+                onTrack.onTrack ? "text-green-600" : "text-amber-600"
+              }`}
+            >
+              <i
+                className={`fas ${
+                  onTrack.onTrack
+                    ? "fa-circle-check"
+                    : "fa-triangle-exclamation"
+                }`}
+              ></i>
+              {onTrack.onTrack ? (
+                <span>
+                  On track — funds last to age {onTrack.lifeExpectancy}
+                </span>
+              ) : (
+                <span>
+                  Off track — savings run out at age {onTrack.depletionAge} (~
+                  {onTrack.yearsShort}yr short of age {onTrack.lifeExpectancy})
+                </span>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Control row — accordion toggle on the left, view/reset/save on the

--- a/src/lib/utils/independence/onTrack.test.ts
+++ b/src/lib/utils/independence/onTrack.test.ts
@@ -1,0 +1,32 @@
+import { deriveOnTrackStatus } from "./onTrack"
+
+describe("deriveOnTrackStatus", () => {
+  it("is on track when the portfolio never depletes (null age)", () => {
+    expect(deriveOnTrackStatus(null, 90)).toEqual({
+      onTrack: true,
+      lifeExpectancy: 90,
+      depletionAge: undefined,
+      yearsShort: 0,
+    })
+  })
+
+  it("is on track when depletion is at or beyond life expectancy", () => {
+    expect(deriveOnTrackStatus(90, 90)?.onTrack).toBe(true)
+    expect(deriveOnTrackStatus(95, 90)?.onTrack).toBe(true)
+  })
+
+  it("is off track when the portfolio depletes before life expectancy", () => {
+    const status = deriveOnTrackStatus(78, 83)
+    expect(status).toEqual({
+      onTrack: false,
+      lifeExpectancy: 83,
+      depletionAge: 78,
+      yearsShort: 5,
+    })
+  })
+
+  it("returns null when life expectancy is unknown", () => {
+    expect(deriveOnTrackStatus(78, undefined)).toBeNull()
+    expect(deriveOnTrackStatus(78, 0)).toBeNull()
+  })
+})

--- a/src/lib/utils/independence/onTrack.ts
+++ b/src/lib/utils/independence/onTrack.ts
@@ -1,0 +1,34 @@
+/**
+ * "On track" verdict for an independence plan.
+ *
+ * Distinct from the accumulation progress gauge (today's liquid ÷ FI number):
+ * this answers whether the *projected* plan actually covers retirement — i.e.
+ * the portfolio does not run dry before life expectancy. `depletionAge` is the
+ * first age the ending balance hits zero under net withdrawals (expenses minus
+ * guaranteed income), so it already accounts for CPF LIFE / pensions: a plan
+ * whose income fully covers expenses never depletes and reads as on track.
+ */
+export interface OnTrackStatus {
+  /** True when funds last to (or beyond) life expectancy. */
+  onTrack: boolean
+  /** Life expectancy the verdict is measured against. */
+  lifeExpectancy: number
+  /** Age the portfolio runs dry — only set when off track. */
+  depletionAge?: number
+  /** Years the money falls short of life expectancy (0 when on track). */
+  yearsShort: number
+}
+
+export function deriveOnTrackStatus(
+  depletionAge: number | null | undefined,
+  lifeExpectancy: number | undefined,
+): OnTrackStatus | null {
+  if (lifeExpectancy == null || lifeExpectancy <= 0) return null
+  const depletes = depletionAge != null && depletionAge < lifeExpectancy
+  return {
+    onTrack: !depletes,
+    lifeExpectancy,
+    depletionAge: depletes ? depletionAge : undefined,
+    yearsShort: depletes ? lifeExpectancy - depletionAge : 0,
+  }
+}

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -57,6 +57,7 @@ import {
   manualAssetsToSlices,
 } from "@lib/independence/planHelpers"
 import { buildCpfSubAccountRows } from "@lib/independence/cpfSubAccountTags"
+import { deriveOnTrackStatus } from "@lib/independence/onTrack"
 
 function PlanView(): React.ReactElement {
   const router = useRouter()
@@ -972,6 +973,10 @@ function PlanView(): React.ReactElement {
               isDirty={scenarioIsDirty}
               currency={effectiveCurrency}
               fiMetrics={adjustedProjection?.fiMetrics}
+              onTrack={deriveOnTrackStatus(
+                adjustedProjection?.depletionAge,
+                scenario.lifeExpectancy,
+              )}
               view={
                 strategyView ??
                 defaultStrategyView(adjustedProjection?.effectiveStrategy)


### PR DESCRIPTION
## Why
The header gauge (e.g. "Retirement-Age FI 73.5%") shows *today's accumulation* progress — it doesn't answer the question the user actually asks: **am I on track to cover retirement?** A plan can read 73.5% accumulated yet still run the portfolio dry before life expectancy.

## What
Adds a one-line verdict directly under the header gauge (sticky ScenarioBar, visible on every tab):
- **On track** — funds last to age {lifeExpectancy} (green ✓)
- **Off track** — savings run out at age {depletionAge} (~{n}yr short of age {lifeExpectancy}) (amber ⚠)

**Definition:** on track iff the projected portfolio does not deplete before life expectancy (`depletionAge == null || depletionAge >= lifeExpectancy`). `depletionAge` is the first year ending balance hits zero under *net* withdrawals (expenses − guaranteed income), so it already accounts for CPF LIFE / pensions — a plan whose income covers expenses never depletes and reads on track. Recomputes live as scenario sliders move.

## Files
- `lib/independence/onTrack.ts` — `deriveOnTrackStatus()` (pure, unit-tested).
- `ScenarioBar.tsx` — renders the verdict under the headline gauge.
- `plans/[id].tsx` — computes from `adjustedProjection.depletionAge` + effective `scenario.lifeExpectancy`.

## Tests
- `onTrack.test.ts` (4): null/≥LE → on track; depletes-before-LE → off track w/ years-short; null LE → no verdict.
- Full independence suite green (366), typecheck + lint clean.

@coderabbitai ignore