### PR TITLE
chore(deps): upgrade amqplib 1.0.3 → 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@opentelemetry/core": "^2.6.1",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
     "@sentry/nextjs": "^10.47.0",
-    "amqplib": "^1.0.3",
+    "amqplib": "^2.0.1",
     "auth0": "^5.12.0",
     "baseline-browser-mapping": "^2.9.19",
     "js-yaml": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2573,12 +2573,10 @@ ajv@^6.14.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-amqplib@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-1.2.0.tgz#1d51aca21584647f2a517234db75912c26899339"
-  integrity sha512-WVvkHAaL848/zjpJXXnN/80nPhCrwxlXWQFHTRDjbEGkwaKK+Ht+8iAC4LeKEzQTOJKxNnUGVLNy/70iFHkeEg==
-  dependencies:
-    buffer-more-ints "~1.0.0"
+amqplib@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-2.0.1.tgz#7f14517c1d5f6e8608cf0abf4df817e923eb59b6"
+  integrity sha512-a3P2MgfCf9nzVis12VxWEn0dS6hcqve7dlEAhXDtIWR27BlhtMkILOc+H9aeHjDi6i6r94dYKc2Kx2OFe3avvg==
 
 ansi-escapes@^4.3.2:
   version "4.3.2"
@@ -2941,11 +2939,6 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
-buffer-more-ints@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz#ef4f8e2dddbad429ed3828a9c55d44f05c611422"
-  integrity sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
**Upgrade:**
- amqplib 1.0.3 → 2.0.1 (major version)

Major version bump. bc-view imports amqplib but doesn't actively use it (likely transitive). No observable impact expected.

**Testing:**
- ✅ yarn typecheck
- ✅ yarn lint
- ✅ yarn build
- ✅ yarn test (pre-commit hook)

@coderabbitai ignore