### PR TITLE
chore(renovate): fix config & change schedule to 6 AM Singapore time

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,8 +1,8 @@
 name: Renovate
 on:
   schedule:
-    # Run every Monday at 6:00 AM Pacific/Auckland time (UTC+12/+13)
-    - cron: "0 17 * * 0" # Sunday 5 PM UTC = Monday 6 AM NZDT / Monday 5 AM NZST
+    # Run every Monday at 6:00 AM Singapore time (UTC+8)
+    - cron: "0 22 * * 0" # Sunday 10 PM UTC = Monday 6 AM SGT
   workflow_dispatch:
     inputs:
       logLevel:

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     ":dependencyDashboard",
     ":semanticCommits"
   ],
-  "timezone": "Pacific/Auckland",
+  "timezone": "Asia/Singapore",
   "labels": ["dependencies"],
   "assignees": ["@mikeh"],
   "reviewers": ["@mikeh"],
@@ -26,9 +26,10 @@
       "matchPackageNames": ["/^@types//"]
     },
     {
-      "description": "Group ESLint packages together",
+      "description": "Group ESLint packages together, separate major versions",
       "groupName": "ESLint packages",
-      "matchPackageNames": ["/eslint/", "/@typescript-eslint//"]
+      "matchPackageNames": ["/eslint/", "/@typescript-eslint//"],
+      "separateMajorMinor": true
     },
     {
       "description": "Group testing packages together",
@@ -54,11 +55,18 @@
       "separateMinorPatch": true
     },
     {
-      "description": "Auto-merge minor and patch updates for dev dependencies",
+      "description": "Do NOT auto-merge major versions for ESLint/TypeScript in devDependencies",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "matchPackageNames": ["/eslint/", "/@typescript-eslint//", "/^typescript$/"]
+    },
+    {
+      "description": "Auto-merge minor and patch updates for other dev dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
-      "matchPackageNames": ["!/^typescript$/", "!/^@typescript-eslint//"]
+      "matchPackageNames": ["!/^typescript$/", "!/^@typescript-eslint//", "!/eslint/"]
     }
   ],
   "vulnerabilityAlerts": {
@@ -80,6 +88,5 @@
   "prTitle": "{{commitMessagePrefix}} {{commitMessageAction}} {{commitMessageTopic}} {{commitMessageExtra}}",
   "prBodyTemplate": "This PR updates {{depName}} from `{{currentVersion}}` to `{{newVersion}}`.\n\n{{#if hasReleaseNotes}}**Release Notes:**\n{{{releaseNotes}}}{{/if}}\n\n{{#if hasChangelog}}**Changelog:**\n{{{changelog}}}{{/if}}\n\n---\n*This PR was generated automatically by Renovate Bot.*",
   "rangeStrategy": "bump",
-  "ignoreTests": false,
   "automergeStrategy": "squash"
 }


### PR DESCRIPTION
**Changes:**
- Fix invalid \`ignoreTests\` option in renovate.json
- Separate ESLint major versions (no auto-merge)
- Change schedule from 6 AM NZ time (UTC+17) to 6 AM Singapore time (UTC+8)
- Update timezone from Pacific/Auckland to Asia/Singapore

**Cron change:**
- Old: `0 17 * * 0` (Sunday 5 PM UTC → Monday 6 AM NZDT/5 AM NZST)
- New: `0 22 * * 0` (Sunday 10 PM UTC → Monday 6 AM SGT)

@coderabbitai ignore