### PR TITLE
feat(independence): show whether income rises with inflation or stays fixed

### DIFF
--- a/__tests__/components/features/independence/IncomeBreakdownTable.test.tsx
+++ b/__tests__/components/features/independence/IncomeBreakdownTable.test.tsx
@@ -1,0 +1,64 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { IncomeBreakdownTable } from "@components/features/independence"
+import { YearlyProjection, ValueBasis } from "types/independence"
+
+function makeYear(overrides: Partial<YearlyProjection> = {}): YearlyProjection {
+  return {
+    year: 2030,
+    age: 65,
+    startingBalance: 100000,
+    investment: 4000,
+    withdrawals: 0,
+    endingBalance: 104000,
+    inflationAdjustedExpenses: 30000,
+    currency: "SGD",
+    nonSpendableValue: 0,
+    totalWealth: 104000,
+    incomeBreakdown: {
+      investmentReturns: 4000,
+      pension: 12000,
+      socialSecurity: 6000,
+      otherIncome: 0,
+      rentalIncome: 0,
+      totalIncome: 22000,
+    },
+    ...overrides,
+  }
+}
+
+describe("IncomeBreakdownTable value basis", () => {
+  it("shows the future dollars caption in plain language", () => {
+    render(<IncomeBreakdownTable projections={[makeYear()]} />)
+    expect(screen.getByText(/future dollars/i)).toBeInTheDocument()
+  })
+
+  it("tags pension as 'stays same' when the backend flag says it is not indexed", () => {
+    const valueBasis: ValueBasis = {
+      balanceBasis: "NOMINAL_FUTURE",
+      incomeStreams: [
+        { key: "pension", inflationIndexed: false },
+        { key: "socialSecurity", inflationIndexed: true },
+      ],
+    }
+    render(
+      <IncomeBreakdownTable
+        projections={[makeYear()]}
+        valueBasis={valueBasis}
+      />,
+    )
+    // Pension column header shows it stays the same each year.
+    const pensionHeader = screen.getByText("Pension").closest("th")
+    expect(pensionHeader).toHaveTextContent("stays same")
+    // Govt Benefits column shows it rises with inflation.
+    const govHeader = screen.getByText("Govt Benefits").closest("th")
+    expect(govHeader).toHaveTextContent("rises")
+  })
+
+  it("falls back to defaults (pension stays same) when valueBasis is absent", () => {
+    render(<IncomeBreakdownTable projections={[makeYear()]} />)
+    const pensionHeader = screen.getByText("Pension").closest("th")
+    expect(pensionHeader).toHaveTextContent("stays same")
+  })
+})

--- a/src/components/features/independence/DetailsTabContent.tsx
+++ b/src/components/features/independence/DetailsTabContent.tsx
@@ -10,6 +10,7 @@ import {
   PlanFindingsCard,
 } from "@components/features/independence"
 import { applyRealReturn } from "@components/features/independence/scenario/scenarioToPayload"
+import { isStreamInflationIndexed } from "@lib/independence/valueBasis"
 import type { ScenarioState } from "@components/features/independence/scenario/types"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
 
@@ -86,6 +87,14 @@ export default function DetailsTabContent({
       displayRentalIncome,
   )
 
+  // Backend-driven: is the pension stream inflation-indexed? When false (the
+  // common case for employer pensions) we flag the figure as fixed nominal so
+  // users don't misread it as today's value.
+  const pensionIndexed = isStreamInflationIndexed(
+    projection?.valueBasis,
+    "pension",
+  )
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       {/* Plan Details */}
@@ -119,15 +128,23 @@ export default function DetailsTabContent({
                 : `${detailsCurrency}${Math.round(displayExpenses).toLocaleString()}`}
             </span>
           </div>
-          <div className="flex justify-between">
-            <span className="text-gray-500">{"Pension"}</span>
-            <span
-              className={`font-medium ${hideValues ? "text-gray-400" : ""}`}
-            >
-              {hideValues
-                ? HIDDEN_VALUE
-                : `${detailsCurrency}${Math.round(displayPension).toLocaleString()}`}
-            </span>
+          <div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">{"Pension"}</span>
+              <span
+                className={`font-medium ${hideValues ? "text-gray-400" : ""}`}
+              >
+                {hideValues
+                  ? HIDDEN_VALUE
+                  : `${detailsCurrency}${Math.round(displayPension).toLocaleString()}`}
+              </span>
+            </div>
+            {pensionIndexed === false && displayPension > 0 && (
+              <p className="text-xs text-amber-700 mt-0.5">
+                This amount stays the same every year, so it buys less over time
+                as prices rise.
+              </p>
+            )}
           </div>
           <div className="flex justify-between">
             <span className="text-gray-500">{"Government Benefits"}</span>

--- a/src/components/features/independence/IncomeBreakdownTable.tsx
+++ b/src/components/features/independence/IncomeBreakdownTable.tsx
@@ -1,17 +1,50 @@
 import React, { useState, useMemo } from "react"
-import { YearlyProjection } from "types/independence"
+import { YearlyProjection, ValueBasis } from "types/independence"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
+import { isStreamInflationIndexed } from "@lib/independence/valueBasis"
 
 const HIDDEN_VALUE = "****"
+
+/**
+ * Small inline tag showing whether an income column goes up each year with
+ * rising prices ("rises") or stays the same ("stays same"). Driven entirely by
+ * the backend `valueBasis` flag (via {@link isStreamInflationIndexed}).
+ * Renders nothing when the flag is unknown.
+ */
+function IndexationTag({
+  indexed,
+}: {
+  indexed: boolean | undefined
+}): React.ReactElement | null {
+  if (indexed === undefined) return null
+  return indexed ? (
+    <span
+      className="ml-1 align-middle text-[10px] font-medium text-emerald-700 bg-emerald-100 rounded px-1 py-0.5 cursor-help"
+      title="Goes up each year to keep up with rising prices (inflation)."
+    >
+      rises
+    </span>
+  ) : (
+    <span
+      className="ml-1 align-middle text-[10px] font-medium text-amber-700 bg-amber-100 rounded px-1 py-0.5 cursor-help"
+      title="Stays the same every year, so it buys less over time as prices rise."
+    >
+      stays same
+    </span>
+  )
+}
 
 interface IncomeBreakdownTableProps {
   projections: YearlyProjection[]
   embedded?: boolean
+  /** Backend-supplied value basis driving the inflation-indexed indicators. */
+  valueBasis?: ValueBasis
 }
 
 export default function IncomeBreakdownTable({
   projections,
   embedded = false,
+  valueBasis,
 }: IncomeBreakdownTableProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
   const { hideValues } = usePrivacyMode()
@@ -106,6 +139,19 @@ export default function IncomeBreakdownTable({
 
   const tableContent = (
     <>
+      <p className="mb-3 text-xs text-gray-600 flex items-start gap-1.5">
+        <i className="fas fa-info-circle text-gray-400 mt-0.5"></i>
+        <span>
+          All amounts are shown in{" "}
+          <span className="font-semibold">future dollars</span> — what
+          you&apos;d actually receive or spend in each year, not today&apos;s
+          prices. Income marked{" "}
+          <span className="text-emerald-700 font-medium">rises</span> goes up
+          each year to keep up with rising prices;{" "}
+          <span className="text-amber-700 font-medium">stays same</span> is a
+          flat amount that buys less over time.
+        </span>
+      </p>
       <div className="overflow-x-auto">
         <table className="min-w-full text-sm">
           <thead>
@@ -126,11 +172,20 @@ export default function IncomeBreakdownTable({
               {columnVisibility.pension && (
                 <th className="text-right py-2 px-2 font-medium text-gray-600">
                   <span className="text-blue-600">Pension</span>
+                  <IndexationTag
+                    indexed={isStreamInflationIndexed(valueBasis, "pension")}
+                  />
                 </th>
               )}
               {columnVisibility.assetPensions && (
                 <th className="text-right py-2 px-2 font-medium text-gray-600">
                   <span className="text-indigo-600">Private Pension</span>
+                  <IndexationTag
+                    indexed={isStreamInflationIndexed(
+                      valueBasis,
+                      "assetPensions",
+                    )}
+                  />
                 </th>
               )}
               {columnVisibility.lumpSum && (
@@ -141,16 +196,34 @@ export default function IncomeBreakdownTable({
               {columnVisibility.socialSecurity && (
                 <th className="text-right py-2 px-2 font-medium text-gray-600">
                   <span className="text-purple-600">Govt Benefits</span>
+                  <IndexationTag
+                    indexed={isStreamInflationIndexed(
+                      valueBasis,
+                      "socialSecurity",
+                    )}
+                  />
                 </th>
               )}
               {columnVisibility.otherIncome && (
                 <th className="text-right py-2 px-2 font-medium text-gray-600">
                   <span className="text-independence-600">Other</span>
+                  <IndexationTag
+                    indexed={isStreamInflationIndexed(
+                      valueBasis,
+                      "otherIncome",
+                    )}
+                  />
                 </th>
               )}
               {columnVisibility.rentalIncome && (
                 <th className="text-right py-2 px-2 font-medium text-gray-600">
                   <span className="text-teal-600">Rental</span>
+                  <IndexationTag
+                    indexed={isStreamInflationIndexed(
+                      valueBasis,
+                      "rentalIncome",
+                    )}
+                  />
                 </th>
               )}
               {columnVisibility.lifeEvents && (
@@ -349,13 +422,13 @@ export default function IncomeBreakdownTable({
               <span className="font-medium text-purple-600">
                 Govt Benefits:
               </span>{" "}
-              Inflation-indexed
+              Rises with inflation
             </span>
           )}
           {columnVisibility.otherIncome && (
             <span>
               <span className="font-medium text-independence-600">Other:</span>{" "}
-              Not indexed
+              Stays the same
             </span>
           )}
           {columnVisibility.rentalIncome && (

--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -650,6 +650,7 @@ export default function TimelineTabContent({
               }),
             ]
           })()}
+          valueBasis={projection.valueBasis}
           embedded
         />
       </CollapsibleSection>

--- a/src/lib/utils/independence/valueBasis.test.ts
+++ b/src/lib/utils/independence/valueBasis.test.ts
@@ -1,0 +1,45 @@
+import { ValueBasis } from "types/independence"
+import { isStreamInflationIndexed } from "./valueBasis"
+
+describe("isStreamInflationIndexed", () => {
+  const valueBasis: ValueBasis = {
+    balanceBasis: "NOMINAL_FUTURE",
+    incomeStreams: [
+      { key: "pension", inflationIndexed: false },
+      { key: "socialSecurity", inflationIndexed: true },
+      { key: "rentalIncome", inflationIndexed: true },
+    ],
+  }
+
+  it("returns the backend flag for a known stream (pension is fixed)", () => {
+    expect(isStreamInflationIndexed(valueBasis, "pension")).toBe(false)
+  })
+
+  it("returns the backend flag for an indexed stream (social security)", () => {
+    expect(isStreamInflationIndexed(valueBasis, "socialSecurity")).toBe(true)
+  })
+
+  it("prefers the backend flag over the fallback map when present", () => {
+    // Fallback map defaults pension to false; assert it actually reads the
+    // supplied basis rather than the fallback by flipping the supplied flag.
+    const flipped: ValueBasis = {
+      balanceBasis: "NOMINAL_FUTURE",
+      incomeStreams: [{ key: "pension", inflationIndexed: true }],
+    }
+    expect(isStreamInflationIndexed(flipped, "pension")).toBe(true)
+  })
+
+  it("falls back to known defaults when valueBasis is undefined", () => {
+    expect(isStreamInflationIndexed(undefined, "pension")).toBe(false)
+    expect(isStreamInflationIndexed(undefined, "socialSecurity")).toBe(true)
+    expect(isStreamInflationIndexed(undefined, "rentalIncome")).toBe(true)
+    expect(isStreamInflationIndexed(undefined, "investmentReturns")).toBe(false)
+  })
+
+  it("returns undefined for an unknown stream with no fallback", () => {
+    expect(
+      isStreamInflationIndexed(valueBasis, "mysteryStream"),
+    ).toBeUndefined()
+    expect(isStreamInflationIndexed(undefined, "mysteryStream")).toBeUndefined()
+  })
+})

--- a/src/lib/utils/independence/valueBasis.ts
+++ b/src/lib/utils/independence/valueBasis.ts
@@ -1,0 +1,43 @@
+import { ValueBasis } from "types/independence"
+
+/**
+ * Fallback inflation treatment per income-stream key, used ONLY when the
+ * backend response omits `valueBasis` (older svc-retire builds). When
+ * `valueBasis` IS present the flag MUST come from it — this map is never
+ * consulted in that case. Mirrors the documented svc-retire defaults so
+ * the UI degrades gracefully instead of going silent.
+ *
+ * Keep in sync with the backend's income-stream definitions; the backend
+ * is the source of truth once it ships `valueBasis`.
+ */
+const FALLBACK_INFLATION_INDEXED: Readonly<Record<string, boolean>> = {
+  investmentReturns: false,
+  pension: false,
+  assetPensions: true,
+  socialSecurity: true,
+  otherIncome: false,
+  rentalIncome: true,
+}
+
+/**
+ * Resolve whether a given income stream is inflation-indexed.
+ *
+ * - When `valueBasis` is present, the answer comes from its `incomeStreams`
+ *   flags (backend drives display data). Returns `undefined` for a stream
+ *   the backend didn't describe.
+ * - When `valueBasis` is absent (older backend), falls back to the known
+ *   default map. Returns `undefined` for an unrecognised key.
+ *
+ * `undefined` means "unknown" — callers should render no indexation tag
+ * rather than guess.
+ */
+export function isStreamInflationIndexed(
+  valueBasis: ValueBasis | undefined,
+  key: string,
+): boolean | undefined {
+  if (valueBasis) {
+    const stream = valueBasis.incomeStreams.find((s) => s.key === key)
+    return stream?.inflationIndexed
+  }
+  return FALLBACK_INFLATION_INDEXED[key]
+}

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -661,6 +661,32 @@ export interface Finding {
   detail: string
 }
 
+/**
+ * Inflation treatment for a single income stream within a projection.
+ * `inflationIndexed: true` => the stream rises with inflation each year.
+ * `false` => the stream is a FIXED nominal amount (e.g. most employer
+ * pensions) and does NOT keep pace with inflation in future dollars.
+ */
+export interface IncomeStreamBasis {
+  /** Stream identifier, e.g. "pension", "socialSecurity", "rentalIncome". */
+  key: string
+  /** True when the stream is inflation-indexed; false when fixed nominal. */
+  inflationIndexed: boolean
+}
+
+/**
+ * Describes the value basis of a projection so the UI can tell users
+ * whether figures are in today's or future (nominal) dollars, and which
+ * income streams keep pace with inflation. Backend-driven — the frontend
+ * must NOT re-derive indexation from its own assumptions.
+ */
+export interface ValueBasis {
+  /** e.g. "NOMINAL_FUTURE" — all balances/expenses are inflated future dollars. */
+  balanceBasis: string
+  /** Per-stream inflation treatment. */
+  incomeStreams: IncomeStreamBasis[]
+}
+
 export interface RetirementProjection {
   planId: string
   asOfDate: string
@@ -745,6 +771,12 @@ export interface RetirementProjection {
    * plan projection used the plan owner's data rather than the viewer's.
    */
   debug?: ProjectionDebug
+  /**
+   * Value basis of the projection: whether figures are nominal/future and
+   * which income streams are inflation-indexed. Optional — older backend
+   * responses omit it, in which case the UI falls back to known defaults.
+   */
+  valueBasis?: ValueBasis
 }
 
 export interface ProjectionResponse {


### PR DESCRIPTION
Consumes svc-retire `valueBasis` to make Independence figures clear about current vs future value.

- Income Breakdown: caption (amounts are future dollars) + per-stream tags (rises / stays same) driven by backend flags; pension marked fixed.
- Pension qualifier on My Plan; plain language for non-financial users.
- Graceful fallback when backend omits `valueBasis`.
- Tests: helper + render.

Needs the svc-retire valueBasis PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators in income projection tables showing which income streams rise with inflation versus stay fixed.
  * Enhanced pension details to display a note when the pension amount remains fixed while prices rise.
  * Added clarifying text explaining that projection figures are displayed in future dollars.

* **Tests**
  * Added comprehensive test coverage for inflation-indexing detection and display logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->