### PR TITLE
fix(independence): rename 'Spendable at Independence' to 'Projected funds at Retirement'

### DIFF
--- a/src/components/features/independence/SpendableAtIndependenceCard.tsx
+++ b/src/components/features/independence/SpendableAtIndependenceCard.tsx
@@ -22,7 +22,7 @@ interface SpendableAtIndependenceCardProps {
 }
 
 /**
- * Spendable at Independence — projected liquid assets available to draw down
+ * Projected funds at Retirement — projected liquid assets available to draw down
  * at the independence date. Paired with Sustainable Spending on My Plan so the
  * two headline outcome figures sit together. The figure prefers the backend's
  * pre-retirement accumulation (net of excluded pension FV) and falls back to
@@ -49,7 +49,7 @@ export default function SpendableAtIndependenceCard({
   return (
     <div className={embedded ? "" : "bg-white rounded-xl shadow-md p-6"}>
       <h2 className="text-lg font-semibold text-gray-900 mb-4">
-        Spendable at Independence
+        Projected funds at Retirement
       </h2>
       <div className="space-y-3">
         <div>


### PR DESCRIPTION
User-facing label only; component symbol unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated retirement planning component label text to better clarify projected funds information, enhancing user understanding of the displayed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->