### PR TITLE
feat(independence): off-track header shows what it takes to reach life expectancy

### DIFF
--- a/src/components/features/independence/AssetsTabContent.tsx
+++ b/src/components/features/independence/AssetsTabContent.tsx
@@ -54,6 +54,7 @@ export default function AssetsTabContent({
           retirementAge={retirementAge}
           backendFiMetrics={projection.fiMetrics}
           effectiveStrategy={projection.effectiveStrategy}
+          pathToHorizon={projection.pathToHorizon}
           view={view}
           inflationRate={effectivePlanValues?.inflationRate ?? 0.025}
           equityReturnRate={effectivePlanValues?.equityReturnRate ?? 0.08}

--- a/src/components/features/independence/FiMetrics.tsx
+++ b/src/components/features/independence/FiMetrics.tsx
@@ -1,6 +1,13 @@
 import React from "react"
-import type { FiMetrics as FiMetricsType } from "types/independence"
+import type {
+  FiMetrics as FiMetricsType,
+  PathToHorizon,
+} from "types/independence"
 import type { StrategyView } from "./strategyView"
+import {
+  formatHorizonHeader,
+  formatHorizonGap,
+} from "@utils/independence/pathToHorizon"
 import InfoTooltip from "@components/ui/Tooltip"
 import PrivateCurrency, {
   PrivatePercentage,
@@ -75,6 +82,13 @@ interface FiMetricsProps {
   equityAllocation?: number
   /** Current cash allocation from plan (as decimal) */
   cashAllocation?: number
+  /**
+   * Off-track diagnostic from the backend: present ONLY when the plan's money
+   * runs out before life expectancy. Drives the off-track header + contribution
+   * gap, and suppresses the green "funded" success styling that would otherwise
+   * contradict the My Path chart. Null/absent when on-track.
+   */
+  pathToHorizon?: PathToHorizon | null
 }
 
 /**
@@ -102,6 +116,7 @@ export default function FiMetrics({
   cashReturnRate = 0.03,
   equityAllocation = 0.8,
   cashAllocation = 0.2,
+  pathToHorizon,
 }: FiMetricsProps): React.ReactElement {
   // Per-field aliases keep the rendering code below readable. All fall back
   // to undefined when the backend hasn't computed a value; the render path
@@ -198,6 +213,17 @@ export default function FiMetrics({
     view === "PENSION" || (view === "ALL" && autoPensionEligible)
   const showBridge = view === "HYBRID" || (view === "ALL" && autoBridgeEligible)
 
+  // Off-track path-to-horizon copy (backend-driven). Present only when the plan
+  // depletes before life expectancy — we surface what it takes to reach the
+  // target age rather than letting a green Retirement-Age FI % mislead.
+  const offTrack = pathToHorizon != null
+  const horizonHeader =
+    offTrack && !hideValues
+      ? formatHorizonHeader(pathToHorizon, currency)
+      : null
+  const horizonGap =
+    offTrack && !hideValues ? formatHorizonGap(pathToHorizon, currency) : null
+
   // Active badge tracks the effective (real) strategy, even when the user is
   // peeking at a different view — so the original picture isn't lost.
   const fireActive = effectiveStrategy === "FIRE"
@@ -216,6 +242,21 @@ export default function FiMetrics({
       </div>
 
       <div className="space-y-4">
+        {horizonHeader && (
+          <div className="p-3 rounded-lg border bg-amber-50 border-amber-200">
+            <div className="flex items-center gap-2 text-amber-700">
+              <i className="fas fa-exclamation-triangle"></i>
+              <span className="font-medium">
+                Won&apos;t last to age {pathToHorizon?.targetAge}
+              </span>
+            </div>
+            <p className="text-xs text-amber-700 mt-1">{horizonHeader.text}</p>
+            {horizonGap && (
+              <p className="text-xs text-amber-600 mt-1">{horizonGap}</p>
+            )}
+          </div>
+        )}
+
         {showFire && (
           <>
             <StrategyHeader
@@ -503,6 +544,7 @@ export default function FiMetrics({
             incomeCoverage={backendIncomeCoverageAtRetirement}
             bridgeProgress={backendBridgeProgress}
             isClassicFi={isFi}
+            offTrack={offTrack}
             active={pensionActive}
             hideValues={hideValues}
           />
@@ -565,6 +607,13 @@ interface PensionStrategySectionProps {
    */
   bridgeProgress?: number
   isClassicFi: boolean
+  /**
+   * True when the backend says the plan depletes before life expectancy. When
+   * set, the green "funded" success banner is suppressed and the Retirement-Age
+   * FI gauge is caveated — the off-track header (rendered above) carries the
+   * real headline so a high RETIREMENT_AGE_FI % can't read as success.
+   */
+  offTrack?: boolean
   active?: boolean
   hideValues: boolean
 }
@@ -579,6 +628,7 @@ function PensionStrategySection({
   incomeCoverage,
   bridgeProgress,
   isClassicFi,
+  offTrack,
   active,
   hideValues,
 }: PensionStrategySectionProps): React.ReactElement {
@@ -588,11 +638,15 @@ function PensionStrategySection({
     gauges.push({
       key: "retirement-age-fi",
       label: "Retirement-Age FI",
-      tooltip:
-        "Adds the present value of guaranteed pension/policy income (discounted to today) to your liquid pot before comparing against the FI Number.",
+      tooltip: offTrack
+        ? "Based on the 4% rule, which this plan's returns don't meet — the off-track guidance above carries the real headline. Adds the present value of guaranteed income (discounted to today) to your liquid pot before comparing against the FI Number."
+        : "Adds the present value of guaranteed pension/policy income (discounted to today) to your liquid pot before comparing against the FI Number.",
       value: retirementAgeFiProgress,
       hideValues,
-      format: (v) => `${v.toFixed(1)}%`,
+      format: (v) =>
+        offTrack
+          ? `${v.toFixed(1)}% — based on the 4% rule`
+          : `${v.toFixed(1)}%`,
     })
   }
 
@@ -616,8 +670,11 @@ function PensionStrategySection({
   // user to cut SGD950/mo — the exact contradiction Ruby surfaced.
   const lifetimeFunded =
     retirementAgeFiProgress != null && retirementAgeFiProgress >= 100
+  // Off-track plans never show the green funded banner — the off-track header
+  // above is the authoritative headline; a green "Funded" here would
+  // contradict the My Path chart showing money running out early.
   const fundedBanner: FundedBanner | null =
-    !isClassicFi && !hideValues && lifetimeFunded
+    !isClassicFi && !hideValues && lifetimeFunded && !offTrack
       ? deriveFundedBanner(bridgeProgress)
       : null
 

--- a/src/components/features/independence/ScenarioBar.tsx
+++ b/src/components/features/independence/ScenarioBar.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react"
-import type { FiMetrics } from "types/independence"
+import type { FiMetrics, PathToHorizon } from "types/independence"
 import InfoTooltip from "@components/ui/Tooltip"
+import { usePrivacyMode } from "@hooks/usePrivacyMode"
+import { formatHorizonHeader } from "@utils/independence/pathToHorizon"
 import type { ScenarioState } from "./scenario/types"
 import StrategyGaugesStrip from "./StrategyGaugesStrip"
 import { STRATEGY_VIEW_LABELS, type StrategyView } from "./strategyView"
@@ -36,6 +38,13 @@ export interface ScenarioBarProps {
   planBlendedReturn: number
   /** Plan's own inflation rate, used to anchor realReturn = blended − inflation. */
   planInflation: number
+  /**
+   * Off-track diagnostic from the latest projection: present ONLY when the
+   * plan's money runs out before life expectancy. Drives the warning banner
+   * above the headline gauge and caveats the Retirement-Age FI gauge so a high
+   * % can't read as success. Null/absent when on-track.
+   */
+  pathToHorizon?: PathToHorizon | null
 }
 
 const N0 = (n: number): string => Math.round(n).toLocaleString()
@@ -61,11 +70,24 @@ export default function ScenarioBar({
   derivedLiquidAssets,
   planBlendedReturn,
   planInflation,
+  pathToHorizon,
 }: ScenarioBarProps): React.ReactElement {
+  const { hideValues } = usePrivacyMode()
   // Sliders default-collapsed at every viewport to keep the page chrome
   // minimal. Gauges + action row stay visible. User clicks "Scenario" to
   // expand the slider grid.
   const [collapsed, setCollapsed] = useState(true)
+
+  // Off-track headline (backend-driven). Present only when the plan depletes
+  // before life expectancy — surfaced above the headline gauge so the first
+  // thing users see is what it takes to reach the target age, not a green %.
+  // Numeric copy is suppressed in privacy mode like the rest of the
+  // path-to-horizon text.
+  const offTrack = pathToHorizon != null
+  const horizonHeader =
+    offTrack && !hideValues
+      ? formatHorizonHeader(pathToHorizon, currency)
+      : null
 
   const effectiveLiquidAssets = scenario.liquidAssets ?? derivedLiquidAssets
   const planRealReturn = planBlendedReturn - planInflation
@@ -79,6 +101,23 @@ export default function ScenarioBar({
   return (
     <div className="sticky top-0 z-30 bg-white border-b shadow-sm mb-3">
       <div className="px-4 py-2">
+        {/* Off-track banner — the primary surface. When the plan won't last to
+            life expectancy this warning sits ABOVE the headline gauge so a
+            high Retirement-Age FI % can't read as success. */}
+        {horizonHeader && (
+          <div className="mb-2 p-2 rounded-lg border bg-amber-50 border-amber-200">
+            <div className="flex items-center gap-2 text-amber-700">
+              <i className="fas fa-exclamation-triangle"></i>
+              <span className="font-medium text-sm">
+                Won&apos;t last to age {pathToHorizon?.targetAge}
+              </span>
+            </div>
+            <p className="text-xs text-amber-700 mt-0.5">
+              {horizonHeader.text}
+            </p>
+          </div>
+        )}
+
         {/* Headline gauge (horizontal bar). The on/off-track verdict now lives
             in the Plan Insights list on My Plan, not under the bar. */}
         <div className="mb-2 flex items-start justify-between gap-3">
@@ -88,6 +127,7 @@ export default function ScenarioBar({
               compact
               view={view}
               singleHeadline
+              offTrack={offTrack}
             />
           </div>
           {/* View selector on the progress-bar row. */}

--- a/src/components/features/independence/StrategyGaugesStrip.tsx
+++ b/src/components/features/independence/StrategyGaugesStrip.tsx
@@ -23,6 +23,13 @@ export interface StrategyGaugesStripProps {
    * full strip. Used by the sticky ScenarioBar so the header stays compact.
    */
   singleHeadline?: boolean
+  /**
+   * Backend says the plan depletes before life expectancy. When set, the
+   * Retirement-Age FI gauge is caveated ("based on the 4% rule") so a high %
+   * can't read as success while the off-track header carries the real
+   * headline. Other gauges are unaffected.
+   */
+  offTrack?: boolean
 }
 
 /**
@@ -37,9 +44,13 @@ export default function StrategyGaugesStrip({
   compact = false,
   view = "ALL",
   singleHeadline = false,
+  offTrack = false,
 }: StrategyGaugesStripProps): React.ReactElement {
   const { hideValues } = usePrivacyMode()
-  const ordered = orderGauges(buildGauges(fiMetrics, hideValues), view)
+  const ordered = orderGauges(
+    buildGauges(fiMetrics, hideValues, offTrack),
+    view,
+  )
   const gauges = singleHeadline ? ordered.slice(0, 1) : ordered
 
   const containerClass = compact
@@ -88,6 +99,7 @@ function orderGauges(
 function buildGauges(
   fi: FiMetrics | undefined,
   hideValues: boolean,
+  offTrack: boolean,
 ): PensionGaugeProps[] {
   const fiProgress = fi?.fiProgress ?? 0
   const out: PensionGaugeProps[] = [
@@ -123,11 +135,15 @@ function buildGauges(
     out.push({
       key: "retirement-age-fi",
       label: "Retirement-Age FI",
-      tooltip:
-        "Liquid plus the present value of your guaranteed pension income, compared to your FI Number.",
+      tooltip: offTrack
+        ? "Based on the 4% rule, which this plan's returns don't meet — the off-track guidance above carries the real headline. Adds the present value of your guaranteed pension income (discounted to today) to your liquid pot before comparing against the FI Number."
+        : "Liquid plus the present value of your guaranteed pension income, compared to your FI Number.",
       value: fi.retirementAgeFiProgress,
       hideValues,
-      format: (v) => `${v.toFixed(1)}%`,
+      format: (v) =>
+        offTrack
+          ? `${v.toFixed(1)}% — based on the 4% rule`
+          : `${v.toFixed(1)}%`,
     })
   }
 

--- a/src/components/features/independence/__tests__/FiMetrics.test.tsx
+++ b/src/components/features/independence/__tests__/FiMetrics.test.tsx
@@ -685,4 +685,55 @@ describe("FiMetrics", () => {
       expect(screen.queryByText(/Lifetime funded/)).not.toBeInTheDocument()
     })
   })
+
+  describe("Path to Horizon (off-track)", () => {
+    // Off-track plan: green Retirement-Age FI 125% would otherwise mislead.
+    const offTrackProps = {
+      ...defaultProps,
+      backendFiMetrics: mkFi({ retirementAgeFiProgress: 125 }),
+      pathToHorizon: {
+        targetAge: 90,
+        currentMonthlyContribution: 1000,
+        requiredMonthlyContribution: 1800,
+        currentReturnRate: 0.015,
+        requiredReturnRate: 0.0432,
+      },
+    }
+
+    it("shows the off-track header with the levers to reach life expectancy", () => {
+      render(<FiMetrics {...offTrackProps} />)
+      expect(screen.getByText(/To last to age 90/)).toBeInTheDocument()
+      expect(screen.getByText(/NZD1,800/)).toBeInTheDocument()
+      expect(screen.getByText(/4\.3%/)).toBeInTheDocument()
+    })
+
+    it("suppresses the green funded banner when off-track", () => {
+      render(<FiMetrics {...offTrackProps} />)
+      // retirementAgeFiProgress 125% would normally fire the green banner
+      expect(screen.queryByText(/Funded — /)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Lifetime funded/)).not.toBeInTheDocument()
+    })
+
+    it("shows the contribution-gap detail in the body", () => {
+      render(<FiMetrics {...offTrackProps} />)
+      // gap = 1800 - 1000 = 800
+      expect(screen.getByText(/Add ~NZD800\/mo/)).toBeInTheDocument()
+    })
+
+    it("keeps the existing funded banner when on-track (no pathToHorizon)", () => {
+      render(
+        <FiMetrics
+          {...defaultProps}
+          backendFiMetrics={mkFi({
+            retirementAgeFiProgress: 106.6,
+            bridgeProgress: 120,
+            bridgeYearsNeeded: 13,
+          })}
+        />,
+      )
+      expect(
+        screen.getByText("Funded — liquid covers the gap to your pension"),
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/src/components/features/independence/__tests__/ScenarioBar.test.tsx
+++ b/src/components/features/independence/__tests__/ScenarioBar.test.tsx
@@ -129,6 +129,56 @@ describe("ScenarioBar", () => {
     expect(props.onScenarioChange).toHaveBeenCalledWith({ liquidAssets: null })
   })
 
+  describe("path-to-horizon header", () => {
+    const offTrack = {
+      targetAge: 90,
+      currentMonthlyContribution: 1000,
+      requiredMonthlyContribution: 1800,
+      currentReturnRate: 0.015,
+      requiredReturnRate: 0.0432,
+    }
+
+    it("shows the off-track banner above the gauge strip when pathToHorizon is present", () => {
+      render(<ScenarioBar {...baseProps} pathToHorizon={offTrack} />)
+      expect(screen.getByText(/Won.t last to age 90/)).toBeInTheDocument()
+      expect(screen.getByText(/To last to age 90/)).toBeInTheDocument()
+      expect(screen.getByText(/SGD1,800/)).toBeInTheDocument()
+    })
+
+    it("hides the off-track banner when on-track (no pathToHorizon)", () => {
+      render(<ScenarioBar {...baseProps} />)
+      expect(screen.queryByText(/Won.t last to age/)).not.toBeInTheDocument()
+    })
+
+    it("caveats the Retirement-Age FI headline gauge when off-track", () => {
+      render(
+        <ScenarioBar
+          {...baseProps}
+          view="PENSION"
+          fiMetrics={
+            { fiProgress: 80, retirementAgeFiProgress: 125.3 } as never
+          }
+          pathToHorizon={offTrack}
+        />,
+      )
+      expect(
+        screen.getByText(/125\.3% — based on the 4% rule/),
+      ).toBeInTheDocument()
+    })
+
+    it("hides the numeric banner copy in privacy mode", () => {
+      const { usePrivacyMode } = jest.requireMock("@hooks/usePrivacyMode")
+      usePrivacyMode.mockReturnValueOnce({
+        hideValues: true,
+        toggleHideValues: jest.fn(),
+      })
+      render(<ScenarioBar {...baseProps} pathToHorizon={offTrack} />)
+      // Numeric levers must not leak when values are hidden.
+      expect(screen.queryByText(/SGD1,800/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/To last to age 90/)).not.toBeInTheDocument()
+    })
+  })
+
   it("restores realReturn=null when slider returns within half a step of plan real", () => {
     // planRealReturn = 0.058 - 0.025 = 0.033. Start with a non-null override.
     const props = {

--- a/src/components/features/independence/__tests__/StrategyGaugesStrip.test.tsx
+++ b/src/components/features/independence/__tests__/StrategyGaugesStrip.test.tsx
@@ -28,3 +28,40 @@ describe("StrategyGaugesStrip headline", () => {
     expect(screen.getByText("FIRE Progress")).toBeInTheDocument()
   })
 })
+
+describe("StrategyGaugesStrip off-track caveat", () => {
+  // Pension headline showing 125% would otherwise read as success even though
+  // the plan's returns fall short of the 4% rule the gauge assumes.
+  const pensionFi = {
+    fiProgress: 80,
+    retirementAgeFiProgress: 125.3,
+  } as unknown as FiMetrics
+
+  it("caveats the Retirement-Age FI gauge value when off-track", () => {
+    render(
+      <StrategyGaugesStrip
+        fiMetrics={pensionFi}
+        view="PENSION"
+        singleHeadline
+        offTrack
+      />,
+    )
+    expect(screen.getByText("Retirement-Age FI")).toBeInTheDocument()
+    // Value still shown, but appended with the plain-language 4%-rule caveat.
+    expect(
+      screen.getByText(/125\.3% — based on the 4% rule/),
+    ).toBeInTheDocument()
+  })
+
+  it("leaves the Retirement-Age FI gauge uncaveated when on-track", () => {
+    render(
+      <StrategyGaugesStrip
+        fiMetrics={pensionFi}
+        view="PENSION"
+        singleHeadline
+      />,
+    )
+    expect(screen.getByText("125.3%")).toBeInTheDocument()
+    expect(screen.queryByText(/based on the 4% rule/)).not.toBeInTheDocument()
+  })
+})

--- a/src/lib/utils/independence/pathToHorizon.test.ts
+++ b/src/lib/utils/independence/pathToHorizon.test.ts
@@ -1,0 +1,93 @@
+import type { PathToHorizon } from "types/independence"
+import { formatHorizonHeader, formatHorizonGap } from "./pathToHorizon"
+
+/** Minimal PathToHorizon fixture; override per case. */
+function mkHorizon(overrides: Partial<PathToHorizon> = {}): PathToHorizon {
+  return {
+    targetAge: 90,
+    currentMonthlyContribution: 1000,
+    requiredMonthlyContribution: 1800,
+    currentReturnRate: 0.015,
+    requiredReturnRate: 0.0432,
+    ...overrides,
+  }
+}
+
+describe("formatHorizonHeader", () => {
+  it("offers both levers when both are solvable", () => {
+    const result = formatHorizonHeader(mkHorizon(), "NZD")
+    expect(result.tone).toBe("warning")
+    // mentions the target age
+    expect(result.text).toContain("90")
+    // both the contribution lever and the return-rate lever
+    expect(result.text).toContain("NZD1,800")
+    expect(result.text).toContain("4.3%")
+    // and what they're doing today
+    expect(result.text).toContain("NZD1,000")
+    expect(result.text).toContain("1.5%")
+  })
+
+  it("offers only the contribution lever when return rate is unsolvable", () => {
+    const result = formatHorizonHeader(
+      mkHorizon({ requiredReturnRate: null }),
+      "NZD",
+    )
+    expect(result.tone).toBe("warning")
+    expect(result.text).toContain("NZD1,800")
+    // no return-rate target shown
+    expect(result.text).not.toContain("4.3%")
+  })
+
+  it("offers only the return-rate lever when contribution is unsolvable", () => {
+    const result = formatHorizonHeader(
+      mkHorizon({ requiredMonthlyContribution: null }),
+      "NZD",
+    )
+    expect(result.tone).toBe("warning")
+    expect(result.text).toContain("4.3%")
+    // no required contribution target shown
+    expect(result.text).not.toContain("NZD1,800")
+  })
+
+  it("falls back to a no-numbers message when both levers are unsolvable", () => {
+    const result = formatHorizonHeader(
+      mkHorizon({
+        requiredMonthlyContribution: null,
+        requiredReturnRate: null,
+      }),
+      "NZD",
+    )
+    expect(result.tone).toBe("warning")
+    expect(result.text).toContain("90")
+    // no solver numbers leak into the fallback copy
+    expect(result.text).not.toContain("NZD1,800")
+    expect(result.text).not.toContain("4.3%")
+  })
+})
+
+describe("formatHorizonGap", () => {
+  it("computes the contribution gap (required - current)", () => {
+    const result = formatHorizonGap(mkHorizon(), "NZD")
+    // 1800 - 1000 = 800
+    expect(result).toContain("NZD800")
+    expect(result).toContain("90")
+  })
+
+  it("returns null when required contribution is unsolvable", () => {
+    expect(
+      formatHorizonGap(mkHorizon({ requiredMonthlyContribution: null }), "NZD"),
+    ).toBeNull()
+  })
+
+  it("returns null when there is no positive gap (already contributing enough)", () => {
+    expect(
+      formatHorizonGap(
+        mkHorizon({
+          currentMonthlyContribution: 2000,
+          requiredMonthlyContribution: 1800,
+        }),
+        "NZD",
+      ),
+    ).toBeNull()
+  })
+})

--- a/src/lib/utils/independence/pathToHorizon.ts
+++ b/src/lib/utils/independence/pathToHorizon.ts
@@ -1,0 +1,107 @@
+import type { PathToHorizon } from "types/independence"
+
+/**
+ * Pure formatters for the off-track "Path to Horizon" block returned by
+ * svc-retire. The backend owns all solver logic — these helpers only turn the
+ * already-computed levers into plain-language copy for non-financial users.
+ *
+ * Amounts are in the plan currency (caller passes the symbol/code). Return
+ * rates are DECIMALS (0.0432 = 4.32%). A null lever means the solver could not
+ * reach `targetAge` within its bounds (unsolvable).
+ */
+
+export type HorizonTone = "warning" | "neutral"
+
+export interface HorizonHeader {
+  /** Plain-language headline describing what carries the plan to targetAge. */
+  text: string
+  /** Visual tone — never "success"; an off-track plan must not read as green. */
+  tone: HorizonTone
+}
+
+const fmtMoney = (value: number, currency: string): string =>
+  `${currency}${Math.round(value).toLocaleString()}`
+
+const fmtRate = (rate: number): string => `${(rate * 100).toFixed(1)}%`
+
+/**
+ * Build the off-track headline. Surfaces whichever levers the backend solved:
+ * both, one, or — when neither is reachable — a no-numbers fallback that nudges
+ * the user toward lower expenses or a later start.
+ */
+export function formatHorizonHeader(
+  horizon: PathToHorizon,
+  currency: string,
+): HorizonHeader {
+  const {
+    targetAge,
+    currentMonthlyContribution,
+    requiredMonthlyContribution,
+    currentReturnRate,
+    requiredReturnRate,
+  } = horizon
+
+  const today = `Currently saving ${fmtMoney(
+    currentMonthlyContribution,
+    currency,
+  )}/mo at ${fmtRate(currentReturnRate)}/yr.`
+
+  const haveContribution = requiredMonthlyContribution != null
+  const haveReturn = requiredReturnRate != null
+
+  if (haveContribution && haveReturn) {
+    return {
+      tone: "warning",
+      text: `To last to age ${targetAge}: save ~${fmtMoney(
+        requiredMonthlyContribution,
+        currency,
+      )}/mo, or grow at ~${fmtRate(requiredReturnRate)}/yr. ${today}`,
+    }
+  }
+
+  if (haveContribution) {
+    return {
+      tone: "warning",
+      text: `To last to age ${targetAge}: save ~${fmtMoney(
+        requiredMonthlyContribution,
+        currency,
+      )}/mo. ${today}`,
+    }
+  }
+
+  if (haveReturn) {
+    return {
+      tone: "warning",
+      text: `To last to age ${targetAge}: grow at ~${fmtRate(
+        requiredReturnRate,
+      )}/yr. ${today}`,
+    }
+  }
+
+  return {
+    tone: "warning",
+    text:
+      `Even large changes won't reach age ${targetAge} at this spending — ` +
+      `consider lower expenses or a later start.`,
+  }
+}
+
+/**
+ * Body-only contribution-gap detail: the extra monthly saving (at today's
+ * return) needed to reach `targetAge`. Returns null when the contribution lever
+ * is unsolvable or when there is no positive gap (already saving enough).
+ */
+export function formatHorizonGap(
+  horizon: PathToHorizon,
+  currency: string,
+): string | null {
+  const { targetAge, currentMonthlyContribution, requiredMonthlyContribution } =
+    horizon
+  if (requiredMonthlyContribution == null) return null
+  const gap = requiredMonthlyContribution - currentMonthlyContribution
+  if (gap <= 0) return null
+  return `Add ~${fmtMoney(
+    gap,
+    currency,
+  )}/mo at today's return to reach age ${targetAge}.`
+}

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -981,6 +981,7 @@ function PlanView(): React.ReactElement {
               derivedLiquidAssets={liquidAssets}
               planBlendedReturn={computeBlendedReturnRate(plan)}
               planInflation={plan.inflationRate}
+              pathToHorizon={adjustedProjection?.pathToHorizon}
             />
           )}
 

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -687,6 +687,29 @@ export interface ValueBasis {
   incomeStreams: IncomeStreamBasis[]
 }
 
+/**
+ * Off-track diagnostic block returned by svc-retire ONLY when the plan's money
+ * runs out before life expectancy. Describes what it would take — extra monthly
+ * contribution OR a higher return rate — to carry the plan all the way to
+ * `targetAge`. Null/absent when the plan is on-track.
+ *
+ * All amounts are in the plan currency (`projection.currency`). A null lever
+ * means the solver could not find a value within its bounds (unsolvable).
+ * Return rates are DECIMALS (e.g. 0.0432 = 4.32%).
+ */
+export interface PathToHorizon {
+  /** Age the plan must last to — equals life expectancy (e.g. 90). */
+  targetAge: number
+  /** Current monthly contribution, plan currency. */
+  currentMonthlyContribution: number
+  /** Monthly contribution needed to reach targetAge; null = unsolvable. */
+  requiredMonthlyContribution: number | null
+  /** Current blended return rate as a decimal (e.g. 0.015 = 1.5%). */
+  currentReturnRate: number
+  /** Return rate needed to reach targetAge as a decimal; null = unsolvable. */
+  requiredReturnRate: number | null
+}
+
 export interface RetirementProjection {
   planId: string
   asOfDate: string
@@ -777,6 +800,12 @@ export interface RetirementProjection {
    * responses omit it, in which case the UI falls back to known defaults.
    */
   valueBasis?: ValueBasis
+  /**
+   * Off-track path to life expectancy. Present ONLY when the plan's money runs
+   * out before life expectancy; null/absent when on-track. Tells the user what
+   * extra contribution OR return rate would carry the plan to `targetAge`.
+   */
+  pathToHorizon?: PathToHorizon | null
 }
 
 export interface ProjectionResponse {


### PR DESCRIPTION
Consumes svc-retire `pathToHorizon`. When a plan is off-track, the headline no longer reads as green success — it shows what carries the plan to life expectancy.

- Top gauge strip (ScenarioBar): amber banner 'Won't last to age N — save ~X/mo or grow at ~Y%'; the Retirement-Age FI gauge is caveated ('based on the 4% rule') so 125% no longer reads as on-track.
- Metrics tab (FiMetrics): same off-track banner; contribution-gap detail in the body (not the header).
- Plain language for non-financial users; privacy-mode aware; on-track view unchanged.
- Helper + render tests.

Needs svc-retire PR #80 (pathToHorizon field). FX conversion of this block is a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added off-track diagnostic messaging for retirement plans that deplete before life expectancy, displaying the target age and required contribution or return rate adjustments needed to sustain retirement.
  * Enhanced "Retirement-Age FI" gauge with conditional caveats when plans are off-track.
  * Suppressed conflicting success messaging for off-track scenarios.

* **Tests**
  * Comprehensive test coverage for off-track scenarios, horizon messaging, and privacy mode interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->