### PR TITLE
fix(independence): pension headline = income coverage; 4% rule caveat to tooltip

### DIFF
--- a/src/components/features/independence/FiMetrics.tsx
+++ b/src/components/features/independence/FiMetrics.tsx
@@ -616,14 +616,11 @@ function PensionStrategySection({
       key: "retirement-age-fi",
       label: "Retirement-Age Progress",
       tooltip: offTrack
-        ? "Based on the 4% rule, which this plan's returns don't meet — the off-track guidance above carries the real headline. Adds the present value of guaranteed income (discounted to today) to your liquid pot before comparing against the FI Number."
+        ? "This % uses the 4% rule, which this plan's returns don't meet — see Plan Insights for what it takes. Adds the present value of guaranteed income (discounted to today) to your liquid pot before comparing against the FI Number."
         : "Adds the present value of guaranteed pension/policy income (discounted to today) to your liquid pot before comparing against the FI Number.",
       value: retirementAgeFiProgress,
       hideValues,
-      format: (v) =>
-        offTrack
-          ? `${v.toFixed(1)}% — based on the 4% rule`
-          : `${v.toFixed(1)}%`,
+      format: (v) => `${v.toFixed(1)}%`,
     })
   }
 

--- a/src/components/features/independence/StrategyGaugesStrip.tsx
+++ b/src/components/features/independence/StrategyGaugesStrip.tsx
@@ -48,7 +48,7 @@ export default function StrategyGaugesStrip({
 }: StrategyGaugesStripProps): React.ReactElement {
   const { hideValues } = usePrivacyMode()
   const ordered = orderGauges(
-    buildGauges(fiMetrics, hideValues, offTrack),
+    buildGauges(fiMetrics, hideValues, offTrack, view),
     view,
   )
   const gauges = singleHeadline ? ordered.slice(0, 1) : ordered
@@ -74,7 +74,10 @@ export default function StrategyGaugesStrip({
  */
 const VIEW_HEADLINE_KEYS: Record<StrategyView, string[]> = {
   FIRE: ["coast-fi", "fire"],
-  PENSION: ["retirement-age-fi", "coast-fi", "fire"],
+  // Pensions have no FI — the meaningful progress is how much of retirement
+  // expenses guaranteed income covers. Fall back to retirement-age FI when
+  // income coverage isn't available.
+  PENSION: ["income-coverage", "retirement-age-fi", "coast-fi", "fire"],
   HYBRID: ["bridge", "coast-fi", "fire"],
   ALL: ["coast-fi", "fire"],
 }
@@ -100,6 +103,7 @@ function buildGauges(
   fi: FiMetrics | undefined,
   hideValues: boolean,
   offTrack: boolean,
+  view: StrategyView,
 ): PensionGaugeProps[] {
   const fiProgress = fi?.fiProgress ?? 0
   const out: PensionGaugeProps[] = [
@@ -136,23 +140,22 @@ function buildGauges(
       key: "retirement-age-fi",
       label: "Retirement-Age Progress",
       tooltip: offTrack
-        ? "Based on the 4% rule, which this plan's returns don't meet — the off-track guidance above carries the real headline. Adds the present value of your guaranteed pension income (discounted to today) to your liquid pot before comparing against the FI Number."
+        ? "This % uses the 4% rule, which this plan's returns don't meet — see Plan Insights for what it takes. Adds the present value of your guaranteed pension income (discounted to today) to your liquid pot before comparing against the FI Number."
         : "Liquid plus the present value of your guaranteed pension income, compared to your FI Number.",
       value: fi.retirementAgeFiProgress,
       hideValues,
-      format: (v) =>
-        offTrack
-          ? `${v.toFixed(1)}% — based on the 4% rule`
-          : `${v.toFixed(1)}%`,
+      format: (v) => `${v.toFixed(1)}%`,
     })
   }
 
   if (fi?.incomeCoverageAtRetirement != null) {
     out.push({
       key: "income-coverage",
-      label: "Income Coverage",
+      // In the Pension view this gauge is the headline: a pension has no FI, so
+      // the meaningful progress is how much of expenses guaranteed income covers.
+      label: view === "PENSION" ? "Pension Progress" : "Income Coverage",
       tooltip:
-        "Share of monthly expenses covered by guaranteed income (pension, social security, other) at retirement age.",
+        "Share of your retirement expenses covered by your guaranteed income (pension, social security, etc.) at retirement age.",
       value: fi.incomeCoverageAtRetirement,
       hideValues,
       format: (v) => `${v.toFixed(1)}%`,

--- a/src/components/features/independence/__tests__/FiMetrics.test.tsx
+++ b/src/components/features/independence/__tests__/FiMetrics.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import type { FiMetrics as FiMetricsType } from "types/independence"
 import FiMetrics from "../FiMetrics"
 
@@ -715,12 +715,23 @@ describe("FiMetrics", () => {
       expect(screen.queryByText(/Add ~NZD800\/mo/)).not.toBeInTheDocument()
     })
 
-    it("still caveats the Retirement-Age Progress gauge when off-track", () => {
+    it("keeps the off-track caveat OUT of the Retirement-Age gauge value", () => {
       render(<FiMetrics {...offTrackProps} />)
-      // The gauge caveat ("— based on the 4% rule") stays so a green % can't
-      // read as success.
+      // The value stays clean ("125.0%"); the 4%-rule explanation now lives in
+      // the gauge tooltip so a green % can't read as success on its own.
+      expect(screen.getByText("125.0%")).toBeInTheDocument()
       expect(
-        screen.getByText(/125\.0% — based on the 4% rule/),
+        screen.queryByText(/125\.0% — based on the 4% rule/),
+      ).not.toBeInTheDocument()
+    })
+
+    it("moves the off-track 4%-rule explanation into the gauge tooltip", () => {
+      render(<FiMetrics {...offTrackProps} />)
+      fireEvent.mouseEnter(screen.getByText("Retirement-Age Progress"))
+      expect(
+        screen.getByText(
+          /uses the 4% rule, which this plan's returns don't meet/,
+        ),
       ).toBeInTheDocument()
     })
 

--- a/src/components/features/independence/__tests__/ScenarioBar.test.tsx
+++ b/src/components/features/independence/__tests__/ScenarioBar.test.tsx
@@ -147,7 +147,7 @@ describe("ScenarioBar", () => {
       expect(screen.queryByText(/SGD1,800/)).not.toBeInTheDocument()
     })
 
-    it("still caveats the Retirement-Age Progress headline gauge when off-track", () => {
+    it("keeps the off-track caveat out of the headline gauge value", () => {
       render(
         <ScenarioBar
           {...baseProps}
@@ -158,9 +158,11 @@ describe("ScenarioBar", () => {
           pathToHorizon={offTrack}
         />,
       )
+      // Value stays clean; the 4%-rule explanation moved to the gauge tooltip.
+      expect(screen.getByText("125.3%")).toBeInTheDocument()
       expect(
-        screen.getByText(/125\.3% — based on the 4% rule/),
-      ).toBeInTheDocument()
+        screen.queryByText(/125\.3% — based on the 4% rule/),
+      ).not.toBeInTheDocument()
     })
 
     it("labels the headline gauge 'Retirement-Age Progress'", () => {

--- a/src/components/features/independence/__tests__/StrategyGaugesStrip.test.tsx
+++ b/src/components/features/independence/__tests__/StrategyGaugesStrip.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import StrategyGaugesStrip from "../StrategyGaugesStrip"
 import type { FiMetrics } from "types/independence"
 
@@ -29,6 +29,53 @@ describe("StrategyGaugesStrip headline", () => {
   })
 })
 
+describe("StrategyGaugesStrip Pension headline", () => {
+  const pensionFi = {
+    fiProgress: 80,
+    retirementAgeFiProgress: 125.3,
+    incomeCoverageAtRetirement: 62.5,
+  } as unknown as FiMetrics
+
+  it("uses Income Coverage as the Pension headline, labelled Pension Progress", () => {
+    render(
+      <StrategyGaugesStrip
+        fiMetrics={pensionFi}
+        view="PENSION"
+        singleHeadline
+      />,
+    )
+    expect(screen.getByText("Pension Progress")).toBeInTheDocument()
+    expect(screen.getByText("62.5%")).toBeInTheDocument()
+    // The retirement-age gauge is no longer the Pension headline.
+    expect(
+      screen.queryByText("Retirement-Age Progress"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("falls back to Retirement-Age Progress when income coverage is null", () => {
+    render(
+      <StrategyGaugesStrip
+        fiMetrics={
+          {
+            fiProgress: 80,
+            retirementAgeFiProgress: 125.3,
+          } as unknown as FiMetrics
+        }
+        view="PENSION"
+        singleHeadline
+      />,
+    )
+    expect(screen.getByText("Retirement-Age Progress")).toBeInTheDocument()
+    expect(screen.queryByText("Pension Progress")).not.toBeInTheDocument()
+  })
+
+  it("labels income-coverage gauge Income Coverage outside the Pension view", () => {
+    render(<StrategyGaugesStrip fiMetrics={pensionFi} view="ALL" compact />)
+    expect(screen.getByText("Income Coverage")).toBeInTheDocument()
+    expect(screen.queryByText("Pension Progress")).not.toBeInTheDocument()
+  })
+})
+
 describe("StrategyGaugesStrip off-track caveat", () => {
   // Pension headline showing 125% would otherwise read as success even though
   // the plan's returns fall short of the 4% rule the gauge assumes.
@@ -37,7 +84,7 @@ describe("StrategyGaugesStrip off-track caveat", () => {
     retirementAgeFiProgress: 125.3,
   } as unknown as FiMetrics
 
-  it("caveats the Retirement-Age Progress gauge value when off-track", () => {
+  it("keeps the off-track caveat OUT of the Retirement-Age gauge value", () => {
     render(
       <StrategyGaugesStrip
         fiMetrics={pensionFi}
@@ -47,9 +94,27 @@ describe("StrategyGaugesStrip off-track caveat", () => {
       />,
     )
     expect(screen.getByText("Retirement-Age Progress")).toBeInTheDocument()
-    // Value still shown, but appended with the plain-language 4%-rule caveat.
+    // Value stays clean — no inline 4%-rule suffix.
+    expect(screen.getByText("125.3%")).toBeInTheDocument()
     expect(
-      screen.getByText(/125\.3% — based on the 4% rule/),
+      screen.queryByText(/125\.3% — based on the 4% rule/),
+    ).not.toBeInTheDocument()
+  })
+
+  it("carries the off-track 4%-rule explanation in the gauge tooltip", () => {
+    render(
+      <StrategyGaugesStrip
+        fiMetrics={pensionFi}
+        view="PENSION"
+        singleHeadline
+        offTrack
+      />,
+    )
+    fireEvent.mouseEnter(screen.getByText("Retirement-Age Progress"))
+    expect(
+      screen.getByText(
+        /uses the 4% rule, which this plan's returns don't meet/,
+      ),
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
Addresses two issues on the plan header gauge:

1. The off-track '— based on the 4% rule' text was appended to the gauge VALUE, wrapping to multiple lines on mobile and breaking layout. Moved it out of the value into the gauge tooltip (value stays clean, e.g. '125.3%'). Applied in both StrategyGaugesStrip and FiMetrics.
2. Pension view now headlines Income Coverage labelled 'Pension Progress' ('share of retirement expenses your guaranteed income covers') instead of the 4%-rule-based Retirement-Age Progress — there is no FI concept for a pension. Falls back to Retirement-Age Progress when income coverage is null. The Retirement-Age Progress gauge still appears in the full strip, just not as the Pension headline.

Frontend-only (incomeCoverageAtRetirement already on fiMetrics). Tests updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retirement-Age Progress gauge now displays cleaner percentage values with the 4% rule explanation accessible via tooltip on hover.

* **Improvements**
  * Pension view label updated to "Pension Progress" for consistency.
  * Gauge priority logic refined to prefer income coverage metrics first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->