### PR TITLE
refactor(independence): share Retirement-Age Progress gauge tooltips

### DIFF
--- a/src/components/features/independence/FiMetrics.tsx
+++ b/src/components/features/independence/FiMetrics.tsx
@@ -31,6 +31,10 @@ import {
   getGapColorScheme,
   getSavingsRateTextColor,
 } from "@utils/independence/fiColorThemes"
+import {
+  RETIREMENT_PROGRESS_TOOLTIP,
+  RETIREMENT_PROGRESS_OFFTRACK_TOOLTIP,
+} from "@utils/independence/gaugeTooltips"
 import FiAgeExplorer from "./FiAgeExplorer"
 
 interface FiMetricsProps {
@@ -616,8 +620,8 @@ function PensionStrategySection({
       key: "retirement-age-fi",
       label: "Retirement-Age Progress",
       tooltip: offTrack
-        ? "This % uses the 4% rule, which this plan's returns don't meet — see Plan Insights for what it takes. Adds the present value of guaranteed income (discounted to today) to your liquid pot before comparing against the FI Number."
-        : "Adds the present value of guaranteed pension/policy income (discounted to today) to your liquid pot before comparing against the FI Number.",
+        ? RETIREMENT_PROGRESS_OFFTRACK_TOOLTIP
+        : RETIREMENT_PROGRESS_TOOLTIP,
       value: retirementAgeFiProgress,
       hideValues,
       format: (v) => `${v.toFixed(1)}%`,

--- a/src/components/features/independence/StrategyGaugesStrip.tsx
+++ b/src/components/features/independence/StrategyGaugesStrip.tsx
@@ -3,6 +3,10 @@ import type { FiMetrics } from "types/independence"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
 import PensionGauge, { type PensionGaugeProps } from "./PensionGauge"
 import type { StrategyView } from "./strategyView"
+import {
+  RETIREMENT_PROGRESS_TOOLTIP,
+  RETIREMENT_PROGRESS_OFFTRACK_TOOLTIP,
+} from "@lib/independence/gaugeTooltips"
 
 export interface StrategyGaugesStripProps {
   /** Live FiMetrics from the latest projection. Undefined while calculating. */
@@ -140,8 +144,8 @@ function buildGauges(
       key: "retirement-age-fi",
       label: "Retirement-Age Progress",
       tooltip: offTrack
-        ? "This % uses the 4% rule, which this plan's returns don't meet — see Plan Insights for what it takes. Adds the present value of your guaranteed pension income (discounted to today) to your liquid pot before comparing against the FI Number."
-        : "Liquid plus the present value of your guaranteed pension income, compared to your FI Number.",
+        ? RETIREMENT_PROGRESS_OFFTRACK_TOOLTIP
+        : RETIREMENT_PROGRESS_TOOLTIP,
       value: fi.retirementAgeFiProgress,
       hideValues,
       format: (v) => `${v.toFixed(1)}%`,

--- a/src/lib/utils/independence/gaugeTooltips.ts
+++ b/src/lib/utils/independence/gaugeTooltips.ts
@@ -1,0 +1,12 @@
+/**
+ * Single source of truth for tooltip copy shared across independence gauges.
+ *
+ * The "Retirement-Age Progress" gauge (key: "retirement-age-fi") is rendered in
+ * both StrategyGaugesStrip and FiMetrics; keep its wording unified here so the
+ * two surfaces never diverge.
+ */
+export const RETIREMENT_PROGRESS_TOOLTIP =
+  "Adds the present value of your guaranteed pension income (discounted to today) to your liquid pot, compared against your FI Number."
+
+export const RETIREMENT_PROGRESS_OFFTRACK_TOOLTIP =
+  "This % uses the 4% rule, which this plan's returns don't meet — see Plan Insights for what it takes. It adds the present value of your guaranteed pension income (discounted to today) to your liquid pot before comparing against the FI Number."


### PR DESCRIPTION
Addresses the CodeRabbit nitpick on #900: the same Retirement-Age Progress gauge had divergent tooltip text in StrategyGaugesStrip vs FiMetrics (FiMetrics off-track dropped 'pension'; on-track wording differed).

Extracts the on-track + off-track tooltips to a shared module (gaugeTooltips.ts) used by both components, so they can't drift. Tooltip text only — no value/label/key/format changes. Tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated retirement progress gauge tooltip text into a centralized utility module to ensure consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->