### PR TITLE
feat(payslip): Enter Payslip modal from Tools menu

### DIFF
--- a/src/components/features/independence/useDefinedContribution.ts
+++ b/src/components/features/independence/useDefinedContribution.ts
@@ -1,12 +1,24 @@
 import useSwr from "swr"
 import { simpleFetcher } from "@utils/api/fetchHelper"
 
+/**
+ * A single defined-contribution bucket (e.g. CPF OA / SA|RA / MA). `amount` is
+ * the TOTAL employee + employer contribution allocated to that bucket.
+ */
+export interface DefinedContributionBucket {
+  code: string
+  amount: number
+}
+
 export interface DefinedContributionResponse {
   employeeContribution: number
   employerContribution: number
   employeeRate: number
   cappedSalary: number
   hasDefinedContribution: boolean
+  // Per-bucket split of the total contribution. Empty when there is no
+  // defined-contribution scheme (e.g. no CPF). Codes: "OA", "SA"|"RA", "MA".
+  buckets?: DefinedContributionBucket[]
 }
 
 /**

--- a/src/components/features/transactions/PayslipModal.tsx
+++ b/src/components/features/transactions/PayslipModal.tsx
@@ -1,0 +1,402 @@
+import React, { useMemo, useState } from "react"
+import useSWR, { mutate as globalMutate } from "swr"
+import Dialog from "@components/ui/Dialog"
+import MathInput from "@components/ui/MathInput"
+import { Asset, Portfolio } from "types/beancounter"
+import {
+  cashKey,
+  holdingKey,
+  portfoliosKey,
+  simpleFetcher,
+} from "@utils/api/fetchHelper"
+import { toCashAssetOptions } from "@components/features/transactions/SettlementAccountSelect"
+import { usePrivateAssetConfigs } from "@lib/assets/usePrivateAssetConfigs"
+import { useUserPreferences } from "@contexts/UserPreferencesContext"
+import {
+  DefinedContributionBucket,
+  useDefinedContribution,
+} from "@components/features/independence/useDefinedContribution"
+import { buildPayslipPayload, PayslipPayload } from "@utils/trns/payslipPayload"
+
+interface PayslipModalProps {
+  modalOpen: boolean
+  onClose: () => void
+}
+
+const todayIso = (): string => new Date().toISOString().slice(0, 10)
+
+const formatAmount = (n: number): string =>
+  n.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+
+const parseNum = (s: string): number => {
+  const n = parseFloat(s)
+  return isNaN(n) ? 0 : n
+}
+
+/**
+ * Apply per-bucket user overrides on top of the computed defined-contribution
+ * buckets. A non-empty override string replaces the computed amount; anything
+ * else falls back to the computed value. Pure + hoisted so the React Compiler
+ * can memoize the caller without a manual-memoization bailout.
+ */
+const applyBucketOverrides = (
+  buckets: DefinedContributionBucket[] | undefined,
+  overrides: Record<string, string>,
+): DefinedContributionBucket[] => {
+  if (!buckets) return []
+  return buckets.map((b) => {
+    const override = overrides[b.code]
+    return {
+      code: b.code,
+      amount:
+        override !== undefined && override !== ""
+          ? parseNum(override)
+          : b.amount,
+    }
+  })
+}
+
+const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
+  const { preferences } = useUserPreferences()
+  const { configs } = usePrivateAssetConfigs()
+
+  // Portfolios + cash assets (account-wide CASH market). Only fetch when open.
+  const { data: portfoliosData } = useSWR(
+    modalOpen ? portfoliosKey : null,
+    simpleFetcher(portfoliosKey),
+  )
+  const { data: cashData } = useSWR(
+    modalOpen ? cashKey : null,
+    simpleFetcher(cashKey),
+  )
+
+  const portfolios: Portfolio[] = useMemo(
+    () => portfoliosData?.data ?? [],
+    [portfoliosData],
+  )
+  const cashAssets: Asset[] = useMemo(() => {
+    const raw = cashData?.data
+    if (!raw) return []
+    return Array.isArray(raw) ? raw : (Object.values(raw) as Asset[])
+  }, [cashData])
+  const cashOptions = useMemo(
+    () => toCashAssetOptions(cashAssets),
+    [cashAssets],
+  )
+
+  // The user's CPF policy asset, if any.
+  const cpfConfig = useMemo(
+    () => configs.find((c) => c.policyType === "CPF"),
+    [configs],
+  )
+  const hasCpfAsset = !!cpfConfig
+
+  // Form state. Portfolio + cash asset prefill from saved preferences (also
+  // re-applied on each open below).
+  const [grossSalary, setGrossSalary] = useState<string>("")
+  const [portfolioId, setPortfolioId] = useState<string>(
+    () => preferences?.defaultPayslipPortfolioId ?? "",
+  )
+  const [cashAssetId, setCashAssetId] = useState<string>(
+    () => preferences?.defaultPayslipCashAssetId ?? "",
+  )
+  const [tax, setTax] = useState<string>("")
+  // Per-bucket overrides keyed by bucket code; undefined = use computed value.
+  const [bucketOverrides, setBucketOverrides] = useState<
+    Record<string, string>
+  >({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitSuccess, setSubmitSuccess] = useState(false)
+
+  // Reset + prefill on open (render-phase reset; React "store previous value").
+  const [prevOpen, setPrevOpen] = useState(modalOpen)
+  if (modalOpen !== prevOpen) {
+    setPrevOpen(modalOpen)
+    if (modalOpen) {
+      setGrossSalary("")
+      setTax("")
+      setBucketOverrides({})
+      setIsSubmitting(false)
+      setSubmitError(null)
+      setSubmitSuccess(false)
+      setPortfolioId(preferences?.defaultPayslipPortfolioId ?? "")
+      setCashAssetId(preferences?.defaultPayslipCashAssetId ?? "")
+    }
+  }
+
+  // Derive current age from year of birth (mirrors ContributionsStep).
+  const currentAge = useMemo(() => {
+    const yob = preferences?.yearOfBirth
+    if (!yob || yob <= 0) return undefined
+    return new Date().getFullYear() - yob
+  }, [preferences?.yearOfBirth])
+
+  const grossNum = parseNum(grossSalary)
+  const { data: dc } = useDefinedContribution(
+    hasCpfAsset ? grossNum : 0,
+    hasCpfAsset ? currentAge : undefined,
+  )
+
+  const showPension =
+    hasCpfAsset &&
+    !!dc?.hasDefinedContribution &&
+    (dc?.buckets?.length ?? 0) > 0
+
+  // Effective buckets = computed amount unless the user overrode it.
+  const effectiveBuckets: DefinedContributionBucket[] = useMemo(
+    () => applyBucketOverrides(dc?.buckets, bucketOverrides),
+    [dc?.buckets, bucketOverrides],
+  )
+
+  const selectedCashCurrency = useMemo(() => {
+    const opt = cashOptions.find((o) => o.value === cashAssetId)
+    return opt?.currency ?? ""
+  }, [cashOptions, cashAssetId])
+
+  const buildPayload = (): PayslipPayload =>
+    buildPayslipPayload({
+      portfolioId,
+      tradeDate: todayIso(),
+      grossSalary: grossNum,
+      tax: parseNum(tax),
+      cashAssetId,
+      cashCurrency: selectedCashCurrency,
+      cpfAssetId: showPension ? cpfConfig?.assetId : undefined,
+      employeeContribution: showPension ? dc?.employeeContribution : undefined,
+      buckets: showPension ? effectiveBuckets : undefined,
+    })
+
+  const canSubmit = grossNum > 0 && !!portfolioId && !!cashAssetId
+
+  const handleSave = async (): Promise<void> => {
+    if (!canSubmit) return
+    setIsSubmitting(true)
+    setSubmitError(null)
+    try {
+      const payload = buildPayload()
+      const response = await fetch("/api/trns", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}))
+        setSubmitError(
+          err.message || err.error || `Failed: ${response.statusText}`,
+        )
+        return
+      }
+
+      // Remember the selection for next time (best-effort).
+      try {
+        await fetch("/api/me", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            defaultPayslipPortfolioId: portfolioId,
+            defaultPayslipCashAssetId: cashAssetId,
+          }),
+        })
+      } catch {
+        // Non-fatal — the transactions already posted.
+      }
+
+      const portfolio = portfolios.find((p) => p.id === portfolioId)
+      setTimeout(() => {
+        if (portfolio) globalMutate(holdingKey(portfolio.code, "today"))
+        globalMutate("/api/holdings/aggregated?asAt=today")
+      }, 1500)
+
+      setSubmitSuccess(true)
+      setTimeout(() => onClose(), 1000)
+    } catch (error) {
+      setSubmitError(
+        error instanceof Error ? error.message : "Failed to save payslip",
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (!modalOpen) return null
+
+  return (
+    <Dialog
+      title={"Enter Payslip"}
+      onClose={onClose}
+      maxWidth={"lg"}
+      scrollable
+      footer={
+        <>
+          <Dialog.CancelButton onClick={onClose} label={"Cancel"} />
+          {submitSuccess ? (
+            <button
+              type="button"
+              className="px-4 py-2 rounded text-white bg-green-600"
+              disabled
+            >
+              <span className="flex items-center">
+                <i className="fas fa-check mr-2"></i>
+                {"Saved"}
+              </span>
+            </button>
+          ) : (
+            <Dialog.SubmitButton
+              onClick={handleSave}
+              label={"Save"}
+              loadingLabel={"Saving..."}
+              isSubmitting={isSubmitting}
+              disabled={!canSubmit}
+            />
+          )}
+        </>
+      }
+    >
+      <p className="text-sm text-gray-500">
+        {
+          "Record your pay: salary in, deductions out, and your pension contribution credited."
+        }
+      </p>
+
+      {/* Gross salary */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {"Gross salary"}
+        </label>
+        <MathInput
+          value={grossSalary === "" ? "" : parseFloat(grossSalary)}
+          onChange={(value) => setGrossSalary(String(value))}
+          placeholder={"0.00"}
+          aria-label={"Gross salary"}
+          className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border"
+        />
+      </div>
+
+      {/* Portfolio */}
+      <div>
+        <label
+          htmlFor="payslip-portfolio"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {"Portfolio"}
+        </label>
+        <select
+          id="payslip-portfolio"
+          value={portfolioId}
+          onChange={(e) => setPortfolioId(e.target.value)}
+          className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border bg-white"
+        >
+          <option value="">{"Select a portfolio..."}</option>
+          {portfolios.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.code} — {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Cash asset */}
+      <div>
+        <label
+          htmlFor="payslip-cash-asset"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          {"Pay into"}
+        </label>
+        <select
+          id="payslip-cash-asset"
+          value={cashAssetId}
+          onChange={(e) => setCashAssetId(e.target.value)}
+          className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border bg-white"
+        >
+          <option value="">{"Select a cash account..."}</option>
+          {cashOptions.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Tax */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {"Tax deducted (optional)"}
+        </label>
+        <MathInput
+          value={tax === "" ? "" : parseFloat(tax)}
+          onChange={(value) => setTax(String(value))}
+          placeholder={"0.00"}
+          aria-label={"Tax deducted"}
+          className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border"
+        />
+      </div>
+
+      {/* Pension section */}
+      {showPension && dc && (
+        <div
+          className="rounded-lg border border-amber-200 bg-amber-50 p-3 space-y-3"
+          data-testid="pension-section"
+        >
+          <div className="font-semibold text-gray-800">
+            {"Pension (CPF) contribution"}
+          </div>
+          <p className="text-xs text-gray-600">
+            {
+              "Split across your accounts. You can adjust each amount to match your payslip."
+            }
+          </p>
+
+          {effectiveBuckets.map((b) => (
+            <div
+              key={b.code}
+              className="flex items-center justify-between gap-3"
+            >
+              <label
+                htmlFor={`payslip-bucket-${b.code}`}
+                className="text-sm font-medium text-gray-700 w-12"
+              >
+                {b.code}
+              </label>
+              <MathInput
+                value={
+                  bucketOverrides[b.code] !== undefined &&
+                  bucketOverrides[b.code] !== ""
+                    ? parseFloat(bucketOverrides[b.code])
+                    : b.amount
+                }
+                onChange={(value) =>
+                  setBucketOverrides((prev) => ({
+                    ...prev,
+                    [b.code]: String(value),
+                  }))
+                }
+                aria-label={`CPF ${b.code}`}
+                className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border"
+              />
+            </div>
+          ))}
+
+          <div className="pt-2 border-t border-amber-200 text-xs text-gray-600 space-y-1">
+            <div className="flex justify-between">
+              <span>{"Your contribution"}</span>
+              <span>{formatAmount(dc.employeeContribution)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>{"Employer contribution"}</span>
+              <span>{formatAmount(dc.employerContribution)}</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Dialog.ErrorAlert message={submitError} />
+    </Dialog>
+  )
+}
+
+export default PayslipModal

--- a/src/components/features/transactions/__tests__/PayslipModal.test.tsx
+++ b/src/components/features/transactions/__tests__/PayslipModal.test.tsx
@@ -1,0 +1,208 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import PayslipModal from "../PayslipModal"
+
+const mockPortfolios = {
+  data: [{ id: "pf-1", code: "MAIN", name: "Main", base: { code: "SGD" } }],
+}
+const mockCash = {
+  data: [
+    {
+      id: "cash-sgd",
+      code: "SGD",
+      name: "SGD Cash",
+      assetCategory: { id: "CASH", name: "Cash" },
+      market: { code: "CASH" },
+    },
+  ],
+}
+
+// Synchronous SWR: route by key substring.
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (!key) return { data: undefined, error: undefined, isLoading: false }
+    if (key.includes("portfolios"))
+      return { data: mockPortfolios, error: undefined, isLoading: false }
+    if (key.includes("cash"))
+      return { data: mockCash, error: undefined, isLoading: false }
+    return { data: { data: [] }, error: undefined, isLoading: false }
+  },
+  mutate: jest.fn(),
+}))
+
+const mockPreferences = {
+  preferences: {
+    id: "u1",
+    yearOfBirth: 1985,
+    defaultPayslipPortfolioId: "pf-1",
+    defaultPayslipCashAssetId: "cash-sgd",
+  },
+  isLoading: false,
+  refetch: jest.fn(),
+}
+jest.mock("@contexts/UserPreferencesContext", () => ({
+  useUserPreferences: () => mockPreferences,
+}))
+
+let mockConfigs: Array<{ assetId: string; policyType: string }> = []
+jest.mock("@lib/assets/usePrivateAssetConfigs", () => ({
+  usePrivateAssetConfigs: () => ({ configs: mockConfigs }),
+}))
+
+let mockDc:
+  | {
+      employeeContribution: number
+      employerContribution: number
+      employeeRate: number
+      cappedSalary: number
+      hasDefinedContribution: boolean
+      buckets?: { code: string; amount: number }[]
+    }
+  | undefined
+jest.mock("@components/features/independence/useDefinedContribution", () => ({
+  useDefinedContribution: () => ({ data: mockDc }),
+}))
+
+describe("PayslipModal", () => {
+  beforeEach(() => {
+    mockConfigs = []
+    mockDc = undefined
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof fetch
+  })
+
+  it("renders the core fields", () => {
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    expect(screen.getByText("Enter Payslip")).toBeInTheDocument()
+    expect(screen.getByLabelText("Gross salary")).toBeInTheDocument()
+    expect(screen.getByLabelText("Portfolio")).toBeInTheDocument()
+    expect(screen.getByLabelText("Pay into")).toBeInTheDocument()
+    expect(screen.getByLabelText("Tax deducted")).toBeInTheDocument()
+  })
+
+  it("hides the pension section when there is no CPF asset", () => {
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    expect(screen.queryByTestId("pension-section")).not.toBeInTheDocument()
+  })
+
+  it("shows the pension section with bucket inputs when a CPF asset exists", () => {
+    mockConfigs = [{ assetId: "cpf-asset", policyType: "CPF" }]
+    mockDc = {
+      employeeContribution: 1200,
+      employerContribution: 1020,
+      employeeRate: 0.2,
+      cappedSalary: 6000,
+      hasDefinedContribution: true,
+      buckets: [
+        { code: "OA", amount: 1380 },
+        { code: "SA", amount: 360 },
+        { code: "MA", amount: 660 },
+      ],
+    }
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    // Gross must be > 0 for the DC fetch to be meaningful; set it.
+    fireEvent.change(screen.getByLabelText("Gross salary"), {
+      target: { value: "6000" },
+    })
+    expect(screen.getByTestId("pension-section")).toBeInTheDocument()
+    expect(screen.getByLabelText("CPF OA")).toBeInTheDocument()
+    expect(screen.getByLabelText("CPF SA")).toBeInTheDocument()
+    expect(screen.getByLabelText("CPF MA")).toBeInTheDocument()
+  })
+
+  it("submits a 4-leg payload with employee-only cash debit and overridden buckets", async () => {
+    mockConfigs = [{ assetId: "cpf-asset", policyType: "CPF" }]
+    mockDc = {
+      employeeContribution: 1200,
+      employerContribution: 1020,
+      employeeRate: 0.2,
+      cappedSalary: 6000,
+      hasDefinedContribution: true,
+      buckets: [
+        { code: "OA", amount: 1380 },
+        { code: "SA", amount: 360 },
+        { code: "MA", amount: 660 },
+      ],
+    }
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    fireEvent.change(screen.getByLabelText("Gross salary"), {
+      target: { value: "6000" },
+    })
+    fireEvent.change(screen.getByLabelText("Tax deducted"), {
+      target: { value: "500" },
+    })
+    // Override the OA bucket.
+    fireEvent.change(screen.getByLabelText("CPF OA"), {
+      target: { value: "1500" },
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      const trnCall = (global.fetch as jest.Mock).mock.calls.find(
+        (c) => c[0] === "/api/trns",
+      )
+      expect(trnCall).toBeDefined()
+    })
+
+    const trnCall = (global.fetch as jest.Mock).mock.calls.find(
+      (c) => c[0] === "/api/trns",
+    )!
+    const body = JSON.parse(trnCall[1].body)
+    expect(body.portfolioId).toBe("pf-1")
+    expect(body.data.map((l: { trnType: string }) => l.trnType)).toEqual([
+      "INCOME",
+      "DEDUCTION",
+      "DEDUCTION",
+      "ADD",
+    ])
+    // Employee-only cash debit
+    expect(body.data[1].cashAmount).toBe(-1200)
+    // Tax leg
+    expect(body.data[2].cashAmount).toBe(-500)
+    // Overridden buckets → subAccounts
+    expect(body.data[3].subAccounts).toEqual({ OA: 1500, SA: 360, MA: 660 })
+    expect(body.data[3].cashAmount).toBe(0)
+
+    // Prefs PATCH on save
+    await waitFor(() => {
+      const meCall = (global.fetch as jest.Mock).mock.calls.find(
+        (c) => c[0] === "/api/me",
+      )
+      expect(meCall).toBeDefined()
+      expect(meCall![1].method).toBe("PATCH")
+    })
+  })
+
+  it("submits salary + optional tax only when no CPF asset", async () => {
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    fireEvent.change(screen.getByLabelText("Gross salary"), {
+      target: { value: "4000" },
+    })
+    fireEvent.change(screen.getByLabelText("Tax deducted"), {
+      target: { value: "300" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      const trnCall = (global.fetch as jest.Mock).mock.calls.find(
+        (c) => c[0] === "/api/trns",
+      )
+      expect(trnCall).toBeDefined()
+    })
+    const trnCall = (global.fetch as jest.Mock).mock.calls.find(
+      (c) => c[0] === "/api/trns",
+    )!
+    const body = JSON.parse(trnCall[1].body)
+    expect(body.data.map((l: { trnType: string }) => l.trnType)).toEqual([
+      "INCOME",
+      "DEDUCTION",
+    ])
+    expect(body.data[0].cashAmount).toBe(4000)
+    expect(body.data[1].cashAmount).toBe(-300)
+  })
+})

--- a/src/components/layout/HeaderBrand.tsx
+++ b/src/components/layout/HeaderBrand.tsx
@@ -3,6 +3,11 @@ import { useRouter } from "next/router"
 import Link from "next/link"
 import { useUser } from "@auth0/nextjs-auth0/client"
 import { usePermissions } from "@hooks/usePermissions"
+import PayslipModal from "@components/features/transactions/PayslipModal"
+
+// Sentinel `action` values for nav items that open a modal instead of
+// navigating. The href is kept (as a hash) so existing rendering still works.
+type NavAction = "payslip"
 
 interface NavItem {
   href: string
@@ -11,6 +16,7 @@ interface NavItem {
   description?: string
   adminOnly?: boolean
   aiOnly?: boolean
+  action?: NavAction
 }
 
 interface NavSection {
@@ -57,6 +63,12 @@ const navSections: NavSection[] = [
     title: "Tools",
     items: [
       { href: "/chat", label: "Chat", icon: "fa-robot", aiOnly: true },
+      {
+        href: "#enter-payslip",
+        label: "Enter Payslip",
+        icon: "fa-money-check-dollar",
+        action: "payslip",
+      },
       {
         href: "/tools/open-brokerage",
         label: "Open Brokerage",
@@ -151,11 +163,13 @@ function DesktopDropdown({
   isAdmin,
   canRunAi,
   router,
+  onAction,
 }: {
   section: NavSection
   isAdmin: boolean
   canRunAi: boolean
   router: ReturnType<typeof useRouter>
+  onAction: (action: NavAction) => void
 }): React.ReactElement | null {
   const [isOpen, setIsOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -245,22 +259,42 @@ function DesktopDropdown({
           {filteredItems.map((item) => {
             const active = isActiveRoute(router.pathname, item.href)
             const colors = sectionColors[section.title] || defaultSectionColor
+            const itemClass = `flex items-center gap-2.5 px-3 py-2 text-sm transition-colors ${
+              active
+                ? `${colors.bg} ${colors.text} font-medium`
+                : "text-gray-700 hover:bg-gray-50"
+            }`
+            const itemIcon = (
+              <i
+                className={`fas ${item.icon} w-4 text-center text-xs ${
+                  active ? colors.text : "text-gray-400"
+                }`}
+              ></i>
+            )
+            if (item.action) {
+              return (
+                <button
+                  key={item.href}
+                  type="button"
+                  onClick={() => {
+                    setIsOpen(false)
+                    onAction(item.action!)
+                  }}
+                  className={`${itemClass} w-full text-left`}
+                >
+                  {itemIcon}
+                  {item.label}
+                </button>
+              )
+            }
             return (
               <Link
                 key={item.href}
                 href={item.href}
                 onClick={() => setIsOpen(false)}
-                className={`flex items-center gap-2.5 px-3 py-2 text-sm transition-colors ${
-                  active
-                    ? `${colors.bg} ${colors.text} font-medium`
-                    : "text-gray-700 hover:bg-gray-50"
-                }`}
+                className={itemClass}
               >
-                <i
-                  className={`fas ${item.icon} w-4 text-center text-xs ${
-                    active ? colors.text : "text-gray-400"
-                  }`}
-                ></i>
+                {itemIcon}
                 {item.label}
               </Link>
             )
@@ -276,8 +310,13 @@ function HeaderBrand(): React.ReactElement {
   const { user } = useUser()
   const { admin: isAdmin, ai: canRunAi } = usePermissions()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [payslipOpen, setPayslipOpen] = useState(false)
   const mobileMenuRef = useRef<HTMLDivElement>(null)
   const isAuthed = !!user
+
+  const openAction = useCallback((action: NavAction): void => {
+    if (action === "payslip") setPayslipOpen(true)
+  }, [])
 
   // Close mobile menu when clicking outside
   useEffect(() => {
@@ -382,21 +421,41 @@ function HeaderBrand(): React.ReactElement {
                         const active = isActiveRoute(router.pathname, item.href)
                         const colors =
                           sectionColors[section.title] || defaultSectionColor
+                        const itemClass = `flex items-center gap-2.5 px-3 py-2 transition-colors ${
+                          active
+                            ? `${colors.bg} ${colors.text} font-medium`
+                            : "text-gray-700 hover:bg-gray-50"
+                        }`
+                        const itemIcon = (
+                          <i
+                            className={`fas ${item.icon} w-4 text-center text-xs ${
+                              active ? colors.text : "text-gray-400"
+                            }`}
+                          ></i>
+                        )
+                        if (item.action) {
+                          return (
+                            <button
+                              key={item.href}
+                              type="button"
+                              onClick={() => {
+                                setMobileMenuOpen(false)
+                                openAction(item.action!)
+                              }}
+                              className={`${itemClass} w-full text-left`}
+                            >
+                              {itemIcon}
+                              <span className="text-sm">{item.label}</span>
+                            </button>
+                          )
+                        }
                         return (
                           <Link
                             key={item.href}
                             href={item.href}
-                            className={`flex items-center gap-2.5 px-3 py-2 transition-colors ${
-                              active
-                                ? `${colors.bg} ${colors.text} font-medium`
-                                : "text-gray-700 hover:bg-gray-50"
-                            }`}
+                            className={itemClass}
                           >
-                            <i
-                              className={`fas ${item.icon} w-4 text-center text-xs ${
-                                active ? colors.text : "text-gray-400"
-                              }`}
-                            ></i>
+                            {itemIcon}
                             <span className="text-sm">{item.label}</span>
                           </Link>
                         )
@@ -437,9 +496,18 @@ function HeaderBrand(): React.ReactElement {
               isAdmin={isAdmin}
               canRunAi={canRunAi}
               router={router}
+              onAction={openAction}
             />
           ))}
         </nav>
+      )}
+
+      {/* Tools → Enter Payslip modal, rendered once for the whole header. */}
+      {isAuthed && (
+        <PayslipModal
+          modalOpen={payslipOpen}
+          onClose={() => setPayslipOpen(false)}
+        />
       )}
     </div>
   )

--- a/src/lib/utils/trns/__tests__/payslipPayload.test.ts
+++ b/src/lib/utils/trns/__tests__/payslipPayload.test.ts
@@ -1,0 +1,157 @@
+import { buildPayslipPayload } from "../payslipPayload"
+
+const base = {
+  portfolioId: "pf-1",
+  tradeDate: "2026-06-17",
+  cashAssetId: "cash-sgd",
+  cashCurrency: "SGD",
+}
+
+describe("buildPayslipPayload", () => {
+  describe("with CPF", () => {
+    const payload = buildPayslipPayload({
+      ...base,
+      grossSalary: 6000,
+      tax: 500,
+      cpfAssetId: "cpf-asset",
+      employeeContribution: 1200,
+      buckets: [
+        { code: "OA", amount: 1380 },
+        { code: "SA", amount: 360 },
+        { code: "MA", amount: 660 },
+      ],
+    })
+
+    it("forwards the chosen portfolio", () => {
+      expect(payload.portfolioId).toBe("pf-1")
+    })
+
+    it("emits four legs: salary, employee CPF, tax, CPF ADD", () => {
+      expect(payload.data).toHaveLength(4)
+      expect(payload.data.map((l) => l.trnType)).toEqual([
+        "INCOME",
+        "DEDUCTION",
+        "DEDUCTION",
+        "ADD",
+      ])
+    })
+
+    it("credits gross salary as INCOME to the cash asset", () => {
+      const salary = payload.data[0]
+      expect(salary.trnType).toBe("INCOME")
+      expect(salary.assetId).toBe("cash-sgd")
+      expect(salary.cashAssetId).toBe("cash-sgd")
+      expect(salary.cashAmount).toBe(6000)
+      expect(salary.tradeAmount).toBe(6000)
+      expect(salary.tradeCurrency).toBe("SGD")
+    })
+
+    it("debits ONLY the employee contribution from cash (employer is on-top)", () => {
+      const employee = payload.data[1]
+      expect(employee.trnType).toBe("DEDUCTION")
+      expect(employee.cashAssetId).toBe("cash-sgd")
+      expect(employee.cashAmount).toBe(-1200)
+    })
+
+    it("debits tax from cash when tax > 0", () => {
+      const taxLeg = payload.data[2]
+      expect(taxLeg.trnType).toBe("DEDUCTION")
+      expect(taxLeg.cashAmount).toBe(-500)
+      expect(taxLeg.tax).toBe(500)
+    })
+
+    it("ADDs the bucket total to the CPF asset with subAccounts and no cash impact", () => {
+      const cpf = payload.data[3]
+      expect(cpf.trnType).toBe("ADD")
+      expect(cpf.assetId).toBe("cpf-asset")
+      expect(cpf.cashAmount).toBe(0)
+      expect(cpf.quantity).toBe(2400) // 1380 + 360 + 660 = employee + employer total
+      expect(cpf.tradeAmount).toBe(2400)
+      expect(cpf.subAccounts).toEqual({ OA: 1380, SA: 360, MA: 660 })
+    })
+
+    it("honours overridden bucket values in the subAccounts and total", () => {
+      const overridden = buildPayslipPayload({
+        ...base,
+        grossSalary: 6000,
+        cpfAssetId: "cpf-asset",
+        employeeContribution: 1200,
+        buckets: [
+          { code: "OA", amount: 1000 },
+          { code: "SA", amount: 500 },
+          { code: "MA", amount: 700 },
+        ],
+      })
+      const cpf = overridden.data[overridden.data.length - 1]
+      expect(cpf.subAccounts).toEqual({ OA: 1000, SA: 500, MA: 700 })
+      expect(cpf.quantity).toBe(2200)
+    })
+
+    it("omits the tax leg when tax is 0", () => {
+      const noTax = buildPayslipPayload({
+        ...base,
+        grossSalary: 6000,
+        tax: 0,
+        cpfAssetId: "cpf-asset",
+        employeeContribution: 1200,
+        buckets: [{ code: "OA", amount: 1200 }],
+      })
+      expect(noTax.data.map((l) => l.trnType)).toEqual([
+        "INCOME",
+        "DEDUCTION",
+        "ADD",
+      ])
+    })
+
+    it("supports RA bucket code (post-retirement)", () => {
+      const ra = buildPayslipPayload({
+        ...base,
+        grossSalary: 5000,
+        cpfAssetId: "cpf-asset",
+        employeeContribution: 1000,
+        buckets: [
+          { code: "RA", amount: 1500 },
+          { code: "MA", amount: 500 },
+        ],
+      })
+      const cpf = ra.data[ra.data.length - 1]
+      expect(cpf.subAccounts).toEqual({ RA: 1500, MA: 500 })
+    })
+  })
+
+  describe("without CPF", () => {
+    it("emits only the salary leg when there is no CPF asset and no tax", () => {
+      const payload = buildPayslipPayload({
+        ...base,
+        grossSalary: 4000,
+      })
+      expect(payload.data).toHaveLength(1)
+      expect(payload.data[0].trnType).toBe("INCOME")
+      expect(payload.data[0].cashAmount).toBe(4000)
+    })
+
+    it("emits salary + tax (no CPF legs) when tax > 0 but no CPF asset", () => {
+      const payload = buildPayslipPayload({
+        ...base,
+        grossSalary: 4000,
+        tax: 300,
+      })
+      expect(payload.data.map((l) => l.trnType)).toEqual([
+        "INCOME",
+        "DEDUCTION",
+      ])
+      expect(payload.data[1].cashAmount).toBe(-300)
+    })
+
+    it("does not add CPF legs when buckets are empty even with a cpfAssetId", () => {
+      const payload = buildPayslipPayload({
+        ...base,
+        grossSalary: 4000,
+        cpfAssetId: "cpf-asset",
+        employeeContribution: 1000,
+        buckets: [],
+      })
+      expect(payload.data.map((l) => l.trnType)).toEqual(["INCOME"])
+    })
+  })
+})

--- a/src/lib/utils/trns/payslipPayload.ts
+++ b/src/lib/utils/trns/payslipPayload.ts
@@ -1,0 +1,191 @@
+import { DefinedContributionBucket } from "@components/features/independence/useDefinedContribution"
+
+/**
+ * One transaction leg of a payslip submission, matching the loose REST shape
+ * accepted by `POST /api/trns` ({ portfolioId, data: PayslipTrnLeg[] }).
+ *
+ * The backend `TrnDto` already supports `subAccounts` and an arbitrary
+ * `trnType`, so the CPF credit leg can carry its OA/SA|RA/MA split directly.
+ */
+export interface PayslipTrnLeg {
+  assetId: string
+  trnType: string
+  quantity: number
+  price: number
+  tradeCurrency: string
+  tradeAmount: number
+  cashCurrency: string
+  cashAssetId?: string
+  cashAmount: number
+  tradeDate: string
+  fees: number
+  tax: number
+  comments: string
+  status: string
+  subAccounts?: Record<string, number>
+}
+
+export interface PayslipPayload {
+  portfolioId: string
+  data: PayslipTrnLeg[]
+}
+
+export interface BuildPayslipPayloadInput {
+  portfolioId: string
+  tradeDate: string
+  /** Gross salary paid into the cash asset (positive). */
+  grossSalary: number
+  /** Optional tax withheld (positive; 0 or undefined = no tax leg). */
+  tax?: number
+  /** Cash asset id the salary is paid into / deductions come out of. */
+  cashAssetId: string
+  /** Currency of the cash asset (also the trade currency of the cash legs). */
+  cashCurrency: string
+  /**
+   * CPF / pension asset id to credit. When absent (no CPF asset) only the
+   * salary + optional tax legs are produced.
+   */
+  cpfAssetId?: string
+  /**
+   * Employee-only contribution that comes OUT of cash (positive). The employer
+   * portion is on-top and never debits cash, so it is excluded here.
+   */
+  employeeContribution?: number
+  /**
+   * Per-bucket CPF allocation (employee + employer total). Drives both the
+   * `subAccounts` map and the ADD leg's quantity/amount (the sum of buckets).
+   */
+  buckets?: DefinedContributionBucket[]
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100
+
+const sumBuckets = (buckets: DefinedContributionBucket[]): number =>
+  round2(buckets.reduce((acc, b) => acc + (b.amount || 0), 0))
+
+const bucketsToSubAccounts = (
+  buckets: DefinedContributionBucket[],
+): Record<string, number> =>
+  buckets.reduce<Record<string, number>>((acc, b) => {
+    if (b.code) acc[b.code] = round2(b.amount || 0)
+    return acc
+  }, {})
+
+/**
+ * Build the multi-leg `POST /api/trns` payload for an Enter-Payslip submission.
+ *
+ * Legs (single request, shared tradeDate):
+ *  1. Salary    — INCOME crediting cash (+gross).
+ *  2. Employee CPF — DEDUCTION debiting cash (−employeeContribution). Only the
+ *     employee portion touches cash; the employer match is on-top.
+ *  3. Tax       — DEDUCTION debiting cash (−tax). Only when tax > 0.
+ *  4. CPF credit — ADD to the CPF asset (no cash impact) with `subAccounts`
+ *     from the (possibly overridden) buckets; amount = sum of buckets.
+ *
+ * Legs 2 & 4 are omitted when there is no CPF asset / no buckets.
+ */
+export function buildPayslipPayload(
+  input: BuildPayslipPayloadInput,
+): PayslipPayload {
+  const {
+    portfolioId,
+    tradeDate,
+    grossSalary,
+    tax,
+    cashAssetId,
+    cashCurrency,
+    cpfAssetId,
+    employeeContribution,
+    buckets,
+  } = input
+
+  const data: PayslipTrnLeg[] = []
+
+  // 1. Salary — INCOME credits the cash asset with the gross amount.
+  const gross = round2(grossSalary)
+  data.push({
+    assetId: cashAssetId,
+    trnType: "INCOME",
+    quantity: 1,
+    price: gross,
+    tradeCurrency: cashCurrency,
+    tradeAmount: gross,
+    cashCurrency,
+    cashAssetId,
+    cashAmount: gross,
+    tradeDate,
+    fees: 0,
+    tax: 0,
+    comments: "Salary",
+    status: "SETTLED",
+  })
+
+  const hasCpf = !!cpfAssetId && !!buckets && buckets.length > 0
+
+  // 2. Employee CPF — DEDUCTION debits cash (employee portion only).
+  if (hasCpf && employeeContribution && employeeContribution > 0) {
+    const employee = round2(employeeContribution)
+    data.push({
+      assetId: cashAssetId,
+      trnType: "DEDUCTION",
+      quantity: 1,
+      price: employee,
+      tradeCurrency: cashCurrency,
+      tradeAmount: employee,
+      cashCurrency,
+      cashAssetId,
+      cashAmount: -employee,
+      tradeDate,
+      fees: 0,
+      tax: 0,
+      comments: "Employee CPF contribution",
+      status: "SETTLED",
+    })
+  }
+
+  // 3. Tax — DEDUCTION debits cash. Optional.
+  if (tax && tax > 0) {
+    const taxAmount = round2(tax)
+    data.push({
+      assetId: cashAssetId,
+      trnType: "DEDUCTION",
+      quantity: 1,
+      price: taxAmount,
+      tradeCurrency: cashCurrency,
+      tradeAmount: taxAmount,
+      cashCurrency,
+      cashAssetId,
+      cashAmount: -taxAmount,
+      tradeDate,
+      fees: 0,
+      tax: taxAmount,
+      comments: "Tax",
+      status: "SETTLED",
+    })
+  }
+
+  // 4. CPF credit — ADD to the CPF asset (no cash impact) with sub-accounts.
+  if (hasCpf) {
+    const subAccounts = bucketsToSubAccounts(buckets!)
+    const total = sumBuckets(buckets!)
+    data.push({
+      assetId: cpfAssetId!,
+      trnType: "ADD",
+      quantity: total,
+      price: 1,
+      tradeCurrency: cashCurrency,
+      tradeAmount: total,
+      // ADD has no cash impact — settlement currency is nominal, no cash asset.
+      cashCurrency,
+      cashAmount: 0,
+      tradeDate,
+      fees: 0,
+      tax: 0,
+      comments: "CPF contribution",
+      status: "SETTLED",
+      subAccounts,
+    })
+  }
+
+  return { portfolioId, data }
+}

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -508,6 +508,10 @@ export interface UserPreferences {
   yearOfBirth?: number
   monthOfBirth?: number
   lifeExpectancy?: number
+  // Enter-Payslip defaults: last portfolio + cash asset used so the dialog
+  // can prefill on the next pay run.
+  defaultPayslipPortfolioId?: string | null
+  defaultPayslipCashAssetId?: string | null
 }
 
 export interface UserPreferencesRequest {
@@ -525,6 +529,8 @@ export interface UserPreferencesRequest {
   yearOfBirth?: number
   monthOfBirth?: number
   lifeExpectancy?: number
+  defaultPayslipPortfolioId?: string | null
+  defaultPayslipCashAssetId?: string | null
 }
 
 export interface RegistrationResponse {


### PR DESCRIPTION
Adds Tools → Enter Payslip, a modal to record a monthly payslip as transactions.

**Form:** gross salary, portfolio, cash asset (reuses SettlementAccountSelect), optional tax. Portfolio + cash asset prefill from saved user prefs and are re-saved on submit (PATCH /api/me).

**Pension (only when the user has a CPF asset):** calls the existing defined-contribution endpoint (now returning per-bucket OA/SA/MA via svc-retire #84), shows the buckets as editable inputs the user can override; employee/employer totals shown read-only.

**On Save — transactions via POST /api/trns (one batch):**
- INCOME: +gross to the cash asset
- DEDUCTION: −employee CPF from cash (employee only — employer is on-top, never debits cash)
- DEDUCTION: −tax (only if tax > 0)
- ADD: credit the CPF asset, subAccounts = {OA, SA|RA, MA} = (overridable) bucket totals, no cash impact
No-CPF users get INCOME (+ optional tax) only.

Pure payload-builder helper (unit-tested, 12 cases) + modal render/submit tests. No backend change to /api/trns or /api/me needed (both already forward arbitrary trnType + subAccounts).

**Depends on:** svc-retire #84 (defined-contribution buckets) + beancounter #950 (payslip prefs) — merge those first; degrades gracefully without them (pension section hidden, prefs PATCH best-effort).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Enter Payslip" feature accessible from the header menu for recording salary, taxes, and CPF contributions
  * Supports overriding individual CPF bucket contribution amounts
  * Auto-prefills default portfolio and cash asset selections from saved user preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->