### PR TITLE
fix(payslip): precision-safe money rounding; address review nits

### DIFF
--- a/src/components/features/transactions/PayslipModal.tsx
+++ b/src/components/features/transactions/PayslipModal.tsx
@@ -206,10 +206,8 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
       }
 
       const portfolio = portfolios.find((p) => p.id === portfolioId)
-      setTimeout(() => {
-        if (portfolio) globalMutate(holdingKey(portfolio.code, "today"))
-        globalMutate("/api/holdings/aggregated?asAt=today")
-      }, 1500)
+      if (portfolio) globalMutate(holdingKey(portfolio.code, "today"))
+      globalMutate("/api/holdings/aggregated?asAt=today")
 
       setSubmitSuccess(true)
       setTimeout(() => onClose(), 1000)

--- a/src/components/layout/HeaderBrand.tsx
+++ b/src/components/layout/HeaderBrand.tsx
@@ -272,13 +272,14 @@ function DesktopDropdown({
               ></i>
             )
             if (item.action) {
+              const action = item.action
               return (
                 <button
                   key={item.href}
                   type="button"
                   onClick={() => {
                     setIsOpen(false)
-                    onAction(item.action!)
+                    onAction(action)
                   }}
                   className={`${itemClass} w-full text-left`}
                 >
@@ -434,13 +435,14 @@ function HeaderBrand(): React.ReactElement {
                           ></i>
                         )
                         if (item.action) {
+                          const action = item.action
                           return (
                             <button
                               key={item.href}
                               type="button"
                               onClick={() => {
                                 setMobileMenuOpen(false)
-                                openAction(item.action!)
+                                openAction(action)
                               }}
                               className={`${itemClass} w-full text-left`}
                             >

--- a/src/lib/utils/trns/__tests__/payslipPayload.test.ts
+++ b/src/lib/utils/trns/__tests__/payslipPayload.test.ts
@@ -1,4 +1,4 @@
-import { buildPayslipPayload } from "../payslipPayload"
+import { buildPayslipPayload } from "@lib/trns/payslipPayload"
 
 const base = {
   portfolioId: "pf-1",
@@ -101,6 +101,32 @@ describe("buildPayslipPayload", () => {
         "DEDUCTION",
         "ADD",
       ])
+    })
+
+    it("rounds .005 amounts half-up to cents (float-safe)", () => {
+      const payload = buildPayslipPayload({
+        ...base,
+        grossSalary: 100.005,
+        cpfAssetId: "cpf-asset",
+        employeeContribution: 1.005,
+        buckets: [
+          { code: "OA", amount: 1.005 },
+          { code: "SA", amount: 2.005 },
+        ],
+      })
+      const salary = payload.data[0]
+      expect(salary.cashAmount).toBe(100.01)
+      expect(salary.tradeAmount).toBe(100.01)
+      expect(salary.price).toBe(100.01)
+
+      const employee = payload.data[1]
+      expect(employee.cashAmount).toBe(-1.01)
+
+      const cpf = payload.data[payload.data.length - 1]
+      expect(cpf.subAccounts).toEqual({ OA: 1.01, SA: 2.01 })
+      // sum-then-round: 1.005 + 2.005 = 3.0099… → 3.01
+      expect(cpf.quantity).toBe(3.01)
+      expect(cpf.tradeAmount).toBe(3.01)
     })
 
     it("supports RA bucket code (post-retirement)", () => {

--- a/src/lib/utils/trns/payslipPayload.ts
+++ b/src/lib/utils/trns/payslipPayload.ts
@@ -58,7 +58,17 @@ export interface BuildPayslipPayloadInput {
   buckets?: DefinedContributionBucket[]
 }
 
-const round2 = (n: number): number => Math.round(n * 100) / 100
+/**
+ * Round a monetary value to cents using decimal half-up. Plain
+ * `Math.round(n * 100) / 100` (and `n.toFixed(2)`) mis-round values whose
+ * IEEE-754 representation lands just below the .5 boundary — e.g. 1.005 is
+ * stored as 1.00499999…, so both naive forms yield 1.00. Nudging by a relative
+ * epsilon before scaling restores the intended half-up result (1.005 → 1.01).
+ */
+const roundMoney = (n: number): number =>
+  Math.round((n + Math.sign(n) * Math.abs(n) * Number.EPSILON) * 100) / 100
+
+const round2 = roundMoney
 
 const sumBuckets = (buckets: DefinedContributionBucket[]): number =>
   round2(buckets.reduce((acc, b) => acc + (b.amount || 0), 0))


### PR DESCRIPTION
Follow-up review fixes for the Enter Payslip feature (original PR #902 was already squash-merged and cannot be reopened).

Addresses CodeRabbit review feedback:

1. **Precision-safe money rounding** — `payslipPayload.ts` no longer uses float-unsafe `Math.round(n * 100) / 100`. New `roundMoney` helper applies a relative-epsilon nudge before scaling so decimal half-up holds (e.g. 1.005 → 1.01, 100.005 → 100.01). Note: `Number.parseFloat(n.toFixed(2))` was insufficient — it also yields 1.00 for 1.005 because the IEEE-754 double is 1.00499…
2. **Removed arbitrary cache delay** — `PayslipModal.tsx` revalidates SWR keys immediately after save (dropped the 1500ms setTimeout); same keys retained.
3. **Removed non-null assertions** — `HeaderBrand.tsx` hoists `item.action` to a const inside the `if (item.action)` block; `!` no longer needed (typecheck green).
4. **Test import alias** — test now imports via `@lib/trns/payslipPayload`.

Added a rounding-edge unit test ("rounds .005 amounts half-up to cents (float-safe)").

Pre-commit: `yarn test` (1524 passed), `yarn prettier`, `yarn lint`, `yarn typecheck` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Enter Payslip" menu option for direct access to payslip submission from the header.
  * Holdings information now updates immediately after successful payslip submission.

* **Bug Fixes**
  * Enhanced monetary rounding precision for financial calculations.

* **Tests**
  * Expanded payslip payload testing coverage for rounding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->