### PR TITLE
fix(ui): Dialog card owns text color so nav-mounted modals stay readable

### DIFF
--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -46,7 +46,7 @@ export default function Dialog({
         onClick={onClose}
       ></div>
       <div
-        className={`bg-white rounded-lg shadow-lg w-full ${maxWidthClasses[maxWidth]} mx-4 z-50 ${scrollable ? "max-h-[90vh] overflow-hidden flex flex-col" : ""}`}
+        className={`bg-white text-gray-900 rounded-lg shadow-lg w-full ${maxWidthClasses[maxWidth]} mx-4 z-50 ${scrollable ? "max-h-[90vh] overflow-hidden flex flex-col" : ""}`}
         onClick={(e) => e.stopPropagation()}
       >
         <header className="flex justify-between items-center border-b p-4">


### PR DESCRIPTION
## Problem
`PayslipModal` (Tools → Enter Payslip) is the only modal mounted inside the dark header `<nav>` (`text-white`). `Dialog`'s white card never set its own text color, so inputs/selects/options inherited white → white-on-white = invisible. Symptom: gross-salary value won't show, portfolio/cash dropdowns look empty (DOM had the value + all options — just unreadable).

## Fix
`Dialog.tsx` card now owns `text-gray-900`, so any modal stays readable regardless of where it mounts. Button/alert colors set explicitly → unaffected.

## Verify
Reproduced + confirmed fix on kauri DOM: input color flipped white → gray-900; "8000", "Select a portfolio…", and cash options all render.

@coderabbitai ignore