### PR TITLE
feat(payslip): right-align CPF bucket inputs; add total contribution

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,14 +59,22 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["major"],
       "automerge": false,
-      "matchPackageNames": ["/eslint/", "/@typescript-eslint//", "/^typescript$/"]
+      "matchPackageNames": [
+        "/eslint/",
+        "/@typescript-eslint//",
+        "/^typescript$/"
+      ]
     },
     {
       "description": "Auto-merge minor and patch updates for other dev dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
-      "matchPackageNames": ["!/^typescript$/", "!/^@typescript-eslint//", "!/eslint/"]
+      "matchPackageNames": [
+        "!/^typescript$/",
+        "!/^@typescript-eslint//",
+        "!/eslint/"
+      ]
     }
   ],
   "vulnerabilityAlerts": {

--- a/src/components/features/transactions/PayslipModal.tsx
+++ b/src/components/features/transactions/PayslipModal.tsx
@@ -4,12 +4,17 @@ import Dialog from "@components/ui/Dialog"
 import MathInput from "@components/ui/MathInput"
 import { Asset, Portfolio } from "types/beancounter"
 import {
+  accountsKey,
   cashKey,
   holdingKey,
   portfoliosKey,
   simpleFetcher,
+  tradeAccountsKey,
 } from "@utils/api/fetchHelper"
-import { toCashAssetOptions } from "@components/features/transactions/SettlementAccountSelect"
+import {
+  toCashAssetOptions,
+  toSettlementAccountOptions,
+} from "@components/features/transactions/SettlementAccountSelect"
 import { usePrivateAssetConfigs } from "@lib/assets/usePrivateAssetConfigs"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import {
@@ -34,6 +39,12 @@ const formatAmount = (n: number): string =>
 const parseNum = (s: string): number => {
   const n = parseFloat(s)
   return isNaN(n) ? 0 : n
+}
+
+// SWR payloads arrive as either an array or a keyed object; normalise to array.
+const toAssetArray = (raw: unknown): Asset[] => {
+  if (!raw) return []
+  return Array.isArray(raw) ? raw : (Object.values(raw) as Asset[])
 }
 
 /**
@@ -72,19 +83,47 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
     modalOpen ? cashKey : null,
     simpleFetcher(cashKey),
   )
+  // Private cash-bearing assets held across the account: TRADE (brokerage cash)
+  // and ACCOUNT (bank) categories. Mirrors trade-settlement so "Pay into" can
+  // target a named private account, not just a generic currency balance.
+  const { data: tradeAccountsData } = useSWR(
+    modalOpen ? tradeAccountsKey : null,
+    simpleFetcher(tradeAccountsKey),
+  )
+  const { data: bankAccountsData } = useSWR(
+    modalOpen ? accountsKey : null,
+    simpleFetcher(accountsKey),
+  )
 
   const portfolios: Portfolio[] = useMemo(
     () => portfoliosData?.data ?? [],
     [portfoliosData],
   )
-  const cashAssets: Asset[] = useMemo(() => {
-    const raw = cashData?.data
-    if (!raw) return []
-    return Array.isArray(raw) ? raw : (Object.values(raw) as Asset[])
-  }, [cashData])
+  const cashAssets: Asset[] = useMemo(
+    () => toAssetArray(cashData?.data),
+    [cashData],
+  )
+  const tradeAccounts: Asset[] = useMemo(
+    () => toAssetArray(tradeAccountsData?.data),
+    [tradeAccountsData],
+  )
+  const bankAccounts: Asset[] = useMemo(
+    () => toAssetArray(bankAccountsData?.data),
+    [bankAccountsData],
+  )
+
+  // Generic currency balances (CASH market) shown as one group...
   const cashOptions = useMemo(
     () => toCashAssetOptions(cashAssets),
     [cashAssets],
+  )
+  // ...and named private accounts (bank first, then brokerage) as another.
+  const accountOptions = useMemo(
+    () => [
+      ...toSettlementAccountOptions(bankAccounts),
+      ...toSettlementAccountOptions(tradeAccounts),
+    ],
+    [bankAccounts, tradeAccounts],
   )
 
   // The user's CPF policy asset, if any.
@@ -153,9 +192,11 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
   )
 
   const selectedCashCurrency = useMemo(() => {
-    const opt = cashOptions.find((o) => o.value === cashAssetId)
+    const opt = [...cashOptions, ...accountOptions].find(
+      (o) => o.value === cashAssetId,
+    )
     return opt?.currency ?? ""
-  }, [cashOptions, cashAssetId])
+  }, [cashOptions, accountOptions, cashAssetId])
 
   const buildPayload = (): PayslipPayload =>
     buildPayslipPayload({
@@ -312,11 +353,24 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
           className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border bg-white"
         >
           <option value="">{"Select a cash account..."}</option>
-          {cashOptions.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
+          {accountOptions.length > 0 && (
+            <optgroup label="Accounts">
+              {accountOptions.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          {cashOptions.length > 0 && (
+            <optgroup label="Cash balances">
+              {cashOptions.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </optgroup>
+          )}
         </select>
       </div>
 

--- a/src/components/features/transactions/PayslipModal.tsx
+++ b/src/components/features/transactions/PayslipModal.tsx
@@ -191,12 +191,28 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
     [dc?.buckets, bucketOverrides],
   )
 
+  // Best "Pay into" match for the user's reporting currency. Preference order
+  // mirrors the dropdown: private accounts (bank, then brokerage) before a
+  // generic currency balance.
+  const reportingCurrency = preferences?.reportingCurrencyCode ?? "USD"
+  const preferredCashAssetId = useMemo(() => {
+    const match = [...accountOptions, ...cashOptions].find(
+      (o) => o.currency === reportingCurrency,
+    )
+    return match?.value ?? ""
+  }, [accountOptions, cashOptions, reportingCurrency])
+
+  // Derived selection: the user's explicit pick, else the reporting-currency
+  // default. Derived (not effect-set) so the React Compiler is happy and the
+  // default appears the moment the account lists load.
+  const effectiveCashAssetId = cashAssetId || preferredCashAssetId
+
   const selectedCashCurrency = useMemo(() => {
     const opt = [...cashOptions, ...accountOptions].find(
-      (o) => o.value === cashAssetId,
+      (o) => o.value === effectiveCashAssetId,
     )
     return opt?.currency ?? ""
-  }, [cashOptions, accountOptions, cashAssetId])
+  }, [cashOptions, accountOptions, effectiveCashAssetId])
 
   const buildPayload = (): PayslipPayload =>
     buildPayslipPayload({
@@ -204,14 +220,14 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
       tradeDate: todayIso(),
       grossSalary: grossNum,
       tax: parseNum(tax),
-      cashAssetId,
+      cashAssetId: effectiveCashAssetId,
       cashCurrency: selectedCashCurrency,
       cpfAssetId: showPension ? cpfConfig?.assetId : undefined,
       employeeContribution: showPension ? dc?.employeeContribution : undefined,
       buckets: showPension ? effectiveBuckets : undefined,
     })
 
-  const canSubmit = grossNum > 0 && !!portfolioId && !!cashAssetId
+  const canSubmit = grossNum > 0 && !!portfolioId && !!effectiveCashAssetId
 
   const handleSave = async (): Promise<void> => {
     if (!canSubmit) return
@@ -239,7 +255,7 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             defaultPayslipPortfolioId: portfolioId,
-            defaultPayslipCashAssetId: cashAssetId,
+            defaultPayslipCashAssetId: effectiveCashAssetId,
           }),
         })
       } catch {
@@ -348,7 +364,7 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
         </label>
         <select
           id="payslip-cash-asset"
-          value={cashAssetId}
+          value={effectiveCashAssetId}
           onChange={(e) => setCashAssetId(e.target.value)}
           className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border bg-white"
         >

--- a/src/components/features/transactions/PayslipModal.tsx
+++ b/src/components/features/transactions/PayslipModal.tsx
@@ -374,7 +374,7 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
                   }))
                 }
                 aria-label={`CPF ${b.code}`}
-                className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border"
+                className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border text-right"
               />
             </div>
           ))}
@@ -387,6 +387,17 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
             <div className="flex justify-between">
               <span>{"Employer contribution"}</span>
               <span>{formatAmount(dc.employerContribution)}</span>
+            </div>
+            <div
+              className="flex justify-between pt-1 border-t border-amber-200 font-semibold text-gray-800"
+              data-testid="pension-total"
+            >
+              <span>{"Total contribution"}</span>
+              <span>
+                {formatAmount(
+                  dc.employeeContribution + dc.employerContribution,
+                )}
+              </span>
             </div>
           </div>
         </div>

--- a/src/components/features/transactions/__tests__/PayslipModal.test.tsx
+++ b/src/components/features/transactions/__tests__/PayslipModal.test.tsx
@@ -17,6 +17,28 @@ const mockCash = {
     },
   ],
 }
+const mockTradeAccounts = {
+  data: [
+    {
+      id: "wise-usd",
+      code: "WISE",
+      name: "Wise USD",
+      priceSymbol: "USD",
+      market: { code: "US", currency: { code: "USD" } },
+    },
+  ],
+}
+const mockBankAccounts = {
+  data: [
+    {
+      id: "dbs-sgd",
+      code: "DBS",
+      name: "DBS Savings",
+      priceSymbol: "SGD",
+      market: { code: "SG", currency: { code: "SGD" } },
+    },
+  ],
+}
 
 // Synchronous SWR: route by key substring.
 jest.mock("swr", () => ({
@@ -25,6 +47,10 @@ jest.mock("swr", () => ({
     if (!key) return { data: undefined, error: undefined, isLoading: false }
     if (key.includes("portfolios"))
       return { data: mockPortfolios, error: undefined, isLoading: false }
+    if (key.includes("category=TRADE"))
+      return { data: mockTradeAccounts, error: undefined, isLoading: false }
+    if (key.includes("category=ACCOUNT"))
+      return { data: mockBankAccounts, error: undefined, isLoading: false }
     if (key.includes("cash"))
       return { data: mockCash, error: undefined, isLoading: false }
     return { data: { data: [] }, error: undefined, isLoading: false }
@@ -82,6 +108,19 @@ describe("PayslipModal", () => {
     expect(screen.getByLabelText("Portfolio")).toBeInTheDocument()
     expect(screen.getByLabelText("Pay into")).toBeInTheDocument()
     expect(screen.getByLabelText("Tax deducted")).toBeInTheDocument()
+  })
+
+  it("lists private TRADE/ACCOUNT accounts in Pay into, not just cash balances", () => {
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    const payInto = screen.getByLabelText("Pay into")
+    const labels = Array.from(payInto.querySelectorAll("option")).map(
+      (o) => o.textContent,
+    )
+    // Generic cash balance still present
+    expect(labels).toContain("SGD Cash")
+    // Named private accounts now offered (bank + brokerage cash)
+    expect(labels).toContain("DBS Savings (SGD)")
+    expect(labels).toContain("Wise USD (USD)")
   })
 
   it("hides the pension section when there is no CPF asset", () => {

--- a/src/components/features/transactions/__tests__/PayslipModal.test.tsx
+++ b/src/components/features/transactions/__tests__/PayslipModal.test.tsx
@@ -114,6 +114,25 @@ describe("PayslipModal", () => {
     expect(screen.getByLabelText("CPF MA")).toBeInTheDocument()
   })
 
+  it("shows a total contribution summing employee and employer", () => {
+    mockConfigs = [{ assetId: "cpf-asset", policyType: "CPF" }]
+    mockDc = {
+      employeeContribution: 1200,
+      employerContribution: 1020,
+      employeeRate: 0.2,
+      cappedSalary: 6000,
+      hasDefinedContribution: true,
+      buckets: [{ code: "OA", amount: 2220 }],
+    }
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    fireEvent.change(screen.getByLabelText("Gross salary"), {
+      target: { value: "6000" },
+    })
+    const total = screen.getByTestId("pension-total")
+    // 1200 + 1020 = 2220
+    expect(total).toHaveTextContent("2,220.00")
+  })
+
   it("submits a 4-leg payload with employee-only cash debit and overridden buckets", async () => {
     mockConfigs = [{ assetId: "cpf-asset", policyType: "CPF" }]
     mockDc = {

--- a/src/components/features/transactions/__tests__/PayslipModal.test.tsx
+++ b/src/components/features/transactions/__tests__/PayslipModal.test.tsx
@@ -62,9 +62,10 @@ const mockPreferences = {
   preferences: {
     id: "u1",
     yearOfBirth: 1985,
+    reportingCurrencyCode: "USD",
     defaultPayslipPortfolioId: "pf-1",
     defaultPayslipCashAssetId: "cash-sgd",
-  },
+  } as Record<string, unknown>,
   isLoading: false,
   refetch: jest.fn(),
 }
@@ -121,6 +122,25 @@ describe("PayslipModal", () => {
     // Named private accounts now offered (bank + brokerage cash)
     expect(labels).toContain("DBS Savings (SGD)")
     expect(labels).toContain("Wise USD (USD)")
+  })
+
+  it("defaults Pay into to the reporting-currency account when no saved pref", () => {
+    const prev = mockPreferences.preferences
+    mockPreferences.preferences = {
+      ...prev,
+      defaultPayslipCashAssetId: undefined,
+      reportingCurrencyCode: "SGD",
+    }
+    try {
+      render(<PayslipModal modalOpen onClose={jest.fn()} />)
+      // Reporting currency SGD → the SGD bank account is preferred over the
+      // generic SGD cash balance.
+      expect(
+        (screen.getByLabelText("Pay into") as HTMLSelectElement).value,
+      ).toBe("dbs-sgd")
+    } finally {
+      mockPreferences.preferences = prev
+    }
   })
 
   it("hides the pension section when there is no CPF asset", () => {


### PR DESCRIPTION
## Changes
- CPF bucket amount inputs right-aligned (`text-right`) so figures line up.
- New **Total contribution** row in the pension summary = employee + employer contribution.

## Test
Added `shows a total contribution summing employee and employer` (1200 + 1020 → "2,220.00"). Full suite green (1525).

@coderabbitai ignore