### PR TITLE
feat(trns): edit CPF transactions with the set-balance bucket display

### DIFF
--- a/src/components/features/holdings/SetBalanceDialog.tsx
+++ b/src/components/features/holdings/SetBalanceDialog.tsx
@@ -19,6 +19,7 @@ import { portfoliosKey, simpleFetcher } from "@utils/api/fetchHelper"
 import MathInput from "@components/ui/MathInput"
 import DateInput from "@components/ui/DateInput"
 import Dialog from "@components/ui/Dialog"
+import SubAccountBalanceInputs from "@components/features/holdings/SubAccountBalanceInputs"
 import { stripOwnerPrefix, getAssetCurrency } from "@lib/assets/assetUtils"
 
 interface PortfoliosResponse {
@@ -266,37 +267,15 @@ export default function SetBalanceDialog({
 
       {/* Sub-account balances (for POLICY assets with sub-accounts) */}
       {hasSubAccounts ? (
-        <div className="space-y-3">
-          <label className="block text-sm font-medium text-gray-700">
-            {"Sub-Account Balances"}
-          </label>
-          {configSubAccounts.map((sa) => (
-            <div key={sa.code} className="flex items-center space-x-3">
-              <span className="text-sm text-gray-700 w-24 flex-shrink-0">
-                {sa.displayName || sa.code}
-              </span>
-              <MathInput
-                value={subAccountBalances[sa.code] || 0}
-                onChange={(value) =>
-                  setSubAccountBalances((prev) => ({
-                    ...prev,
-                    [sa.code]: value,
-                  }))
-                }
-                placeholder="0"
-                className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-amber-500 focus:border-amber-500"
-              />
-            </div>
-          ))}
-          <div className="flex justify-between items-center pt-2 border-t border-gray-200">
-            <span className="text-sm font-medium text-gray-700">
-              {"Target Balance"}
-            </span>
-            <span className="text-sm font-medium">
-              {getAssetCurrency(asset)} {targetBalance.toLocaleString()}
-            </span>
-          </div>
-        </div>
+        <SubAccountBalanceInputs
+          subAccounts={configSubAccounts}
+          values={subAccountBalances}
+          onChange={(code, value) =>
+            setSubAccountBalances((prev) => ({ ...prev, [code]: value }))
+          }
+          currency={getAssetCurrency(asset)}
+          total={targetBalance}
+        />
       ) : (
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/src/components/features/holdings/SubAccountBalanceInputs.tsx
+++ b/src/components/features/holdings/SubAccountBalanceInputs.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import MathInput from "@components/ui/MathInput"
+
+/**
+ * Minimal shape needed to render a sub-account row. `SubAccount` (config) and
+ * any `{ code, displayName }` projection both satisfy it.
+ */
+export interface SubAccountRow {
+  code: string
+  displayName?: string
+}
+
+interface SubAccountBalanceInputsProps {
+  subAccounts: SubAccountRow[]
+  values: Record<string, number>
+  onChange: (code: string, value: number) => void
+  currency: string
+  total: number
+  label?: string
+  totalLabel?: string
+}
+
+/**
+ * Per-sub-account amount entry for composite policies (e.g. CPF OA / SA / MA),
+ * with a running total footer. Presentational only — shared by the "set
+ * balance" dialog and the CPF transaction editor so both surfaces offer the
+ * identical bucket data-entry display.
+ */
+export default function SubAccountBalanceInputs({
+  subAccounts,
+  values,
+  onChange,
+  currency,
+  total,
+  label = "Sub-Account Balances",
+  totalLabel = "Target Balance",
+}: SubAccountBalanceInputsProps): React.ReactElement {
+  return (
+    <div className="space-y-3">
+      <label className="block text-sm font-medium text-gray-700">{label}</label>
+      {subAccounts.map((sa) => (
+        <div key={sa.code} className="flex items-center space-x-3">
+          <span className="text-sm text-gray-700 w-24 flex-shrink-0">
+            {sa.displayName || sa.code}
+          </span>
+          <MathInput
+            value={values[sa.code] || 0}
+            onChange={(value) => onChange(sa.code, value)}
+            placeholder="0"
+            aria-label={sa.displayName || sa.code}
+            className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-amber-500 focus:border-amber-500"
+          />
+        </div>
+      ))}
+      <div className="flex justify-between items-center pt-2 border-t border-gray-200">
+        <span className="text-sm font-medium text-gray-700">{totalLabel}</span>
+        <span className="text-sm font-medium">
+          {currency} {total.toLocaleString()}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/transactions/SubAccountTrnEditModal.tsx
+++ b/src/components/features/transactions/SubAccountTrnEditModal.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useMemo, useState } from "react"
+import { useSWRConfig } from "swr"
+import { PrivateAssetConfig, Transaction } from "types/beancounter"
+import Dialog from "@components/ui/Dialog"
+import DateInput from "@components/ui/DateInput"
+import SubAccountBalanceInputs, {
+  SubAccountRow,
+} from "@components/features/holdings/SubAccountBalanceInputs"
+import { getAssetCurrency, stripOwnerPrefix } from "@lib/assets/assetUtils"
+import { holdingKey } from "@utils/api/fetchHelper"
+import { updateTrn } from "@utils/trns/apiHelper"
+
+interface SubAccountTrnEditModalProps {
+  trn: Transaction
+  onClose: () => void
+  onDelete?: () => void
+}
+
+/**
+ * Edit a composite-policy transaction (e.g. CPF) by its per-sub-account split,
+ * presenting the same bucket data-entry display as the "set balance" dialog.
+ * The new total drives quantity/tradeAmount; the sub-account map is PATCHed and
+ * the backend overwrites the snapshot split. Cash legs and other fields are
+ * preserved untouched.
+ */
+export default function SubAccountTrnEditModal({
+  trn,
+  onClose,
+  onDelete,
+}: SubAccountTrnEditModalProps): React.ReactElement {
+  const { mutate } = useSWRConfig()
+  const currency = getAssetCurrency(trn.asset) || trn.tradeCurrency.code
+
+  const [date, setDate] = useState<string>(trn.tradeDate)
+  const [values, setValues] = useState<Record<string, number>>(
+    () => ({ ...(trn.subAccounts ?? {}) }),
+  )
+  // Canonical sub-account rows (code + displayName + order) come from the asset
+  // config; fall back to the codes carried on the transaction itself.
+  const [configRows, setConfigRows] = useState<SubAccountRow[] | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const fetchConfig = async (): Promise<void> => {
+      try {
+        const res = await fetch(`/api/assets/config/${trn.asset.id}`)
+        if (!res.ok) return
+        const body: { data: PrivateAssetConfig } = await res.json()
+        const subs = body.data?.subAccounts
+        if (!cancelled && subs?.length) {
+          setConfigRows(
+            subs.map((s) => ({ code: s.code, displayName: s.displayName })),
+          )
+        }
+      } catch {
+        // No config — fall back to the transaction's own sub-account codes.
+      }
+    }
+    fetchConfig()
+    return () => {
+      cancelled = true
+    }
+  }, [trn.asset.id])
+
+  const rows: SubAccountRow[] = useMemo(() => {
+    if (configRows) return configRows
+    return Object.keys(trn.subAccounts ?? {}).map((code) => ({ code }))
+  }, [configRows, trn.subAccounts])
+
+  const total = useMemo(
+    () => Object.values(values).reduce((sum, v) => sum + (v || 0), 0),
+    [values],
+  )
+
+  const handleSave = async (): Promise<void> => {
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      const subAccounts = Object.fromEntries(
+        Object.entries(values).filter(([, v]) => v > 0),
+      )
+      const response = await updateTrn(trn.portfolio.id, trn.id, {
+        trnType: trn.trnType,
+        assetId: trn.asset.id,
+        tradeDate: date,
+        quantity: total,
+        price: trn.price,
+        tradeCurrency: trn.tradeCurrency.code,
+        tradeAmount: total,
+        cashCurrency: trn.cashCurrency || trn.tradeCurrency.code,
+        cashAssetId: trn.cashAsset?.id,
+        cashAmount: trn.cashAmount,
+        fees: trn.fees,
+        tax: trn.tax,
+        comments: trn.comments,
+        status: trn.status,
+        modelId: trn.modelId,
+        subAccounts,
+      })
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}))
+        setError(body.message || body.detail || "Failed to update transaction")
+        return
+      }
+      setTimeout(() => {
+        mutate(holdingKey(trn.portfolio.code, "today"))
+        mutate("/api/holdings/aggregated?asAt=today")
+      }, 1500)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog
+      title={"Edit CPF Transaction"}
+      onClose={onClose}
+      scrollable
+      footer={
+        <>
+          {onDelete && (
+            <Dialog.SubmitButton
+              onClick={onDelete}
+              label={"Delete"}
+              variant="red"
+            />
+          )}
+          <Dialog.CancelButton onClick={onClose} label={"Cancel"} />
+          <Dialog.SubmitButton
+            onClick={handleSave}
+            label={"Save"}
+            loadingLabel={"Saving..."}
+            isSubmitting={isSubmitting}
+            disabled={total <= 0}
+            variant="amber"
+          />
+        </>
+      }
+    >
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+        <div className="font-semibold text-lg">{trn.asset.name}</div>
+        <div className="text-sm text-gray-600">
+          {stripOwnerPrefix(trn.asset.code)} — {trn.trnType}
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {"Transaction Date"}
+        </label>
+        <DateInput
+          value={date}
+          onChange={setDate}
+          className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-amber-500 focus:border-amber-500"
+        />
+      </div>
+
+      <SubAccountBalanceInputs
+        subAccounts={rows}
+        values={values}
+        onChange={(code, value) =>
+          setValues((prev) => ({ ...prev, [code]: value }))
+        }
+        currency={currency}
+        total={total}
+      />
+
+      <Dialog.ErrorAlert message={error} />
+    </Dialog>
+  )
+}

--- a/src/components/features/transactions/__tests__/SubAccountTrnEditModal.test.tsx
+++ b/src/components/features/transactions/__tests__/SubAccountTrnEditModal.test.tsx
@@ -1,0 +1,97 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import SubAccountTrnEditModal from "../SubAccountTrnEditModal"
+import { Transaction } from "types/beancounter"
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  useSWRConfig: () => ({ mutate: jest.fn() }),
+}))
+
+const makeTrn = (): Transaction =>
+  ({
+    id: "trn-1",
+    trnType: "BALANCE",
+    status: "SETTLED",
+    portfolio: { id: "pf-1", code: "MAIN", name: "Main" },
+    asset: {
+      id: "cpf-1",
+      code: "CPF",
+      name: "CPF Policy",
+      priceSymbol: "SGD",
+      market: { code: "SG", currency: { code: "SGD" } },
+    },
+    tradeDate: "2026-06-01",
+    quantity: 100000,
+    price: 1,
+    tradeCurrency: { code: "SGD" },
+    tradeAmount: 100000,
+    cashCurrency: "SGD",
+    cashAmount: 0,
+    fees: 0,
+    tax: 0,
+    comments: "",
+    subAccounts: { OA: 60000, SA: 20000, MA: 20000 },
+  }) as unknown as Transaction
+
+const mockFetch = (): void => {
+  global.fetch = jest.fn((url: RequestInfo | URL) => {
+    if (String(url).includes("/api/assets/config/")) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              subAccounts: [
+                { code: "OA", displayName: "Ordinary" },
+                { code: "SA", displayName: "Special" },
+                { code: "MA", displayName: "Medisave" },
+              ],
+            },
+          }),
+      })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  }) as unknown as typeof fetch
+}
+
+describe("SubAccountTrnEditModal", () => {
+  beforeEach(mockFetch)
+
+  it("prefills the bucket inputs from the transaction sub-accounts", async () => {
+    render(<SubAccountTrnEditModal trn={makeTrn()} onClose={jest.fn()} />)
+    // Rows resolve from the asset config (display names) once it loads.
+    const oa = (await screen.findByLabelText("Ordinary")) as HTMLInputElement
+    expect(oa.value).toBe("60000")
+    expect((screen.getByLabelText("Special") as HTMLInputElement).value).toBe(
+      "20000",
+    )
+  })
+
+  it("PATCHes the edited split with a recomputed total", async () => {
+    render(<SubAccountTrnEditModal trn={makeTrn()} onClose={jest.fn()} />)
+    const oa = (await screen.findByLabelText("Ordinary")) as HTMLInputElement
+    fireEvent.change(oa, { target: { value: "70000" } })
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      const patch = (global.fetch as jest.Mock).mock.calls.find(
+        (c) =>
+          String(c[0]).includes("/api/trns/trn-1") && c[1]?.method === "PATCH",
+      )
+      expect(patch).toBeDefined()
+    })
+    const patch = (global.fetch as jest.Mock).mock.calls.find(
+      (c) =>
+        String(c[0]).includes("/api/trns/trn-1") && c[1]?.method === "PATCH",
+    )!
+    const body = JSON.parse(patch[1].body)
+    expect(body.subAccounts).toEqual({ OA: 70000, SA: 20000, MA: 20000 })
+    // 70000 + 20000 + 20000
+    expect(body.tradeAmount).toBe(110000)
+    expect(body.quantity).toBe(110000)
+    expect(body.trnType).toBe("BALANCE")
+  })
+})

--- a/src/lib/utils/trns/apiHelper.ts
+++ b/src/lib/utils/trns/apiHelper.ts
@@ -37,6 +37,8 @@ export interface TrnUpdatePayload {
   brokerId?: string
   /** Model ID for tracking which rebalance model this transaction belongs to */
   modelId?: string
+  /** Per-sub-account split for composite policies (e.g. CPF OA/SA/MA). */
+  subAccounts?: Record<string, number>
 }
 
 export function updateTrn(

--- a/src/pages/trns/trades/[...trades].tsx
+++ b/src/pages/trns/trades/[...trades].tsx
@@ -16,6 +16,7 @@ import { errorOut } from "@components/errors/ErrorOut"
 import useSwr, { mutate } from "swr"
 import { getDisplayCode } from "@lib/assets/assetUtils"
 import FxEditModal from "@components/features/transactions/FxEditModal"
+import SubAccountTrnEditModal from "@components/features/transactions/SubAccountTrnEditModal"
 import TradeInputForm from "@components/features/transactions/TradeInputForm"
 import { unsettleTrn } from "@utils/trns/apiHelper"
 
@@ -269,10 +270,22 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
     const isFxType =
       transaction.trnType === "FX" || transaction.trnType.startsWith("FX_")
 
+    // Composite-policy trns (e.g. CPF) carry a per-sub-account split; edit them
+    // with the same bucket data-entry display as "set balance".
+    const hasSubAccounts =
+      !!transaction.subAccounts &&
+      Object.keys(transaction.subAccounts).length > 0
+
     return (
       <>
         {editModalOpen ? (
-          isFxType ? (
+          hasSubAccounts ? (
+            <SubAccountTrnEditModal
+              trn={transaction}
+              onClose={handleClose}
+              onDelete={() => setShowDeleteConfirm(true)}
+            />
+          ) : isFxType ? (
             <FxEditModal
               trn={transaction}
               onClose={handleClose}


### PR DESCRIPTION
## Problem
Editing a CPF (composite-policy) transaction routed to the generic `TradeInputForm` — no OA/SA/MA bucket entry, and the edit path dropped `subAccounts` entirely. "Set balance" already has the right per-sub-account display.

## Change (frontend only — backend already persists `subAccounts` on PATCH)
- Extracted `SubAccountBalanceInputs` — the per-sub-account MathInputs + running total — out of `SetBalanceDialog` into a shared presentational component (set-balance flow unchanged).
- New `SubAccountTrnEditModal`: edits a trn's sub-account split with that same display, prefilled from `trn.subAccounts` (+ display names from asset config). New total drives quantity/tradeAmount; PATCHes `subAccounts`; cash legs and other fields preserved.
- Trades edit page routes any trn carrying `subAccounts` to the new modal (before FX / TradeInputForm).
- Added `subAccounts` to `TrnUpdatePayload`.

## Notes
- Backend `TrnInputMapper` already does `subAccounts = input ?: existing` (svc-data), so non-composite edits are unaffected and existing splits are never wiped.
- Trigger = any trn with a non-empty `subAccounts` map (covers CPF BALANCE snapshots + payslip CPF contribution legs).

## Test
`SubAccountTrnEditModal`: prefills buckets from the trn; PATCHes the edited split with recomputed total. Full suite 1529 green, lint + typecheck clean.

@coderabbitai ignore