### PR TITLE
fix(holdings): report aggregate view in user's reporting currency

### DIFF
--- a/src/lib/utils/api/__tests__/routes/aggregated-holdings.route.test.ts
+++ b/src/lib/utils/api/__tests__/routes/aggregated-holdings.route.test.ts
@@ -1,0 +1,109 @@
+import aggregatedHandler from "@pages/api/holdings/aggregated"
+
+jest.mock("@lib/auth0", () => ({
+  auth0: {
+    getSession: jest.fn().mockResolvedValue({ user: { sub: "test-user" } }),
+    getAccessToken: jest.fn().mockResolvedValue({ token: "test-token" }),
+  },
+}))
+
+jest.mock("@utils/api/fetchHelper", () => ({
+  requestInit: jest.fn(
+    (token: string, method: string) =>
+      ({
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+      }) as unknown,
+  ),
+}))
+
+jest.mock("@utils/api/responseWriter", () => {
+  const handleResponse = jest
+    .fn()
+    .mockImplementation(
+      (_response: Response, res: { status: jest.Mock; json: jest.Mock }) => {
+        res.status(200).json({ data: {} })
+      },
+    )
+  return {
+    __esModule: true,
+    default: handleResponse,
+    handleResponse,
+    fetchError: jest.fn(
+      (
+        _req: unknown,
+        res: { status: jest.Mock; json: jest.Mock },
+        error: { message: string },
+      ) => {
+        res.status(500).json({ error: error.message })
+      },
+    ),
+  }
+})
+
+jest.mock("@utils/api/bcConfig", () => ({
+  getPositionsUrl: (path: string): string => `http://positions.test${path}`,
+}))
+
+const mockFetch = jest
+  .fn()
+  .mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
+global.fetch = mockFetch as unknown as typeof fetch
+
+function makeReq(query: Record<string, string>): {
+  method: string
+  query: Record<string, string>
+  headers: Record<string, string>
+} {
+  return { method: "GET", query, headers: {} }
+}
+
+function makeRes(): {
+  status: jest.Mock
+  end: jest.Mock
+  json: jest.Mock
+  setHeader: jest.Mock
+} {
+  return {
+    status: jest.fn().mockReturnThis(),
+    end: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("/api/holdings/aggregated route", () => {
+  it("forwards the reporting currency query param to the backend", async () => {
+    const req = makeReq({ asAt: "today", codes: "P1,P2", currency: "SGD" })
+    const res = makeRes()
+
+    await aggregatedHandler(
+      req as unknown as Parameters<typeof aggregatedHandler>[0],
+      res as unknown as Parameters<typeof aggregatedHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://positions.test/aggregated?asAt=today&codes=P1%2CP2&currency=SGD",
+      expect.any(Object),
+    )
+  })
+
+  it("omits currency when not supplied", async () => {
+    const req = makeReq({ asAt: "today" })
+    const res = makeRes()
+
+    await aggregatedHandler(
+      req as unknown as Parameters<typeof aggregatedHandler>[0],
+      res as unknown as Parameters<typeof aggregatedHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://positions.test/aggregated?asAt=today",
+      expect.any(Object),
+    )
+  })
+})

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -34,6 +34,7 @@ import IncomeView from "@components/features/holdings/IncomeView"
 import { ViewMode } from "@components/features/holdings/ViewToggle"
 import { usePermissions } from "@hooks/usePermissions"
 import { usePortfolioReview } from "@components/features/holdings/usePortfolioReview"
+import { useUserPreferences } from "@contexts/UserPreferencesContext"
 
 /** View mode icon component */
 const ViewModeIcon: React.FC<{ mode: string; className?: string }> = ({
@@ -219,20 +220,31 @@ function AggregatedHoldingsPage(): React.ReactElement {
   const router = useRouter()
   const holdingState = useHoldingState()
   const groupOptions = useGroupOptions()
+  const { preferences } = useUserPreferences()
   const { ai: canRunAi, isLoading: permsLoading } = usePermissions()
   const { popup: reviewPopup, showReview } = usePortfolioReview()
   // Get portfolio codes from URL query parameter
   const codes = router.query.codes as string | undefined
   const portfolioCodes = useMemo(() => (codes ? codes.split(",") : []), [codes])
 
-  // Build the API URL with optional codes parameter
+  // Report aggregate values in the user's preferred reporting currency
+  // (falling back to base). Without this the backend prices the consolidated
+  // bucket in the first portfolio's currency, which is wrong for users whose
+  // reporting currency differs from that portfolio (e.g. SGD shown as USD).
+  const reportCurrency =
+    preferences?.reportingCurrencyCode || preferences?.baseCurrencyCode
+
+  // Build the API URL with optional codes + currency parameters
   const aggregatedHoldingsKey = codes
     ? `/api/holdings/aggregated?asAt=today&codes=${encodeURIComponent(codes)}`
     : "/api/holdings/aggregated?asAt=today"
+  const aggregatedHoldingsUrl = reportCurrency
+    ? `${aggregatedHoldingsKey}&currency=${encodeURIComponent(reportCurrency)}`
+    : aggregatedHoldingsKey
 
   const { data, error, isLoading } = useSwr(
-    aggregatedHoldingsKey,
-    simpleFetcher(aggregatedHoldingsKey),
+    aggregatedHoldingsUrl,
+    simpleFetcher(aggregatedHoldingsUrl),
   )
 
   // Use shared hook for view state and calculations


### PR DESCRIPTION
## Problem

Aggregate holdings view rendered all values in USD even when the user's reporting/base currency is SGD. The Wealth view showed SGD correctly.

## Root cause

`holdings/aggregated.tsx` never sent a `currency` param. The backend (`ValuationService.getAggregatedPositions`) then prices the consolidated bucket in `portfolios.first().currency` — a USD portfolio sorting first forced the whole aggregate to USD. The Wealth view avoids this entirely (reads the preference + converts client-side).

All backend plumbing for `currency` already existed (API route forwards it; backend honors a non-null `targetCurrencyCode`). The param was simply never supplied.

## Fix

Frontend-only, surgical:

- `holdings/aggregated.tsx` reads `useUserPreferences()` and appends `&currency=<reportingCurrencyCode || baseCurrencyCode>` to the SWR key.
- Uses `reportingCurrencyCode` (the report-display preference, consistent with independence/account views), falling back to `baseCurrencyCode`.

Backend default-to-user-preference was rejected: `getAggregatedPositions` is shared by allocation, sector-exposure, and svc-retire M2M callers that rely on the current first-portfolio-currency fallback.

## Tests

- New `aggregated-holdings.route.test.ts` locks the API route's currency forwarding (forwards `SGD`; omits when absent), mirroring the existing `allocation.route.test.ts`.
- No page-level test (Next.js forbids tests under `src/pages/`).

Green: typecheck · lint · prettier · new tests 2/2 · semgrep clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aggregated holdings now respect your preferred reporting currency setting, automatically applying your chosen currency to holdings reports. Falls back to your base currency if no preference is configured.

* **Tests**
  * Added test coverage for the aggregated holdings API endpoint to verify currency parameters are correctly handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->