### PR TITLE
feat(wealth): asset allocation above metrics, group-by with persisted preference

### DIFF
--- a/src/components/features/wealth/AssetAllocationCharts.tsx
+++ b/src/components/features/wealth/AssetAllocationCharts.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 import { Currency, HoldingContract } from "types/beancounter"
 import {
   PieChart,
@@ -47,10 +47,10 @@ const AssetAllocationCharts: React.FC<AssetAllocationChartsProps> = ({
   const [groupBy, setGroupBy] = useState<GroupingMode>(() =>
     getLocalValue<GroupingMode>(GROUP_BY_STORAGE_KEY, "asset"),
   )
-  const handleGroupByChange = (next: GroupingMode): void => {
+  const handleGroupByChange = useCallback((next: GroupingMode): void => {
     setGroupBy(next)
     setLocalValue(GROUP_BY_STORAGE_KEY, next)
-  }
+  }, [])
 
   const allocationData = useMemo(
     () =>

--- a/src/components/features/wealth/AssetAllocationCharts.tsx
+++ b/src/components/features/wealth/AssetAllocationCharts.tsx
@@ -1,14 +1,35 @@
-import React from "react"
-import { Currency } from "types/beancounter"
-import { PieChart, Pie, ResponsiveContainer, Tooltip, Legend } from "recharts"
+import React, { useMemo, useState } from "react"
+import { Currency, HoldingContract } from "types/beancounter"
 import {
-  WealthSummary,
-  COLORS,
-  LIQUIDITY_COLORS,
-} from "@lib/wealth/liquidityGroups"
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from "recharts"
+import { WealthSummary, LIQUIDITY_COLORS } from "@lib/wealth/liquidityGroups"
+import {
+  transformFxAllocationSlices,
+  GroupingMode,
+} from "@lib/allocation/aggregateHoldings"
+import AllocationControls from "@components/features/allocation/AllocationControls"
+import { ValueIn } from "@components/features/holdings/GroupByOptions"
+import { getLocalValue, setLocalValue } from "@lib/storage/localState"
+
+const GROUP_BY_STORAGE_KEY = "wealth-allocation-groupby"
+
+const GROUP_LABELS: Record<GroupingMode, string> = {
+  category: "Category",
+  sector: "Sector",
+  asset: "Asset",
+  market: "Market",
+}
 
 interface AssetAllocationChartsProps {
   summary: WealthSummary
+  holdings: HoldingContract | undefined
+  fxRates: Record<string, number>
   displayCurrency: Currency | null
   collapsed: boolean
   onToggle: () => void
@@ -16,17 +37,28 @@ interface AssetAllocationChartsProps {
 
 const AssetAllocationCharts: React.FC<AssetAllocationChartsProps> = ({
   summary,
+  holdings,
+  fxRates,
   displayCurrency,
   collapsed,
   onToggle,
 }) => {
-  if (summary.portfolioBreakdown.length === 0) return null
+  // Grouping preference persists across sessions; defaults to "asset".
+  const [groupBy, setGroupBy] = useState<GroupingMode>(() =>
+    getLocalValue<GroupingMode>(GROUP_BY_STORAGE_KEY, "asset"),
+  )
+  const handleGroupByChange = (next: GroupingMode): void => {
+    setGroupBy(next)
+    setLocalValue(GROUP_BY_STORAGE_KEY, next)
+  }
 
-  const portfolioChartData = summary.portfolioBreakdown.map((p, index) => ({
-    name: p.code,
-    value: p.value,
-    fill: COLORS[index % COLORS.length],
-  }))
+  const allocationData = useMemo(
+    () =>
+      holdings ? transformFxAllocationSlices(holdings, groupBy, fxRates) : [],
+    [holdings, groupBy, fxRates],
+  )
+
+  if (summary.portfolioBreakdown.length === 0) return null
 
   return (
     <div className="bg-white rounded-xl shadow-md p-6 mb-8">
@@ -43,114 +75,135 @@ const AssetAllocationCharts: React.FC<AssetAllocationChartsProps> = ({
       </button>
 
       {!collapsed && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {/* Portfolio Breakdown Chart */}
-          <div className="bg-gray-50 rounded-lg p-4">
-            <h3 className="text-md font-medium text-gray-700 mb-4">
-              By Portfolio
-            </h3>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                  <Pie
-                    data={portfolioChartData}
-                    cx="50%"
-                    cy="50%"
-                    innerRadius={60}
-                    outerRadius={100}
-                    paddingAngle={2}
-                    dataKey="value"
-                  />
-                  <Tooltip
-                    formatter={(value) => [
-                      `${displayCurrency?.symbol}${Number(value).toLocaleString(undefined, { maximumFractionDigits: 0 })}`,
-                      "Value",
-                    ]}
-                  />
-                  <Legend />
-                </PieChart>
-              </ResponsiveContainer>
-            </div>
-          </div>
-
-          {/* Liquidity Breakdown */}
-          <div className="bg-gray-50 rounded-lg p-4">
-            <h3 className="text-md font-medium text-gray-700 mb-4">
-              By Liquidity
-            </h3>
-            <div className="flex flex-col gap-3">
-              {/* Stacked bar overview */}
-              <div className="flex h-6 rounded-full overflow-hidden">
-                {summary.classificationBreakdown.map((item) => (
-                  <div
-                    key={item.classification}
-                    className="transition-all"
-                    style={{
-                      width: `${Math.max(item.percentage, 1)}%`,
-                      backgroundColor:
-                        LIQUIDITY_COLORS[item.classification] || "#6B7280",
-                    }}
-                    title={`${item.classification}: ${item.percentage.toFixed(1)}%`}
-                  />
-                ))}
-              </div>
-
-              {/* Category rows */}
-              <div className="flex flex-col gap-2 mt-1">
-                {summary.classificationBreakdown.map((item) => (
-                  <div
-                    key={item.classification}
-                    className="flex items-center justify-between"
-                  >
-                    <div className="flex items-center gap-2">
-                      <div
-                        className="w-3 h-3 rounded-full shrink-0"
-                        style={{
-                          backgroundColor:
-                            LIQUIDITY_COLORS[item.classification] || "#6B7280",
-                        }}
+        <>
+          <AllocationControls
+            groupBy={groupBy}
+            onGroupByChange={handleGroupByChange}
+            valueIn={ValueIn.PORTFOLIO}
+            onValueInChange={() => {}}
+            hideValueIn
+          />
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* Grouped Allocation Chart — driven by the group-by control */}
+            <div className="bg-gray-50 rounded-lg p-4">
+              <h3 className="text-md font-medium text-gray-700 mb-4">
+                {`By ${GROUP_LABELS[groupBy]}`}
+              </h3>
+              <div className="h-64">
+                {allocationData.length === 0 ? (
+                  <div className="flex items-center justify-center h-full text-gray-500">
+                    No allocation data available
+                  </div>
+                ) : (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={allocationData}
+                        cx="50%"
+                        cy="50%"
+                        innerRadius={60}
+                        outerRadius={100}
+                        paddingAngle={2}
+                        dataKey="value"
+                        nameKey="label"
+                      >
+                        {allocationData.map((slice) => (
+                          <Cell key={slice.key} fill={slice.color} />
+                        ))}
+                      </Pie>
+                      <Tooltip
+                        formatter={(value) => [
+                          `${displayCurrency?.symbol}${Number(value).toLocaleString(undefined, { maximumFractionDigits: 0 })}`,
+                          "Value",
+                        ]}
                       />
-                      <span className="text-sm text-gray-700">
-                        {item.classification}
-                      </span>
-                    </div>
-                    <div className="flex items-baseline gap-2">
-                      <span className="text-sm font-semibold text-gray-900 tabular-nums">
-                        {displayCurrency?.symbol}
-                        {item.value.toLocaleString(undefined, {
-                          maximumFractionDigits: 0,
-                        })}
-                      </span>
-                      <span className="text-xs text-gray-500 tabular-nums w-12 text-right">
-                        {item.percentage.toFixed(1)}%
-                      </span>
-                    </div>
-                  </div>
-                ))}
+                      <Legend />
+                    </PieChart>
+                  </ResponsiveContainer>
+                )}
               </div>
+            </div>
 
-              {/* Market exposure callout */}
-              {(() => {
-                const investmentPct =
-                  summary.classificationBreakdown.find(
-                    (c) => c.classification === "Investment",
-                  )?.percentage ?? 0
-                return (
-                  <div className="mt-2 pt-3 border-t border-gray-200">
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-gray-500 uppercase tracking-wider">
-                        Market Exposure
-                      </span>
-                      <span className="text-lg font-bold text-blue-600 tabular-nums">
-                        {investmentPct.toFixed(1)}%
-                      </span>
+            {/* Liquidity Breakdown */}
+            <div className="bg-gray-50 rounded-lg p-4">
+              <h3 className="text-md font-medium text-gray-700 mb-4">
+                By Liquidity
+              </h3>
+              <div className="flex flex-col gap-3">
+                {/* Stacked bar overview */}
+                <div className="flex h-6 rounded-full overflow-hidden">
+                  {summary.classificationBreakdown.map((item) => (
+                    <div
+                      key={item.classification}
+                      className="transition-all"
+                      style={{
+                        width: `${Math.max(item.percentage, 1)}%`,
+                        backgroundColor:
+                          LIQUIDITY_COLORS[item.classification] || "#6B7280",
+                      }}
+                      title={`${item.classification}: ${item.percentage.toFixed(1)}%`}
+                    />
+                  ))}
+                </div>
+
+                {/* Category rows */}
+                <div className="flex flex-col gap-2 mt-1">
+                  {summary.classificationBreakdown.map((item) => (
+                    <div
+                      key={item.classification}
+                      className="flex items-center justify-between"
+                    >
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="w-3 h-3 rounded-full shrink-0"
+                          style={{
+                            backgroundColor:
+                              LIQUIDITY_COLORS[item.classification] ||
+                              "#6B7280",
+                          }}
+                        />
+                        <span className="text-sm text-gray-700">
+                          {item.classification}
+                        </span>
+                      </div>
+                      <div className="flex items-baseline gap-2">
+                        <span className="text-sm font-semibold text-gray-900 tabular-nums">
+                          {displayCurrency?.symbol}
+                          {item.value.toLocaleString(undefined, {
+                            maximumFractionDigits: 0,
+                          })}
+                        </span>
+                        <span className="text-xs text-gray-500 tabular-nums w-12 text-right">
+                          {item.percentage.toFixed(1)}%
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                )
-              })()}
+                  ))}
+                </div>
+
+                {/* Market exposure callout */}
+                {(() => {
+                  const investmentPct =
+                    summary.classificationBreakdown.find(
+                      (c) => c.classification === "Investment",
+                    )?.percentage ?? 0
+                  return (
+                    <div className="mt-2 pt-3 border-t border-gray-200">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs text-gray-500 uppercase tracking-wider">
+                          Market Exposure
+                        </span>
+                        <span className="text-lg font-bold text-blue-600 tabular-nums">
+                          {investmentPct.toFixed(1)}%
+                        </span>
+                      </div>
+                    </div>
+                  )
+                })()}
+              </div>
             </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   )

--- a/src/lib/utils/allocation/aggregateHoldings.test.ts
+++ b/src/lib/utils/allocation/aggregateHoldings.test.ts
@@ -1,6 +1,9 @@
 import { HoldingContract } from "types/beancounter"
 import { ValueIn } from "@components/features/holdings/GroupByOptions"
-import { transformToAllocationSlices } from "./aggregateHoldings"
+import {
+  transformToAllocationSlices,
+  transformFxAllocationSlices,
+} from "./aggregateHoldings"
 import testHoldings from "../holdings/__fixtures__/test-holdings.json"
 
 describe("transformToAllocationSlices", () => {
@@ -207,6 +210,66 @@ describe("transformToAllocationSlices", () => {
 
       const cash = result.find((s) => s.key === "Cash")
       expect(cash?.color).toBe("#6B7280") // gray
+    })
+  })
+
+  describe("transformFxAllocationSlices", () => {
+    it("matches BASE valueIn slices at unit FX rate", () => {
+      const fx = transformFxAllocationSlices(holdingContract, "category", {
+        USD: 1,
+      })
+      const base = transformToAllocationSlices(
+        holdingContract,
+        "category",
+        ValueIn.BASE,
+      )
+
+      expect(fx.map((s) => s.key)).toEqual(base.map((s) => s.key))
+      fx.forEach((slice, i) => {
+        expect(slice.value).toBeCloseTo(base[i].value, 2)
+      })
+    })
+
+    it("applies per-currency FX rate to market values", () => {
+      const fx = transformFxAllocationSlices(holdingContract, "category", {
+        USD: 2,
+      })
+
+      // All positions are USD in the fixture → every value doubles.
+      const cash = fx.find((s) => s.key === "Cash")
+      expect(cash?.value).toBeCloseTo(5741.0 * 2, 2)
+
+      // Percentages are rate-invariant.
+      const percentSum = fx.reduce((sum, s) => sum + s.percentage, 0)
+      expect(percentSum).toBeCloseTo(100, 1)
+    })
+
+    it("defaults to a rate of 1 for currencies missing from the map", () => {
+      const withRate = transformFxAllocationSlices(holdingContract, "asset", {
+        USD: 1,
+      })
+      const noRate = transformFxAllocationSlices(holdingContract, "asset", {})
+
+      withRate.forEach((slice, i) => {
+        expect(slice.value).toBeCloseTo(noRate[i].value, 2)
+      })
+    })
+
+    it("suppresses zero-value holdings", () => {
+      const fx = transformFxAllocationSlices(holdingContract, "asset", {
+        USD: 1,
+      })
+
+      // SMH is held at 0 value in the fixture — it must not appear.
+      expect(fx.map((s) => s.key)).not.toContain("SMH")
+      fx.forEach((slice) => expect(slice.value).not.toBe(0))
+    })
+
+    it("returns [] for holdings with no positions", () => {
+      const empty: HoldingContract = { ...holdingContract, positions: {} }
+      expect(
+        transformFxAllocationSlices(empty, "category", { USD: 1 }),
+      ).toEqual([])
     })
   })
 

--- a/src/lib/utils/allocation/aggregateHoldings.ts
+++ b/src/lib/utils/allocation/aggregateHoldings.ts
@@ -153,6 +153,76 @@ export function transformToAllocationSlices(
 }
 
 /**
+ * FX-aware variant of {@link transformToAllocationSlices} for the Net Worth
+ * (wealth) view, where positions span multiple base currencies. Values are
+ * taken from each position's BASE money values and converted to the display
+ * currency via `fxRates[baseCurrencyCode]` — the same per-position rule
+ * `useWealthSummary` applies — so the grouped allocation reconciles with the
+ * rest of the wealth page rather than mixing raw currencies.
+ */
+export function transformFxAllocationSlices(
+  holdingContract: HoldingContract,
+  groupBy: GroupingMode,
+  fxRates: Record<string, number>,
+): AllocationSlice[] {
+  if (!holdingContract.positions) {
+    return []
+  }
+
+  const aggregated = new Map<string, AggregatedData>()
+
+  for (const positionKey of Object.keys(holdingContract.positions)) {
+    const position = holdingContract.positions[positionKey]
+    const moneyValues = position.moneyValues?.BASE
+    if (!moneyValues) continue
+
+    const currency = moneyValues.currency?.code
+    const rate = currency ? fxRates[currency] || 1 : 1
+    const { key, label } = getGroupKey(position, groupBy)
+    const marketValue = (moneyValues.marketValue || 0) * rate
+    const gainOnDay = (moneyValues.gainOnDay || 0) * rate
+    const irr = moneyValues.irr || 0
+
+    const existing = aggregated.get(key)
+    if (existing) {
+      existing.value += marketValue
+      existing.gainOnDay += gainOnDay
+      existing.weightedIrrSum += marketValue * irr
+    } else {
+      aggregated.set(key, {
+        label,
+        value: marketValue,
+        gainOnDay,
+        weightedIrrSum: marketValue * irr,
+      })
+    }
+  }
+
+  const entries = Array.from(aggregated.entries())
+  const total = entries.reduce((sum, [, data]) => sum + data.value, 0)
+  if (total === 0) {
+    return []
+  }
+
+  // Suppress zero-value holdings (e.g. fully-exited positions) — they add
+  // noise to the legend and render as invisible slices.
+  const slices: AllocationSlice[] = entries
+    .filter(([, data]) => data.value !== 0)
+    .map(([key, data], index) => ({
+      key,
+      label: data.label,
+      value: data.value,
+      percentage: (data.value / total) * 100,
+      color: getColor(key, index),
+      gainOnDay: data.gainOnDay,
+      irr: data.value > 0 ? data.weightedIrrSum / data.value : 0,
+    }))
+
+  slices.sort((a, b) => b.value - a.value)
+  return slices
+}
+
+/**
  * Build chart slices from svc-retire's server-side asset breakdown. Used by
  * the Independence plan page so composite assets (CPF / ILP / generic
  * pensions) appear alongside portfolio categories without bc-view having to

--- a/src/pages/wealth.tsx
+++ b/src/pages/wealth.tsx
@@ -312,6 +312,16 @@ function WealthDashboard(): React.ReactElement {
             onShareClick={() => setShowShareDialog(true)}
           />
 
+          {/* Asset Allocation — surfaced above Independence metrics */}
+          <AssetAllocationCharts
+            summary={summary}
+            holdings={holdingsData}
+            fxRates={fxRates}
+            displayCurrency={displayCurrency}
+            collapsed={collapsedSections.charts}
+            onToggle={() => toggleSection("charts")}
+          />
+
           {/* Independence Metrics - shown if user has an independence plan */}
           {primaryPlan && (
             <IndependenceMetrics
@@ -325,7 +335,7 @@ function WealthDashboard(): React.ReactElement {
             />
           )}
 
-          {/* Wealth Performance — after IndependenceMetrics, before Charts */}
+          {/* Wealth Performance */}
           {preferences?.enableTwr && (
             <WealthPerformanceChart
               portfolios={portfolios}
@@ -334,14 +344,6 @@ function WealthDashboard(): React.ReactElement {
               onToggle={() => toggleSection("performance")}
             />
           )}
-
-          {/* Charts Row */}
-          <AssetAllocationCharts
-            summary={summary}
-            displayCurrency={displayCurrency}
-            collapsed={collapsedSections.charts}
-            onToggle={() => toggleSection("charts")}
-          />
 
           {/* Portfolio Details Table */}
           <PortfolioDetailsTable


### PR DESCRIPTION
## What
- Move **Asset Allocation** above the Independence metrics on the Net Worth view.
- Add the same group-by categories as the /Allocation view (Category / Sector / Asset / Market); default **Asset**, preference persisted in localStorage.
- New `transformFxAllocationSlices` — per-position BASE→display FX (mirrors `useWealthSummary`) so grouped slices reconcile across currencies.
- Suppress zero-value holdings from the grouped allocation by default.

## Tests
- Added `transformFxAllocationSlices` unit tests (FX scaling, missing-rate default, zero suppression, empty).
- typecheck + lint + jest green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wealth asset allocation charts now support FX-aware calculations and a dynamic “By Category/Sector/Asset/Market” grouping, with the selection saved for future sessions.
  * Updated chart rendering (including improved tooltips and an empty state when no allocation data is available).

* **Tests**
  * Added coverage for FX-aware allocation slice transformations, including default FX handling and edge cases.

* **Chores**
  * Reorganized the wealth page to render the asset allocation charts earlier for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->