### PR TITLE
fix(trns): reset running qty to BALANCE in position trade totals

### DIFF
--- a/src/lib/utils/trns/tradeUtils.test.ts
+++ b/src/lib/utils/trns/tradeUtils.test.ts
@@ -981,6 +981,17 @@ describe("computeTradeGroupTotals", () => {
     expect(totals.quantity).toBe(105)
   })
 
+  test("BALANCE wins over a same-date trade regardless of input order", () => {
+    const trade = trn({ tradeDate: "2025-02-01", quantity: 7 })
+    const balance = trn({
+      trnType: "BALANCE",
+      tradeDate: "2025-02-01",
+      quantity: 100,
+    })
+    expect(computeTradeGroupTotals([trade, balance]).quantity).toBe(100)
+    expect(computeTradeGroupTotals([balance, trade]).quantity).toBe(100)
+  })
+
   test("the latest BALANCE wins when several exist", () => {
     const totals = computeTradeGroupTotals([
       trn({ trnType: "BALANCE", tradeDate: "2025-01-01", quantity: 50 }),

--- a/src/lib/utils/trns/tradeUtils.test.ts
+++ b/src/lib/utils/trns/tradeUtils.test.ts
@@ -17,8 +17,9 @@ import {
   getQtyPriceTint,
   getAssetCurrency,
   deriveDefaultMarket,
+  computeTradeGroupTotals,
 } from "./tradeUtils"
-import { TradeFormData } from "types/beancounter"
+import { TradeFormData, Transaction } from "types/beancounter"
 
 describe("TradeUtils", () => {
   test("calculateTradeAmount for BUY type", () => {
@@ -929,5 +930,87 @@ describe("TradeUtils", () => {
       const result = convertToTradeImport(data)
       expect(result.cashAccount).toBe("MY-USD-ACCOUNT")
     })
+  })
+})
+
+describe("computeTradeGroupTotals", () => {
+  const trn = (over: Partial<Transaction>): Transaction =>
+    ({
+      trnType: "BUY",
+      tradeDate: "2025-01-01",
+      quantity: 0,
+      tradeAmount: 0,
+      cashAmount: 0,
+      fees: 0,
+      tax: 0,
+      ...over,
+    }) as Transaction
+
+  test("sums quantity when no BALANCE present", () => {
+    const totals = computeTradeGroupTotals([
+      trn({ tradeDate: "2025-01-01", quantity: 10 }),
+      trn({ tradeDate: "2025-02-01", quantity: 5 }),
+    ])
+    expect(totals.quantity).toBe(15)
+  })
+
+  test("resets running quantity to the BALANCE quantity", () => {
+    const totals = computeTradeGroupTotals([
+      trn({ tradeDate: "2025-01-01", quantity: 10 }),
+      trn({ tradeDate: "2025-02-01", quantity: 7 }),
+      trn({ trnType: "BALANCE", tradeDate: "2025-03-01", quantity: 100 }),
+    ])
+    expect(totals.quantity).toBe(100)
+  })
+
+  test("accumulates trades dated after the BALANCE on top of it", () => {
+    const totals = computeTradeGroupTotals([
+      trn({ tradeDate: "2025-01-01", quantity: 10 }),
+      trn({ trnType: "BALANCE", tradeDate: "2025-02-01", quantity: 100 }),
+      trn({ tradeDate: "2025-03-01", quantity: 5 }),
+    ])
+    expect(totals.quantity).toBe(105)
+  })
+
+  test("is order-independent (input arrives newest-first)", () => {
+    const totals = computeTradeGroupTotals([
+      trn({ tradeDate: "2025-03-01", quantity: 5 }),
+      trn({ trnType: "BALANCE", tradeDate: "2025-02-01", quantity: 100 }),
+      trn({ tradeDate: "2025-01-01", quantity: 10 }),
+    ])
+    expect(totals.quantity).toBe(105)
+  })
+
+  test("the latest BALANCE wins when several exist", () => {
+    const totals = computeTradeGroupTotals([
+      trn({ trnType: "BALANCE", tradeDate: "2025-01-01", quantity: 50 }),
+      trn({ tradeDate: "2025-02-01", quantity: 5 }),
+      trn({ trnType: "BALANCE", tradeDate: "2025-03-01", quantity: 200 }),
+    ])
+    expect(totals.quantity).toBe(200)
+  })
+
+  test("still sums cash-side totals across the group", () => {
+    const totals = computeTradeGroupTotals([
+      trn({
+        tradeDate: "2025-01-01",
+        tradeAmount: 1000,
+        cashAmount: -1000,
+        fees: 2,
+        tax: 1,
+      }),
+      trn({ trnType: "BALANCE", tradeDate: "2025-02-01", quantity: 100 }),
+      trn({
+        tradeDate: "2025-03-01",
+        tradeAmount: 500,
+        cashAmount: -500,
+        fees: 3,
+        tax: 4,
+      }),
+    ])
+    expect(totals.tradeAmount).toBe(1500)
+    expect(totals.cashAmount).toBe(-1500)
+    expect(totals.fees).toBe(5)
+    expect(totals.tax).toBe(5)
   })
 })

--- a/src/lib/utils/trns/tradeUtils.ts
+++ b/src/lib/utils/trns/tradeUtils.ts
@@ -434,12 +434,23 @@ export interface TradeGroupTotals {
  * recent BALANCE then accumulate on top of it. Input order is irrelevant — the
  * trades endpoint returns newest-first, so we sort chronologically before
  * folding. Cash-side totals (tradeAmount/cashAmount/fees/tax) are plain sums.
+ *
+ * Same-date tiebreak: a BALANCE is the authoritative position as at end of its
+ * trade date, so any non-BALANCE trade sharing that date is already subsumed by
+ * it. We therefore sort BALANCE last on equal dates so the reset wins, keeping
+ * the result deterministic regardless of input order.
  */
 export const computeTradeGroupTotals = (
   transactions: Transaction[],
 ): TradeGroupTotals =>
   [...transactions]
-    .sort((a, b) => a.tradeDate.localeCompare(b.tradeDate))
+    .sort((a, b) => {
+      const byDate = a.tradeDate.localeCompare(b.tradeDate)
+      if (byDate !== 0) return byDate
+      if (a.trnType === "BALANCE" && b.trnType !== "BALANCE") return 1
+      if (a.trnType !== "BALANCE" && b.trnType === "BALANCE") return -1
+      return 0
+    })
     .reduce<TradeGroupTotals>(
       (totals, trn) => ({
         quantity:

--- a/src/lib/utils/trns/tradeUtils.ts
+++ b/src/lib/utils/trns/tradeUtils.ts
@@ -1,4 +1,4 @@
-import { TradeFormData } from "types/beancounter"
+import { TradeFormData, Transaction } from "types/beancounter"
 import { stripOwnerPrefix } from "@lib/assets/assetUtils"
 
 // Cash transaction types
@@ -416,3 +416,40 @@ export const convert = (tradeFormData: TradeFormData): string => {
     ? getCashRow(tradeFormData)
     : getTradeRow(tradeFormData)
 }
+
+export interface TradeGroupTotals {
+  quantity: number
+  tradeAmount: number
+  cashAmount: number
+  fees: number
+  tax: number
+}
+
+/**
+ * Accumulate the display totals for a collection of trades on one asset.
+ *
+ * A BALANCE transaction states the absolute position held as at its trade date
+ * (it has no cash impact), so the running quantity must RESET to the BALANCE
+ * quantity rather than add to the prior sum. Trades dated on/after the most
+ * recent BALANCE then accumulate on top of it. Input order is irrelevant — the
+ * trades endpoint returns newest-first, so we sort chronologically before
+ * folding. Cash-side totals (tradeAmount/cashAmount/fees/tax) are plain sums.
+ */
+export const computeTradeGroupTotals = (
+  transactions: Transaction[],
+): TradeGroupTotals =>
+  [...transactions]
+    .sort((a, b) => a.tradeDate.localeCompare(b.tradeDate))
+    .reduce<TradeGroupTotals>(
+      (totals, trn) => ({
+        quantity:
+          trn.trnType === "BALANCE"
+            ? trn.quantity || 0
+            : totals.quantity + (trn.quantity || 0),
+        tradeAmount: totals.tradeAmount + (trn.tradeAmount || 0),
+        cashAmount: totals.cashAmount + (trn.cashAmount || 0),
+        fees: totals.fees + (trn.fees || 0),
+        tax: totals.tax + (trn.tax || 0),
+      }),
+      { quantity: 0, tradeAmount: 0, cashAmount: 0, fees: 0, tax: 0 },
+    )

--- a/src/pages/trns/trades/[...trades].tsx
+++ b/src/pages/trns/trades/[...trades].tsx
@@ -19,6 +19,7 @@ import FxEditModal from "@components/features/transactions/FxEditModal"
 import SubAccountTrnEditModal from "@components/features/transactions/SubAccountTrnEditModal"
 import TradeInputForm from "@components/features/transactions/TradeInputForm"
 import { unsettleTrn } from "@utils/trns/apiHelper"
+import { computeTradeGroupTotals } from "@utils/trns/tradeUtils"
 
 export default withPageAuthRequired(function Trades(): React.ReactElement {
   const router = useRouter()
@@ -99,13 +100,6 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
       {
         broker: { id: string; name: string } | null
         transactions: Transaction[]
-        totals: {
-          quantity: number
-          tradeAmount: number
-          cashAmount: number
-          fees: number
-          tax: number
-        }
       }
     > = {}
 
@@ -115,25 +109,21 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
         groups[brokerKey] = {
           broker: trn.broker || null,
           transactions: [],
-          totals: {
-            quantity: 0,
-            tradeAmount: 0,
-            cashAmount: 0,
-            fees: 0,
-            tax: 0,
-          },
         }
       }
       groups[brokerKey].transactions.push(trn)
-      groups[brokerKey].totals.quantity += trn.quantity || 0
-      groups[brokerKey].totals.tradeAmount += trn.tradeAmount || 0
-      groups[brokerKey].totals.cashAmount += trn.cashAmount || 0
-      groups[brokerKey].totals.fees += trn.fees || 0
-      groups[brokerKey].totals.tax += trn.tax || 0
     })
 
+    // A BALANCE transaction states the absolute position as at its trade date,
+    // so the running quantity must reset to it — computeTradeGroupTotals folds
+    // the trades chronologically rather than naively summing every quantity.
+    const withTotals = Object.values(groups).map((group) => ({
+      ...group,
+      totals: computeTradeGroupTotals(group.transactions),
+    }))
+
     // Sort: brokers with names first (alphabetically), then "No Broker" last
-    return Object.values(groups).sort((a, b) => {
+    return withTotals.sort((a, b) => {
       if (!a.broker && b.broker) return 1
       if (a.broker && !b.broker) return -1
       if (!a.broker && !b.broker) return 0


### PR DESCRIPTION
## Problem
Position drill-down → trades (`/trns/trades/[portfolioId]/[assetId]`) summed every `trn.quantity` for the footer "Total Qty". A `BALANCE` transaction states the **absolute** position as at its trade date (no cash impact), so blindly adding it double-counts the running total.

## Fix
- New `computeTradeGroupTotals(transactions)` in `tradeUtils.ts`:
  - Sorts chronologically (trades endpoint returns `tradeDate DESC`), so it is order-independent.
  - On `BALANCE`, running quantity **resets** to the balance qty; subsequent trades accumulate on top. Latest BALANCE wins.
  - Cash-side totals (tradeAmount/cashAmount/fees/tax) remain plain sums (BALANCE has no cash impact).
- `[...trades].tsx` `groupedByBroker` now folds via the helper instead of inline `+=`.

## Tests
- Red→Green TDD. 6 new cases: no-balance sum, reset, post-balance accumulation, order-independence, multi-balance latest-wins, cash totals still sum.
- 243/243 trns suite, typecheck, eslint, prettier clean.

## Not covered
Not exercised in a live browser (needs a demo position carrying a BALANCE trn). Logic is pure and unit-tested against the real DESC ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for trade group total calculations, including edge cases around `BALANCE` handling and order independence.
* **Refactor**
  * Updated trade aggregation on the Trades page to use a shared totals helper instead of inline accumulation, reducing duplication.
* **Bug Fixes**
  * Corrected per-broker totals to apply `BALANCE` quantity/reset and latest-`BALANCE` precedence consistently, regardless of transaction order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->