### PR TITLE
fix(wealth): page long asset-allocation tail as list, keep pie for ≤10

### DIFF
--- a/src/components/features/wealth/AssetAllocationCharts.tsx
+++ b/src/components/features/wealth/AssetAllocationCharts.tsx
@@ -18,6 +18,7 @@ import { ValueIn } from "@components/features/holdings/GroupByOptions"
 import { getLocalValue, setLocalValue } from "@lib/storage/localState"
 
 const GROUP_BY_STORAGE_KEY = "wealth-allocation-groupby"
+const PAGE_SIZE = 10
 
 const GROUP_LABELS: Record<GroupingMode, string> = {
   category: "Category",
@@ -47,9 +48,11 @@ const AssetAllocationCharts: React.FC<AssetAllocationChartsProps> = ({
   const [groupBy, setGroupBy] = useState<GroupingMode>(() =>
     getLocalValue<GroupingMode>(GROUP_BY_STORAGE_KEY, "asset"),
   )
+  const [page, setPage] = useState(0)
   const handleGroupByChange = useCallback((next: GroupingMode): void => {
     setGroupBy(next)
     setLocalValue(GROUP_BY_STORAGE_KEY, next)
+    setPage(0) // item count differs per grouping; restart paging
   }, [])
 
   const allocationData = useMemo(
@@ -57,6 +60,12 @@ const AssetAllocationCharts: React.FC<AssetAllocationChartsProps> = ({
       holdings ? transformFxAllocationSlices(holdings, groupBy, fxRates) : [],
     [holdings, groupBy, fxRates],
   )
+
+  // Clamp the active page if the underlying data shrinks beneath it.
+  const pageCount = Math.max(1, Math.ceil(allocationData.length / PAGE_SIZE))
+  const safePage = Math.min(page, pageCount - 1)
+  const pageStart = safePage * PAGE_SIZE
+  const pagedSlices = allocationData.slice(pageStart, pageStart + PAGE_SIZE)
 
   if (summary.portfolioBreakdown.length === 0) return null
 
@@ -84,17 +93,20 @@ const AssetAllocationCharts: React.FC<AssetAllocationChartsProps> = ({
             hideValueIn
           />
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {/* Grouped Allocation Chart — driven by the group-by control */}
+            {/* Grouped Allocation — driven by the group-by control. A pie reads
+                well for a short set (≤ PAGE_SIZE slices); a long holdings tail
+                (e.g. grouping by asset) renders as a paged list instead, so the
+                chart never degenerates into an unreadable wheel of slivers. */}
             <div className="bg-gray-50 rounded-lg p-4">
               <h3 className="text-md font-medium text-gray-700 mb-4">
                 {`By ${GROUP_LABELS[groupBy]}`}
               </h3>
-              <div className="h-64">
-                {allocationData.length === 0 ? (
-                  <div className="flex items-center justify-center h-full text-gray-500">
-                    No allocation data available
-                  </div>
-                ) : (
+              {allocationData.length === 0 ? (
+                <div className="flex items-center justify-center h-64 text-gray-500">
+                  No allocation data available
+                </div>
+              ) : allocationData.length <= PAGE_SIZE ? (
+                <div className="h-64">
                   <ResponsiveContainer width="100%" height="100%">
                     <PieChart>
                       <Pie
@@ -120,8 +132,64 @@ const AssetAllocationCharts: React.FC<AssetAllocationChartsProps> = ({
                       <Legend />
                     </PieChart>
                   </ResponsiveContainer>
-                )}
-              </div>
+                </div>
+              ) : (
+                <>
+                  <div className="flex flex-col gap-2">
+                    {pagedSlices.map((slice) => (
+                      <div
+                        key={slice.key}
+                        className="flex items-center justify-between gap-2"
+                      >
+                        <div className="flex items-center gap-2 min-w-0">
+                          <div
+                            className="w-3 h-3 rounded-full shrink-0"
+                            style={{ backgroundColor: slice.color }}
+                          />
+                          <span className="text-sm text-gray-700 truncate">
+                            {slice.label}
+                          </span>
+                        </div>
+                        <div className="flex items-baseline gap-2 shrink-0">
+                          <span className="text-sm font-semibold text-gray-900 tabular-nums">
+                            {displayCurrency?.symbol}
+                            {Number(slice.value).toLocaleString(undefined, {
+                              maximumFractionDigits: 0,
+                            })}
+                          </span>
+                          <span className="text-xs text-gray-500 tabular-nums w-12 text-right">
+                            {Number(slice.percentage).toFixed(1)}%
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-200">
+                    <button
+                      type="button"
+                      onClick={() => setPage(safePage - 1)}
+                      disabled={safePage === 0}
+                      className="text-sm text-gray-600 hover:text-gray-900 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      <i className="fas fa-chevron-left mr-1"></i>Prev
+                    </button>
+                    <span className="text-xs text-gray-500 tabular-nums">
+                      {pageStart + 1}–
+                      {Math.min(pageStart + PAGE_SIZE, allocationData.length)}{" "}
+                      of {allocationData.length}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setPage(safePage + 1)}
+                      disabled={safePage >= pageCount - 1}
+                      className="text-sm text-gray-600 hover:text-gray-900 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      Next<i className="fas fa-chevron-right ml-1"></i>
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
 
             {/* Liquidity Breakdown */}

--- a/src/components/features/wealth/__tests__/AssetAllocationCharts.test.tsx
+++ b/src/components/features/wealth/__tests__/AssetAllocationCharts.test.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { render, screen, fireEvent, RenderResult } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import AssetAllocationCharts from "../AssetAllocationCharts"
+import { USD } from "@test-fixtures/beancounter"
+import { WealthSummary } from "@lib/wealth/liquidityGroups"
+import { HoldingContract } from "types/beancounter"
+
+// Deterministic group-by default; avoid persisted localStorage state.
+jest.mock("@lib/storage/localState", () => ({
+  getLocalValue: (_key: string, fallback: unknown) => fallback,
+  setLocalValue: jest.fn(),
+}))
+
+function makeSummary(overrides: Partial<WealthSummary> = {}): WealthSummary {
+  return {
+    totalValue: 100_000,
+    totalGainOnDay: 0,
+    portfolioCount: 1,
+    healthcareReserve: 0,
+    classificationBreakdown: [],
+    portfolioBreakdown: [{ code: "P1", name: "P1", value: 100_000 }],
+    ...overrides,
+  } as WealthSummary
+}
+
+// Build a holdings contract with `count` distinct asset positions, each worth
+// a descending market value so the resulting allocation list is stable-ordered.
+function makeHoldings(count: number): HoldingContract {
+  const positions: Record<string, unknown> = {}
+  for (let i = 0; i < count; i++) {
+    const code = `AST${String(i).padStart(2, "0")}`
+    positions[code] = {
+      asset: {
+        code,
+        name: `Asset ${i}`,
+        market: { code: "NASDAQ" },
+      },
+      moneyValues: {
+        BASE: {
+          currency: { code: "USD" },
+          marketValue: (count - i) * 1000,
+          gainOnDay: 0,
+          irr: 0,
+        },
+      },
+    }
+  }
+  return { positions } as unknown as HoldingContract
+}
+
+function renderCharts(holdings: HoldingContract): RenderResult {
+  return render(
+    <AssetAllocationCharts
+      summary={makeSummary()}
+      holdings={holdings}
+      fxRates={{ USD: 1 }}
+      displayCurrency={USD}
+      collapsed={false}
+      onToggle={() => {}}
+    />,
+  )
+}
+
+void React
+
+describe("AssetAllocationCharts — paged asset list", () => {
+  it("renders a pie (not a list) for 10 or fewer slices", () => {
+    const { container } = renderCharts(makeHoldings(10))
+    // recharts pie wrapper present; the paged list / paging are not rendered.
+    expect(
+      container.querySelector(".recharts-responsive-container"),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Asset 0")).toBeNull()
+    expect(screen.queryByRole("button", { name: /Next/i })).toBeNull()
+    expect(screen.queryByText(/of 10/)).toBeNull()
+  })
+
+  it("renders a paged list (no pie) when there are more than 10 assets", () => {
+    const { container } = renderCharts(makeHoldings(15))
+    expect(container.querySelector(".recharts-responsive-container")).toBeNull()
+    // First page: assets 0..9 (descending value), asset 10 not yet shown.
+    expect(screen.getByText("Asset 0")).toBeInTheDocument()
+    expect(screen.getByText("Asset 9")).toBeInTheDocument()
+    expect(screen.queryByText("Asset 10")).toBeNull()
+    expect(screen.getByText(/1–10 of 15/)).toBeInTheDocument()
+    // asset 0 = (15 - 0) * 1000 = 15,000; symbol + amount share one span.
+    expect(screen.getByText("$15,000")).toBeInTheDocument()
+  })
+
+  it("pages to the remaining assets via Next", () => {
+    renderCharts(makeHoldings(15))
+    fireEvent.click(screen.getByRole("button", { name: /Next/i }))
+    expect(screen.getByText("Asset 10")).toBeInTheDocument()
+    expect(screen.getByText("Asset 14")).toBeInTheDocument()
+    expect(screen.queryByText("Asset 0")).toBeNull()
+    expect(screen.getByText(/11–15 of 15/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Problem
Net Worth → Asset Allocation "By Asset" rendered every holding as a pie slice. With a large portfolio the chart became an unreadable wheel of slivers overlapping the page.

## Change
`AssetAllocationCharts.tsx` grouped panel now renders by size:
- **≤10 slices** (Category / Sector / Market, short asset sets) → pie chart (unchanged).
- **>10 slices** → paged list: name + value + %, sorted by value desc, 10 rows/page, Prev/Next with "1–10 of N".

Page resets on group-by switch and clamps if the data shrinks. Threshold is a single `PAGE_SIZE` constant.

## Tests
New `AssetAllocationCharts.test.tsx`:
- pie for ≤10 (no list/paging)
- paged list for >10 (no pie wrapper, ≤10 rows, range label)
- Next pages to the tail

eslint + tsc + prettier + semgrep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Grouped asset allocation view now paginates when holdings exceed 10 assets, displaying assets with navigation controls and page indicators showing current position and total asset count.

* **Tests**
  * Added test coverage for pagination behavior, including pie chart rendering for small lists and paginated rendering for larger asset collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->