### PR TITLE
feat(holdings): aggregate drill-down lists trades grouped by portfolio

### DIFF
--- a/src/components/features/holdings/ActionsMenus.tsx
+++ b/src/components/features/holdings/ActionsMenus.tsx
@@ -156,6 +156,8 @@ export interface ActionsMenuProps {
   onRecordIncome?: (data: QuickSellData) => void
   onRecordExpense?: (data: QuickSellData) => void
   onEditAsset?: (asset: Asset) => void
+  /** Aggregated holdings: jump to one of the portfolios holding this asset. */
+  onGoToPortfolio?: (asset: Asset) => void
 }
 
 export const ActionsMenu: React.FC<ActionsMenuProps> = ({
@@ -180,6 +182,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
   onRecordIncome,
   onRecordExpense,
   onEditAsset,
+  onGoToPortfolio,
 }) => {
   const { isOpen, buttonRef, menuRef, menuPos, toggle, close } =
     useDropdownMenu()
@@ -187,6 +190,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
 
   const tradePayload = (): QuickSellData => ({
     asset: assetCode,
+    assetId: asset.id,
     market: asset.market.code,
     quantity,
     price,
@@ -332,6 +336,13 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
                   )}
                 />
               )}
+              {onGoToPortfolio && (
+                <MenuItem
+                  iconClass="fas fa-folder-open text-slate-500 w-4"
+                  label="Go to portfolio"
+                  onClick={handle(() => onGoToPortfolio(asset))}
+                />
+              )}
               {onEditAsset && (
                 <MenuItem
                   iconClass="fas fa-pen-to-square text-slate-500 w-4"
@@ -358,6 +369,8 @@ export interface CashActionsMenuProps {
   onRecordIncome?: (data: QuickSellData) => void
   onRecordExpense?: (data: QuickSellData) => void
   onEditAsset?: (asset: Asset) => void
+  /** Aggregated holdings: jump to one of the portfolios holding this asset. */
+  onGoToPortfolio?: (asset: Asset) => void
 }
 
 export const CashActionsMenu: React.FC<CashActionsMenuProps> = ({
@@ -371,6 +384,7 @@ export const CashActionsMenu: React.FC<CashActionsMenuProps> = ({
   onRecordIncome,
   onRecordExpense,
   onEditAsset,
+  onGoToPortfolio,
 }) => {
   const { isOpen, buttonRef, menuRef, menuPos, toggle, close } =
     useDropdownMenu()
@@ -419,6 +433,7 @@ export const CashActionsMenu: React.FC<CashActionsMenuProps> = ({
                       market: isAccountAsset ? "PRIVATE" : "CASH",
                       assetCode: isAccountAsset ? asset.code : undefined,
                       assetName: isAccountAsset ? asset.name : undefined,
+                      assetId: asset.id,
                     })
                   })}
                 />
@@ -486,6 +501,13 @@ export const CashActionsMenu: React.FC<CashActionsMenuProps> = ({
                       type: "EXPENSE",
                     }),
                   )}
+                />
+              )}
+              {onGoToPortfolio && (
+                <MenuItem
+                  iconClass="fas fa-folder-open text-slate-500 w-4"
+                  label="Go to portfolio"
+                  onClick={handle(() => onGoToPortfolio(asset))}
                 />
               )}
               {onEditAsset && asset.market?.code === "PRIVATE" && (

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -55,6 +55,7 @@ interface SharedActionHandlers {
   onPriceChart?: (data: PriceChartData) => void
   onPortfolioBreakdown?: (data: PortfolioBreakdownData) => void
   onEditAsset?: (asset: Asset) => void
+  onGoToPortfolio?: (asset: Asset) => void
 }
 
 interface CardViewProps extends SharedActionHandlers {
@@ -280,6 +281,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
   onPriceChart,
   onPortfolioBreakdown,
   onEditAsset,
+  onGoToPortfolio,
 }) => {
   const router = useRouter()
   const { popup, showNews } = useNewsAsset()
@@ -330,7 +332,8 @@ const PositionCard: React.FC<PositionCardProps> = ({
       (!!onSectorWeightings && asset.assetCategory?.id === "ETF") ||
       (asset.assetCategory?.id === "RE" &&
         (!!onRecordIncome || !!onRecordExpense)) ||
-      !!onEditAsset)
+      !!onEditAsset ||
+      !!onGoToPortfolio)
 
   const hasCashActions =
     supportsBalanceSetting(asset) &&
@@ -339,6 +342,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
       !!onCashTransaction ||
       !!onRecordIncome ||
       !!onRecordExpense ||
+      !!onGoToPortfolio ||
       (!!onEditAsset && asset.market?.code === "PRIVATE"))
 
   const tradeMoney = moneyValues["TRADE"]
@@ -372,6 +376,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
             onRecordIncome={onRecordIncome}
             onRecordExpense={onRecordExpense}
             onEditAsset={onEditAsset}
+            onGoToPortfolio={onGoToPortfolio}
           />
         )}
         {hasCashActions && (
@@ -383,6 +388,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
             onRecordIncome={onRecordIncome}
             onRecordExpense={onRecordExpense}
             onEditAsset={onEditAsset}
+            onGoToPortfolio={onGoToPortfolio}
             onSetCashBalance={onSetCashBalance}
             onCashTransfer={onCashTransfer}
             onCashTransaction={onCashTransaction}
@@ -535,6 +541,7 @@ const CardView: React.FC<CardViewProps> = ({
   onPriceChart,
   onPortfolioBreakdown,
   onEditAsset,
+  onGoToPortfolio,
 }) => {
   // Group positions by holdingGroups, sorted by group comparator
   const groupedPositions = useMemo((): GroupedPositions[] => {
@@ -785,6 +792,7 @@ const CardView: React.FC<CardViewProps> = ({
                     onPriceChart={onPriceChart}
                     onPortfolioBreakdown={onPortfolioBreakdown}
                     onEditAsset={onEditAsset}
+                    onGoToPortfolio={onGoToPortfolio}
                   />
                 ))}
               </div>

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -18,6 +18,7 @@ import {
 import { FormatValue, PrivateQuantity } from "@components/ui/MoneyUtils"
 import {
   buildTradesHref,
+  buildAggregatedTradesHref,
   getPositionDisplayName,
   isCashRelated,
   isConstantPrice,
@@ -304,7 +305,13 @@ const PositionCard: React.FC<PositionCardProps> = ({
   const hasDistinctName = name.length > 0 && name !== asset.code
   const truncatedName = name.length > 30 ? name.substring(0, 30) + "..." : name
 
-  const tradesHref = buildTradesHref(portfolio.id, asset.id)
+  const tradesHref =
+    portfolioBreakdown && portfolioBreakdown.length > 0
+      ? buildAggregatedTradesHref(
+          asset.id,
+          portfolioBreakdown.map((b) => b.portfolioId),
+        )
+      : buildTradesHref(portfolio.id, asset.id)
   const cashLadderHref = `/trns/cash-ladder/${portfolio.id}/${asset.id}`
 
   const hasActions =

--- a/src/components/features/holdings/PortfolioBreakdownPopup.tsx
+++ b/src/components/features/holdings/PortfolioBreakdownPopup.tsx
@@ -6,28 +6,43 @@ import { PrivateQuantity } from "@components/ui/MoneyUtils"
 import { stripOwnerPrefix } from "@lib/assets/assetUtils"
 
 interface PortfolioBreakdownPopupProps {
-  asset: Asset
+  /** Used for the default "Held by — CODE" title; omit when `title` is set. */
+  asset?: Asset
   breakdown: PortfolioBreakdown[]
   onClose: () => void
+  /**
+   * When provided, picking a portfolio calls this instead of navigating to its
+   * holdings — used by the aggregated actions to choose which portfolio to act
+   * on. Default behaviour (no handler) navigates to the portfolio.
+   */
+  onSelect?: (row: PortfolioBreakdown) => void
+  /** Overrides the default "Held by — CODE" dialog title. */
+  title?: string
 }
 
 const PortfolioBreakdownPopup: React.FC<PortfolioBreakdownPopupProps> = ({
   asset,
   breakdown,
   onClose,
+  onSelect,
+  title,
 }) => {
   const router = useRouter()
 
-  const handleSelect = (portfolioCode: string): void => {
+  const handleSelect = (row: PortfolioBreakdown): void => {
     onClose()
-    router.push(`/holdings/${portfolioCode}`)
+    if (onSelect) {
+      onSelect(row)
+    } else {
+      router.push(`/holdings/${row.portfolioCode}`)
+    }
   }
 
   const sorted = [...breakdown].sort((a, b) => b.quantity - a.quantity)
 
   return (
     <Dialog
-      title={`Held by — ${stripOwnerPrefix(asset.code)}`}
+      title={title ?? `Held by — ${asset ? stripOwnerPrefix(asset.code) : ""}`}
       onClose={onClose}
       maxWidth="md"
       scrollable
@@ -38,7 +53,7 @@ const PortfolioBreakdownPopup: React.FC<PortfolioBreakdownPopupProps> = ({
             <button
               type="button"
               className="w-full flex items-center justify-between gap-3 px-2 py-3 text-left rounded-md hover:bg-slate-50 focus:bg-slate-100 focus:outline-none"
-              onClick={() => handleSelect(row.portfolioCode)}
+              onClick={() => handleSelect(row)}
               aria-label={`Open ${row.portfolioCode} holdings`}
             >
               <span className="min-w-0">

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -21,6 +21,7 @@ import {
 } from "@components/ui/MoneyUtils"
 import {
   buildTradesHref,
+  buildAggregatedTradesHref,
   getPositionDisplayName,
   isCash,
   isCashRelated,
@@ -148,7 +149,14 @@ export default function Rows({
             onDoubleClick={() =>
               supportsBalanceSetting(asset)
                 ? router.push(`/trns/cash-ladder/${portfolio.id}/${asset.id}`)
-                : router.push(buildTradesHref(portfolio.id, asset.id))
+                : portfolioBreakdown && portfolioBreakdown.length > 0
+                  ? router.push(
+                      buildAggregatedTradesHref(
+                        asset.id,
+                        portfolioBreakdown.map((b) => b.portfolioId),
+                      ),
+                    )
+                  : router.push(buildTradesHref(portfolio.id, asset.id))
             }
             title={"Double-click to open"}
           >

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -65,6 +65,7 @@ interface RowsProps extends HoldingValues {
   onPriceChart?: (data: PriceChartData) => void
   onPortfolioBreakdown?: (data: PortfolioBreakdownData) => void
   onEditAsset?: (asset: Asset) => void
+  onGoToPortfolio?: (asset: Asset) => void
 }
 
 // Helper function to truncate text with ellipsis
@@ -96,6 +97,7 @@ export default function Rows({
   onPriceChart,
   onPortfolioBreakdown,
   onEditAsset,
+  onGoToPortfolio,
 }: RowsProps): React.ReactElement {
   const router = useRouter()
   const { popup: newsPopup, showNews } = useNewsAsset()
@@ -197,7 +199,8 @@ export default function Rows({
                     isConstantPrice(asset)) ||
                   (asset.assetCategory?.id === "RE" &&
                     (onRecordIncome || onRecordExpense)) ||
-                  onEditAsset) ? (
+                  onEditAsset ||
+                  onGoToPortfolio) ? (
                   <div className="flex items-center">
                     <ActionsMenu
                       asset={asset}
@@ -232,6 +235,7 @@ export default function Rows({
                       onRecordIncome={onRecordIncome}
                       onRecordExpense={onRecordExpense}
                       onEditAsset={onEditAsset}
+                      onGoToPortfolio={onGoToPortfolio}
                     />
                   </div>
                 ) : null}
@@ -241,6 +245,7 @@ export default function Rows({
                     onCashTransaction ||
                     onRecordIncome ||
                     onRecordExpense ||
+                    onGoToPortfolio ||
                     (onEditAsset && asset.market?.code === "PRIVATE")) && (
                     <div className="flex items-center">
                       <CashActionsMenu
@@ -256,6 +261,7 @@ export default function Rows({
                         onRecordIncome={onRecordIncome}
                         onRecordExpense={onRecordExpense}
                         onEditAsset={onEditAsset}
+                        onGoToPortfolio={onGoToPortfolio}
                       />
                     </div>
                   )}

--- a/src/components/features/holdings/__tests__/ActionsMenus.test.tsx
+++ b/src/components/features/holdings/__tests__/ActionsMenus.test.tsx
@@ -1,0 +1,50 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { ActionsMenu } from "../ActionsMenus"
+import { makeAsset } from "@test-fixtures/beancounter"
+
+const asset = makeAsset({ id: "asset-aapl", code: "AAPL" })
+
+const baseProps = {
+  asset,
+  portfolioId: "ctx",
+  portfolioCode: "CTX",
+  quantity: 10,
+  price: 100,
+  costBasis: 900,
+  tradeCurrency: { code: "USD", symbol: "$", name: "Dollar" },
+  valueIn: "PORTFOLIO",
+}
+
+const openMenu = (): void => {
+  fireEvent.click(screen.getByRole("button", { name: /Actions AAPL/i }))
+}
+
+describe("ActionsMenu", () => {
+  it("includes the asset id in the trade payload so the page can resolve the portfolio", () => {
+    const onTrade = jest.fn()
+    render(<ActionsMenu {...baseProps} onTrade={onTrade} />)
+    openMenu()
+    fireEvent.click(screen.getByRole("button", { name: "Trade" }))
+    expect(onTrade).toHaveBeenCalledWith(
+      expect.objectContaining({ asset: "AAPL", assetId: "asset-aapl" }),
+    )
+  })
+
+  it("renders Go to portfolio and calls onGoToPortfolio with the asset", () => {
+    const onGoToPortfolio = jest.fn()
+    render(<ActionsMenu {...baseProps} onGoToPortfolio={onGoToPortfolio} />)
+    openMenu()
+    fireEvent.click(screen.getByRole("button", { name: "Go to portfolio" }))
+    expect(onGoToPortfolio).toHaveBeenCalledWith(asset)
+  })
+
+  it("omits Go to portfolio when no handler is provided", () => {
+    render(<ActionsMenu {...baseProps} onTrade={jest.fn()} />)
+    openMenu()
+    expect(
+      screen.queryByRole("button", { name: "Go to portfolio" }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/features/holdings/__tests__/CardView.test.tsx
+++ b/src/components/features/holdings/__tests__/CardView.test.tsx
@@ -358,6 +358,7 @@ describe("CardView footer (Quantity / Price / Weight)", () => {
 
       expect(onQuickSell).toHaveBeenCalledWith({
         asset: "AAPL",
+        assetId: "asset-aapl",
         market: "NASDAQ",
         quantity: 100,
         price: 150,

--- a/src/components/features/holdings/__tests__/CardView.test.tsx
+++ b/src/components/features/holdings/__tests__/CardView.test.tsx
@@ -14,6 +14,18 @@ import {
 
 jest.mock("@hooks/usePrivacyMode")
 
+const mockPush = jest.fn()
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    query: {},
+    isReady: true,
+    events: { on: jest.fn(), off: jest.fn() },
+    prefetch: jest.fn(),
+    beforePopState: jest.fn(),
+  }),
+}))
+
 const mockedUsePrivacyMode = usePrivacyMode as jest.MockedFunction<
   typeof usePrivacyMode
 >
@@ -470,6 +482,75 @@ describe("CardView footer (Quantity / Price / Weight)", () => {
           market: "CASH",
           currentBalance: 5000,
         }),
+      )
+    })
+  })
+
+  describe("trade-history drill-down", () => {
+    beforeEach(() => mockPush.mockClear())
+
+    it("double-click routes to the single-portfolio trades page when not aggregated", () => {
+      const portfolio = makePortfolio()
+      const asset = makeAsset({ id: "asset-aapl" })
+      const position = makePosition({ asset, quantityValues: { total: 100 } })
+      const holdings = makeHoldings({
+        portfolio,
+        holdingGroups: { Equity: makeHoldingGroup({ positions: [position] }) },
+      })
+      render(
+        <CardView
+          holdings={holdings}
+          portfolio={portfolio}
+          valueIn={ValueIn.PORTFOLIO}
+        />,
+      )
+
+      fireEvent.doubleClick(document.getElementById("asset-asset-aapl")!)
+
+      expect(mockPush).toHaveBeenCalledWith(
+        `/trns/trades/${portfolio.id}/asset-aapl`,
+      )
+    })
+
+    it("double-click routes to the aggregated trades page when the asset is held across portfolios", () => {
+      const portfolio = makePortfolio()
+      const asset = makeAsset({ id: "asset-aapl" })
+      const position = makePosition({
+        asset,
+        quantityValues: { total: 100 },
+        overrides: {
+          portfolioBreakdown: [
+            {
+              portfolioId: "p-1",
+              portfolioCode: "GROWTH",
+              portfolioName: "Growth",
+              quantity: 60,
+            },
+            {
+              portfolioId: "p-2",
+              portfolioCode: "KIDS",
+              portfolioName: "Kids",
+              quantity: 40,
+            },
+          ],
+        },
+      })
+      const holdings = makeHoldings({
+        portfolio,
+        holdingGroups: { Equity: makeHoldingGroup({ positions: [position] }) },
+      })
+      render(
+        <CardView
+          holdings={holdings}
+          portfolio={portfolio}
+          valueIn={ValueIn.PORTFOLIO}
+        />,
+      )
+
+      fireEvent.doubleClick(document.getElementById("asset-asset-aapl")!)
+
+      expect(mockPush).toHaveBeenCalledWith(
+        "/trns/trades/asset-aapl?portfolios=p-1,p-2",
       )
     })
   })

--- a/src/components/features/holdings/__tests__/PortfolioBreakdownPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PortfolioBreakdownPopup.test.tsx
@@ -85,4 +85,26 @@ describe("PortfolioBreakdownPopup", () => {
     expect(onClose).toHaveBeenCalled()
     expect(push).toHaveBeenCalledWith("/holdings/MAIN")
   })
+
+  it("calls onSelect with the row instead of navigating when provided", () => {
+    const onSelect = jest.fn()
+    const onClose = jest.fn()
+    render(
+      <PortfolioBreakdownPopup
+        breakdown={breakdown}
+        title="Trade AAPL — choose portfolio"
+        onSelect={onSelect}
+        onClose={onClose}
+      />,
+    )
+    expect(
+      screen.getByText("Trade AAPL — choose portfolio"),
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /Open MAIN holdings/i }))
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ portfolioId: "p1", portfolioCode: "MAIN" }),
+    )
+    expect(onClose).toHaveBeenCalled()
+    expect(push).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/features/holdings/__tests__/QuickSell.test.tsx
+++ b/src/components/features/holdings/__tests__/QuickSell.test.tsx
@@ -104,6 +104,7 @@ describe("Quick Sell Feature via Actions Menu", () => {
       // holdings/[code].tsx) applies `type: "BUY"`.
       expect(mockOnTrade).toHaveBeenCalledWith({
         asset: "AAPL",
+        assetId: "asset-AAPL",
         market: "NASDAQ",
         quantity: 100,
         price: 150,
@@ -189,6 +190,7 @@ describe("Quick Sell Feature via Actions Menu", () => {
       expect(mockOnQuickSell).toHaveBeenCalledTimes(1)
       expect(mockOnQuickSell).toHaveBeenCalledWith({
         asset: "AAPL",
+        assetId: "asset-AAPL",
         market: "NASDAQ",
         quantity: 100,
         price: 150,

--- a/src/lib/utils/api/fetchHelper.ts
+++ b/src/lib/utils/api/fetchHelper.ts
@@ -89,6 +89,10 @@ export const assetKey = (assetId: string): string =>
   `${apiRoot}/assets/${assetId}`
 export const tradeKey = (portfolioId: string, assetId: string): string =>
   `${trnsKey}/trades/${portfolioId}/${assetId}`
+export const tradeKeyMulti = (
+  assetId: string,
+  portfolioIds: string[],
+): string => `${trnsKey}/trades/${assetId}?portfolios=${portfolioIds.join(",")}`
 export const eventKey = (portfolioId: string, assetId: string): string =>
   `${trnsKey}/events/${portfolioId}/${assetId}`
 

--- a/src/lib/utils/assets/__tests__/assetUtils.test.ts
+++ b/src/lib/utils/assets/__tests__/assetUtils.test.ts
@@ -5,6 +5,7 @@ import {
   isNonTradeable,
   getPositionDisplayName,
   buildTradesHref,
+  buildAggregatedTradesHref,
   buildNewsAsset,
 } from "../assetUtils"
 import { makeAsset, makeCashAsset } from "@test-fixtures/beancounter"
@@ -133,6 +134,14 @@ describe("buildTradesHref", () => {
   it("returns canonical trades route", () => {
     expect(buildTradesHref("p-1", "asset-aapl")).toBe(
       "/trns/trades/p-1/asset-aapl",
+    )
+  })
+})
+
+describe("buildAggregatedTradesHref", () => {
+  it("routes by asset with portfolios as a query param", () => {
+    expect(buildAggregatedTradesHref("asset-aapl", ["p-1", "p-2"])).toBe(
+      "/trns/trades/asset-aapl?portfolios=p-1,p-2",
     )
   })
 })

--- a/src/lib/utils/assets/assetUtils.ts
+++ b/src/lib/utils/assets/assetUtils.ts
@@ -126,6 +126,18 @@ export function buildTradesHref(portfolioId: string, assetId: string): string {
   return `/trns/trades/${portfolioId}/${assetId}`
 }
 
+/**
+ * Href for an asset's trade history across multiple portfolios — used by the
+ * aggregated holdings drill-down. The trades page switches to portfolio-grouped
+ * mode when the `portfolios` query param is present.
+ */
+export function buildAggregatedTradesHref(
+  assetId: string,
+  portfolioIds: string[],
+): string {
+  return `/trns/trades/${assetId}?portfolios=${portfolioIds.join(",")}`
+}
+
 export interface NewsAssetRef {
   ticker: string
   market: string

--- a/src/lib/utils/holdings/__tests__/aggregatedActions.test.ts
+++ b/src/lib/utils/holdings/__tests__/aggregatedActions.test.ts
@@ -1,0 +1,52 @@
+import { indexBreakdownByAssetId, resolveTarget } from "../aggregatedActions"
+import { makePortfolioBreakdown } from "@test-fixtures/beancounter"
+
+describe("indexBreakdownByAssetId", () => {
+  it("maps each position's asset id to its portfolio breakdown", () => {
+    const aBreakdown = [makePortfolioBreakdown({ portfolioId: "p1" })]
+    const bBreakdown = [
+      makePortfolioBreakdown({ portfolioId: "p1" }),
+      makePortfolioBreakdown({ portfolioId: "p2" }),
+    ]
+    const holdingGroups = {
+      Equity: {
+        positions: [
+          { asset: { id: "asset-a" }, portfolioBreakdown: aBreakdown },
+          { asset: { id: "asset-b" }, portfolioBreakdown: bBreakdown },
+        ],
+      },
+    }
+
+    const index = indexBreakdownByAssetId(holdingGroups)
+
+    expect(index.get("asset-a")).toBe(aBreakdown)
+    expect(index.get("asset-b")).toBe(bBreakdown)
+  })
+
+  it("skips positions without a breakdown", () => {
+    const holdingGroups = {
+      Equity: { positions: [{ asset: { id: "asset-a" } }] },
+    }
+    expect(indexBreakdownByAssetId(holdingGroups).has("asset-a")).toBe(false)
+  })
+})
+
+describe("resolveTarget", () => {
+  it("returns direct with the single portfolio when held in one", () => {
+    const only = makePortfolioBreakdown({ portfolioId: "p1" })
+    expect(resolveTarget([only])).toEqual({ kind: "direct", target: only })
+  })
+
+  it("returns choose with all options when held in multiple", () => {
+    const options = [
+      makePortfolioBreakdown({ portfolioId: "p1" }),
+      makePortfolioBreakdown({ portfolioId: "p2" }),
+    ]
+    expect(resolveTarget(options)).toEqual({ kind: "choose", options })
+  })
+
+  it("returns none when there is no breakdown", () => {
+    expect(resolveTarget(undefined)).toEqual({ kind: "none" })
+    expect(resolveTarget([])).toEqual({ kind: "none" })
+  })
+})

--- a/src/lib/utils/holdings/aggregatedActions.ts
+++ b/src/lib/utils/holdings/aggregatedActions.ts
@@ -1,0 +1,51 @@
+import { PortfolioBreakdown } from "types/beancounter"
+
+/**
+ * Minimal shape of the aggregated holdings groups needed to find, per asset,
+ * the portfolios that hold it. Kept structural so it accepts the full
+ * `HoldingGroup` map without coupling to its other fields.
+ */
+interface BreakdownPosition {
+  asset: { id: string }
+  portfolioBreakdown?: PortfolioBreakdown[]
+}
+interface BreakdownGroup {
+  positions: BreakdownPosition[]
+}
+
+/**
+ * Build a lookup from asset id to the list of portfolios holding that asset,
+ * so the aggregated holdings actions can resolve which portfolio to act on.
+ */
+export function indexBreakdownByAssetId(
+  holdingGroups: Record<string, BreakdownGroup>,
+): Map<string, PortfolioBreakdown[]> {
+  const index = new Map<string, PortfolioBreakdown[]>()
+  for (const group of Object.values(holdingGroups)) {
+    for (const position of group.positions) {
+      if (position.portfolioBreakdown && position.portfolioBreakdown.length) {
+        index.set(position.asset.id, position.portfolioBreakdown)
+      }
+    }
+  }
+  return index
+}
+
+export type TargetResolution =
+  | { kind: "direct"; target: PortfolioBreakdown }
+  | { kind: "choose"; options: PortfolioBreakdown[] }
+  | { kind: "none" }
+
+/**
+ * Decide how an aggregated action picks its portfolio:
+ * - held in exactly one  → act on it directly
+ * - held in several      → caller must prompt the user to choose
+ * - held in none         → nothing to act on
+ */
+export function resolveTarget(
+  breakdown: PortfolioBreakdown[] | undefined,
+): TargetResolution {
+  if (!breakdown || breakdown.length === 0) return { kind: "none" }
+  if (breakdown.length === 1) return { kind: "direct", target: breakdown[0] }
+  return { kind: "choose", options: breakdown }
+}

--- a/src/pages/api/trns/trades/[...trades].ts
+++ b/src/pages/api/trns/trades/[...trades].ts
@@ -8,6 +8,19 @@ import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 export default createApiHandler({
   url: (req) => {
     const trades = req.query.trades as string[]
+    // Aggregated drill-down: /api/trns/trades/{assetId}?portfolios=a,b
+    const portfolios = req.query.portfolios as string | undefined
+    if (portfolios && req.method !== "DELETE") {
+      const assetId = sanitizePathParam(trades[0], "assetId")
+      const portfolioIds = portfolios
+        .split(",")
+        .map((id) => sanitizePathParam(id, "portfolioId"))
+      return getDataUrl(
+        `/trns/asset/${assetId}/trades?portfolios=${encodeURIComponent(
+          portfolioIds.join(","),
+        )}`,
+      )
+    }
     const portfolioId = sanitizePathParam(trades[0], "portfolioId")
     if (req.method === "DELETE") {
       return getDataUrl(`/trns/${portfolioId}`)

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -6,16 +6,30 @@ import {
 import { useRouter } from "next/router"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import useSwr from "swr"
-import { simpleFetcher } from "@utils/api/fetchHelper"
+import { simpleFetcher, portfoliosKey } from "@utils/api/fetchHelper"
 import { errorOut } from "@components/errors/ErrorOut"
 import { useHoldingState } from "@lib/holdings/holdingState"
 import { useHoldingsView } from "@lib/holdings/useHoldingsView"
+import {
+  indexBreakdownByAssetId,
+  resolveTarget,
+} from "@lib/holdings/aggregatedActions"
 import HoldingsHeader from "@components/features/holdings/HoldingsHeader"
 import HoldingMenu from "@components/features/holdings/HoldingMenu"
 import Rows from "@components/features/holdings/Rows"
 import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
 import PortfolioBreakdownPopup from "@components/features/holdings/PortfolioBreakdownPopup"
-import { PortfolioBreakdownData, PriceChartData } from "types/beancounter"
+import SetCashBalanceDialog from "@components/features/holdings/SetCashBalanceDialog"
+import TradeInputForm from "@components/features/transactions/TradeInputForm"
+import {
+  Asset,
+  Portfolio,
+  PortfolioBreakdown,
+  PortfolioBreakdownData,
+  PriceChartData,
+  QuickSellData,
+  SetCashBalanceData,
+} from "types/beancounter"
 import SubTotal from "@components/features/holdings/SubTotal"
 import Header from "@components/features/holdings/Header"
 import GrandTotal from "@components/features/holdings/GrandTotal"
@@ -289,6 +303,156 @@ function AggregatedHoldingsPage(): React.ReactElement {
     setPortfolioBreakdownData(undefined)
   }, [])
 
+  // --- Aggregated trading -------------------------------------------------
+  // The aggregated context portfolio is synthetic, so actions must target a
+  // real portfolio. We resolve it from each asset's portfolioBreakdown: act
+  // directly when held in one, prompt to choose when held in several.
+  const { data: portfoliosData } = useSwr<{ data: Portfolio[] }>(
+    portfoliosKey,
+    simpleFetcher(portfoliosKey),
+  )
+  const portfolioById = useMemo(() => {
+    const map = new Map<string, Portfolio>()
+    for (const p of portfoliosData?.data ?? []) map.set(p.id, p)
+    return map
+  }, [portfoliosData])
+
+  const breakdownByAssetId = useMemo(
+    () => indexBreakdownByAssetId(holdings?.holdingGroups ?? {}),
+    [holdings],
+  )
+  const assetById = useMemo(() => {
+    const map = new Map<string, Asset>()
+    for (const group of Object.values(holdings?.holdingGroups ?? {})) {
+      for (const pos of group.positions) map.set(pos.asset.id, pos.asset)
+    }
+    return map
+  }, [holdings])
+
+  // Trade modal bound to the resolved portfolio
+  const [tradePortfolio, setTradePortfolio] = useState<Portfolio | undefined>(
+    undefined,
+  )
+  const [quickSellData, setQuickSellData] = useState<QuickSellData | undefined>(
+    undefined,
+  )
+  // Set-balance dialog bound to the resolved portfolio
+  const [cashPortfolio, setCashPortfolio] = useState<Portfolio | undefined>(
+    undefined,
+  )
+  const [cashBalanceData, setCashBalanceData] = useState<
+    SetCashBalanceData | undefined
+  >(undefined)
+  // Portfolio chooser for assets held in multiple portfolios
+  const [pendingChoice, setPendingChoice] = useState<{
+    asset?: Asset
+    title: string
+    options: PortfolioBreakdown[]
+    onPick: (row: PortfolioBreakdown) => void
+  } | null>(null)
+
+  // Resolve the target portfolio for an asset, then run `act`. Held in one →
+  // run immediately; held in several → open the chooser; held in none → no-op.
+  const withTargetPortfolio = useCallback(
+    (
+      assetId: string | undefined,
+      title: string,
+      act: (portfolio: Portfolio, row: PortfolioBreakdown) => void,
+    ): void => {
+      const resolution = resolveTarget(
+        assetId ? breakdownByAssetId.get(assetId) : undefined,
+      )
+      if (resolution.kind === "none") return
+      const run = (row: PortfolioBreakdown): void => {
+        const portfolio = portfolioById.get(row.portfolioId)
+        if (portfolio) act(portfolio, row)
+      }
+      if (resolution.kind === "direct") {
+        run(resolution.target)
+        return
+      }
+      setPendingChoice({
+        asset: assetId ? assetById.get(assetId) : undefined,
+        title,
+        options: resolution.options,
+        onPick: run,
+      })
+    },
+    [breakdownByAssetId, portfolioById, assetById],
+  )
+
+  const openTrade = useCallback(
+    (data: QuickSellData, type: NonNullable<QuickSellData["type"]>): void => {
+      withTargetPortfolio(
+        data.assetId,
+        `${data.asset} — choose portfolio`,
+        (portfolio, row) => {
+          setTradePortfolio(portfolio)
+          // Selling acts on the chosen portfolio's holding, not the aggregate.
+          const quantity = type === "SELL" ? row.quantity : data.quantity
+          setQuickSellData({ ...data, type, quantity })
+        },
+      )
+    },
+    [withTargetPortfolio],
+  )
+
+  const handleTrade = useCallback(
+    (data: QuickSellData) => openTrade(data, "BUY"),
+    [openTrade],
+  )
+  const handleQuickSell = useCallback(
+    (data: QuickSellData) => openTrade(data, "SELL"),
+    [openTrade],
+  )
+  const handleRecordIncome = useCallback(
+    (data: QuickSellData) => openTrade(data, "INCOME"),
+    [openTrade],
+  )
+  const handleRecordExpense = useCallback(
+    (data: QuickSellData) => openTrade(data, "EXPENSE"),
+    [openTrade],
+  )
+
+  const handleSetCashBalance = useCallback(
+    (data: SetCashBalanceData) => {
+      withTargetPortfolio(
+        data.assetId,
+        `${data.assetCode ?? data.currency} — choose portfolio`,
+        (portfolio) => {
+          setCashPortfolio(portfolio)
+          setCashBalanceData(data)
+        },
+      )
+    },
+    [withTargetPortfolio],
+  )
+
+  const handleGoToPortfolio = useCallback(
+    (asset: Asset) => {
+      const resolution = resolveTarget(breakdownByAssetId.get(asset.id))
+      if (resolution.kind === "none") return
+      if (resolution.kind === "direct") {
+        router.push(`/holdings/${resolution.target.portfolioCode}`)
+        return
+      }
+      // Multiple holders → reuse the breakdown popup (navigates on select)
+      setPortfolioBreakdownData({ asset, breakdown: resolution.options })
+    },
+    [breakdownByAssetId, router],
+  )
+
+  const handleTradeClose = useCallback((open: boolean) => {
+    if (!open) {
+      setQuickSellData(undefined)
+      setTradePortfolio(undefined)
+    }
+  }, [])
+  const handleCashBalanceClose = useCallback(() => {
+    setCashBalanceData(undefined)
+    setCashPortfolio(undefined)
+  }, [])
+
   // Determine the subtitle based on selected portfolios
   const subtitle = useMemo(() => {
     if (portfolioCodes.length === 0) {
@@ -478,6 +642,12 @@ function AggregatedHoldingsPage(): React.ReactElement {
                             onColumnsChange={setColumns}
                             onPriceChart={handlePriceChart}
                             onPortfolioBreakdown={handlePortfolioBreakdown}
+                            onTrade={handleTrade}
+                            onQuickSell={handleQuickSell}
+                            onRecordIncome={handleRecordIncome}
+                            onRecordExpense={handleRecordExpense}
+                            onSetCashBalance={handleSetCashBalance}
+                            onGoToPortfolio={handleGoToPortfolio}
                           />
                           <SubTotal
                             groupBy={groupKey}
@@ -511,6 +681,12 @@ function AggregatedHoldingsPage(): React.ReactElement {
               isMixedCurrencies={holdingResults.isMixedCurrencies}
               onPriceChart={handlePriceChart}
               onPortfolioBreakdown={handlePortfolioBreakdown}
+              onTrade={handleTrade}
+              onQuickSell={handleQuickSell}
+              onRecordIncome={handleRecordIncome}
+              onRecordExpense={handleRecordExpense}
+              onSetCashBalance={handleSetCashBalance}
+              onGoToPortfolio={handleGoToPortfolio}
             />
           </div>
         ) : viewMode === "heatmap" ? (
@@ -584,6 +760,39 @@ function AggregatedHoldingsPage(): React.ReactElement {
             asset={portfolioBreakdownData.asset}
             breakdown={portfolioBreakdownData.breakdown}
             onClose={handlePortfolioBreakdownClose}
+          />
+        )}
+        {pendingChoice && (
+          <PortfolioBreakdownPopup
+            asset={pendingChoice.asset}
+            breakdown={pendingChoice.options}
+            title={pendingChoice.title}
+            onSelect={(row) => {
+              const pick = pendingChoice.onPick
+              setPendingChoice(null)
+              pick(row)
+            }}
+            onClose={() => setPendingChoice(null)}
+          />
+        )}
+        {quickSellData && tradePortfolio && (
+          <TradeInputForm
+            portfolio={tradePortfolio}
+            modalOpen={true}
+            setModalOpen={handleTradeClose}
+            initialValues={quickSellData}
+          />
+        )}
+        {cashBalanceData && cashPortfolio && (
+          <SetCashBalanceDialog
+            modalOpen={true}
+            onClose={handleCashBalanceClose}
+            portfolio={cashPortfolio}
+            currency={cashBalanceData.currency}
+            currentBalance={cashBalanceData.currentBalance}
+            market={cashBalanceData.market}
+            assetCode={cashBalanceData.assetCode}
+            assetName={cashBalanceData.assetName}
           />
         )}
         {reviewPopup}

--- a/src/pages/trns/trades/[...trades].tsx
+++ b/src/pages/trns/trades/[...trades].tsx
@@ -6,6 +6,7 @@ import {
   assetKey,
   simpleFetcher,
   tradeKey,
+  tradeKeyMulti,
   trnKey,
   holdingKey,
 } from "@utils/api/fetchHelper"
@@ -37,14 +38,30 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
   // Detect if this is an edit request: /trns/trades/edit/[portfolioId]/[trnId]
   const isEditMode = tradesParam && tradesParam[0] === "edit"
 
+  // Aggregated drill-down: /trns/trades/[assetId]?portfolios=a,b — one asset
+  // held in several portfolios, grouped by portfolio instead of broker.
+  const portfoliosParam = router.query.portfolios as string | undefined
+  const isMulti = !isEditMode && !!portfoliosParam
+  const portfolioIds = useMemo(
+    () => (portfoliosParam ? portfoliosParam.split(",").filter(Boolean) : []),
+    [portfoliosParam],
+  )
+
   // For edit mode: trades[1] = portfolioId, trades[2] = trnId
-  // For list mode: trades[0] = portfolioId, trades[1] = assetId
+  // For single-portfolio list mode: trades[0] = portfolioId, trades[1] = assetId
+  // For aggregated mode: trades[0] = assetId (portfolios come from the query)
   const portfolioId = isEditMode
     ? tradesParam![1]
+    : isMulti
+      ? undefined
+      : tradesParam
+        ? tradesParam[0]
+        : undefined
+  const assetId = isMulti
+    ? tradesParam?.[0]
     : tradesParam
-      ? tradesParam[0]
+      ? tradesParam[1]
       : undefined
-  const assetId = tradesParam ? tradesParam[1] : undefined
   const trnId = isEditMode ? tradesParam![2] : undefined
 
   // Reset modal state when entering edit mode with a new transaction
@@ -78,58 +95,72 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
       ? simpleFetcher(assetKey(assetId as string))
       : null,
   )
-  const trades = useSwr(
-    router.isReady && !isEditMode && portfolioId && assetId
-      ? tradeKey(portfolioId as string, assetId as string)
-      : null,
-    router.isReady && !isEditMode && portfolioId && assetId
-      ? simpleFetcher(tradeKey(portfolioId as string, assetId as string))
-      : null,
-  )
+  const tradesUrl =
+    router.isReady && !isEditMode && assetId
+      ? isMulti
+        ? portfolioIds.length > 0
+          ? tradeKeyMulti(assetId as string, portfolioIds)
+          : null
+        : portfolioId
+          ? tradeKey(portfolioId as string, assetId as string)
+          : null
+      : null
+  const trades = useSwr(tradesUrl, tradesUrl ? simpleFetcher(tradesUrl) : null)
 
   // Group transactions by broker (must be called before any early returns for hooks rules)
   const trnResults = useMemo(
     (): Transaction[] => trades.data?.data || [],
     [trades.data?.data],
   )
-  const groupedByBroker = useMemo(() => {
+  // Single-portfolio view groups by broker; the aggregated drill-down groups by
+  // portfolio (one asset held across several portfolios).
+  const groups = useMemo(() => {
     if (!trnResults || trnResults.length === 0) return []
 
-    const groups: Record<
+    const acc: Record<
       string,
       {
-        broker: { id: string; name: string } | null
+        id: string
+        label: string
+        sortName: string
         transactions: Transaction[]
       }
     > = {}
 
     trnResults.forEach((trn: Transaction) => {
-      const brokerKey = trn.broker?.id || "__no_broker__"
-      if (!groups[brokerKey]) {
-        groups[brokerKey] = {
-          broker: trn.broker || null,
+      const key = isMulti
+        ? trn.portfolio?.id || "__no_portfolio__"
+        : trn.broker?.id || "__no_broker__"
+      const named = isMulti ? !!trn.portfolio : !!trn.broker
+      const label = isMulti
+        ? trn.portfolio?.code || "Unknown Portfolio"
+        : trn.broker?.name || "No Broker"
+      if (!acc[key]) {
+        acc[key] = {
+          id: key,
+          label,
+          sortName: named ? label : "",
           transactions: [],
         }
       }
-      groups[brokerKey].transactions.push(trn)
+      acc[key].transactions.push(trn)
     })
 
     // A BALANCE transaction states the absolute position as at its trade date,
     // so the running quantity must reset to it — computeTradeGroupTotals folds
     // the trades chronologically rather than naively summing every quantity.
-    const withTotals = Object.values(groups).map((group) => ({
+    const withTotals = Object.values(acc).map((group) => ({
       ...group,
       totals: computeTradeGroupTotals(group.transactions),
     }))
 
-    // Sort: brokers with names first (alphabetically), then "No Broker" last
+    // Named groups first (alphabetically), unnamed ("No Broker") last
     return withTotals.sort((a, b) => {
-      if (!a.broker && b.broker) return 1
-      if (a.broker && !b.broker) return -1
-      if (!a.broker && !b.broker) return 0
-      return (a.broker?.name || "").localeCompare(b.broker?.name || "")
+      if (!a.sortName && b.sortName) return 1
+      if (a.sortName && !b.sortName) return -1
+      return a.sortName.localeCompare(b.sortName)
     })
-  }, [trnResults])
+  }, [trnResults, isMulti])
 
   // Copy row data to clipboard as tab-separated values
   const copyRowToClipboard = useCallback(
@@ -372,40 +403,44 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
         </div>
       </nav>
 
-      {/* Tabs for switching between Trades and Events */}
-      <div className="bg-white border-b">
-        <div className="container mx-auto px-4">
-          <div className="flex">
-            <button
-              className="px-4 py-2 font-medium border-b-2 border-blue-500 text-blue-600"
-              onClick={() =>
-                router.replace(`/trns/trades/${portfolioId}/${assetId}`)
-              }
-            >
-              {"Trades"}
-            </button>
-            <button
-              className="px-4 py-2 font-medium border-b-2 border-transparent text-gray-500 hover:text-gray-700"
-              onClick={() =>
-                router.replace(`/trns/events/${portfolioId}/${assetId}`)
-              }
-            >
-              {"Events"}
-            </button>
+      {/* Tabs for switching between Trades and Events.
+          Events are per-portfolio, so they are hidden in the aggregated
+          (multi-portfolio) drill-down. */}
+      {!isMulti && (
+        <div className="bg-white border-b">
+          <div className="container mx-auto px-4">
+            <div className="flex">
+              <button
+                className="px-4 py-2 font-medium border-b-2 border-blue-500 text-blue-600"
+                onClick={() =>
+                  router.replace(`/trns/trades/${portfolioId}/${assetId}`)
+                }
+              >
+                {"Trades"}
+              </button>
+              <button
+                className="px-4 py-2 font-medium border-b-2 border-transparent text-gray-500 hover:text-gray-700"
+                onClick={() =>
+                  router.replace(`/trns/events/${portfolioId}/${assetId}`)
+                }
+              >
+                {"Events"}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       <div className="container mx-auto px-4 py-4">
         {/* Mobile: Card layout grouped by broker */}
         <div className="md:hidden space-y-4">
-          {groupedByBroker.map((group) => (
-            <div key={group.broker?.id || "no-broker"}>
+          {groups.map((group) => (
+            <div key={group.id}>
               {/* Broker Header */}
               <div className="bg-indigo-50 border border-indigo-200 rounded-t-lg px-4 py-2 flex justify-between items-center">
                 <span className="font-medium text-indigo-900">
                   <i className="fas fa-building mr-2 text-indigo-400"></i>
-                  {group.broker?.name || "No Broker"}
+                  {group.label}
                 </span>
                 <span className="text-sm text-indigo-600">
                   {group.transactions.length}{" "}
@@ -596,16 +631,16 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
 
         {/* Desktop: Table layout grouped by broker */}
         <div className="hidden md:block space-y-4">
-          {groupedByBroker.map((group) => (
+          {groups.map((group) => (
             <div
-              key={group.broker?.id || "no-broker"}
+              key={group.id}
               className="bg-white rounded-lg shadow overflow-hidden"
             >
               {/* Broker Header */}
               <div className="bg-indigo-50 border-b border-indigo-200 px-4 py-3 flex justify-between items-center">
                 <span className="font-medium text-indigo-900">
                   <i className="fas fa-building mr-2 text-indigo-400"></i>
-                  {group.broker?.name || "No Broker"}
+                  {group.label}
                 </span>
                 <span className="text-sm text-indigo-600">
                   {group.transactions.length}{" "}

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -53,6 +53,7 @@ export interface SetCashBalanceData {
   market?: string // Market code: "CASH" for currencies, "PRIVATE" for bank accounts
   assetCode?: string // Asset code for bank accounts (e.g., "WISE", "USD-SAVINGS")
   assetName?: string // Asset name for display
+  assetId?: string // Asset id — lets aggregated holdings resolve the target portfolio
 }
 
 export interface CashTransferData {


### PR DESCRIPTION
## What
From Aggregated Holdings, drilling into an asset now lists **all** its transactions across the portfolios that hold it, grouped by portfolio.

## Why
The drill-down navigated to `/trns/trades/{portfolio.id}/{asset.id}` using the synthesized aggregate context portfolio (the first portfolio), so trades in any other portfolio were missing. `Position.portfolioBreakdown[]` already carries every holding portfolio — now used.

## Design
- `buildAggregatedTradesHref` → `/trns/trades/{assetId}?portfolios=a,b`
- `Rows` / `CardView` use it when `portfolioBreakdown` is present, else the single-portfolio href
- API route `[...trades]` proxies the `portfolios` query to the new backend endpoint
- Trades page groups by **portfolio** (not broker) in aggregated mode; per-portfolio Events tab hidden

## Tests
- `buildAggregatedTradesHref` unit test
- CardView double-click routes single vs aggregated href
- `test` + `typecheck` + `prettier` + `lint` green

Verified live: grouped-by-portfolio trades render end-to-end. Pairs with beancounter `feat/aggregate-trades-by-portfolio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a multi-portfolio aggregated trades drill-down for holdings (including link behavior from holdings rows/cards).
  * Enabled row double-click navigation to aggregated trades when an asset is held across multiple portfolios.
  * Added “Go to portfolio” actions in holdings menus, including the correct asset identifier in trade-related action payloads.
  * Updated Trades/Events page behavior and grouping for aggregated multi-portfolio mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->