### PR TITLE
fix(trns): same-date ADD accrues on top of BALANCE; reset amount on value BALANCE

### DIFF
--- a/src/lib/utils/trns/tradeUtils.test.ts
+++ b/src/lib/utils/trns/tradeUtils.test.ts
@@ -1066,8 +1066,13 @@ describe("computeTradeGroupTotals", () => {
       quantity: 100,
       tradeAmount: 100,
     })
-    expect(computeTradeGroupTotals([buy, balance]).quantity).toBe(100)
-    expect(computeTradeGroupTotals([balance, buy]).quantity).toBe(100)
-    expect(computeTradeGroupTotals([buy, balance]).tradeAmount).toBe(100)
+    for (const input of [
+      [buy, balance],
+      [balance, buy],
+    ]) {
+      const totals = computeTradeGroupTotals(input)
+      expect(totals.quantity).toBe(100)
+      expect(totals.tradeAmount).toBe(100)
+    }
   })
 })

--- a/src/lib/utils/trns/tradeUtils.test.ts
+++ b/src/lib/utils/trns/tradeUtils.test.ts
@@ -1024,4 +1024,50 @@ describe("computeTradeGroupTotals", () => {
     expect(totals.fees).toBe(5)
     expect(totals.tax).toBe(5)
   })
+
+  test("adds a same-date ADD on top of the BALANCE (CPF contribution)", () => {
+    const totals = computeTradeGroupTotals([
+      // Newest-first, as the endpoint returns them
+      trn({
+        trnType: "ADD",
+        tradeDate: "2026-06-17",
+        quantity: 2877.49,
+        tradeAmount: 2877.49,
+      }),
+      trn({
+        trnType: "BALANCE",
+        tradeDate: "2026-06-17",
+        quantity: 185900,
+        tradeAmount: 185900,
+      }),
+      trn({
+        trnType: "BALANCE",
+        tradeDate: "2026-06-14",
+        quantity: 281000,
+        tradeAmount: 281000,
+      }),
+    ])
+    // BALANCE resets to 185,900, then the same-date ADD accumulates on top.
+    expect(totals.quantity).toBeCloseTo(188777.49)
+    // A value-bearing BALANCE resets the amount too — snapshots are not summed.
+    expect(totals.tradeAmount).toBeCloseTo(188777.49)
+  })
+
+  test("a value-bearing same-date BALANCE still overrides a regular BUY", () => {
+    const buy = trn({
+      trnType: "BUY",
+      tradeDate: "2025-02-01",
+      quantity: 7,
+      tradeAmount: 700,
+    })
+    const balance = trn({
+      trnType: "BALANCE",
+      tradeDate: "2025-02-01",
+      quantity: 100,
+      tradeAmount: 100,
+    })
+    expect(computeTradeGroupTotals([buy, balance]).quantity).toBe(100)
+    expect(computeTradeGroupTotals([balance, buy]).quantity).toBe(100)
+    expect(computeTradeGroupTotals([buy, balance]).tradeAmount).toBe(100)
+  })
 })

--- a/src/lib/utils/trns/tradeUtils.ts
+++ b/src/lib/utils/trns/tradeUtils.ts
@@ -435,11 +435,23 @@ export interface TradeGroupTotals {
  * trades endpoint returns newest-first, so we sort chronologically before
  * folding. Cash-side totals (tradeAmount/cashAmount/fees/tax) are plain sums.
  *
- * Same-date tiebreak: a BALANCE is the authoritative position as at end of its
- * trade date, so any non-BALANCE trade sharing that date is already subsumed by
- * it. We therefore sort BALANCE last on equal dates so the reset wins, keeping
- * the result deterministic regardless of input order.
+ * Same-date ordering is by trade kind, because a BALANCE is the authoritative
+ * position as at end of its trade date:
+ *   1. plain trades (BUY/SELL/DIVI…) — subsumed by an end-of-day BALANCE
+ *   2. BALANCE — resets the running position to its stated figure
+ *   3. position adjustments (ADD/REDUCE) — applied on top of the BALANCE
+ * So a same-date BUY is overridden by the BALANCE, while a same-date ADD (e.g. a
+ * CPF contribution recorded alongside the statement) accumulates on top of it.
+ * Input order is irrelevant — the trades endpoint returns newest-first.
+ *
+ * A BALANCE that carries a value (non-zero tradeAmount) is a value snapshot, so
+ * it resets the running tradeAmount the same way it resets quantity; a
+ * value-less BALANCE leaves the cash-flow sum untouched. Other cash-side totals
+ * (cashAmount/fees/tax) are plain sums — a BALANCE has no cash impact.
  */
+const sameDateRank = (trnType: string): number =>
+  trnType === "BALANCE" ? 1 : isPositionAdjustment(trnType) ? 2 : 0
+
 export const computeTradeGroupTotals = (
   transactions: Transaction[],
 ): TradeGroupTotals =>
@@ -447,20 +459,24 @@ export const computeTradeGroupTotals = (
     .sort((a, b) => {
       const byDate = a.tradeDate.localeCompare(b.tradeDate)
       if (byDate !== 0) return byDate
-      if (a.trnType === "BALANCE" && b.trnType !== "BALANCE") return 1
-      if (a.trnType !== "BALANCE" && b.trnType === "BALANCE") return -1
-      return 0
+      return sameDateRank(a.trnType) - sameDateRank(b.trnType)
     })
     .reduce<TradeGroupTotals>(
-      (totals, trn) => ({
-        quantity:
-          trn.trnType === "BALANCE"
+      (totals, trn) => {
+        const isBalance = trn.trnType === "BALANCE"
+        const tradeAmount = trn.tradeAmount || 0
+        return {
+          quantity: isBalance
             ? trn.quantity || 0
             : totals.quantity + (trn.quantity || 0),
-        tradeAmount: totals.tradeAmount + (trn.tradeAmount || 0),
-        cashAmount: totals.cashAmount + (trn.cashAmount || 0),
-        fees: totals.fees + (trn.fees || 0),
-        tax: totals.tax + (trn.tax || 0),
-      }),
+          tradeAmount:
+            isBalance && tradeAmount !== 0
+              ? tradeAmount
+              : totals.tradeAmount + tradeAmount,
+          cashAmount: totals.cashAmount + (trn.cashAmount || 0),
+          fees: totals.fees + (trn.fees || 0),
+          tax: totals.tax + (trn.tax || 0),
+        }
+      },
       { quantity: 0, tradeAmount: 0, cashAmount: 0, fees: 0, tax: 0 },
     )

--- a/src/lib/utils/trns/tradeUtils.ts
+++ b/src/lib/utils/trns/tradeUtils.ts
@@ -433,7 +433,8 @@ export interface TradeGroupTotals {
  * quantity rather than add to the prior sum. Trades dated on/after the most
  * recent BALANCE then accumulate on top of it. Input order is irrelevant — the
  * trades endpoint returns newest-first, so we sort chronologically before
- * folding. Cash-side totals (tradeAmount/cashAmount/fees/tax) are plain sums.
+ * folding. cashAmount/fees/tax are plain sums; tradeAmount may reset on a
+ * value-bearing BALANCE (see below).
  *
  * Same-date ordering is by trade kind, because a BALANCE is the authoritative
  * position as at end of its trade date:

--- a/src/pages/api/trns/trades/[...trades].ts
+++ b/src/pages/api/trns/trades/[...trades].ts
@@ -9,7 +9,12 @@ export default createApiHandler({
   url: (req) => {
     const trades = req.query.trades as string[]
     // Aggregated drill-down: /api/trns/trades/{assetId}?portfolios=a,b
-    const portfolios = req.query.portfolios as string | undefined
+    // Next.js gives string[] when the param repeats (?portfolios=a&portfolios=b),
+    // so normalise to a single comma string before splitting.
+    const portfoliosRaw = req.query.portfolios
+    const portfolios = Array.isArray(portfoliosRaw)
+      ? portfoliosRaw.join(",")
+      : portfoliosRaw
     if (portfolios && req.method !== "DELETE") {
       const assetId = sanitizePathParam(trades[0], "assetId")
       const portfolioIds = portfolios

--- a/src/pages/trns/trades/[...trades].tsx
+++ b/src/pages/trns/trades/[...trades].tsx
@@ -40,7 +40,11 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
 
   // Aggregated drill-down: /trns/trades/[assetId]?portfolios=a,b — one asset
   // held in several portfolios, grouped by portfolio instead of broker.
-  const portfoliosParam = router.query.portfolios as string | undefined
+  // router.query gives string[] when the param repeats — normalise to a string.
+  const portfoliosQuery = router.query.portfolios
+  const portfoliosParam = Array.isArray(portfoliosQuery)
+    ? portfoliosQuery.join(",")
+    : portfoliosQuery
   const isMulti = !isEditMode && !!portfoliosParam
   const portfolioIds = useMemo(
     () => (portfoliosParam ? portfoliosParam.split(",").filter(Boolean) : []),


### PR DESCRIPTION
## Bug
On the trades page, an asset's group Total dropped a same-date `ADD` from the quantity, and the Amount total double-counted `BALANCE` value-snapshots.

Example (CPF): `BALANCE 185,900` + same-date `ADD 2,877.49` → QTY total showed **185,900** (ADD lost); AMOUNT total showed **469,777.49** (two BALANCE snapshots summed). Expected **188,777.49** for both.

## Cause
`computeTradeGroupTotals` sorted `BALANCE` *after* every same-date row, so the ADD was applied first and the BALANCE reset clobbered it. `tradeAmount` was always a plain sum, so value-bearing BALANCE snapshots were added together.

## Fix
- Same-date ordering by kind: plain trades (BUY/SELL) → **BALANCE** → position adjustments (ADD/REDUCE). A same-date BUY stays subsumed by the end-of-day BALANCE; a same-date ADD accrues on top.
- A BALANCE that carries a value (non-zero `tradeAmount`) resets the running amount like it resets quantity; a value-less BALANCE leaves the cash-flow sum untouched (existing behaviour preserved).

## Tests
- New: same-date ADD on top of BALANCE (CPF) → qty + amount = 188,777.49
- New: value-bearing same-date BALANCE still overrides a BUY
- Existing BALANCE/cash-side tests unchanged & green (103 in the suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of trade group total calculations when multiple transactions share the same date, including correct handling of position snapshots (quantity and value) and consistent aggregation order.
  * Fixed portfolio query handling in trade drill-down so repeated `portfolios` parameters are interpreted correctly.

* **Tests**
  * Added unit tests covering same-date aggregation semantics, including scenarios involving balance/value snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->