### PR TITLE
feat(independence): explain the age-55 CPF LIFE lock on the wealth chart

### DIFF
--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -91,6 +91,26 @@ export default function TimelineTabContent({
     return year?.age ?? null
   }, [projection])
 
+  // Age at which CPF savings first lock into the CPF LIFE annuity — the year
+  // annuitizedValue transitions 0 → >0 (Singapore's age-55 OA/SA → RA
+  // transfer). This is what makes the blue Liquid line dip: the money isn't
+  // lost, it moves into the grey "CPF LIFE principal" band and becomes a
+  // lifelong income stream from the payout age. Surfaced as a chart marker +
+  // caption so the dip reads as "locked", not "gone".
+  const cpfLockAge = useMemo(() => {
+    if (!projection) return null
+    const series = [
+      ...(projection.accumulationProjections ?? []),
+      ...projection.yearlyProjections,
+    ]
+    for (let i = 1; i < series.length; i++) {
+      const prev = series[i - 1].annuitizedValue ?? 0
+      const cur = series[i].annuitizedValue ?? 0
+      if (prev === 0 && cur > 0) return series[i].age ?? null
+    }
+    return null
+  }, [projection])
+
   // Active scenario = backend captured a baseline overlay alongside the
   // adjusted projection. Used to gate the "compared to baseline" UI.
   const hasActiveWhatIf = baselineProjection !== null
@@ -394,6 +414,28 @@ export default function TimelineTabContent({
                 }}
               />
             )}
+            {/* CPF LIFE lock marker — the age savings move from spendable
+                  CPF (OA/SA) into the locked CPF LIFE annuity (RA). Slate to
+                  match the grey annuitized band so the dip + the band read as
+                  the same event. Traditional view only (the band is hidden in
+                  FIRE view). */}
+            {timelineViewMode === "traditional" &&
+              hasAnnuitizedLayer &&
+              cpfLockAge != null && (
+                <ReferenceLine
+                  x={cpfLockAge}
+                  stroke="#64748b"
+                  strokeDasharray="4 4"
+                  strokeWidth={1.5}
+                  label={{
+                    value: `🔒 CPF LIFE (${cpfLockAge})`,
+                    position: "insideTopLeft",
+                    fill: "#64748b",
+                    fontSize: 11,
+                    fontWeight: 500,
+                  }}
+                />
+              )}
             {/* Stacked wealth journey — bottom-up: Liquid (spendable),
                   Housing, CPF LIFE principal. Top of the stack equals
                   drawdownable + locked principal at each age. CPF MA is
@@ -471,6 +513,25 @@ export default function TimelineTabContent({
             )}
           </ComposedChart>
         </ChartFrame>
+        {timelineViewMode === "traditional" &&
+          hasAnnuitizedLayer &&
+          cpfLockAge != null && (
+            <p
+              data-testid="cpf-lock-note"
+              className="mt-2 text-xs text-gray-500 flex items-start gap-1.5"
+            >
+              <i className="fas fa-lock text-slate-400 mt-0.5"></i>
+              <span>
+                At age {cpfLockAge}, CPF savings move from spendable into the{" "}
+                <span className="text-slate-600 font-medium">
+                  CPF LIFE principal
+                </span>{" "}
+                (grey band). The Liquid line dips because that money is now
+                locked — not spent — and returns as guaranteed lifelong income
+                from your payout age.
+              </span>
+            </p>
+          )}
       </CollapsibleSection>
 
       <CollapsibleSection

--- a/src/components/features/independence/__tests__/TimelineTabContent.cpfLock.test.tsx
+++ b/src/components/features/independence/__tests__/TimelineTabContent.cpfLock.test.tsx
@@ -1,0 +1,83 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import TimelineTabContent from "@components/features/independence/TimelineTabContent"
+import { RetirementProjection } from "types/independence"
+
+// Minimal projection: accumulation runs 53→56, with the CPF RA transfer
+// locking 213k into annuitizedValue at age 55 (0 → >0 transition).
+function makeProjection(
+  overrides: Partial<RetirementProjection> = {},
+): RetirementProjection {
+  const accum = [53, 54, 55, 56].map((age) => ({
+    year: 2000 + age,
+    age,
+    startingBalance: 100000,
+    contribution: 0,
+    investmentGrowth: 0,
+    endingBalance: 100000,
+    nonSpendableValue: age >= 55 ? 213000 : 0,
+    annuitizedValue: age >= 55 ? 213000 : 0,
+    totalWealth: 100000 + (age >= 55 ? 213000 : 0),
+    currency: "SGD",
+  }))
+  return {
+    yearlyProjections: [
+      {
+        age: 65,
+        endingBalance: 90000,
+        nonSpendableValue: 213000,
+        annuitizedValue: 213000,
+        totalWealth: 303000,
+        currency: "SGD",
+      },
+    ],
+    accumulationProjections: accum,
+    monthlyExpenses: 3500,
+    ...overrides,
+  } as unknown as RetirementProjection
+}
+
+const baseProps = {
+  baselineProjection: null,
+  retirementAge: 65,
+  lifeExpectancy: 90,
+  hideValues: false,
+  isCalculating: false,
+}
+
+describe("TimelineTabContent — CPF lock note", () => {
+  it("shows the CPF LIFE lock note at the age the annuity bucket first funds", () => {
+    render(<TimelineTabContent projection={makeProjection()} {...baseProps} />)
+    expect(screen.getByTestId("cpf-lock-note")).toHaveTextContent(/55/)
+    expect(screen.getByTestId("cpf-lock-note")).toHaveTextContent(/CPF LIFE/i)
+  })
+
+  it("omits the note when there is no CPF annuity (no locked layer)", () => {
+    const noCpf = makeProjection({
+      accumulationProjections: [53, 54, 55, 56].map((age) => ({
+        year: 2000 + age,
+        age,
+        startingBalance: 100000,
+        contribution: 0,
+        investmentGrowth: 0,
+        endingBalance: 100000,
+        nonSpendableValue: 0,
+        annuitizedValue: 0,
+        totalWealth: 100000,
+        currency: "SGD",
+      })),
+      yearlyProjections: [
+        {
+          age: 65,
+          endingBalance: 90000,
+          nonSpendableValue: 0,
+          annuitizedValue: 0,
+          totalWealth: 90000,
+          currency: "SGD",
+        },
+      ],
+    } as unknown as Partial<RetirementProjection>)
+    render(<TimelineTabContent projection={noCpf} {...baseProps} />)
+    expect(screen.queryByTestId("cpf-lock-note")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Why
Users (and we) found the grey "CPF LIFE principal (locked)" band hard to explain. The Liquid line dips sharply at age 55 — the Singapore CPF OA/SA → RA transfer — which reads as a loss but is actually money locking into the CPF LIFE annuity.

## What
On the Wealth Journey timeline (Traditional view), when a CPF annuity layer exists:
- **Chart marker** — a slate dashed `ReferenceLine` at the lock age labelled `🔒 CPF LIFE (55)`, colour-matched to the grey band so the dip and the band read as one event.
- **Caption** — a plain-language note under the chart: the money is *locked, not spent*, and returns as guaranteed lifelong income from the payout age.

Lock age is detected from the data (first year `annuitizedValue` goes 0 → >0), so it tracks whatever the projection produces — no hard-coded 55.

## Pairs with
svc-retire PR #88 (per-account CPF statutory floor rates + accretive age-55 transfer), which produces the `annuitizedValue` series this note describes.

## Tests
`TimelineTabContent.cpfLock.test.tsx` — note renders with the lock age + CPF LIFE text when the annuity bucket funds; omitted when there's no CPF. `yarn typecheck` + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual marker on the Wealth Journey chart to highlight the specific age when CPF LIFE becomes locked.
  * Added an explanatory note clarifying how CPF savings transition from spendable funds to locked CPF LIFE status and the corresponding impact on retirement income.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->