### PR TITLE
feat(portfolios): group managed portfolios by owner

### DIFF
--- a/src/components/features/portfolios/ManagedPortfolios.tsx
+++ b/src/components/features/portfolios/ManagedPortfolios.tsx
@@ -71,6 +71,7 @@ export default function ManagedPortfolios({
   const activeShares = managed.filter(
     (s: PortfolioShare) => s.status === "ACTIVE",
   )
+  const ownerGroups = groupByOwner(activeShares)
 
   return (
     <div className="px-4 py-4">
@@ -112,89 +113,103 @@ export default function ManagedPortfolios({
             </button>
           </div>
 
-          {/* Managed portfolio cards */}
-          {activeShares.map((share) => (
+          {/* Managed portfolios grouped by owner */}
+          {ownerGroups.map((group) => (
             <div
-              key={share.id}
-              className="bg-white rounded-xl shadow-sm border border-gray-200 p-4 cursor-pointer hover:border-wealth-200 hover:shadow-md transition-all"
-              onClick={() => {
-                // Route via portfolio.id (?byId=1) — code is only unique
-                // within an owner, so an adviser opening a managed portfolio
-                // could otherwise collide with one of their own with the
-                // same code.
-                if (share.portfolio?.id) {
-                  router.push(`/holdings/${share.portfolio.id}?byId=1`)
-                }
-              }}
+              key={group.key}
+              data-testid="owner-group"
+              className="space-y-2"
             >
-              <div className="flex justify-between items-start">
-                <div>
-                  <div className="flex items-center space-x-2">
-                    <span className="font-semibold text-wealth-600">
-                      {share.portfolio?.code || "N/A"}
-                    </span>
-                    <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full">
-                      {share.accessLevel === "VIEW"
-                        ? "View Only"
-                        : "Full Access"}
-                    </span>
-                  </div>
-                  <div className="text-gray-900 mt-1">
-                    {share.portfolio?.name}
-                  </div>
-                  <div className="text-xs text-gray-500 mt-1">
-                    {"Owner"}:{" "}
-                    {share.portfolio?.owner?.email
-                      ? maskEmail(share.portfolio.owner.email)
-                      : "Owner"}
-                  </div>
-                </div>
-                <div
-                  className="flex items-center space-x-2"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {canRunAi && share.portfolio && (
-                    <button
-                      onClick={() =>
-                        showReview({
-                          kind: "portfolio",
-                          id: share.portfolio!.id,
-                          code: share.portfolio!.code,
-                          name: share.portfolio!.name,
-                        })
-                      }
-                      className="p-1 text-purple-500 hover:text-purple-700"
-                      title={"AI Summary"}
-                      aria-label={"AI Summary"}
-                    >
-                      <i className="fas fa-wand-magic-sparkles"></i>
-                    </button>
-                  )}
-                  {onCorporateActions && share.portfolio && (
-                    <button
-                      onClick={() => onCorporateActions(share.portfolio!)}
-                      className="text-blue-500 hover:text-blue-700 p-1"
-                      title={"Scan Corporate Actions"}
-                      aria-label={"Scan Corporate Actions"}
-                    >
-                      <i className="fas fa-calendar-check"></i>
-                    </button>
-                  )}
-                  {share.acceptedAt && (
-                    <span className="text-xs text-gray-400">
-                      {"Since"}{" "}
-                      {new Date(share.acceptedAt).toLocaleDateString(
-                        undefined,
-                        { month: "short", day: "numeric" },
-                      )}
-                    </span>
-                  )}
-                  <RevokeButton
-                    shareId={share.id}
-                    onRevoked={handlePendingAction}
-                  />
-                </div>
+              <div className="flex items-center space-x-2 px-1">
+                <i className="fas fa-user text-xs text-gray-400"></i>
+                <span className="text-sm font-semibold text-gray-700">
+                  {group.label}
+                </span>
+                <span className="text-xs text-gray-400">
+                  {"("}
+                  {group.shares.length}
+                  {")"}
+                </span>
               </div>
+
+              {group.shares.map((share) => (
+                <div
+                  key={share.id}
+                  className="bg-white rounded-xl shadow-sm border border-gray-200 p-4 cursor-pointer hover:border-wealth-200 hover:shadow-md transition-all"
+                  onClick={() => {
+                    // Route via portfolio.id (?byId=1) — code is only unique
+                    // within an owner, so an adviser opening a managed portfolio
+                    // could otherwise collide with one of their own with the
+                    // same code.
+                    if (share.portfolio?.id) {
+                      router.push(`/holdings/${share.portfolio.id}?byId=1`)
+                    }
+                  }}
+                >
+                  <div className="flex justify-between items-start">
+                    <div>
+                      <div className="flex items-center space-x-2">
+                        <span className="font-semibold text-wealth-600">
+                          {share.portfolio?.code || "N/A"}
+                        </span>
+                        <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full">
+                          {share.accessLevel === "VIEW"
+                            ? "View Only"
+                            : "Full Access"}
+                        </span>
+                      </div>
+                      <div className="text-gray-900 mt-1">
+                        {share.portfolio?.name}
+                      </div>
+                    </div>
+                    <div
+                      className="flex items-center space-x-2"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {canRunAi && share.portfolio && (
+                        <button
+                          onClick={() =>
+                            showReview({
+                              kind: "portfolio",
+                              id: share.portfolio!.id,
+                              code: share.portfolio!.code,
+                              name: share.portfolio!.name,
+                            })
+                          }
+                          className="p-1 text-purple-500 hover:text-purple-700"
+                          title={"AI Summary"}
+                          aria-label={"AI Summary"}
+                        >
+                          <i className="fas fa-wand-magic-sparkles"></i>
+                        </button>
+                      )}
+                      {onCorporateActions && share.portfolio && (
+                        <button
+                          onClick={() => onCorporateActions(share.portfolio!)}
+                          className="text-blue-500 hover:text-blue-700 p-1"
+                          title={"Scan Corporate Actions"}
+                          aria-label={"Scan Corporate Actions"}
+                        >
+                          <i className="fas fa-calendar-check"></i>
+                        </button>
+                      )}
+                      {share.acceptedAt && (
+                        <span className="text-xs text-gray-400">
+                          {"Since"}{" "}
+                          {new Date(share.acceptedAt).toLocaleDateString(
+                            undefined,
+                            { month: "short", day: "numeric" },
+                          )}
+                        </span>
+                      )}
+                      <RevokeButton
+                        shareId={share.id}
+                        onRevoked={handlePendingAction}
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
             </div>
           ))}
         </div>
@@ -208,6 +223,35 @@ export default function ManagedPortfolios({
       )}
       {reviewPopup}
     </div>
+  )
+}
+
+interface OwnerGroup {
+  key: string
+  label: string
+  shares: PortfolioShare[]
+}
+
+/**
+ * Group active shares by their portfolio owner. Keyed on owner id (falling
+ * back to email) so two owners that happen to share a masked label stay
+ * distinct. Groups are sorted by label for a stable order.
+ */
+function groupByOwner(shares: PortfolioShare[]): OwnerGroup[] {
+  const groups = new Map<string, OwnerGroup>()
+  for (const share of shares) {
+    const owner = share.portfolio?.owner
+    const key = owner?.id ?? owner?.email ?? "unknown"
+    const label = owner?.email ? maskEmail(owner.email) : "Owner"
+    const existing = groups.get(key)
+    if (existing) {
+      existing.shares.push(share)
+    } else {
+      groups.set(key, { key, label, shares: [share] })
+    }
+  }
+  return Array.from(groups.values()).sort((a, b) =>
+    a.label.localeCompare(b.label),
   )
 }
 

--- a/src/components/features/portfolios/__tests__/ManagedPortfolios.test.tsx
+++ b/src/components/features/portfolios/__tests__/ManagedPortfolios.test.tsx
@@ -1,0 +1,131 @@
+import React from "react"
+import { render, screen, within } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { PortfolioShare } from "types/beancounter"
+import { makePortfolio } from "@test-fixtures/beancounter"
+import { sharesManagedKey } from "@utils/api/fetchHelper"
+import ManagedPortfolios from "../ManagedPortfolios"
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock("@components/ui/PageLoader", () => ({
+  rootLoader: (text: string) => <div data-testid="loading">{text}</div>,
+}))
+
+jest.mock("@hooks/usePermissions", () => ({
+  usePermissions: () => ({ ai: false, preview: false, admin: false }),
+}))
+
+jest.mock("@components/features/holdings/usePortfolioReview", () => ({
+  usePortfolioReview: () => ({ popup: null, showReview: jest.fn() }),
+}))
+
+jest.mock("../PendingSharesPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="pending-panel" />,
+}))
+
+jest.mock("../RequestAccessDialog", () => ({
+  __esModule: true,
+  default: () => <div data-testid="request-dialog" />,
+}))
+
+import useSwr from "swr"
+
+const mockUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
+
+function makeShare(
+  id: string,
+  ownerEmail: string,
+  code: string,
+): PortfolioShare {
+  return {
+    id,
+    accessLevel: "VIEW",
+    status: "ACTIVE",
+    createdAt: "2026-01-01",
+    sharedWith: { id: "me", active: true, email: "me@x.com", since: "" },
+    createdBy: { id: "me", active: true, email: "me@x.com", since: "" },
+    portfolio: makePortfolio({
+      id: `pf-${id}`,
+      code,
+      name: `Portfolio ${code}`,
+      owner: {
+        id: `owner-${ownerEmail}`,
+        active: true,
+        email: ownerEmail,
+        since: "",
+      },
+    }),
+  } as PortfolioShare
+}
+
+function mockShares(shares: PortfolioShare[]): void {
+  mockUseSwr.mockImplementation(
+    (key: any) =>
+      (key === sharesManagedKey
+        ? { data: { data: shares }, error: undefined, mutate: jest.fn() }
+        : {
+            data: { invites: [], requests: [] },
+            error: undefined,
+            mutate: jest.fn(),
+          }) as any,
+  )
+}
+
+describe("ManagedPortfolios — group by owner", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it("renders one group section per owner", () => {
+    mockShares([
+      makeShare("1", "alice@example.com", "AAA"),
+      makeShare("2", "alice@example.com", "BBB"),
+      makeShare("3", "bob@example.com", "CCC"),
+    ])
+
+    render(<ManagedPortfolios />)
+
+    const groups = screen.getAllByTestId("owner-group")
+    expect(groups).toHaveLength(2)
+  })
+
+  it("places each owner's portfolios under their own group", () => {
+    mockShares([
+      makeShare("1", "alice@example.com", "AAA"),
+      makeShare("2", "alice@example.com", "BBB"),
+      makeShare("3", "bob@example.com", "CCC"),
+    ])
+
+    render(<ManagedPortfolios />)
+
+    const groups = screen.getAllByTestId("owner-group")
+    const aliceGroup = groups.find((g) => within(g).queryByText("AAA"))!
+    expect(within(aliceGroup).getByText("BBB")).toBeInTheDocument()
+    expect(within(aliceGroup).queryByText("CCC")).not.toBeInTheDocument()
+  })
+
+  it("shows the masked owner email in the group header", () => {
+    mockShares([makeShare("1", "alice@example.com", "AAA")])
+
+    render(<ManagedPortfolios />)
+
+    const group = screen.getByTestId("owner-group")
+    expect(within(group).getByText(/a\*\*\*e@example\.com/)).toBeInTheDocument()
+  })
+
+  it("shows the empty state when there are no active shares", () => {
+    mockShares([])
+
+    render(<ManagedPortfolios />)
+
+    expect(screen.getByText("No managed portfolios yet")).toBeInTheDocument()
+    expect(screen.queryByTestId("owner-group")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

Managed Portfolios view now groups portfolio cards by owner instead of one flat list.

- New `groupByOwner()` helper buckets active shares by owner id (falls back to email), sorted by masked-email label.
- Each group renders a header (user icon + masked owner email + count) above that owner's cards.
- Removed the now-redundant per-card "Owner:" line.

## Tests

New `ManagedPortfolios.test.tsx` — group-per-owner, correct bucketing, masked header, empty state. Full suite green (1569 passing); prettier/eslint/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LvzfW7tgx29sVQQKCv8Bo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed portfolio shares are now grouped and displayed by portfolio owner, with headers showing the number of shares per owner.

* **Tests**
  * Added test coverage for the portfolio grouping functionality, including owner grouping and empty-state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->