### PR TITLE
fix(sentry): wire AI-query tracing — SSE headers + dynamic browser sample rate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,10 @@ jobs:
           # the browser revalidates against /api/register. Set via repo Variable
           # (Settings → Variables), defaults to 30 if unset.
           NEXT_PUBLIC_REGISTRATION_TTL_DAYS: ${{ vars.NEXT_PUBLIC_REGISTRATION_TTL_DAYS || '30' }}
+          # Browser trace sample rate. Empty by default → the client derives a
+          # per-environment default (local 1.0 / deployed 0.2). Set repo Variable
+          # to override (e.g. 1.0 to debug deployed tracing).
+          NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE }}
         run: yarn build
 
       - name: Verify Sentry DSN is inlined into client bundle
@@ -273,6 +277,7 @@ jobs:
             BUILD_ID=${{ github.run_number }}
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_REGISTRATION_TTL_DAYS=${{ vars.NEXT_PUBLIC_REGISTRATION_TTL_DAYS || '30' }}
+            NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=${{ vars.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           # mode=min stores only final-stage layers, not every intermediate
           # builder layer. mode=max ballooned the GHA cache pool.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ ARG NEXT_PUBLIC_SENTRY_DSN
 # browser revalidates against /api/register. Inlined at build time; defaults
 # in code to 30 if absent. Configurable via repo Variable NEXT_PUBLIC_REGISTRATION_TTL_DAYS.
 ARG NEXT_PUBLIC_REGISTRATION_TTL_DAYS
+# Browser Sentry trace sample rate. Inlined at build time; when empty/unset the
+# client derives a per-environment default (local 1.0 / deployed 0.2). Override
+# via repo Variable NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE (e.g. 1.0 to debug a
+# deployed env). Runtime ConfigMap env never reaches the browser bundle.
+ARG NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE
 
 # Environment variables - Build info
 ENV GIT_BRANCH=$GIT_BRANCH
@@ -37,6 +42,8 @@ ARG NEXT_PUBLIC_SENTRY_DSN
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 ARG NEXT_PUBLIC_REGISTRATION_TTL_DAYS
 ENV NEXT_PUBLIC_REGISTRATION_TTL_DAYS=$NEXT_PUBLIC_REGISTRATION_TTL_DAYS
+ARG NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE
+ENV NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=$NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE
 COPY . .
 
 RUN yarn install --frozen-lockfile --prefer-offline --production=false

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -41,6 +41,25 @@ function detectEnvironment(): string {
 const environment = detectEnvironment()
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
 
+// Browser trace sampling. The client bundle cannot read the runtime ConfigMap
+// env (NEXT_PUBLIC_* is inlined by the bundler at build time, like the DSN), so
+// the server-side SENTRY_TRACES_SAMPLE_RATE never reaches the browser. Derive a
+// per-environment default here (local → 1.0 for full-fidelity debugging;
+// deployed → 0.2 to cap volume), overridable at build via the
+// NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE build-arg (repo Variable). Empty/unset
+// falls through to the environment default; non-numeric or out-of-range values
+// are ignored — the override must parse to a number within Sentry's [0, 1] range.
+const sampleRateOverride = process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE
+const parsedSampleRate = sampleRateOverride ? Number(sampleRateOverride) : NaN
+const tracesSampleRate =
+  Number.isFinite(parsedSampleRate) &&
+  parsedSampleRate >= 0 &&
+  parsedSampleRate <= 1
+    ? parsedSampleRate
+    : environment === "local"
+      ? 1.0
+      : 0.2
+
 if (!dsn) {
   console.log("[Sentry Client] No DSN configured, skipping initialization")
 } else {
@@ -50,8 +69,9 @@ if (!dsn) {
     dsn,
     environment,
 
-    // Define how likely traces are sampled. Adjust this value in production.
-    tracesSampleRate: 0.2,
+    // Environment-derived default, overridable via the
+    // NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE build-arg (computed above).
+    tracesSampleRate,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,

--- a/src/pages/api/agent/query/stream.ts
+++ b/src/pages/api/agent/query/stream.ts
@@ -38,13 +38,28 @@ export default async function handler(
       return
     }
 
+    // Forward distributed-tracing headers so the SSE path stays on the same
+    // Sentry trace as the browser → bc-view request (mirrors fetchHelper.ts,
+    // which the non-streaming /api/agent/query path uses via createApiHandler).
+    const sentryTrace = req.headers["sentry-trace"]
+    const baggage = req.headers["baggage"]
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    }
+    if (sentryTrace) {
+      headers["sentry-trace"] = Array.isArray(sentryTrace)
+        ? sentryTrace[0]
+        : sentryTrace
+    }
+    if (baggage) {
+      headers["baggage"] = Array.isArray(baggage) ? baggage[0] : baggage
+    }
+
     const upstream = await fetch(getAgentUrl("/agent/query/stream"), {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-        Accept: "text/event-stream",
-      },
+      headers,
       body: JSON.stringify(req.body),
     })
 


### PR DESCRIPTION
Two related Sentry distributed-tracing fixes on the AI-query path.

## 1. SSE proxy dropped trace headers
`/api/agent/query/stream` bypasses `createApiHandler`/`fetchHelper` (to keep the SSE body unbuffered) and did **not** forward `sentry-trace` / `baggage`. The trace broke at bc-view → svc-agent for the dominant (streaming) AI-query path. Now forwards both, array-guarded, mirroring `fetchHelper.ts`.

## 2. Browser trace sample rate was hardcoded
`instrumentation-client.ts` hardcoded `tracesSampleRate: 0.2`. The browser bundle can't read the runtime ConfigMap env (`NEXT_PUBLIC_*` is inlined at build time, like the DSN), so the server-side `SENTRY_TRACES_SAMPLE_RATE` never reaches it. Now:
- Derives a per-environment default from the runtime hostname (`local` -> 1.0, deployed -> 0.2).
- Overridable at build via `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` (repo Variable), inlined like the DSN — wired through Dockerfile (both stages) and build.yml.
- Bounds-checked to Sentry's [0, 1] range.

## Test
`yarn test` (1569 pass), lint, typecheck, prettier all clean. Reviewed via CodeRabbit CLI pre-push (1 Major addressed: sample-rate bounds validation).

@coderabbitai ignore
