### PR TITLE
feat(holdings): card price tooltip + shared held-duration alpha bar

### DIFF
--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -29,6 +29,8 @@ import {
 import { useDisplayCurrencyConversion } from "@lib/hooks/useDisplayCurrencyConversion"
 import { getGroupComparator } from "@lib/categoryMapping"
 import { useRouter } from "next/router"
+import { AlphaProgress } from "@components/ui/ProgressBar"
+import { QuickTooltip } from "@components/ui/Tooltip"
 import AssetNewsButton from "@components/features/holdings/AssetNewsButton"
 import { useNewsAsset } from "@components/features/holdings/useNewsAsset"
 import {
@@ -101,6 +103,7 @@ interface PositionFooterProps {
   quantity: number
   precision: number
   price: number | undefined
+  priceDate?: string
   weight: number
   currencySymbol: string
   onPriceClick?: (e: React.MouseEvent) => void
@@ -113,6 +116,7 @@ const PositionFooter: React.FC<PositionFooterProps> = ({
   quantity,
   precision,
   price,
+  priceDate,
   weight,
   currencySymbol,
   onPriceClick,
@@ -126,7 +130,7 @@ const PositionFooter: React.FC<PositionFooterProps> = ({
       {price?.toFixed(2) || "-"}
     </>
   )
-  const priceValue = onPriceClick ? (
+  const priceButton = onPriceClick ? (
     <button
       type="button"
       aria-label={priceAriaLabel}
@@ -137,6 +141,13 @@ const PositionFooter: React.FC<PositionFooterProps> = ({
     </button>
   ) : (
     priceText
+  )
+  // Surface the price's as-at date on hover (mirrors the table view, which
+  // shows priceDate inline beneath the price).
+  const priceValue = priceDate ? (
+    <QuickTooltip text={`Price as at ${priceDate}`}>{priceButton}</QuickTooltip>
+  ) : (
+    priceButton
   )
   const quantityText = (
     <PrivateQuantity value={quantity} precision={precision} />
@@ -468,25 +479,36 @@ const PositionCard: React.FC<PositionCardProps> = ({
               }
             : undefined
           return (
-            <PositionFooter
-              quantity={quantityValues.total}
-              precision={quantityValues.precision}
-              price={values.priceData?.close}
-              weight={values.weight}
-              currencySymbol={currencySymbol}
-              onPriceClick={handlePriceClick}
-              priceAriaLabel={
-                isChartable
-                  ? `Show price chart for ${stripOwnerPrefix(asset.code)}`
-                  : undefined
-              }
-              onQuantityClick={handleQuantityClick}
-              quantityAriaLabel={
-                isBreakdownable
-                  ? `Show portfolios holding ${stripOwnerPrefix(asset.code)}`
-                  : undefined
-              }
-            />
+            <>
+              <PositionFooter
+                quantity={quantityValues.total}
+                precision={quantityValues.precision}
+                price={values.priceData?.close}
+                priceDate={values.priceData?.priceDate}
+                weight={values.weight}
+                currencySymbol={currencySymbol}
+                onPriceClick={handlePriceClick}
+                priceAriaLabel={
+                  isChartable
+                    ? `Show price chart for ${stripOwnerPrefix(asset.code)}`
+                    : undefined
+                }
+                onQuantityClick={handleQuantityClick}
+                quantityAriaLabel={
+                  isBreakdownable
+                    ? `Show portfolios holding ${stripOwnerPrefix(asset.code)}`
+                    : undefined
+                }
+              />
+              {/* Alpha bar — holding period + time-weighted alpha, shared with
+                  the table view. Tooltip explains the figure on hover. */}
+              <div className="mt-3 pt-3 border-t border-gray-100">
+                <AlphaProgress
+                  irr={values.irr}
+                  lastTradeDate={dateValues?.opened || undefined}
+                />
+              </div>
+            </>
           )
         })()}
     </div>

--- a/src/components/features/holdings/__tests__/CardView.test.tsx
+++ b/src/components/features/holdings/__tests__/CardView.test.tsx
@@ -556,3 +556,50 @@ describe("CardView footer (Quantity / Price / Weight)", () => {
     })
   })
 })
+
+describe("CardView price tooltip + alpha bar", () => {
+  beforeEach(() => {
+    mockedUsePrivacyMode.mockReturnValue({
+      hideValues: false,
+      toggleHideValues: jest.fn(),
+    })
+  })
+
+  const renderCard = (): void => {
+    const portfolio = makePortfolio()
+    // Fixture defaults: priceData.priceDate "2024-01-15", dateValues.opened
+    // "2023-01-01" — enough to exercise the tooltip + alpha bar.
+    const position = makePosition({
+      price: 150,
+      quantityValues: { total: 100 },
+    })
+    const holdings = makeHoldings({
+      portfolio,
+      holdingGroups: { Equity: makeHoldingGroup({ positions: [position] }) },
+    })
+    render(
+      <CardView
+        holdings={holdings}
+        portfolio={portfolio}
+        valueIn={ValueIn.PORTFOLIO}
+      />,
+    )
+  }
+
+  it("shows the price as-at date on hover", () => {
+    renderCard()
+    const priceHost = screen.getByText("$150.00").closest("span.cursor-help")
+    expect(priceHost).not.toBeNull()
+    fireEvent.mouseEnter(priceHost!)
+    expect(screen.getByText("Price as at 2024-01-15")).toBeInTheDocument()
+  })
+
+  it("renders the shared alpha bar (held-duration) on the card", () => {
+    renderCard()
+    // AlphaProgress's tooltip content is always in the DOM (revealed on hover).
+    expect(screen.getByText("Time-Weighted Alpha")).toBeInTheDocument()
+    expect(
+      screen.getByText(/Position opened: /, { exact: false }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { holdingYears, formatHoldingPeriod } from "@lib/holdings/holdingPeriod"
 
 interface ProgressBarProps {
   value: number
@@ -69,12 +70,8 @@ export const AlphaProgress: React.FC<AlphaProgressProps> = ({
     irr: number,
     lastTradeDate?: string,
   ): number => {
-    if (!lastTradeDate) return irr
-
-    const tradeDate = new Date(lastTradeDate)
-    const now = new Date()
-    const holdingPeriodYears =
-      (now.getTime() - tradeDate.getTime()) / (365.25 * 24 * 60 * 60 * 1000)
+    const holdingPeriodYears = holdingYears(lastTradeDate)
+    if (holdingPeriodYears === undefined) return irr
 
     // Apply time penalty/bonus to alpha
     // Shorter holding periods get penalty, longer periods get stability bonus
@@ -100,23 +97,7 @@ export const AlphaProgress: React.FC<AlphaProgressProps> = ({
     return "gray" // <3% = gray (poor)
   }
 
-  // Calculate holding period for display
-  const getHoldingPeriod = (lastTradeDate?: string): string => {
-    if (!lastTradeDate) return ""
-
-    const tradeDate = new Date(lastTradeDate)
-    const now = new Date()
-    const holdingPeriodYears =
-      (now.getTime() - tradeDate.getTime()) / (365.25 * 24 * 60 * 60 * 1000)
-
-    if (holdingPeriodYears < 1) {
-      const months = Math.floor(holdingPeriodYears * 12)
-      return `${months}m`
-    }
-    return `${holdingPeriodYears.toFixed(1)}y`
-  }
-
-  const holdingPeriod = getHoldingPeriod(lastTradeDate)
+  const holdingPeriod = formatHoldingPeriod(lastTradeDate)
 
   return (
     <div className={`relative group flex items-center space-x-2 ${className}`}>

--- a/src/lib/utils/holdings/__tests__/holdingPeriod.test.ts
+++ b/src/lib/utils/holdings/__tests__/holdingPeriod.test.ts
@@ -1,0 +1,41 @@
+import { holdingYears, formatHoldingPeriod } from "@lib/holdings/holdingPeriod"
+
+const NOW = new Date("2024-07-01T00:00:00Z")
+
+describe("holdingPeriod", () => {
+  describe("holdingYears", () => {
+    it("returns undefined when no open date", () => {
+      expect(holdingYears(undefined, NOW)).toBeUndefined()
+    })
+
+    it("returns the elapsed years from the open date", () => {
+      // 2022-07-01 → 2024-07-01 ≈ 2 years
+      expect(holdingYears("2022-07-01", NOW)).toBeCloseTo(2, 1)
+    })
+
+    it("returns undefined for an invalid date string (no NaN leak)", () => {
+      expect(holdingYears("not-a-date", NOW)).toBeUndefined()
+      expect(holdingYears("2024-99-99", NOW)).toBeUndefined()
+    })
+  })
+
+  describe("formatHoldingPeriod", () => {
+    it("is empty when no open date", () => {
+      expect(formatHoldingPeriod(undefined, NOW)).toBe("")
+    })
+
+    it("is empty for an invalid date string (no 'NaNy')", () => {
+      expect(formatHoldingPeriod("not-a-date", NOW)).toBe("")
+    })
+
+    it("renders whole months under a year", () => {
+      // 2024-01-01 → 2024-07-01 ≈ 5.98 months → floored to 5m
+      expect(formatHoldingPeriod("2024-01-01", NOW)).toBe("5m")
+    })
+
+    it("renders one-decimal years from a year and over", () => {
+      // 2022-01-01 → 2024-07-01 ≈ 2.5 years
+      expect(formatHoldingPeriod("2022-01-01", NOW)).toBe("2.5y")
+    })
+  })
+})

--- a/src/lib/utils/holdings/holdingPeriod.ts
+++ b/src/lib/utils/holdings/holdingPeriod.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared helpers for "how long has this position been held" — derived from a
+ * position's open date (`dateValues.opened`). Used by the holdings table and
+ * card views via the AlphaProgress "alpha bar" so the period label and its
+ * tooltip stay consistent across both.
+ *
+ * `now` is injectable to keep the formatting deterministic in tests.
+ */
+const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000
+
+/**
+ * Elapsed years since `fromDate`, or undefined when no open date is known.
+ */
+export function holdingYears(
+  fromDate?: string,
+  now: Date = new Date(),
+): number | undefined {
+  if (!fromDate) return undefined
+  const openDate = new Date(fromDate)
+  if (Number.isNaN(openDate.getTime())) return undefined
+  return (now.getTime() - openDate.getTime()) / YEAR_MS
+}
+
+/**
+ * Compact holding-period label: whole months under a year (e.g. "5m"),
+ * one-decimal years from a year and over (e.g. "2.5y"). Empty string when the
+ * open date is unknown.
+ */
+export function formatHoldingPeriod(
+  fromDate?: string,
+  now: Date = new Date(),
+): string {
+  const years = holdingYears(fromDate, now)
+  if (years === undefined) return ""
+  if (years < 1) {
+    const months = Math.floor(years * 12)
+    return `${months}m`
+  }
+  return `${years.toFixed(1)}y`
+}


### PR DESCRIPTION
## What

On the holdings **card view**:
- **Price tooltip** — hovering the price now shows `Price as at <priceDate>` (shared `QuickTooltip`), mirroring the table view which shows the date inline.
- **Alpha bar** — each card now renders the held-duration pill + time-weighted alpha (`AlphaProgress`) with its hover tooltip, reused from the table view.

## Refactor (reusable + shared)

Extracted the duplicated holding-period math (it appeared twice inline in `AlphaProgress`) into `@lib/holdings/holdingPeriod`:
- `holdingYears(fromDate, now?)` and `formatHoldingPeriod(fromDate, now?)` — `now` injectable for deterministic tests.
- `AlphaProgress` (table + card) now consume the shared helper.

## Tests

- `holdingPeriod.test.ts` — months/years formatting, no open date, and invalid-date guard (no `NaNy` leak).
- `CardView.test.tsx` — price as-at tooltip on hover; alpha bar present on the card.
- typecheck + lint + prettier clean.

## Review

CodeRabbit CLI run pre-push; both findings addressed (NaN-date guard added; stray watchman cookie kept out of the commit).

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)