### PR TITLE
feat(chat): send think flag — FAB thinking, canned prompts fast

### DIFF
--- a/src/components/features/chat/ChatPanel.tsx
+++ b/src/components/features/chat/ChatPanel.tsx
@@ -14,7 +14,11 @@ interface ChatPanelProps {
    * parent does not need to plumb state through unless it wants to persist
    * the preference across mounts.
    */
-  onSend: (query: string, deepThink: boolean) => void
+  /**
+   * `think` enables DeepSeek thinking mode. Free-text Chat FAB queries pass
+   * `true`; suggested/pre-canned prompts pass `false` for the fastest response.
+   */
+  onSend: (query: string, deepThink: boolean, think: boolean) => void
   onClear: () => void
   /**
    * Aborts an in-flight stream. When provided and `isLoading` is true the
@@ -94,7 +98,8 @@ export default function ChatPanel({
     // the streaming answer immediately, even if they were scrolled up
     // reading earlier output.
     stickToBottomRef.current = true
-    onSend(trimmed, deepThink)
+    // Free-text Chat FAB query → thinking mode on.
+    onSend(trimmed, deepThink, true)
     setInput("")
   }
 
@@ -207,7 +212,7 @@ export default function ChatPanel({
                 {suggestions.map((suggestion) => (
                   <button
                     key={suggestion}
-                    onClick={() => onSend(suggestion, deepThink)}
+                    onClick={() => onSend(suggestion, deepThink, false)}
                     className="text-left text-xs px-3 py-2 rounded-lg border border-gray-200 hover:bg-gray-50 hover:border-blue-300 text-gray-500 hover:text-blue-600 transition-colors"
                   >
                     {suggestion}
@@ -218,7 +223,11 @@ export default function ChatPanel({
           </div>
         )}
         {messages.map((msg) => (
-          <ChatBubble key={msg.id} message={msg} onRetry={onSend} />
+          <ChatBubble
+            key={msg.id}
+            message={msg}
+            onRetry={(content, deepThink) => onSend(content, deepThink, true)}
+          />
         ))}
         {isLoading && (
           <div className="flex items-center gap-2 text-gray-400 text-sm">

--- a/src/components/features/chat/__tests__/ChatPanel.test.tsx
+++ b/src/components/features/chat/__tests__/ChatPanel.test.tsx
@@ -40,7 +40,12 @@ describe("ChatPanel", () => {
     const input = screen.getByRole("textbox")
     fireEvent.change(input, { target: { value: "show portfolios" } })
     fireEvent.submit(input.closest("form")!)
-    expect(defaultProps.onSend).toHaveBeenCalledWith("show portfolios", false)
+    // Free-text Chat FAB query → think=true (thinking mode).
+    expect(defaultProps.onSend).toHaveBeenCalledWith(
+      "show portfolios",
+      false,
+      true,
+    )
   })
 
   it("forwards deepThink=true to onSend when the toggle is on", () => {
@@ -54,6 +59,7 @@ describe("ChatPanel", () => {
     fireEvent.submit(input.closest("form")!)
     expect(defaultProps.onSend).toHaveBeenCalledWith(
       "analyse my retirement plan",
+      true,
       true,
     )
   })

--- a/src/hooks/__tests__/useChat.test.ts
+++ b/src/hooks/__tests__/useChat.test.ts
@@ -221,6 +221,7 @@ describe("useChat", () => {
           query: "test query",
           context: undefined,
           deepThink: false,
+          think: false,
         }),
       }),
     )
@@ -240,7 +241,12 @@ describe("useChat", () => {
     expect(mockFetch).toHaveBeenCalledWith(
       "/api/agent/query/stream",
       expect.objectContaining({
-        body: JSON.stringify({ query: "help", context: ctx, deepThink: false }),
+        body: JSON.stringify({
+          query: "help",
+          context: ctx,
+          deepThink: false,
+          think: false,
+        }),
       }),
     )
   })
@@ -309,6 +315,7 @@ describe("useChat", () => {
           query: "explain",
           context: undefined,
           deepThink: true,
+          think: false,
         }),
       }),
     )

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -26,12 +26,17 @@ interface UseChatReturn {
   isLoading: boolean
   /**
    * Send a query to svc-agent. `deepThink` (default `false`) escalates the
-   * agent to its DEEP tier — see `AgentQuery.deepThink` in svc-agent. The
-   * caller is responsible for collecting the toggle from the UI; the hook
-   * forwards it verbatim and persists it on the user message via the
-   * `deepThink` field on `ChatMessage` so chat history can render a badge.
+   * agent to its DEEP tier — see `AgentQuery.deepThink`. `think` (default
+   * `false`) enables DeepSeek thinking mode — pre-canned / suggested prompts
+   * leave it `false` for the fastest response; the free-text Chat FAB passes
+   * `true` (`AgentQuery.think`). Persisted on the user message via `deepThink`
+   * so chat history can render a badge.
    */
-  sendMessage: (query: string, deepThink?: boolean) => Promise<void>
+  sendMessage: (
+    query: string,
+    deepThink?: boolean,
+    think?: boolean,
+  ) => Promise<void>
   clearMessages: () => void
   /**
    * Aborts the in-flight stream. Any tokens already received remain on the
@@ -58,7 +63,11 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
   }, [])
 
   const sendMessage = useCallback(
-    async (query: string, deepThink: boolean = false) => {
+    async (
+      query: string,
+      deepThink: boolean = false,
+      think: boolean = false,
+    ) => {
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
         role: "user",
@@ -101,7 +110,7 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
             "Content-Type": "application/json",
             Accept: "text/event-stream",
           },
-          body: JSON.stringify({ query, context, deepThink }),
+          body: JSON.stringify({ query, context, deepThink, think }),
           signal: controller.signal,
         })
         if (!res.ok || !res.body) {


### PR DESCRIPTION
Pairs with beancounter #970 (DeepSeek non-thinking fast path). The chat now tells svc-agent whether to use thinking mode via `AgentQuery.think`:

- **Free-text Chat FAB** queries send `think: true` → DeepSeek thinking mode (more considered).
- **Suggested / pre-canned prompts** send `think: false` → routed to the non-thinking `fastChatClient` for the **quickest** response.

Required because beancounter #970 defaults to non-thinking; without this the FAB would lose thinking.

## Changes
- `useChat.sendMessage(query, deepThink?, think?)` — adds `think` (default false) to the request body.
- `ChatPanel`: free-text submit → `true`; suggestion click → `false`; bubble retry → `true`.

## Tests
`useChat`/`ChatPanel` suites updated (body + onSend arity); `yarn test` (1569), lint, typecheck, prettier all green.

> ⚠️ Merge/deploy **after** beancounter #970, or `think:true` hits a backend that ignores it (harmless) and `think:false` won't have a fast client yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat now intelligently manages thinking mode across different input types. Manual text submissions and message retries enable thinking mode for deeper analysis, while suggested prompts disable it for faster response times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->