### PR TITLE
fix(pension): CPF-aware form, policy double-select, DOB sync to plan

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -926,19 +926,22 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                       cpfLifePlan={config.cpfLifePlan}
                       cpfPayoutStartAge={config.cpfPayoutStartAge}
                       onPolicyTypeChange={(val) =>
-                        setConfig({ ...config, policyType: val })
+                        // Functional updates: selecting CPF fires policy +
+                        // template + CPF-LIFE setters in one tick; stale-closure
+                        // spreads would clobber each other.
+                        setConfig((prev) => ({ ...prev, policyType: val }))
                       }
                       onLockedUntilDateChange={(val) =>
-                        setConfig({ ...config, lockedUntilDate: val })
+                        setConfig((prev) => ({ ...prev, lockedUntilDate: val }))
                       }
                       onSubAccountsChange={(accounts) =>
-                        setConfig({ ...config, subAccounts: accounts })
+                        setConfig((prev) => ({ ...prev, subAccounts: accounts }))
                       }
                       onCpfLifePlanChange={(val) =>
-                        setConfig({ ...config, cpfLifePlan: val })
+                        setConfig((prev) => ({ ...prev, cpfLifePlan: val }))
                       }
                       onCpfPayoutStartAgeChange={(val) =>
-                        setConfig({ ...config, cpfPayoutStartAge: val })
+                        setConfig((prev) => ({ ...prev, cpfPayoutStartAge: val }))
                       }
                     />
                   </div>

--- a/src/components/features/assets/CompositeAssetEditor.tsx
+++ b/src/components/features/assets/CompositeAssetEditor.tsx
@@ -147,20 +147,27 @@ export default function CompositeAssetEditor({
             onChange={(e) => {
               const val = e.target.value as PolicyType | ""
               onPolicyTypeChange(val === "" ? undefined : val)
-              if (val === "" && subAccounts.length > 0) {
-                onSubAccountsChange([])
-              }
+              // Changing the policy type resets the sub-accounts to the new
+              // type's default template. Safe to reset unconditionally: this
+              // onChange only fires on an explicit user change, never on
+              // initial load of an existing asset.
               if (val === "CPF") {
-                // CPF is fully prescribed: auto-apply the OA/SA/MA/RA template
-                // (the user can't add codes) and default CPF LIFE to Standard
-                // — otherwise svc-retire's enrichCpfConfigs reports zero
-                // pension income. Both gate on "not already set" so we don't
-                // stomp a returning user's edits.
-                if (subAccounts.length === 0) {
-                  onSubAccountsChange(CPF_TEMPLATE.map((t) => ({ ...t })))
-                }
+                // CPF is fully prescribed: apply the OA/SA/MA/RA template (the
+                // user can't add codes) and default CPF LIFE to Standard —
+                // otherwise svc-retire's enrichCpfConfigs reports zero pension
+                // income. Keep an already-chosen plan (BASIC/ESCALATING).
+                onSubAccountsChange(CPF_TEMPLATE.map((t) => ({ ...t })))
                 if (!cpfLifePlan) {
                   onCpfLifePlanChange?.("STANDARD")
+                }
+              } else {
+                // ILP / Generic / None have no prescribed buckets — start from
+                // an empty template and drop CPF-only settings.
+                if (subAccounts.length > 0) {
+                  onSubAccountsChange([])
+                }
+                if (cpfLifePlan) {
+                  onCpfLifePlanChange?.(undefined)
                 }
               }
             }}

--- a/src/components/features/assets/CompositeAssetEditor.tsx
+++ b/src/components/features/assets/CompositeAssetEditor.tsx
@@ -131,20 +131,8 @@ export default function CompositeAssetEditor({
     [subAccounts, onSubAccountsChange],
   )
 
-  const handleApplyTemplate = useCallback(
-    (template: SubAccountRequest[]) => {
-      onSubAccountsChange(template.map((t) => ({ ...t })))
-      // Belt-and-braces: if someone reaches the CPF template button with
-      // the plan still unset (e.g. policyType was already CPF from a
-      // prior session), seed STANDARD here too.
-      if (policyType === "CPF" && !cpfLifePlan) {
-        onCpfLifePlanChange?.("STANDARD")
-      }
-    },
-    [onSubAccountsChange, policyType, cpfLifePlan, onCpfLifePlanChange],
-  )
-
   const isComposite = policyType !== undefined
+  const isCpf = policyType === "CPF"
 
   return (
     <div className="space-y-4">
@@ -162,12 +150,18 @@ export default function CompositeAssetEditor({
               if (val === "" && subAccounts.length > 0) {
                 onSubAccountsChange([])
               }
-              // Default CPF LIFE plan to Standard the moment policy turns
-              // CPF — otherwise projections silently report zero pension
-              // income (svc-retire's enrichCpfConfigs gates on the plan
-              // being set). User can switch to Basic/Escalating after.
-              if (val === "CPF" && !cpfLifePlan) {
-                onCpfLifePlanChange?.("STANDARD")
+              if (val === "CPF") {
+                // CPF is fully prescribed: auto-apply the OA/SA/MA/RA template
+                // (the user can't add codes) and default CPF LIFE to Standard
+                // — otherwise svc-retire's enrichCpfConfigs reports zero
+                // pension income. Both gate on "not already set" so we don't
+                // stomp a returning user's edits.
+                if (subAccounts.length === 0) {
+                  onSubAccountsChange(CPF_TEMPLATE.map((t) => ({ ...t })))
+                }
+                if (!cpfLifePlan) {
+                  onCpfLifePlanChange?.("STANDARD")
+                }
               }
             }}
             className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-indigo-500 focus:border-indigo-500"
@@ -187,29 +181,18 @@ export default function CompositeAssetEditor({
 
       {isComposite && (
         <>
-          {/* Locked Until Date - Touch-friendly picker */}
-          <TouchDatePicker
-            value={lockedUntilDate}
-            onChange={onLockedUntilDateChange}
-            label="Locked Until Date"
-            hint="Asset cannot be liquidated before this date."
-            minYear={new Date().getFullYear()}
-            maxYear={new Date().getFullYear() + 40}
-          />
-
-          {/* Template Buttons */}
-          <div className="flex space-x-2">
-            {policyType === "CPF" && (
-              <button
-                type="button"
-                onClick={() => handleApplyTemplate(CPF_TEMPLATE)}
-                className="text-xs px-3 py-1.5 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 transition-colors"
-              >
-                <i className="fas fa-magic mr-1"></i>
-                Apply CPF Template
-              </button>
-            )}
-          </div>
+          {/* Locked Until Date — CPF has a statutory lock, so we don't prompt
+              for it; only non-CPF composites expose a manual lock date. */}
+          {policyType !== "CPF" && (
+            <TouchDatePicker
+              value={lockedUntilDate}
+              onChange={onLockedUntilDateChange}
+              label="Locked Until Date"
+              hint="Asset cannot be liquidated before this date."
+              minYear={new Date().getFullYear()}
+              maxYear={new Date().getFullYear() + 40}
+            />
+          )}
 
           {/* CPF LIFE Settings */}
           {policyType === "CPF" && (
@@ -401,14 +384,16 @@ export default function CompositeAssetEditor({
                       />
                     </td>
                     <td className="px-3 py-2">
-                      <button
-                        type="button"
-                        onClick={() => handleRemoveSubAccount(index)}
-                        className="text-red-400 hover:text-red-600"
-                        title="Remove sub-account"
-                      >
-                        <i className="fas fa-times"></i>
-                      </button>
+                      {!isCpf && (
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveSubAccount(index)}
+                          className="text-red-400 hover:text-red-600"
+                          title="Remove sub-account"
+                        >
+                          <i className="fas fa-times"></i>
+                        </button>
+                      )}
                     </td>
                   </tr>
                 ))}
@@ -422,31 +407,34 @@ export default function CompositeAssetEditor({
             )}
           </div>
 
-          {/* Add Sub-Account Row */}
-          <div className="flex items-center space-x-2">
-            <input
-              type="text"
-              value={newCode}
-              onChange={(e) => setNewCode(e.target.value.toUpperCase())}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault()
-                  handleAddSubAccount()
-                }
-              }}
-              placeholder="Sub-account code"
-              className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-indigo-500 focus:border-indigo-500 text-sm"
-            />
-            <button
-              type="button"
-              onClick={handleAddSubAccount}
-              disabled={!newCode.trim()}
-              className="px-3 py-2 bg-indigo-600 text-white rounded-md text-sm hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <i className="fas fa-plus mr-1"></i>
-              Add
-            </button>
-          </div>
+          {/* Add Sub-Account Row — CPF's sub-accounts are fixed (OA/SA/MA/RA),
+              so adding codes is disabled for CPF. */}
+          {!isCpf && (
+            <div className="flex items-center space-x-2">
+              <input
+                type="text"
+                value={newCode}
+                onChange={(e) => setNewCode(e.target.value.toUpperCase())}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault()
+                    handleAddSubAccount()
+                  }
+                }}
+                placeholder="Sub-account code"
+                className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-indigo-500 focus:border-indigo-500 text-sm"
+              />
+              <button
+                type="button"
+                onClick={handleAddSubAccount}
+                disabled={!newCode.trim()}
+                className="px-3 py-2 bg-indigo-600 text-white rounded-md text-sm hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <i className="fas fa-plus mr-1"></i>
+                Add
+              </button>
+            </div>
+          )}
 
           {/* Balance Summary */}
           {subAccounts.length > 0 && (

--- a/src/components/features/assets/CompositeAssetEditor.tsx
+++ b/src/components/features/assets/CompositeAssetEditor.tsx
@@ -160,6 +160,12 @@ export default function CompositeAssetEditor({
                 if (!cpfLifePlan) {
                   onCpfLifePlanChange?.("STANDARD")
                 }
+                // CPF's lock is statutory and the field is hidden — drop any
+                // manual lock date carried over from a previous policy type so
+                // it can't leak into the CPF save.
+                if (lockedUntilDate) {
+                  onLockedUntilDateChange("")
+                }
               } else {
                 // ILP / Generic / None have no prescribed buckets — start from
                 // an empty template and drop CPF-only settings.
@@ -168,6 +174,9 @@ export default function CompositeAssetEditor({
                 }
                 if (cpfLifePlan) {
                   onCpfLifePlanChange?.(undefined)
+                }
+                if (cpfPayoutStartAge != null) {
+                  onCpfPayoutStartAgeChange?.(undefined)
                 }
               }
             }}

--- a/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
+++ b/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
@@ -54,24 +54,53 @@ describe("CompositeAssetEditor — CPF LIFE plan default", () => {
     expect(onCpfLifePlanChange).not.toHaveBeenCalled()
   })
 
-  it("seeds STANDARD when Apply CPF Template is clicked with no plan set", () => {
-    const onCpfLifePlanChange = jest.fn()
+  it("auto-applies the OA/SA/MA/RA template when policy turns CPF with no sub-accounts", () => {
     const onSubAccountsChange = jest.fn()
     render(
       <CompositeAssetEditor
-        policyType="CPF"
+        policyType={undefined}
         lockedUntilDate=""
         subAccounts={[]}
         cpfLifePlan={undefined}
         onPolicyTypeChange={jest.fn()}
         onLockedUntilDateChange={jest.fn()}
         onSubAccountsChange={onSubAccountsChange}
-        onCpfLifePlanChange={onCpfLifePlanChange}
+        onCpfLifePlanChange={jest.fn()}
         onCpfPayoutStartAgeChange={jest.fn()}
       />,
     )
-    fireEvent.click(screen.getByRole("button", { name: /Apply CPF Template/i }))
+    const policySelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement
+    fireEvent.change(policySelect, { target: { value: "CPF" } })
     expect(onSubAccountsChange).toHaveBeenCalled()
-    expect(onCpfLifePlanChange).toHaveBeenCalledWith("STANDARD")
+    const applied = onSubAccountsChange.mock.calls[0][0] as { code: string }[]
+    expect(applied.map((a) => a.code)).toEqual(["OA", "SA", "MA", "RA"])
+  })
+
+  it("hides the locked-date picker and the add-sub-account row for CPF", () => {
+    render(
+      <CompositeAssetEditor
+        policyType="CPF"
+        lockedUntilDate=""
+        subAccounts={[
+          { code: "OA", balance: 0, liquid: true },
+          { code: "MA", balance: 0, liquid: false },
+        ]}
+        cpfLifePlan="STANDARD"
+        onPolicyTypeChange={jest.fn()}
+        onLockedUntilDateChange={jest.fn()}
+        onSubAccountsChange={jest.fn()}
+        onCpfLifePlanChange={jest.fn()}
+        onCpfPayoutStartAgeChange={jest.fn()}
+      />,
+    )
+    // CPF is statutorily locked → no manual lock date prompt.
+    expect(screen.queryByText(/Locked Until Date/i)).not.toBeInTheDocument()
+    // CPF sub-accounts are fixed → no "add code" affordance.
+    expect(
+      screen.queryByPlaceholderText(/Sub-account code/i),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /^Add$/i }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
+++ b/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
@@ -76,6 +76,32 @@ describe("CompositeAssetEditor — CPF LIFE plan default", () => {
     expect(applied.map((a) => a.code)).toEqual(["OA", "SA", "MA", "RA"])
   })
 
+  it("resets sub-accounts and clears the CPF LIFE plan when switching away from CPF", () => {
+    const onSubAccountsChange = jest.fn()
+    const onCpfLifePlanChange = jest.fn()
+    render(
+      <CompositeAssetEditor
+        policyType="CPF"
+        lockedUntilDate=""
+        subAccounts={[
+          { code: "OA", balance: 1000, liquid: true },
+          { code: "MA", balance: 500, liquid: false },
+        ]}
+        cpfLifePlan="STANDARD"
+        onPolicyTypeChange={jest.fn()}
+        onLockedUntilDateChange={jest.fn()}
+        onSubAccountsChange={onSubAccountsChange}
+        onCpfLifePlanChange={onCpfLifePlanChange}
+        onCpfPayoutStartAgeChange={jest.fn()}
+      />,
+    )
+    const policySelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement
+    fireEvent.change(policySelect, { target: { value: "ILP" } })
+    // Template resets to the new type's default (empty) and CPF-only state clears.
+    expect(onSubAccountsChange).toHaveBeenCalledWith([])
+    expect(onCpfLifePlanChange).toHaveBeenCalledWith(undefined)
+  })
+
   it("hides the locked-date picker and the add-sub-account row for CPF", () => {
     render(
       <CompositeAssetEditor

--- a/src/components/features/onboarding/steps/AssetsStep.tsx
+++ b/src/components/features/onboarding/steps/AssetsStep.tsx
@@ -638,6 +638,7 @@ const AssetsStep: React.FC<AssetsStepProps> = ({
             <CompositeAssetEditor
               policyType={newPension.policyType}
               cpfLifePlan={newPension.cpfLifePlan}
+              cpfPayoutStartAge={newPension.payoutAge}
               lockedUntilDate={newPension.lockedUntilDate || ""}
               subAccounts={newPension.subAccounts || []}
               onPolicyTypeChange={(value: PolicyType | undefined) =>
@@ -662,6 +663,9 @@ const AssetsStep: React.FC<AssetsStepProps> = ({
               }
               onSubAccountsChange={(accounts: SubAccountRequest[]) =>
                 setNewPension((prev) => ({ ...prev, subAccounts: accounts }))
+              }
+              onCpfPayoutStartAgeChange={(value) =>
+                setNewPension((prev) => ({ ...prev, payoutAge: value }))
               }
             />
 

--- a/src/components/features/onboarding/steps/AssetsStep.tsx
+++ b/src/components/features/onboarding/steps/AssetsStep.tsx
@@ -633,48 +633,84 @@ const AssetsStep: React.FC<AssetsStepProps> = ({
                 </select>
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  {"Current Balance"}
-                </label>
-                <MathInput
-                  value={newPension.balance}
-                  onChange={(value) =>
-                    setNewPension({
-                      ...newPension,
-                      balance: value || undefined,
-                    })
-                  }
-                  placeholder={"Optional"}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg"
-                />
+            {/* Composite Policy Type — asked first so a CPF selection can
+                prescribe the rest of the form (template, hidden fields). */}
+            <CompositeAssetEditor
+              policyType={newPension.policyType}
+              cpfLifePlan={newPension.cpfLifePlan}
+              lockedUntilDate={newPension.lockedUntilDate || ""}
+              subAccounts={newPension.subAccounts || []}
+              onPolicyTypeChange={(value: PolicyType | undefined) =>
+                // Functional update: the CPF branch also fires
+                // onCpfLifePlanChange in the same tick, and a stale-closure
+                // spread would clobber this policyType write (the
+                // "select twice" bug).
+                setNewPension((prev) => ({
+                  ...prev,
+                  policyType: value,
+                  // CPF contributions are salary-derived; drop any amount the
+                  // user typed before switching the policy to CPF.
+                  monthlyContribution:
+                    value === "CPF" ? undefined : prev.monthlyContribution,
+                }))
+              }
+              onCpfLifePlanChange={(value) =>
+                setNewPension((prev) => ({ ...prev, cpfLifePlan: value }))
+              }
+              onLockedUntilDateChange={(value: string) =>
+                setNewPension((prev) => ({ ...prev, lockedUntilDate: value }))
+              }
+              onSubAccountsChange={(accounts: SubAccountRequest[]) =>
+                setNewPension((prev) => ({ ...prev, subAccounts: accounts }))
+              }
+            />
+
+            {/* Balance + return are derived from CPF sub-accounts, so hide
+                them for CPF. */}
+            {newPension.policyType !== "CPF" && (
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    {"Current Balance"}
+                  </label>
+                  <MathInput
+                    value={newPension.balance}
+                    onChange={(value) =>
+                      setNewPension((prev) => ({
+                        ...prev,
+                        balance: value || undefined,
+                      }))
+                    }
+                    placeholder={"Optional"}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    {"Expected Return %"}
+                  </label>
+                  <input
+                    type="number"
+                    step="0.1"
+                    value={
+                      newPension.expectedReturnRate
+                        ? (newPension.expectedReturnRate * 100).toFixed(1)
+                        : ""
+                    }
+                    onChange={(e) =>
+                      setNewPension((prev) => ({
+                        ...prev,
+                        expectedReturnRate: e.target.value
+                          ? Number(e.target.value) / 100
+                          : undefined,
+                      }))
+                    }
+                    placeholder="5.0"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                  />
+                </div>
               </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  {"Expected Return %"}
-                </label>
-                <input
-                  type="number"
-                  step="0.1"
-                  value={
-                    newPension.expectedReturnRate
-                      ? (newPension.expectedReturnRate * 100).toFixed(1)
-                      : ""
-                  }
-                  onChange={(e) =>
-                    setNewPension({
-                      ...newPension,
-                      expectedReturnRate: e.target.value
-                        ? Number(e.target.value) / 100
-                        : undefined,
-                    })
-                  }
-                  placeholder="5.0"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg"
-                />
-              </div>
-            </div>
+            )}
 
             {/* Monthly Contribution — CPF is statutory and derived from
                 salary, so we don't ask for an amount on a CPF plan. */}
@@ -715,106 +751,84 @@ const AssetsStep: React.FC<AssetsStepProps> = ({
               </div>
             )}
 
-            {/* Composite Policy Type */}
-            <CompositeAssetEditor
-              policyType={newPension.policyType}
-              cpfLifePlan={newPension.cpfLifePlan}
-              lockedUntilDate={newPension.lockedUntilDate || ""}
-              subAccounts={newPension.subAccounts || []}
-              onPolicyTypeChange={(value: PolicyType | undefined) =>
-                setNewPension({
-                  ...newPension,
-                  policyType: value,
-                  // CPF contributions are salary-derived; drop any amount the
-                  // user may have typed before switching the policy to CPF.
-                  monthlyContribution:
-                    value === "CPF"
-                      ? undefined
-                      : newPension.monthlyContribution,
-                })
-              }
-              onCpfLifePlanChange={(value) =>
-                setNewPension({ ...newPension, cpfLifePlan: value })
-              }
-              onLockedUntilDateChange={(value: string) =>
-                setNewPension({ ...newPension, lockedUntilDate: value })
-              }
-              onSubAccountsChange={(accounts: SubAccountRequest[]) =>
-                setNewPension({ ...newPension, subAccounts: accounts })
-              }
-            />
-
-            {/* Lump Sum Toggle */}
-            <div className="flex items-center p-3 bg-purple-100 rounded-lg">
-              <input
-                type="checkbox"
-                id="pension-lump-sum"
-                checked={newPension.lumpSum || false}
-                onChange={(e) =>
-                  setNewPension({
-                    ...newPension,
-                    lumpSum: e.target.checked,
-                    // Clear monthly payout if switching to lump sum
-                    monthlyPayoutAmount: e.target.checked
-                      ? undefined
-                      : newPension.monthlyPayoutAmount,
-                  })
-                }
-                className="h-4 w-4 text-purple-600 border-gray-300 rounded focus:ring-purple-500"
-              />
-              <label
-                htmlFor="pension-lump-sum"
-                className="ml-3 text-sm text-gray-700"
-              >
-                {"Pays out in full (lump sum) rather than monthly"}
-              </label>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  {"Payout Age"}
-                </label>
-                <input
-                  type="number"
-                  value={newPension.payoutAge || ""}
-                  onChange={(e) =>
-                    setNewPension({
-                      ...newPension,
-                      payoutAge: e.target.value
-                        ? Number(e.target.value)
-                        : undefined,
-                    })
-                  }
-                  placeholder={"e.g., 65"}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg"
-                />
-                <p className="text-xs text-gray-500 mt-1">
-                  {"Age when you can start withdrawing"}
-                </p>
-              </div>
-              {!newPension.lumpSum && (
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    {"Monthly Payout"}
-                  </label>
-                  <MathInput
-                    value={newPension.monthlyPayoutAmount}
-                    onChange={(value) =>
-                      setNewPension({
-                        ...newPension,
-                        monthlyPayoutAmount: value || undefined,
-                      })
+            {/* Payout settings — CPF uses its own CPF LIFE payout (age +
+                plan, handled in the policy editor), so hide the generic
+                lump-sum / payout-age / monthly-payout fields for CPF. */}
+            {newPension.policyType !== "CPF" && (
+              <>
+                {/* Lump Sum Toggle */}
+                <div className="flex items-center p-3 bg-purple-100 rounded-lg">
+                  <input
+                    type="checkbox"
+                    id="pension-lump-sum"
+                    checked={newPension.lumpSum || false}
+                    onChange={(e) =>
+                      setNewPension((prev) => ({
+                        ...prev,
+                        lumpSum: e.target.checked,
+                        // Clear monthly payout if switching to lump sum
+                        monthlyPayoutAmount: e.target.checked
+                          ? undefined
+                          : prev.monthlyPayoutAmount,
+                      }))
                     }
-                    placeholder={"Optional"}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                    className="h-4 w-4 text-purple-600 border-gray-300 rounded focus:ring-purple-500"
                   />
-                  <p className="text-xs text-gray-500 mt-1">
-                    {"Expected monthly income at payout age"}
-                  </p>
+                  <label
+                    htmlFor="pension-lump-sum"
+                    className="ml-3 text-sm text-gray-700"
+                  >
+                    {"Pays out in full (lump sum) rather than monthly"}
+                  </label>
                 </div>
-              )}
-            </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      {"Payout Age"}
+                    </label>
+                    <input
+                      type="number"
+                      value={newPension.payoutAge || ""}
+                      onChange={(e) =>
+                        setNewPension((prev) => ({
+                          ...prev,
+                          payoutAge: e.target.value
+                            ? Number(e.target.value)
+                            : undefined,
+                        }))
+                      }
+                      placeholder={"e.g., 65"}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                      {"Age when you can start withdrawing"}
+                    </p>
+                  </div>
+                  {!newPension.lumpSum && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        {"Monthly Payout"}
+                      </label>
+                      <MathInput
+                        value={newPension.monthlyPayoutAmount}
+                        onChange={(value) =>
+                          setNewPension((prev) => ({
+                            ...prev,
+                            monthlyPayoutAmount: value || undefined,
+                          }))
+                        }
+                        placeholder={"Optional"}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                      />
+                      <p className="text-xs text-gray-500 mt-1">
+                        {"Expected monthly income at payout age"}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
             <div className="flex justify-end gap-3 pt-2">
               <button
                 type="button"

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -234,6 +234,20 @@ function SettingsPage(): React.ReactElement {
       })
 
       if (response.ok) {
+        // Date of birth lives in two stores: UserPreferences (here) and the
+        // independence settings the plan wizard / projections read. Keep them
+        // in sync so a DOB edited here is reflected when creating a plan.
+        if (yearOfBirth !== "") {
+          try {
+            await fetch("/api/independence/settings", {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ yearOfBirth, monthOfBirth }),
+            })
+          } catch {
+            // Non-fatal — preferences already saved.
+          }
+        }
         await refetchPreferences()
         setSuccess("Settings saved successfully")
         setTimeout(() => setSuccess(null), 3000)

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -238,14 +238,27 @@ function SettingsPage(): React.ReactElement {
         // independence settings the plan wizard / projections read. Keep them
         // in sync so a DOB edited here is reflected when creating a plan.
         if (yearOfBirth !== "") {
+          // Best-effort + bounded: don't let a slow/failed sync hold up the
+          // (already-succeeded) preferences save.
+          const controller = new AbortController()
+          const timeoutId = setTimeout(() => controller.abort(), 3000)
           try {
-            await fetch("/api/independence/settings", {
+            const syncRes = await fetch("/api/independence/settings", {
               method: "PATCH",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ yearOfBirth, monthOfBirth }),
+              signal: controller.signal,
             })
+            if (!syncRes.ok) {
+              console.warn(
+                "DOB saved, but independence-settings sync failed:",
+                syncRes.status,
+              )
+            }
           } catch {
             // Non-fatal — preferences already saved.
+          } finally {
+            clearTimeout(timeoutId)
           }
         }
         await refetchPreferences()


### PR DESCRIPTION
Follow-up to #921. Pension-form CPF UX, the policy-type "select twice" bug, and a date-of-birth sync gap.

## Fixes
1. **Composite Policy Type asked first** — moved to the top of the pension form so a CPF selection can prescribe the rest.
2. **CPF auto-applies the template** — selecting CPF seeds the OA/SA/MA/RA sub-accounts and defaults CPF LIFE to Standard (no more manual "Apply CPF Template" button).
3. **Policy-type "select twice" bug fixed** — the CPF branch fires `onCpfLifePlanChange` in the same tick as `onPolicyTypeChange`; a stale-closure spread clobbered the policyType write. Switched to functional `setState`.
4. **CPF hides irrelevant fields** — Current Balance, Expected Return, Monthly Contribution, Payout Age, Monthly Payout, Lump Sum, and the statutory Locked-Until date. Sub-account codes can't be added for CPF.
5. **DOB sync** — editing date of birth in Profile/Settings now also updates the independence settings, so a plan created afterwards uses the new birth date (they were separate stores; the wizard read the stale one).

## Tests
1586 pass; `prettier`/`lint`/`typecheck` clean. New tests: CPF auto-template on select, CPF hides locked-date + add-sub-account.

> Note: live verification of the DOB sync was blocked by local svc-data returning 502 at the time (the PATCH never reached the backend; the sync only fires on a successful save). Logic + unit coverage are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CPF policy now auto-populates OA/SA/MA/RA sub-accounts (when switching to CPF) and defaults CPF life plan to **STANDARD**
  * Saving settings now best-effort syncs date of birth to independence settings when year of birth is provided

* **Improvements**
  * CPF policy now hides non-applicable pension inputs, including “Locked Until Date,” current balance, and expected return %
  * CPF sub-account editing is restricted (add/remove controls hidden as applicable)
  * Switching policy/payout options correctly clears CPF-related fields, including resetting monthly payout when toggling lump sum
<!-- end of auto-generated comment: release notes by coderabbit.ai -->