### PR TITLE
fix(payslip): refresh Wealth total on save; default Gross from plan income

### DIFF
--- a/src/components/features/transactions/PayslipModal.tsx
+++ b/src/components/features/transactions/PayslipModal.tsx
@@ -3,6 +3,7 @@ import useSWR, { mutate as globalMutate } from "swr"
 import Dialog from "@components/ui/Dialog"
 import MathInput from "@components/ui/MathInput"
 import { Asset, Portfolio } from "types/beancounter"
+import { PlansResponse } from "types/independence"
 import {
   accountsKey,
   cashKey,
@@ -94,6 +95,15 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
     modalOpen ? accountsKey : null,
     simpleFetcher(accountsKey),
   )
+  // Primary independence plan (backend sorts primary first). Its monthly
+  // working income seeds the Gross salary field — a payslip is one month's pay.
+  const plansKey = "/api/independence/plans"
+  const { data: plansData } = useSWR<PlansResponse>(
+    modalOpen ? plansKey : null,
+    simpleFetcher(plansKey),
+  )
+  const planIncome = plansData?.data?.[0]?.workingIncomeMonthly
+  const defaultGross = planIncome && planIncome > 0 ? String(planIncome) : ""
 
   const portfolios: Portfolio[] = useMemo(
     () => portfoliosData?.data ?? [],
@@ -151,7 +161,10 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
 
   // Form state. Portfolio + cash asset prefill from saved preferences (also
   // re-applied on each open below).
-  const [grossSalary, setGrossSalary] = useState<string>("")
+  const [grossSalary, setGrossSalary] = useState<string>(() => defaultGross)
+  // Tracks whether the user has typed into Gross salary, so the plan-income
+  // default never clobbers a manual entry.
+  const [grossTouched, setGrossTouched] = useState(false)
   // Explicit user pick; "" follows the derived default (CPF portfolio first).
   const [portfolioId, setPortfolioId] = useState<string>("")
   const [cashAssetId, setCashAssetId] = useState<string>(
@@ -171,7 +184,8 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
   if (modalOpen !== prevOpen) {
     setPrevOpen(modalOpen)
     if (modalOpen) {
-      setGrossSalary("")
+      setGrossSalary(defaultGross)
+      setGrossTouched(false)
       setTax("")
       setBucketOverrides({})
       setIsSubmitting(false)
@@ -179,6 +193,16 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
       setSubmitSuccess(false)
       setPortfolioId("")
       setCashAssetId(preferences?.defaultPayslipCashAssetId ?? "")
+    }
+  }
+
+  // The plan often loads after the modal opens; apply its income once it
+  // arrives, but only while the field is still untouched and pristine.
+  const [prevDefaultGross, setPrevDefaultGross] = useState(defaultGross)
+  if (defaultGross !== prevDefaultGross) {
+    setPrevDefaultGross(defaultGross)
+    if (modalOpen && !grossTouched && defaultGross !== "") {
+      setGrossSalary(defaultGross)
     }
   }
 
@@ -288,6 +312,9 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
       const portfolio = portfolios.find((p) => p.id === effectivePortfolioId)
       if (portfolio) globalMutate(holdingKey(portfolio.code, "today"))
       globalMutate("/api/holdings/aggregated?asAt=today")
+      // Wealth screen sums portfolio.marketValue from this list; without
+      // invalidating it the top-line total stays stale after a payslip posts.
+      globalMutate(portfoliosKey)
 
       setSubmitSuccess(true)
       setTimeout(() => onClose(), 1000)
@@ -347,7 +374,10 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
         </label>
         <MathInput
           value={grossSalary === "" ? "" : parseFloat(grossSalary)}
-          onChange={(value) => setGrossSalary(String(value))}
+          onChange={(value) => {
+            setGrossTouched(true)
+            setGrossSalary(String(value))
+          }}
           placeholder={"0.00"}
           aria-label={"Gross salary"}
           className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border"

--- a/src/components/features/transactions/__tests__/PayslipModal.test.tsx
+++ b/src/components/features/transactions/__tests__/PayslipModal.test.tsx
@@ -40,6 +40,9 @@ const mockBankAccounts = {
   ],
 }
 
+let mockPlans: { data: Array<{ workingIncomeMonthly?: number }> } = { data: [] }
+const mockMutate = jest.fn()
+
 // Synchronous SWR: route by key substring.
 jest.mock("swr", () => ({
   __esModule: true,
@@ -48,6 +51,8 @@ jest.mock("swr", () => ({
     // CPF "where held" lookup → the CPF asset lives in pf-1.
     if (key.includes("/positions"))
       return { data: "pf-1", error: undefined, isLoading: false }
+    if (key.includes("independence/plans"))
+      return { data: mockPlans, error: undefined, isLoading: false }
     if (key.includes("portfolios"))
       return { data: mockPortfolios, error: undefined, isLoading: false }
     if (key.includes("category=TRADE"))
@@ -58,7 +63,7 @@ jest.mock("swr", () => ({
       return { data: mockCash, error: undefined, isLoading: false }
     return { data: { data: [] }, error: undefined, isLoading: false }
   },
-  mutate: jest.fn(),
+  mutate: (...args: unknown[]) => mockMutate(...args),
 }))
 
 const mockPreferences = {
@@ -99,6 +104,8 @@ describe("PayslipModal", () => {
   beforeEach(() => {
     mockConfigs = []
     mockDc = undefined
+    mockPlans = { data: [] }
+    mockMutate.mockClear()
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({}),
@@ -112,6 +119,33 @@ describe("PayslipModal", () => {
     expect(screen.getByLabelText("Portfolio")).toBeInTheDocument()
     expect(screen.getByLabelText("Pay into")).toBeInTheDocument()
     expect(screen.getByLabelText("Tax deducted")).toBeInTheDocument()
+  })
+
+  it("defaults Gross salary to the primary plan's monthly working income", () => {
+    mockPlans = { data: [{ workingIncomeMonthly: 6000 }] }
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    expect(
+      (screen.getByLabelText("Gross salary") as HTMLInputElement).value,
+    ).toBe("6000")
+  })
+
+  it("leaves Gross salary empty when the user has no plan", () => {
+    mockPlans = { data: [] }
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    expect(
+      (screen.getByLabelText("Gross salary") as HTMLInputElement).value,
+    ).toBe("")
+  })
+
+  it("revalidates the portfolios list on save so the Wealth total refreshes", async () => {
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    fireEvent.change(screen.getByLabelText("Gross salary"), {
+      target: { value: "4000" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledWith("/api/portfolios?inactive=true")
+    })
   })
 
   it("lists private TRADE/ACCOUNT accounts in Pay into, not just cash balances", () => {


### PR DESCRIPTION
## What

Two payslip-flow fixes, both in `PayslipModal`.

### 🔴 Wealth total not refreshing after a payslip
Saving a payslip invalidated only the holdings caches (`holdingKey`, aggregated holdings) but never the portfolios list. The Wealth screen's top-line total sums `portfolio.marketValue` from `/api/portfolios?inactive=true`, so it kept showing the pre-payslip figure. Now also `mutate(portfoliosKey)` on successful save.

### 🟣 Default Gross salary from the Workplan
When the user has an independence plan, the Gross salary field now pre-fills from the primary plan's `workingIncomeMonthly` (a payslip = one month's pay, so no annualisation). A `grossTouched` flag ensures a manual entry is never clobbered; the default applies on initial mount, on modal open, and reactively once the plan loads after the modal is already open.

## Test plan
- 3 new unit tests: default-from-plan, empty-when-no-plan, portfolios revalidated on save
- `yarn test` (PayslipModal 13/13), `yarn typecheck`, `yarn lint`, `yarn prettier` all clean

## Note
Frontend cache fix. If `marketValue` recompute lags (async valuation), the total may trail the refetch by a beat — confirm on live that it moves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gross salary field now auto-populates with a default value derived from your independence plan.
  * The payslip modal resets to the latest default gross salary on each open while preserving any manual edits you've made.
  * Payslip saves now automatically refresh your wealth screen totals to ensure account information stays accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->