### PR TITLE
fix(independence): Monthly Investment target uses real net contribution

### DIFF
--- a/src/components/features/wealth/IndependenceMetrics.tsx
+++ b/src/components/features/wealth/IndependenceMetrics.tsx
@@ -81,13 +81,23 @@ export default function IndependenceMetrics({
             <div className="bg-blue-50 rounded-lg p-4">
               <p className="text-sm text-gray-600 mb-1">Monthly Investment</p>
               {(() => {
-                // Monthly investment target = surplus × allocation %
-                // Surplus = working income - working expenses
-                const surplus =
-                  (primaryPlan.workingIncomeMonthly ?? 0) -
-                  (primaryPlan.workingExpensesMonthly ?? 0)
+                // Monthly investment target = the backend-computed net
+                // contribution. Prefer the projection echo (authoritative,
+                // full formula); fall back to computing it from the plan with
+                // the SAME formula the backend uses — surplus includes bonus
+                // and is net of taxes, which the old surplus calc dropped,
+                // collapsing the target to 0 whenever income ≈ expenses.
+                const planContribution = Math.max(
+                  ((primaryPlan.workingIncomeMonthly ?? 0) +
+                    (primaryPlan.bonusMonthly ?? 0) -
+                    (primaryPlan.workingExpensesMonthly ?? 0) -
+                    (primaryPlan.taxesMonthly ?? 0)) *
+                    (primaryPlan.investmentAllocationPercent ?? 0.8),
+                  0,
+                )
                 const target = Math.round(
-                  surplus * (primaryPlan.investmentAllocationPercent ?? 0.8),
+                  projectionData?.preRetirementAccumulation
+                    ?.monthlyContribution ?? planContribution,
                 )
                 const actual = Math.round(
                   monthlyInvestmentData?.totalInvested ?? 0,

--- a/src/components/features/wealth/__tests__/IndependenceMetrics.test.tsx
+++ b/src/components/features/wealth/__tests__/IndependenceMetrics.test.tsx
@@ -1,0 +1,67 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import IndependenceMetrics from "../IndependenceMetrics"
+import type { RetirementPlan, RetirementProjection } from "types/independence"
+import type { Currency } from "types/beancounter"
+
+// Modal SWR is gated on a null key here; return nothing.
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: () => ({ data: undefined, error: undefined, isLoading: false }),
+}))
+jest.mock("@hooks/usePrivacyMode", () => ({
+  usePrivacyMode: () => ({ hideValues: false }),
+}))
+
+const usd = { code: "USD", symbol: "$" } as unknown as Currency
+
+// Mary: monthly income ≈ expenses, but a bonus drives the real net
+// contribution. The old (income - expenses) × pct target collapsed to 0.
+const maryPlan = {
+  id: "plan-1",
+  workingIncomeMonthly: 2000,
+  workingExpensesMonthly: 2000,
+  taxesMonthly: 0,
+  bonusMonthly: 2350,
+  investmentAllocationPercent: 0.8,
+} as unknown as RetirementPlan
+
+const render_ = (
+  projectionData: RetirementProjection | null,
+  totalInvested = 0,
+): void => {
+  render(
+    <IndependenceMetrics
+      primaryPlan={maryPlan}
+      projectionData={projectionData}
+      projectionLoading={false}
+      monthlyInvestmentData={{ yearMonth: "2026-06", totalInvested }}
+      displayCurrency={usd}
+      collapsed={false}
+      onToggle={jest.fn()}
+    />,
+  )
+}
+
+describe("IndependenceMetrics — Monthly Investment target", () => {
+  it("uses the projection's net-contribution echo as the target", () => {
+    render_({
+      preRetirementAccumulation: { monthlyContribution: 1880 },
+    } as unknown as RetirementProjection)
+    // Target denominator reflects the backend-computed contribution, not 0.
+    expect(screen.getByText("/ $1,880")).toBeInTheDocument()
+  })
+
+  it("falls back to the full net-contribution formula (incl. bonus, net of taxes) when no echo", () => {
+    // (2000 + 2350 - 2000 - 0) × 0.8 = 1880 — bonus included, not dropped.
+    render_(null)
+    expect(screen.getByText("/ $1,880")).toBeInTheDocument()
+  })
+
+  it("keeps the actual (this-month invested) as the headline number", () => {
+    render_(null, 0)
+    // Actual is genuinely 0 (no BUY/SELL this month); target is still 1,880.
+    expect(screen.getByText("0% of monthly target")).toBeInTheDocument()
+  })
+})

--- a/src/components/features/wealth/__tests__/IndependenceMetrics.test.tsx
+++ b/src/components/features/wealth/__tests__/IndependenceMetrics.test.tsx
@@ -16,16 +16,40 @@ jest.mock("@hooks/usePrivacyMode", () => ({
 
 const usd = { code: "USD", symbol: "$" } as unknown as Currency
 
-// Mary: monthly income ≈ expenses, but a bonus drives the real net
-// contribution. The old (income - expenses) × pct target collapsed to 0.
-const maryPlan = {
+// Typed builder so field names are checked against RetirementPlan (no cast),
+// catching schema drift. Defaults encode "Mary": monthly income ≈ expenses,
+// but a bonus drives the real net contribution — the old (income - expenses)
+// × pct target collapsed to 0.
+const makePlan = (overrides: Partial<RetirementPlan> = {}): RetirementPlan => ({
   id: "plan-1",
+  ownerId: "owner-1",
+  name: "Retirement",
+  planningHorizonYears: 25,
+  lifeExpectancy: 90,
+  monthlyExpenses: 3000,
+  expensesCurrency: "SGD",
+  cashReturnRate: 0.03,
+  equityReturnRate: 0.07,
+  housingReturnRate: 0.04,
+  inflationRate: 0.02,
+  cashAllocation: 0.2,
+  equityAllocation: 0.6,
+  housingAllocation: 0.2,
+  pensionMonthly: 0,
+  socialSecurityMonthly: 0,
+  otherIncomeMonthly: 0,
   workingIncomeMonthly: 2000,
   workingExpensesMonthly: 2000,
   taxesMonthly: 0,
   bonusMonthly: 2350,
   investmentAllocationPercent: 0.8,
-} as unknown as RetirementPlan
+  isPrimary: true,
+  createdDate: "2026-01-01",
+  updatedDate: "2026-01-01",
+  ...overrides,
+})
+
+const maryPlan = makePlan()
 
 const render_ = (
   projectionData: RetirementProjection | null,


### PR DESCRIPTION
## What

The Wealth screen's **Independence Metrics → Monthly Investment** tile shows `actual / target`. The `target` was derived locally as `(workingIncome − workingExpenses) × allocationPercent`, which **drops `bonusMonthly` and `taxesMonthly`**. When monthly income ≈ expenses but a bonus drives the contribution, the target collapsed to **0** — so the tile read "0% of monthly target" despite the work scenario showing a net contribution of ~1880.

## Fix

`target` now prefers the backend's net-contribution echo (`projection.preRetirementAccumulation.monthlyContribution`) — authoritative, computed with the full formula. Fallback (pre-projection / null) uses the **corrected** formula `(income + bonus − expenses − taxes) × pct`, clamped ≥ 0, matching `WorkScenario.computedMonthlyContribution`.

`actual` (this-month BUY/SELL) is unchanged — 0 trades stays 0.

## Test plan
- New `IndependenceMetrics.test.tsx` (3): echo path → `/ $1,880`; formula fallback (bonus included) → `/ $1,880`; headline stays actual (`0% of monthly target`)
- `yarn typecheck`, `yarn lint` clean

## Note
Net contribution is already surfaced on the work-scenario editor/cards/banner; no change needed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the “Monthly Investment” target calculation to use a backend-aligned net monthly contribution formula, applying the investment allocation percentage (defaulting to 80%) and preventing negative targets.
  * The displayed monthly target now prioritizes available projection data, with a fallback to the full net-contribution calculation.

* **Tests**
  * Added a React Testing Library suite covering the monthly target display across scenarios where projection data is available or missing, and verifying headline progress behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->