### PR TITLE
fix(independence): read authoritative CPF LIFE lock age from backend

### DIFF
--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -91,25 +91,17 @@ export default function TimelineTabContent({
     return year?.age ?? null
   }, [projection])
 
-  // Age at which CPF savings first lock into the CPF LIFE annuity — the year
-  // annuitizedValue transitions 0 → >0 (Singapore's age-55 OA/SA → RA
-  // transfer). This is what makes the blue Liquid line dip: the money isn't
-  // lost, it moves into the grey "CPF LIFE principal" band and becomes a
-  // lifelong income stream from the payout age. Surfaced as a chart marker +
-  // caption so the dip reads as "locked", not "gone".
-  const cpfLockAge = useMemo(() => {
-    if (!projection) return null
-    const series = [
-      ...(projection.accumulationProjections ?? []),
-      ...projection.yearlyProjections,
-    ]
-    for (let i = 1; i < series.length; i++) {
-      const prev = series[i - 1].annuitizedValue ?? 0
-      const cur = series[i].annuitizedValue ?? 0
-      if (prev === 0 && cur > 0) return series[i].age ?? null
-    }
-    return null
-  }, [projection])
+  // Age at which CPF savings lock into the CPF LIFE annuity (Singapore's
+  // statutory age-55 OA/SA → RA transfer). This is what makes the blue Liquid
+  // line dip: the money isn't lost, it moves into the grey "CPF LIFE principal"
+  // band and becomes a lifelong income stream from the payout age. Surfaced as
+  // a chart marker + caption so the dip reads as "locked", not "gone".
+  //
+  // Read from the backend's authoritative `cpfLifeAge` (55). Do NOT re-derive
+  // it from the annuitizedValue 0 → >0 transition: each projection row carries
+  // end-of-year balances, so the transition lands on the start-of-year row
+  // (age 54) and the marker would read "CPF LIFE (54)".
+  const cpfLockAge = projection?.cpfLifeAge ?? null
 
   // Active scenario = backend captured a baseline overlay alongside the
   // adjusted projection. Used to gate the "compared to baseline" UI.

--- a/src/components/features/independence/__tests__/TimelineTabContent.cpfLock.test.tsx
+++ b/src/components/features/independence/__tests__/TimelineTabContent.cpfLock.test.tsx
@@ -3,8 +3,11 @@ import { render, screen } from "@testing-library/react"
 import TimelineTabContent from "@components/features/independence/TimelineTabContent"
 import { RetirementProjection } from "types/independence"
 
-// Minimal projection: accumulation runs 53→56, with the CPF RA transfer
-// locking 213k into annuitizedValue at age 55 (0 → >0 transition).
+// Accumulation runs 53→56. The CPF RA transfer funds annuitizedValue when the
+// user turns 55, but because each row carries END-of-year balances the 0 → >0
+// transition lands on the row keyed by the start-of-year age (54). The marker
+// must therefore come from the backend's authoritative `cpfLifeAge` (55), NOT
+// from the transition row.
 function makeProjection(
   overrides: Partial<RetirementProjection> = {},
 ): RetirementProjection {
@@ -15,9 +18,10 @@ function makeProjection(
     contribution: 0,
     investmentGrowth: 0,
     endingBalance: 100000,
-    nonSpendableValue: age >= 55 ? 213000 : 0,
-    annuitizedValue: age >= 55 ? 213000 : 0,
-    totalWealth: 100000 + (age >= 55 ? 213000 : 0),
+    // Off-by-one reality: annuity first funds on the age-54 row.
+    nonSpendableValue: age >= 54 ? 213000 : 0,
+    annuitizedValue: age >= 54 ? 213000 : 0,
+    totalWealth: 100000 + (age >= 54 ? 213000 : 0),
     currency: "SGD",
   }))
   return {
@@ -32,6 +36,7 @@ function makeProjection(
       },
     ],
     accumulationProjections: accum,
+    cpfLifeAge: 55,
     monthlyExpenses: 3500,
     ...overrides,
   } as unknown as RetirementProjection
@@ -46,36 +51,18 @@ const baseProps = {
 }
 
 describe("TimelineTabContent — CPF lock note", () => {
-  it("shows the CPF LIFE lock note at the age the annuity bucket first funds", () => {
+  it("shows the statutory CPF LIFE lock age (55) even when the annuity bucket funds on the age-54 row", () => {
     render(<TimelineTabContent projection={makeProjection()} {...baseProps} />)
-    expect(screen.getByTestId("cpf-lock-note")).toHaveTextContent(/55/)
-    expect(screen.getByTestId("cpf-lock-note")).toHaveTextContent(/CPF LIFE/i)
+    const note = screen.getByTestId("cpf-lock-note")
+    expect(note).toHaveTextContent(/CPF LIFE/i)
+    expect(note).toHaveTextContent(/55/)
+    // Must NOT surface the off-by-one transition age.
+    expect(note).not.toHaveTextContent(/54/)
   })
 
-  it("omits the note when there is no CPF annuity (no locked layer)", () => {
+  it("omits the note when the backend reports no CPF LIFE lock (cpfLifeAge absent)", () => {
     const noCpf = makeProjection({
-      accumulationProjections: [53, 54, 55, 56].map((age) => ({
-        year: 2000 + age,
-        age,
-        startingBalance: 100000,
-        contribution: 0,
-        investmentGrowth: 0,
-        endingBalance: 100000,
-        nonSpendableValue: 0,
-        annuitizedValue: 0,
-        totalWealth: 100000,
-        currency: "SGD",
-      })),
-      yearlyProjections: [
-        {
-          age: 65,
-          endingBalance: 90000,
-          nonSpendableValue: 0,
-          annuitizedValue: 0,
-          totalWealth: 90000,
-          currency: "SGD",
-        },
-      ],
+      cpfLifeAge: undefined,
     } as unknown as Partial<RetirementProjection>)
     render(<TimelineTabContent projection={noCpf} {...baseProps} />)
     expect(screen.queryByTestId("cpf-lock-note")).not.toBeInTheDocument()

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -324,131 +324,184 @@ export default function OpenBrokerageWizard(): React.ReactElement {
       )}
 
       {step === "portfolio" && (
-        <div className="space-y-3">
+        <div className="space-y-6">
+          <p className="text-sm text-gray-500">
+            How would you like to keep this brokerage?
+          </p>
+
           <fieldset className="space-y-3">
-            <label className="flex items-center gap-2">
+            <legend className="sr-only">
+              Choose how to track this brokerage
+            </legend>
+
+            <label
+              className={`flex items-start gap-3 rounded-xl border p-4 cursor-pointer transition-colors ${
+                portfolio.mode === "new"
+                  ? "border-blue-300 bg-blue-50/50 ring-1 ring-blue-300"
+                  : "border-gray-200 hover:border-gray-300"
+              }`}
+            >
               <input
                 type="radio"
                 name="portfolio-mode"
+                className="mt-1"
                 checked={portfolio.mode === "new"}
                 onChange={() => setPortfolio({ ...portfolio, mode: "new" })}
               />
-              <span>Create a new portfolio for this brokerage</span>
+              <span className="flex-1">
+                <span className="block font-medium text-gray-900">
+                  Create a new portfolio for this brokerage
+                </span>
+                <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
+                  Its own space with its own objectives, kept apart from your
+                  non-investment assets — cash, savings, property. Choose this
+                  when you want to judge the brokerage on its own goals.
+                </span>
+              </span>
             </label>
-            <label className="flex items-center gap-2">
+
+            <label
+              className={`flex items-start gap-3 rounded-xl border p-4 transition-colors ${
+                portfolios.length === 0
+                  ? "border-gray-200 opacity-50 cursor-not-allowed"
+                  : portfolio.mode === "existing"
+                    ? "border-blue-300 bg-blue-50/50 ring-1 ring-blue-300 cursor-pointer"
+                    : "border-gray-200 hover:border-gray-300 cursor-pointer"
+              }`}
+            >
               <input
                 type="radio"
                 name="portfolio-mode"
+                className="mt-1"
                 checked={portfolio.mode === "existing"}
                 onChange={() =>
                   setPortfolio({ ...portfolio, mode: "existing" })
                 }
                 disabled={portfolios.length === 0}
               />
-              <span>
-                Attach to an existing portfolio{" "}
-                {portfolios.length === 0 && "(none yet)"}
+              <span className="flex-1">
+                <span className="block font-medium text-gray-900">
+                  Attach to an existing portfolio{" "}
+                  {portfolios.length === 0 && (
+                    <span className="font-normal text-gray-400">
+                      (none yet)
+                    </span>
+                  )}
+                </span>
+                <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
+                  Fold these holdings in beside assets you already track — one
+                  combined view. Choose this when you think of everything as a
+                  single pot.
+                </span>
               </span>
             </label>
           </fieldset>
 
-          {portfolio.mode === "existing" ? (
-            <div>
-              <label
-                htmlFor="pf-existing"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                {"Existing portfolio"}
-              </label>
-              <select
-                id="pf-existing"
-                value={portfolio.existingId}
-                onChange={(e) => {
-                  const id = e.target.value
-                  const pf = portfolios.find((p) => p.id === id)
-                  setPortfolio({
-                    ...portfolio,
-                    existingId: id,
-                    currency: pf?.currency?.code ?? portfolio.currency,
-                  })
-                }}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md"
-              >
-                <option value="">— Select —</option>
-                {portfolios.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name} ({p.code}, {p.currency?.code})
-                  </option>
-                ))}
-              </select>
-              <p className="text-xs text-gray-500 mt-1">
-                {`Deposits will land on a per-broker cash line (e.g. ${broker.newName || "BROKER"}-${portfolio.currency}) so the brokerage cash stays separate from any existing cash on this portfolio.`}
-              </p>
-            </div>
-          ) : (
-            <>
+          <p className="text-xs text-gray-500 leading-relaxed">
+            Either way, Beancounter totals your net worth across every
+            portfolio — this only decides how you{"’"}d like to view these
+            assets, not what you can see.
+          </p>
+
+          <div className="space-y-4 pt-4 border-t border-gray-100">
+            {portfolio.mode === "existing" ? (
               <div>
                 <label
-                  htmlFor="pf-code"
+                  htmlFor="pf-existing"
                   className="block text-sm font-medium text-gray-700 mb-1"
                 >
-                  {"Portfolio code"}
+                  {"Existing portfolio"}
                 </label>
-                <input
-                  id="pf-code"
-                  type="text"
-                  value={portfolio.code}
-                  onChange={(e) =>
-                    setPortfolio({ ...portfolio, code: e.target.value })
-                  }
+                <select
+                  id="pf-existing"
+                  value={portfolio.existingId}
+                  onChange={(e) => {
+                    const id = e.target.value
+                    const pf = portfolios.find((p) => p.id === id)
+                    setPortfolio({
+                      ...portfolio,
+                      existingId: id,
+                      currency: pf?.currency?.code ?? portfolio.currency,
+                    })
+                  }}
                   className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                  placeholder="e.g. IBRK"
-                />
+                >
+                  <option value="">— Select —</option>
+                  {portfolios.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name} ({p.code}, {p.currency?.code})
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-gray-500 mt-1">
+                  {`Deposits will land on a per-broker cash line (e.g. ${broker.newName || "BROKER"}-${portfolio.currency}) so the brokerage cash stays separate from any existing cash on this portfolio.`}
+                </p>
               </div>
+            ) : (
+              <>
+                <div>
+                  <label
+                    htmlFor="pf-code"
+                    className="block text-sm font-medium text-gray-700 mb-1"
+                  >
+                    {"Portfolio code"}
+                  </label>
+                  <input
+                    id="pf-code"
+                    type="text"
+                    value={portfolio.code}
+                    onChange={(e) =>
+                      setPortfolio({ ...portfolio, code: e.target.value })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="e.g. IBRK"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="pf-name"
+                    className="block text-sm font-medium text-gray-700 mb-1"
+                  >
+                    {"Portfolio name"}
+                  </label>
+                  <input
+                    id="pf-name"
+                    type="text"
+                    value={portfolio.name}
+                    onChange={(e) =>
+                      setPortfolio({ ...portfolio, name: e.target.value })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="e.g. Interactive Brokers"
+                  />
+                </div>
+              </>
+            )}
+            {portfolio.mode === "new" && (
               <div>
                 <label
-                  htmlFor="pf-name"
+                  htmlFor="pf-ccy"
                   className="block text-sm font-medium text-gray-700 mb-1"
                 >
-                  {"Portfolio name"}
+                  {"Currency"}
                 </label>
-                <input
-                  id="pf-name"
-                  type="text"
-                  value={portfolio.name}
+                <select
+                  id="pf-ccy"
+                  value={portfolio.currency}
                   onChange={(e) =>
-                    setPortfolio({ ...portfolio, name: e.target.value })
+                    setPortfolio({ ...portfolio, currency: e.target.value })
                   }
                   className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                  placeholder="e.g. Interactive Brokers"
-                />
+                >
+                  {currencyCodes.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
               </div>
-            </>
-          )}
-          {portfolio.mode === "new" && (
-            <div>
-              <label
-                htmlFor="pf-ccy"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                {"Currency"}
-              </label>
-              <select
-                id="pf-ccy"
-                value={portfolio.currency}
-                onChange={(e) =>
-                  setPortfolio({ ...portfolio, currency: e.target.value })
-                }
-                className="w-full px-3 py-2 border border-gray-300 rounded-md"
-              >
-                {currencyCodes.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       )}
 

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -767,6 +767,13 @@ export interface RetirementProjection {
   adjustmentPercentWithLiquidation?: number
   /** Age at which illiquid asset disposal begins in the with-liquidation scenario */
   liquidationAge?: number
+  /**
+   * Statutory CPF LIFE lock age (55) when the OA/SA -> RA annuity fold falls
+   * within the horizon; absent when already past the lock or no CPF. Read this
+   * directly for the "🔒 CPF LIFE" marker — do NOT re-derive from the
+   * annuitizedValue transition (that lands one row early, at age 54).
+   */
+  cpfLifeAge?: number
   /** Data quality warnings - empty means all data fetched successfully */
   warnings?: ProjectionWarning[]
   /** Plan-level insights derived from the projection (Plan Insights list). */


### PR DESCRIPTION
## Problem
The "🔒 CPF LIFE" marker on the single-plan timeline read **"CPF LIFE (54)"** instead of 55.

## Cause
The lock age was re-derived from the `annuitizedValue` 0→>0 transition, which lands on the age-54 row because each projection row carries end-of-year balances.

## Fix
Read the backend's authoritative `RetirementProjection.cpfLifeAge` (statutory 55; absent when already locked / no CPF) instead of re-deriving it. Aligns with the "backend drives data, frontend displays it" rule.

Requires svc-retire companion PR (adds `cpfLifeAge`).

## Tests
Updated `TimelineTabContent.cpfLock` — proves the marker reads **55** even when the annuity bucket funds on the age-54 row, and is omitted when `cpfLifeAge` is absent. Typecheck / lint / 307 independence tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)