### PR TITLE
feat(brokerage): share portfolio-choice UI; offer new-vs-existing in onboarding

### DIFF
--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -954,7 +954,22 @@ const OnboardingWizard: React.FC = () => {
             onSourceChange={setBrokerageSource}
             onAmountChange={setBrokerageAmount}
             onCurrencyChange={setBrokerageCurrency}
-            onPortfolioModeChange={setBrokeragePortfolioMode}
+            onPortfolioModeChange={(mode) => {
+              setBrokeragePortfolioMode(mode)
+              // Re-sync currency to the still-selected existing portfolio so a
+              // currency changed while in "new" mode can't leave the source
+              // filter / deposit on a stale currency.
+              if (mode === "existing" && brokerageExistingId) {
+                const pf = existingPortfolios.find(
+                  (p) => p.id === brokerageExistingId,
+                )
+                const nextCurrency = pf?.currency?.code
+                if (nextCurrency && nextCurrency !== brokerageCurrency) {
+                  setBrokerageCurrency(nextCurrency)
+                  setBrokerageSource("")
+                }
+              }
+            }}
             onExistingPortfolioChange={(id) => {
               setBrokerageExistingId(id)
               // Sync the brokerage currency to the chosen portfolio so the

--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -18,6 +18,7 @@ import CompleteStep from "./steps/CompleteStep"
 import IndependencePlanStep from "./steps/IndependencePlanStep"
 import BrokerageStep from "./steps/BrokerageStep"
 import type { SourceValue } from "./steps/BrokerageStep"
+import { type PortfolioMode } from "@components/features/openBrokerage/PortfolioModeChooser"
 import { openBrokerage } from "@lib/openBrokerage/orchestrate"
 import { useRegistration } from "@contexts/RegistrationContext"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
@@ -156,6 +157,11 @@ const OnboardingWizard: React.FC = () => {
   const [brokerageSource, setBrokerageSource] = useState<SourceValue>("")
   const [brokerageAmount, setBrokerageAmount] = useState("")
   const [brokerageCurrency, setBrokerageCurrency] = useState("")
+  // Portfolio choice for the brokerage — mirrors the standalone wizard so
+  // onboarding can also attach the brokerage to an existing portfolio.
+  const [brokeragePortfolioMode, setBrokeragePortfolioMode] =
+    useState<PortfolioMode>("new")
+  const [brokerageExistingId, setBrokerageExistingId] = useState("")
   const [brokerageCreated, setBrokerageCreated] = useState(false)
 
   // Pre-fill fields from user preferences or Auth0 profile (render-phase
@@ -741,7 +747,16 @@ const OnboardingWizard: React.FC = () => {
       // Use the local `portfolioId` variable (set just above), not the
       // React state `createdPortfolioId` — setState hasn't flushed inside
       // the same async function call.
-      if (brokerageEnabled && brokerageBrokerName.trim() && portfolioId) {
+      const brokerageExistingPortfolio =
+        brokeragePortfolioMode === "existing"
+          ? existingPortfolios.find((p) => p.id === brokerageExistingId)
+          : undefined
+      if (
+        brokerageEnabled &&
+        brokerageBrokerName.trim() &&
+        portfolioId &&
+        (brokeragePortfolioMode === "new" || !!brokerageExistingPortfolio)
+      ) {
         const amt = parseFloat(brokerageAmount)
         try {
           // Brokerage gets its own dedicated portfolio (named after the
@@ -755,16 +770,24 @@ const OnboardingWizard: React.FC = () => {
           // step 7; falls back to baseCurrency if they didn't touch the
           // dropdown. `base` stays as the user's overall base currency for
           // consolidated reporting upstream.
-          const brokerageCcy = brokerageCurrency || baseCurrency
+          const brokerageCcy = brokerageExistingPortfolio
+            ? (brokerageExistingPortfolio.currency?.code ?? brokerageCurrency)
+            : brokerageCurrency || baseCurrency
           const brokerageResult = await openBrokerage({
             broker: { mode: "new", newName: brokerCode },
-            portfolio: {
-              mode: "new",
-              code: brokerCode,
-              name: `${brokerCode} Portfolio`,
-              currency: brokerageCcy,
-              base: baseCurrency,
-            },
+            portfolio: brokerageExistingPortfolio
+              ? {
+                  mode: "existing",
+                  existingId: brokerageExistingPortfolio.id,
+                  currency: brokerageCcy,
+                }
+              : {
+                  mode: "new",
+                  code: brokerCode,
+                  name: `${brokerCode} Portfolio`,
+                  currency: brokerageCcy,
+                  base: baseCurrency,
+                },
             funding:
               Number.isFinite(amt) && amt > 0
                 ? (() => {
@@ -799,7 +822,8 @@ const OnboardingWizard: React.FC = () => {
           // portfolios list shows it with no market value until the user
           // opens it.
           try {
-            await fetch(`/api/holdings/${brokerCode}?asAt=${today}`, {
+            const valuationCode = brokerageExistingPortfolio?.code ?? brokerCode
+            await fetch(`/api/holdings/${valuationCode}?asAt=${today}`, {
               credentials: "include",
             })
           } catch (vErr) {
@@ -923,11 +947,22 @@ const OnboardingWizard: React.FC = () => {
             existingPortfolios={existingPortfolios}
             bankAccounts={bankAccounts}
             defaultPortfolioName={portfolioName}
+            portfolioMode={brokeragePortfolioMode}
+            existingPortfolioId={brokerageExistingId}
             onEnabledChange={setBrokerageEnabled}
             onBrokerNameChange={setBrokerageBrokerName}
             onSourceChange={setBrokerageSource}
             onAmountChange={setBrokerageAmount}
             onCurrencyChange={setBrokerageCurrency}
+            onPortfolioModeChange={setBrokeragePortfolioMode}
+            onExistingPortfolioChange={(id) => {
+              setBrokerageExistingId(id)
+              // Sync the brokerage currency to the chosen portfolio so the
+              // source filter + deposit stay same-currency (mirrors the
+              // standalone wizard).
+              const pf = existingPortfolios.find((p) => p.id === id)
+              if (pf?.currency?.code) setBrokerageCurrency(pf.currency.code)
+            }}
           />
         )
       case 7:

--- a/src/components/features/onboarding/steps/BrokerageStep.tsx
+++ b/src/components/features/onboarding/steps/BrokerageStep.tsx
@@ -1,6 +1,9 @@
 import React from "react"
 import Link from "next/link"
 import MathInput from "@components/ui/MathInput"
+import PortfolioModeChooser, {
+  type PortfolioMode,
+} from "@components/features/openBrokerage/PortfolioModeChooser"
 import type { Portfolio } from "types/beancounter"
 import type { BankAccount } from "../OnboardingWizard"
 
@@ -35,11 +38,17 @@ export interface BrokerageStepProps {
   // bank-account line on the default portfolio.
   bankAccounts: BankAccount[]
   defaultPortfolioName: string
+  // Portfolio choice — same new-vs-existing decision as the standalone
+  // /tools/open-brokerage wizard, so onboarding behaves identically.
+  portfolioMode: PortfolioMode
+  existingPortfolioId: string
   onEnabledChange: (v: boolean) => void
   onBrokerNameChange: (v: string) => void
   onSourceChange: (v: SourceValue) => void
   onAmountChange: (v: string) => void
   onCurrencyChange: (v: string) => void
+  onPortfolioModeChange: (v: PortfolioMode) => void
+  onExistingPortfolioChange: (id: string) => void
 }
 
 /**
@@ -58,11 +67,15 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
   existingPortfolios,
   bankAccounts,
   defaultPortfolioName,
+  portfolioMode,
+  existingPortfolioId,
   onEnabledChange,
   onBrokerNameChange,
   onSourceChange,
   onAmountChange,
   onCurrencyChange,
+  onPortfolioModeChange,
+  onExistingPortfolioChange,
 }) => {
   // Filter source options to the chosen currency (same-currency v1).
   const sameCurrencyPortfolios = existingPortfolios.filter(
@@ -121,34 +134,69 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
               className="w-full px-3 py-2 border border-gray-300 rounded-md"
               placeholder="e.g. IBRK"
             />
-            <p className="text-xs text-gray-500 mt-1">
-              {`A new portfolio "${brokerName || "BROKER"} Portfolio" will be created for your brokerage, keeping its cash and trades separate from your "${defaultPortfolioName}" bank-account portfolio.`}
-            </p>
+            {portfolioMode === "new" && (
+              <p className="text-xs text-gray-500 mt-1">
+                {`A new portfolio "${brokerName || "BROKER"} Portfolio" will be created for your brokerage, keeping its cash and trades separate from your "${defaultPortfolioName}" bank-account portfolio.`}
+              </p>
+            )}
           </div>
 
-          <div>
-            <label
-              htmlFor="ob-currency"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              {"Reporting currency"}
-            </label>
-            <select
-              id="ob-currency"
-              value={currency}
-              onChange={(e) => onCurrencyChange(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
-            >
-              {currencyCodes.map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-gray-500 mt-1">
-              {`Cash and trades in this brokerage portfolio will report in ${currency}. Picking a different currency from the bank-account source needs FX (not handled in v1 — same-currency source only).`}
-            </p>
-          </div>
+          <PortfolioModeChooser
+            mode={portfolioMode}
+            onSelect={onPortfolioModeChange}
+            existingDisabled={existingPortfolios.length === 0}
+          />
+
+          {portfolioMode === "existing" ? (
+            <div>
+              <label
+                htmlFor="ob-existing"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {"Existing portfolio"}
+              </label>
+              <select
+                id="ob-existing"
+                value={existingPortfolioId}
+                onChange={(e) => onExistingPortfolioChange(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              >
+                <option value="">— Select —</option>
+                {existingPortfolios.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} ({p.code}, {p.currency?.code})
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-gray-500 mt-1">
+                {`The brokerage's cash lands on a per-broker line (e.g. ${brokerName || "BROKER"}-${currency}) so it stays separate from any existing cash on this portfolio.`}
+              </p>
+            </div>
+          ) : (
+            <div>
+              <label
+                htmlFor="ob-currency"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {"Reporting currency"}
+              </label>
+              <select
+                id="ob-currency"
+                value={currency}
+                onChange={(e) => onCurrencyChange(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              >
+                {currencyCodes.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-gray-500 mt-1">
+                {`Cash and trades in this brokerage portfolio will report in ${currency}. Picking a different currency from the bank-account source needs FX (not handled in v1 — same-currency source only).`}
+              </p>
+            </div>
+          )}
 
           <div>
             <label

--- a/src/components/features/onboarding/steps/__tests__/BrokerageStep.test.tsx
+++ b/src/components/features/onboarding/steps/__tests__/BrokerageStep.test.tsx
@@ -1,0 +1,75 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import BrokerageStep from "../BrokerageStep"
+import type { BrokerageStepProps } from "../BrokerageStep"
+import type { Portfolio } from "types/beancounter"
+
+const existingPortfolios = [
+  {
+    id: "pf-1",
+    code: "MAIN",
+    name: "Main",
+    currency: { code: "SGD" },
+  },
+] as unknown as Portfolio[]
+
+const baseProps: BrokerageStepProps = {
+  enabled: true,
+  brokerName: "IBKR",
+  source: "",
+  amount: "",
+  currency: "SGD",
+  currencyCodes: ["SGD", "USD"],
+  existingPortfolios,
+  bankAccounts: [],
+  defaultPortfolioName: "Cash",
+  portfolioMode: "new",
+  existingPortfolioId: "",
+  onEnabledChange: jest.fn(),
+  onBrokerNameChange: jest.fn(),
+  onSourceChange: jest.fn(),
+  onAmountChange: jest.fn(),
+  onCurrencyChange: jest.fn(),
+  onPortfolioModeChange: jest.fn(),
+  onExistingPortfolioChange: jest.fn(),
+}
+
+const renderStep = (overrides: Partial<BrokerageStepProps> = {}): void => {
+  render(<BrokerageStep {...baseProps} {...overrides} />)
+}
+
+describe("BrokerageStep portfolio choice", () => {
+  it("new mode shows the currency picker, not the existing-portfolio selector", () => {
+    renderStep({ portfolioMode: "new" })
+    expect(screen.getByLabelText("Reporting currency")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Existing portfolio")).not.toBeInTheDocument()
+    // Shared chooser is present.
+    expect(
+      screen.getByRole("radio", {
+        name: /Create a new portfolio for this brokerage/i,
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("existing mode shows the existing-portfolio selector, not the currency picker", () => {
+    renderStep({ portfolioMode: "existing" })
+    const select = screen.getByLabelText("Existing portfolio")
+    expect(select).toBeInTheDocument()
+    expect(
+      Array.from(select.querySelectorAll("option")).map((o) => o.textContent),
+    ).toContain("Main (MAIN, SGD)")
+    expect(
+      screen.queryByLabelText("Reporting currency"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("selecting the existing portfolio reports its id", () => {
+    const onExistingPortfolioChange = jest.fn()
+    renderStep({ portfolioMode: "existing", onExistingPortfolioChange })
+    fireEvent.change(screen.getByLabelText("Existing portfolio"), {
+      target: { value: "pf-1" },
+    })
+    expect(onExistingPortfolioChange).toHaveBeenCalledWith("pf-1")
+  })
+})

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -341,7 +341,22 @@ export default function OpenBrokerageWizard(): React.ReactElement {
         <div className="space-y-6">
           <PortfolioModeChooser
             mode={portfolio.mode}
-            onSelect={(mode) => setPortfolio({ ...portfolio, mode })}
+            onSelect={(mode) =>
+              setPortfolio((prev) => {
+                // Re-sync currency to the still-selected existing portfolio so
+                // a currency changed while in "new" mode can't leak into the
+                // existing-mode submit / source filter.
+                if (mode === "existing" && prev.existingId) {
+                  const pf = portfolios.find((p) => p.id === prev.existingId)
+                  return {
+                    ...prev,
+                    mode,
+                    currency: pf?.currency?.code ?? prev.currency,
+                  }
+                }
+                return { ...prev, mode }
+              })
+            }
             existingDisabled={portfolios.length === 0}
           />
 

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -19,9 +19,8 @@ interface BrokerState {
 
 interface PortfolioState {
   mode: "new" | "existing"
-  // mode === "new"
-  code: string
-  name: string
+  // mode === "new": the portfolio code + name are derived from the broker
+  // name (one less thing to type; matches the onboarding flow).
   currency: string
   // mode === "existing"
   existingId: string
@@ -92,8 +91,6 @@ export default function OpenBrokerageWizard(): React.ReactElement {
   })
   const [portfolio, setPortfolio] = useState<PortfolioState>({
     mode: "new",
-    code: "",
-    name: "",
     currency: "USD",
     existingId: "",
   })
@@ -119,6 +116,16 @@ export default function OpenBrokerageWizard(): React.ReactElement {
   )
   const brokers = useMemo(() => brokersData?.data ?? [], [brokersData])
   const portfolios = useMemo(() => portfoliosData?.data ?? [], [portfoliosData])
+
+  // The new brokerage portfolio takes its identity from the broker: code is
+  // the broker name uppercased/alphanumeric, the display name appends
+  // "Portfolio". Mirrors the onboarding flow so the two surfaces match.
+  const brokerName =
+    broker.mode === "new"
+      ? broker.newName.trim()
+      : (brokers.find((b) => b.id === broker.existingId)?.name ?? "")
+  const derivedCode = deriveCode(brokerName)
+  const derivedName = brokerName ? `${brokerName} Portfolio` : ""
   const currencyCodes = useMemo(() => {
     const codes = currenciesData?.data?.map((c) => c.code)
     return codes && codes.length > 0 ? codes : FALLBACK_CURRENCIES
@@ -148,7 +155,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
   const portfolioValid =
     portfolio.mode === "existing"
       ? !!portfolio.existingId
-      : portfolio.code.trim().length > 0 && portfolio.name.trim().length > 0
+      : derivedCode.length > 0
 
   const back = (): void => {
     const i = STEP_ORDER.indexOf(step as Exclude<Step, "done">)
@@ -181,8 +188,8 @@ export default function OpenBrokerageWizard(): React.ReactElement {
               }
             : {
                 mode: "new",
-                code: portfolio.code,
-                name: portfolio.name,
+                code: derivedCode,
+                name: derivedName,
                 currency: portfolio.currency,
                 base: portfolio.currency,
               },
@@ -211,7 +218,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
           {"Done — brokerage opened"}
         </h1>
         <p className="text-gray-600 mb-6">
-          {`Portfolio ${portfolio.code} ready. `}
+          {`Portfolio ${portfolio.mode === "existing" ? (portfolios.find((p) => p.id === portfolio.existingId)?.code ?? "") : derivedCode} ready. `}
           {result?.trnIds.length
             ? `${result.trnIds.length} cash transaction(s) posted.`
             : "No initial deposit posted."}
@@ -373,30 +380,18 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                 </p>
               </div>
             ) : (
-              <div>
-                <label
-                  htmlFor="pf-name"
-                  className="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  {"Portfolio name"}
-                </label>
-                <input
-                  id="pf-name"
-                  type="text"
-                  value={portfolio.name}
-                  onChange={(e) =>
-                    setPortfolio({
-                      ...portfolio,
-                      name: e.target.value,
-                      code: deriveCode(e.target.value),
-                    })
-                  }
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                  placeholder="e.g. Interactive Brokers"
-                />
-                {portfolio.code && (
-                  <p className="text-xs text-gray-500 mt-1">
-                    {`Code: ${portfolio.code}`}
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm">
+                <p className="text-gray-500">New portfolio</p>
+                {derivedCode ? (
+                  <p className="font-medium text-gray-900">
+                    {derivedName}
+                    <span className="ml-1 font-normal text-gray-500">
+                      {`(code ${derivedCode})`}
+                    </span>
+                  </p>
+                ) : (
+                  <p className="text-gray-400">
+                    Name your broker first — the portfolio takes its name.
                   </p>
                 )}
               </div>
@@ -495,7 +490,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
               <dd className="col-span-2 text-gray-900">
                 {portfolio.mode === "existing"
                   ? `${portfolios.find((p) => p.id === portfolio.existingId)?.name ?? "?"} (existing, ${portfolio.currency})`
-                  : `${portfolio.code} — ${portfolio.name} (new, ${portfolio.currency})`}
+                  : `${derivedCode} — ${derivedName} (new, ${portfolio.currency})`}
               </dd>
               <dt className="text-gray-500">Funding</dt>
               <dd className="col-span-2 text-gray-900">

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -46,6 +46,12 @@ const FALLBACK_CURRENCIES = [
   "JPY",
 ]
 
+// Portfolio code is derived from the name (uppercased alphanumerics) so the
+// user only types one field — mirrors how onboarding names the brokerage
+// portfolio from the broker name.
+const deriveCode = (name: string): string =>
+  name.replace(/[^A-Za-z0-9]/g, "").toUpperCase()
+
 const STEP_TITLES: Record<Exclude<Step, "done">, string> = {
   broker: "Broker",
   portfolio: "Portfolio",
@@ -367,44 +373,33 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                 </p>
               </div>
             ) : (
-              <>
-                <div>
-                  <label
-                    htmlFor="pf-code"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
-                    {"Portfolio code"}
-                  </label>
-                  <input
-                    id="pf-code"
-                    type="text"
-                    value={portfolio.code}
-                    onChange={(e) =>
-                      setPortfolio({ ...portfolio, code: e.target.value })
-                    }
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                    placeholder="e.g. IBRK"
-                  />
-                </div>
-                <div>
-                  <label
-                    htmlFor="pf-name"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
-                    {"Portfolio name"}
-                  </label>
-                  <input
-                    id="pf-name"
-                    type="text"
-                    value={portfolio.name}
-                    onChange={(e) =>
-                      setPortfolio({ ...portfolio, name: e.target.value })
-                    }
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                    placeholder="e.g. Interactive Brokers"
-                  />
-                </div>
-              </>
+              <div>
+                <label
+                  htmlFor="pf-name"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  {"Portfolio name"}
+                </label>
+                <input
+                  id="pf-name"
+                  type="text"
+                  value={portfolio.name}
+                  onChange={(e) =>
+                    setPortfolio({
+                      ...portfolio,
+                      name: e.target.value,
+                      code: deriveCode(e.target.value),
+                    })
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  placeholder="e.g. Interactive Brokers"
+                />
+                {portfolio.code && (
+                  <p className="text-xs text-gray-500 mt-1">
+                    {`Code: ${portfolio.code}`}
+                  </p>
+                )}
+              </div>
             )}
             {portfolio.mode === "new" && (
               <div>

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -5,6 +5,7 @@ import {
   type OpenBrokerageResult,
 } from "@lib/openBrokerage/orchestrate"
 import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
+import PortfolioModeChooser from "@components/features/openBrokerage/PortfolioModeChooser"
 import type { Broker, Currency, Portfolio } from "types/beancounter"
 
 type Step = "broker" | "portfolio" | "funding" | "review" | "done"
@@ -325,83 +326,11 @@ export default function OpenBrokerageWizard(): React.ReactElement {
 
       {step === "portfolio" && (
         <div className="space-y-6">
-          <p className="text-sm text-gray-500">
-            How would you like to keep this brokerage?
-          </p>
-
-          <fieldset className="space-y-3">
-            <legend className="sr-only">
-              Choose how to track this brokerage
-            </legend>
-
-            <label
-              className={`flex items-start gap-3 rounded-xl border p-4 cursor-pointer transition-colors ${
-                portfolio.mode === "new"
-                  ? "border-blue-300 bg-blue-50/50 ring-1 ring-blue-300"
-                  : "border-gray-200 hover:border-gray-300"
-              }`}
-            >
-              <input
-                type="radio"
-                name="portfolio-mode"
-                className="mt-1"
-                checked={portfolio.mode === "new"}
-                onChange={() => setPortfolio({ ...portfolio, mode: "new" })}
-              />
-              <span className="flex-1">
-                <span className="block font-medium text-gray-900">
-                  Create a new portfolio for this brokerage
-                </span>
-                <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
-                  Its own space with its own objectives, kept apart from your
-                  non-investment assets — cash, savings, property. Choose this
-                  when you want to judge the brokerage on its own goals.
-                </span>
-              </span>
-            </label>
-
-            <label
-              className={`flex items-start gap-3 rounded-xl border p-4 transition-colors ${
-                portfolios.length === 0
-                  ? "border-gray-200 opacity-50 cursor-not-allowed"
-                  : portfolio.mode === "existing"
-                    ? "border-blue-300 bg-blue-50/50 ring-1 ring-blue-300 cursor-pointer"
-                    : "border-gray-200 hover:border-gray-300 cursor-pointer"
-              }`}
-            >
-              <input
-                type="radio"
-                name="portfolio-mode"
-                className="mt-1"
-                checked={portfolio.mode === "existing"}
-                onChange={() =>
-                  setPortfolio({ ...portfolio, mode: "existing" })
-                }
-                disabled={portfolios.length === 0}
-              />
-              <span className="flex-1">
-                <span className="block font-medium text-gray-900">
-                  Attach to an existing portfolio{" "}
-                  {portfolios.length === 0 && (
-                    <span className="font-normal text-gray-400">
-                      (none yet)
-                    </span>
-                  )}
-                </span>
-                <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
-                  Fold these holdings in beside assets you already track — one
-                  combined view. Choose this when you think of everything as a
-                  single pot.
-                </span>
-              </span>
-            </label>
-          </fieldset>
-
-          <p className="text-xs text-gray-500 leading-relaxed">
-            Either way, Beancounter totals your net worth across every
-            portfolio — this only decides how you{"’"}d like to view these
-            assets, not what you can see.
-          </p>
+          <PortfolioModeChooser
+            mode={portfolio.mode}
+            onSelect={(mode) => setPortfolio({ ...portfolio, mode })}
+            existingDisabled={portfolios.length === 0}
+          />
 
           <div className="space-y-4 pt-4 border-t border-gray-100">
             {portfolio.mode === "existing" ? (

--- a/src/components/features/openBrokerage/PortfolioModeChooser.tsx
+++ b/src/components/features/openBrokerage/PortfolioModeChooser.tsx
@@ -1,0 +1,98 @@
+import React from "react"
+
+export type PortfolioMode = "new" | "existing"
+
+interface PortfolioModeChooserProps {
+  mode: PortfolioMode
+  onSelect: (mode: PortfolioMode) => void
+  // Disable the "existing" option when the user has no portfolios to attach to.
+  existingDisabled: boolean
+}
+
+/**
+ * Shared "how do you want to keep this brokerage?" chooser: the new-vs-existing
+ * explanatory cards plus the net-worth reassurance note. Used by both the
+ * standalone Open Brokerage wizard and the onboarding brokerage step so the
+ * guidance stays identical. Each caller renders its own contextual inputs
+ * (code/name vs existing-portfolio selector) beneath this control.
+ */
+const PortfolioModeChooser: React.FC<PortfolioModeChooserProps> = ({
+  mode,
+  onSelect,
+  existingDisabled,
+}) => (
+  <div className="space-y-6">
+    <p className="text-sm text-gray-500">
+      How would you like to keep this brokerage?
+    </p>
+
+    <fieldset className="space-y-3">
+      <legend className="sr-only">Choose how to track this brokerage</legend>
+
+      <label
+        className={`flex items-start gap-3 rounded-xl border p-4 cursor-pointer transition-colors ${
+          mode === "new"
+            ? "border-blue-300 bg-blue-50/50 ring-1 ring-blue-300"
+            : "border-gray-200 hover:border-gray-300"
+        }`}
+      >
+        <input
+          type="radio"
+          name="portfolio-mode"
+          className="mt-1"
+          checked={mode === "new"}
+          onChange={() => onSelect("new")}
+        />
+        <span className="flex-1">
+          <span className="block font-medium text-gray-900">
+            Create a new portfolio for this brokerage
+          </span>
+          <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
+            Its own space with its own objectives, kept apart from your
+            non-investment assets — cash, savings, property. Choose this when you
+            want to judge the brokerage on its own goals.
+          </span>
+        </span>
+      </label>
+
+      <label
+        className={`flex items-start gap-3 rounded-xl border p-4 transition-colors ${
+          existingDisabled
+            ? "border-gray-200 opacity-50 cursor-not-allowed"
+            : mode === "existing"
+              ? "border-blue-300 bg-blue-50/50 ring-1 ring-blue-300 cursor-pointer"
+              : "border-gray-200 hover:border-gray-300 cursor-pointer"
+        }`}
+      >
+        <input
+          type="radio"
+          name="portfolio-mode"
+          className="mt-1"
+          checked={mode === "existing"}
+          onChange={() => onSelect("existing")}
+          disabled={existingDisabled}
+        />
+        <span className="flex-1">
+          <span className="block font-medium text-gray-900">
+            Attach to an existing portfolio{" "}
+            {existingDisabled && (
+              <span className="font-normal text-gray-400">(none yet)</span>
+            )}
+          </span>
+          <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
+            Fold these holdings in beside assets you already track — one combined
+            view. Choose this when you think of everything as a single pot.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <p className="text-xs text-gray-500 leading-relaxed">
+      Either way, Beancounter totals your net worth across every portfolio —
+      this only decides how you{"’"}d like to view these assets, not what you can
+      see.
+    </p>
+  </div>
+)
+
+export default PortfolioModeChooser

--- a/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
@@ -114,10 +114,10 @@ describe("<OpenBrokerageWizard />", () => {
     await user.type(screen.getByLabelText(/Broker name/i), "Brand New Broker")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 2 — portfolio: fill code + currency
+    // Step 2 — portfolio: name only; code is derived from it.
     await screen.findByRole("heading", { name: /Portfolio/i })
-    await user.type(screen.getByLabelText(/Portfolio code/i), "IBKR")
     await user.type(screen.getByLabelText(/Portfolio name/i), "IBKR USD")
+    expect(screen.getByText("Code: IBKRUSD")).toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 3 — funding: skip
@@ -158,7 +158,6 @@ describe("<OpenBrokerageWizard />", () => {
 
     // Step 2 — portfolio
     await screen.findByRole("heading", { name: /Portfolio/i })
-    await user.type(screen.getByLabelText(/Portfolio code/i), "IBKR")
     await user.type(screen.getByLabelText(/Portfolio name/i), "IBKR USD")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
@@ -214,7 +213,6 @@ describe("<OpenBrokerageWizard />", () => {
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 2 — portfolio
-    await user.type(screen.getByLabelText(/Portfolio code/i), "IBRK")
     await user.type(
       screen.getByLabelText(/Portfolio name/i),
       "Interactive Brokers USD",

--- a/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
@@ -114,10 +114,10 @@ describe("<OpenBrokerageWizard />", () => {
     await user.type(screen.getByLabelText(/Broker name/i), "Brand New Broker")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 2 — portfolio: name only; code is derived from it.
+    // Step 2 — portfolio: no inputs in new mode; code + name derive from the
+    // broker name entered in step 1.
     await screen.findByRole("heading", { name: /Portfolio/i })
-    await user.type(screen.getByLabelText(/Portfolio name/i), "IBKR USD")
-    expect(screen.getByText("Code: IBKRUSD")).toBeInTheDocument()
+    expect(screen.getByText(/code BRANDNEWBROKER/i)).toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 3 — funding: skip
@@ -126,8 +126,8 @@ describe("<OpenBrokerageWizard />", () => {
 
     // Step 4 — review
     await screen.findByRole("heading", { name: /Review/i })
-    expect(screen.getByText(/Brand New Broker/)).toBeInTheDocument()
-    expect(screen.getByText(/IBKR/)).toBeInTheDocument()
+    expect(screen.getByText(/Brand New Broker \(new\)/)).toBeInTheDocument()
+    expect(screen.getByText(/BRANDNEWBROKER/)).toBeInTheDocument()
     await user.click(
       screen.getByRole("button", { name: /Create|Confirm|Open Brokerage/i }),
     )
@@ -156,9 +156,8 @@ describe("<OpenBrokerageWizard />", () => {
     await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 2 — portfolio
+    // Step 2 — portfolio (new mode derives code/name from the broker)
     await screen.findByRole("heading", { name: /Portfolio/i })
-    await user.type(screen.getByLabelText(/Portfolio name/i), "IBKR USD")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 3 — funding: enter amount + source
@@ -212,11 +211,8 @@ describe("<OpenBrokerageWizard />", () => {
     )
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 2 — portfolio
-    await user.type(
-      screen.getByLabelText(/Portfolio name/i),
-      "Interactive Brokers USD",
-    )
+    // Step 2 — portfolio (new mode derives code/name from the broker)
+    await screen.findByRole("heading", { name: /Portfolio/i })
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 3 — skip funding
@@ -303,7 +299,7 @@ describe("<OpenBrokerageWizard />", () => {
     expect(brokerCashAsset).toBeDefined()
   })
 
-  test("blocks Next on Portfolio step when code is empty", async () => {
+  test("derives the portfolio code from the broker; blocks Next only when attaching without a pick", async () => {
     const user = userEvent.setup()
     render(<OpenBrokerageWizard />)
     await screen.findByRole("heading", { name: /Broker/i })
@@ -313,9 +309,19 @@ describe("<OpenBrokerageWizard />", () => {
     await user.type(screen.getByLabelText(/Broker name/i), "Test Broker")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Portfolio step — Next button disabled while code empty
     await screen.findByRole("heading", { name: /Portfolio/i })
-    const nextBtn = screen.getByRole("button", { name: /Next|Continue/i })
-    expect(nextBtn).toBeDisabled()
+    // New mode: code derives from the broker name → Next enabled.
+    expect(screen.getByText(/code TESTBROKER/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /Next|Continue/i }),
+    ).not.toBeDisabled()
+
+    // Switch to attach-to-existing without choosing one → Next blocked.
+    await user.click(
+      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
+    )
+    expect(
+      screen.getByRole("button", { name: /Next|Continue/i }),
+    ).toBeDisabled()
   })
 })

--- a/src/components/features/openBrokerage/__tests__/PortfolioModeChooser.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/PortfolioModeChooser.test.tsx
@@ -1,0 +1,56 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import PortfolioModeChooser from "../PortfolioModeChooser"
+
+describe("PortfolioModeChooser", () => {
+  it("renders both options and the net-worth reassurance", () => {
+    render(
+      <PortfolioModeChooser
+        mode="new"
+        onSelect={jest.fn()}
+        existingDisabled={false}
+      />,
+    )
+    expect(
+      screen.getByRole("radio", {
+        name: /Create a new portfolio for this brokerage/i,
+      }),
+    ).toBeChecked()
+    expect(
+      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
+    ).not.toBeChecked()
+    expect(
+      screen.getByText(/totals your net worth across every portfolio/i),
+    ).toBeInTheDocument()
+  })
+
+  it("fires onSelect when a different option is chosen", () => {
+    const onSelect = jest.fn()
+    render(
+      <PortfolioModeChooser
+        mode="new"
+        onSelect={onSelect}
+        existingDisabled={false}
+      />,
+    )
+    fireEvent.click(
+      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
+    )
+    expect(onSelect).toHaveBeenCalledWith("existing")
+  })
+
+  it("disables the existing option when there is nothing to attach to", () => {
+    render(
+      <PortfolioModeChooser
+        mode="new"
+        onSelect={jest.fn()}
+        existingDisabled
+      />,
+    )
+    expect(
+      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
+    ).toBeDisabled()
+    expect(screen.getByText(/\(none yet\)/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

Makes the onboarding brokerage step behave like the standalone `/tools/open-brokerage` wizard — same new-vs-existing portfolio choice, same orchestrator — by extracting the shared decision UI.

### Shared component
`PortfolioModeChooser` — the two explanatory cards (new portfolio vs attach to existing) plus the net-worth reassurance note. Single source of the copy, used by both flows.

### Standalone wizard
Refactored Step 2 to render `PortfolioModeChooser` (no behaviour change; the inline cards are gone).

### Onboarding
`BrokerageStep` now renders the chooser and, when "attach to existing" is picked, an existing-portfolio selector (currency syncs from the chosen portfolio); "new" keeps the broker-derived portfolio. `OnboardingWizard` drives `openBrokerage` with the chosen `mode`/`existingId` — the existing path posts `{ mode: "existing", existingId, currency }`, identical to the wizard. Valuation trigger uses the resolved portfolio code.

## Test plan
- New `PortfolioModeChooser.test.tsx` (3): both options render, onSelect fires, existing disabled when nothing to attach to.
- New `BrokerageStep.test.tsx` (3): new mode shows currency picker; existing mode shows the portfolio selector + reports the chosen id.
- Existing `OpenBrokerageWizard` suite still green (refactor is behaviour-preserving).
- `yarn typecheck`, `yarn lint` clean; 22/22 across the touched suites.

## Note
Onboarding's "attach to existing" lists backend portfolios; for a brand-new user that's usually empty, so the option disables gracefully and the explanation still shows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to attach a brokerage to an existing portfolio or create a new one during onboarding.
  * Portfolio names for newly created brokerage portfolios are now automatically generated from the broker name.
  * New portfolio mode selector for choosing between new and existing portfolio attachment.

* **Tests**
  * Added comprehensive test coverage for portfolio mode selection and related UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->