### PR TITLE
fix(payslip): default Gross salary from the active work scenario income

### DIFF
--- a/src/components/features/transactions/PayslipModal.tsx
+++ b/src/components/features/transactions/PayslipModal.tsx
@@ -3,7 +3,7 @@ import useSWR, { mutate as globalMutate } from "swr"
 import Dialog from "@components/ui/Dialog"
 import MathInput from "@components/ui/MathInput"
 import { Asset, Portfolio } from "types/beancounter"
-import { PlansResponse } from "types/independence"
+import { PlansResponse, WorkScenariosResponse } from "types/independence"
 import {
   accountsKey,
   cashKey,
@@ -95,15 +95,26 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
     modalOpen ? accountsKey : null,
     simpleFetcher(accountsKey),
   )
-  // Primary independence plan (backend sorts primary first). Its monthly
-  // working income seeds the Gross salary field — a payslip is one month's pay.
+  // Seed the Gross salary from the user's work plan — a payslip is one
+  // month's pay. The authoritative monthly working income lives on the
+  // ACTIVE work scenario, not the RetirementPlan (whose workingIncomeMonthly
+  // is 0 when income is held in the scenario). Prefer the current scenario,
+  // fall back to the primary plan's field.
+  const scenariosKey = "/api/independence/work-scenarios"
+  const { data: scenariosData } = useSWR<WorkScenariosResponse>(
+    modalOpen ? scenariosKey : null,
+    simpleFetcher(scenariosKey),
+  )
   const plansKey = "/api/independence/plans"
   const { data: plansData } = useSWR<PlansResponse>(
     modalOpen ? plansKey : null,
     simpleFetcher(plansKey),
   )
+  const scenarioIncome = scenariosData?.data?.find((s) => s.isCurrent)
+    ?.workingIncomeMonthly
   const planIncome = plansData?.data?.[0]?.workingIncomeMonthly
-  const defaultGross = planIncome && planIncome > 0 ? String(planIncome) : ""
+  const income = scenarioIncome ?? planIncome
+  const defaultGross = income && income > 0 ? String(income) : ""
 
   const portfolios: Portfolio[] = useMemo(
     () => portfoliosData?.data ?? [],

--- a/src/components/features/transactions/__tests__/PayslipModal.test.tsx
+++ b/src/components/features/transactions/__tests__/PayslipModal.test.tsx
@@ -41,6 +41,9 @@ const mockBankAccounts = {
 }
 
 let mockPlans: { data: Array<{ workingIncomeMonthly?: number }> } = { data: [] }
+let mockScenarios: {
+  data: Array<{ isCurrent: boolean; workingIncomeMonthly?: number }>
+} = { data: [] }
 const mockMutate = jest.fn()
 
 // Synchronous SWR: route by key substring.
@@ -51,6 +54,8 @@ jest.mock("swr", () => ({
     // CPF "where held" lookup → the CPF asset lives in pf-1.
     if (key.includes("/positions"))
       return { data: "pf-1", error: undefined, isLoading: false }
+    if (key.includes("work-scenarios"))
+      return { data: mockScenarios, error: undefined, isLoading: false }
     if (key.includes("independence/plans"))
       return { data: mockPlans, error: undefined, isLoading: false }
     if (key.includes("portfolios"))
@@ -105,6 +110,7 @@ describe("PayslipModal", () => {
     mockConfigs = []
     mockDc = undefined
     mockPlans = { data: [] }
+    mockScenarios = { data: [] }
     mockMutate.mockClear()
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
@@ -121,15 +127,32 @@ describe("PayslipModal", () => {
     expect(screen.getByLabelText("Tax deducted")).toBeInTheDocument()
   })
 
-  it("defaults Gross salary to the primary plan's monthly working income", () => {
-    mockPlans = { data: [{ workingIncomeMonthly: 6000 }] }
+  it("defaults Gross salary to the active work scenario's monthly income", () => {
+    // Scenario income wins over the plan field (the authoritative source).
+    mockScenarios = {
+      data: [
+        { isCurrent: false, workingIncomeMonthly: 1000 },
+        { isCurrent: true, workingIncomeMonthly: 6000 },
+      ],
+    }
+    mockPlans = { data: [{ workingIncomeMonthly: 999 }] }
     render(<PayslipModal modalOpen onClose={jest.fn()} />)
     expect(
       (screen.getByLabelText("Gross salary") as HTMLInputElement).value,
     ).toBe("6000")
   })
 
-  it("leaves Gross salary empty when the user has no plan", () => {
+  it("falls back to the primary plan's income when there is no work scenario", () => {
+    mockScenarios = { data: [] }
+    mockPlans = { data: [{ workingIncomeMonthly: 4200 }] }
+    render(<PayslipModal modalOpen onClose={jest.fn()} />)
+    expect(
+      (screen.getByLabelText("Gross salary") as HTMLInputElement).value,
+    ).toBe("4200")
+  })
+
+  it("leaves Gross salary empty when there is no scenario or plan income", () => {
+    mockScenarios = { data: [] }
     mockPlans = { data: [] }
     render(<PayslipModal modalOpen onClose={jest.fn()} />)
     expect(


### PR DESCRIPTION
## What

Live verification on the deployed app showed the payslip **Gross salary did not pre-fill** — the earlier feature read `RetirementPlan.workingIncomeMonthly`, which is **0** when a user's income lives on their active **work scenario** (the same plan-vs-scenario source-of-truth split surfaced by the Monthly Investment fix).

## Fix

`PayslipModal` now seeds `defaultGross` from the **active `WorkScenario.workingIncomeMonthly`** (`/api/independence/work-scenarios` → `isCurrent`), falling back to the primary plan's field when there's no scenario. This matches the original ask — default Gross to the *work plan* income.

## Test plan
- Updated `PayslipModal.test.tsx`: scenario income wins over plan; plan fallback when no scenario; empty when neither. 14/14 pass.
- `yarn typecheck`, `yarn lint` clean.

## Note
Caught by live verification against Mary (plan field 0, scenario income several thousand → Gross was blank).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payslip modal now intelligently defaults gross salary based on your current work scenario income, with fallback to your primary plan's income.

* **Tests**
  * Enhanced test suite to verify scenario-based salary defaulting and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->