### PR TITLE
fix(brokerage): abbreviate broker code, multi-currency funding, code links, transfer fix

### DIFF
--- a/src/components/features/holdings/CashTransferDialog.tsx
+++ b/src/components/features/holdings/CashTransferDialog.tsx
@@ -151,6 +151,10 @@ const CashTransferDialog: React.FC<CashTransferDialogProps> = ({
       setSubmitError(
         err instanceof Error ? err.message : "Failed to resolve target asset",
       )
+      // Reset the submitting flag — this early return skips the finally below,
+      // and leaving it true would keep the Transfer button disabled for the
+      // rest of the dialog session.
+      setIsSubmitting(false)
       return
     }
 
@@ -294,7 +298,7 @@ const CashTransferDialog: React.FC<CashTransferDialogProps> = ({
     parsedReceivedAmount <= parsedSentAmount
 
   // Validation for step 2
-  const isTargetValid = targetPortfolioId && targetAssetId
+  const isTargetValid = Boolean(targetPortfolioId && targetAssetId)
 
   const selectedPortfolio = portfolios.find((p) => p.id === targetPortfolioId)
   const selectedAsset =
@@ -451,6 +455,11 @@ const CashTransferDialog: React.FC<CashTransferDialogProps> = ({
               onChange={(e) => setTargetPortfolioId(e.target.value)}
               className="w-full border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-purple-500 focus:border-purple-500"
             >
+              {/* Placeholder so an empty targetPortfolioId is VISIBLE. Without
+                  it the browser shows the first portfolio while state stays
+                  "", and re-picking that already-shown portfolio fires no
+                  onChange — leaving the Transfer button silently disabled. */}
+              <option value="">{"Select target portfolio..."}</option>
               {portfolios.map((portfolio) => (
                 <option key={portfolio.id} value={portfolio.id}>
                   {portfolio.code} - {portfolio.name}

--- a/src/components/features/holdings/__tests__/CashTransferDialog.test.tsx
+++ b/src/components/features/holdings/__tests__/CashTransferDialog.test.tsx
@@ -1,0 +1,155 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { enableFetchMocks } from "jest-fetch-mock"
+import CashTransferDialog from "../CashTransferDialog"
+import type { CashTransferData, Portfolio } from "types/beancounter"
+
+enableFetchMocks()
+
+const portfolios = [
+  {
+    id: "sgd-pf",
+    code: "SGD",
+    name: "SGD Portfolio",
+    currency: { code: "SGD", name: "Singapore Dollar", symbol: "$" },
+  },
+] as unknown as Portfolio[]
+
+// IB-SGD broker cash line + the DBS source, both SGD ACCOUNT assets. Currency
+// resolves via accountingType (priceSymbol is null for private assets).
+const accountAssets = {
+  "ib-sgd": {
+    id: "ib-sgd-id",
+    code: "owner.INTERACTIVE BROKERS-SGD",
+    name: "Interactive Brokers SGD Balance",
+    accountingType: { currency: { code: "SGD" } },
+  },
+  dbs: {
+    id: "dbs-id",
+    code: "owner.DBS",
+    name: "DBS",
+    accountingType: { currency: { code: "SGD" } },
+  },
+}
+
+function mockEndpoints(): void {
+  fetchMock.mockResponse((req) => {
+    const url = req.url
+    if (url.includes("/api/assets") && url.includes("ACCOUNT")) {
+      return Promise.resolve(JSON.stringify({ data: accountAssets }))
+    }
+    if (url.includes("/api/currencies")) {
+      return Promise.resolve(
+        JSON.stringify({ data: [{ code: "SGD", name: "Singapore Dollar" }] }),
+      )
+    }
+    return Promise.resolve(JSON.stringify({}))
+  })
+}
+
+// Source = DBS with a healthy balance. portfolioId is intentionally empty to
+// reproduce the call-site where the source portfolio id didn't reach the
+// dialog (the screenshot bug: target looks picked but Transfer stays disabled).
+function makeSource(portfolioId: string): CashTransferData {
+  return {
+    portfolioId,
+    portfolioCode: "SGD",
+    assetId: "dbs-id",
+    assetCode: "owner.DBS",
+    assetName: "DBS",
+    currency: "SGD",
+    currentBalance: 85000,
+  }
+}
+
+// The open-reset (which seeds the amounts from the balance) only runs when
+// modalOpen *toggles*, so mount closed then open.
+function renderOpen(source: CashTransferData): void {
+  const { rerender } = render(
+    <CashTransferDialog
+      modalOpen={false}
+      onClose={() => {}}
+      sourceData={source}
+      portfolios={portfolios}
+    />,
+  )
+  rerender(
+    <CashTransferDialog
+      modalOpen
+      onClose={() => {}}
+      sourceData={source}
+      portfolios={portfolios}
+    />,
+  )
+}
+
+describe("CashTransferDialog target step", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    mockEndpoints()
+  })
+
+  test("renders a placeholder for an empty target portfolio so it isn't silently unselected", async () => {
+    const user = userEvent.setup()
+    renderOpen(makeSource(""))
+
+    // Step 1 — amounts default to the full balance, so Next is enabled.
+    await user.click(await screen.findByRole("button", { name: "Next" }))
+
+    // Step 2 — target. The portfolio combobox must show the placeholder
+    // (value ""), NOT silently display the only portfolio.
+    const combos = await screen.findAllByRole("combobox")
+    const portfolioSelect = combos[0] as HTMLSelectElement
+    expect(portfolioSelect.value).toBe("")
+    expect(
+      screen.getByRole("option", { name: /Select target portfolio/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("enables Transfer once an empty-source target portfolio + asset are picked", async () => {
+    const user = userEvent.setup()
+    renderOpen(makeSource(""))
+
+    await user.click(await screen.findByRole("button", { name: "Next" }))
+
+    const transferBtn = await screen.findByRole("button", { name: "Transfer" })
+    expect(transferBtn).toBeDisabled()
+
+    const combos = await screen.findAllByRole("combobox")
+    // Pick the target portfolio (a real change off the placeholder → fires
+    // onChange, which the silent-display bug prevented).
+    await user.selectOptions(combos[0], "sgd-pf")
+    // Pick the IB-SGD target asset.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", {
+          name: /Interactive Brokers SGD Balance/i,
+        }),
+      ).toBeInTheDocument(),
+    )
+    await user.selectOptions(combos[1], "ib-sgd-id")
+
+    expect(transferBtn).toBeEnabled()
+  })
+
+  test("pre-selects a valid source portfolio so Transfer enables after only the asset is picked", async () => {
+    const user = userEvent.setup()
+    renderOpen(makeSource("sgd-pf"))
+
+    await user.click(await screen.findByRole("button", { name: "Next" }))
+
+    const combos = await screen.findAllByRole("combobox")
+    expect((combos[0] as HTMLSelectElement).value).toBe("sgd-pf")
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", {
+          name: /Interactive Brokers SGD Balance/i,
+        }),
+      ).toBeInTheDocument(),
+    )
+    await user.selectOptions(combos[1], "ib-sgd-id")
+
+    expect(screen.getByRole("button", { name: "Transfer" })).toBeEnabled()
+  })
+})

--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -20,6 +20,7 @@ import BrokerageStep from "./steps/BrokerageStep"
 import type { SourceValue } from "./steps/BrokerageStep"
 import { type PortfolioMode } from "@components/features/openBrokerage/PortfolioModeChooser"
 import { openBrokerage } from "@lib/openBrokerage/orchestrate"
+import { deriveBrokerCode } from "@lib/openBrokerage/brokerCode"
 import { useRegistration } from "@contexts/RegistrationContext"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import Spinner from "@components/ui/Spinner"
@@ -765,7 +766,10 @@ const OnboardingWizard: React.FC = () => {
           // resolves to a bank-account asset on the default portfolio
           // when the user picked one, so a paired WITHDRAWAL hits the
           // right line.
-          const brokerCode = brokerageBrokerName.trim()
+          const brokerName = brokerageBrokerName.trim()
+          // Abbreviated code (Interactive Brokers → IB) for the portfolio
+          // code; the display name keeps the full broker name.
+          const brokerCode = deriveBrokerCode(brokerName)
           // Reporting currency for the brokerage portfolio. User-picked in
           // step 7; falls back to baseCurrency if they didn't touch the
           // dropdown. `base` stays as the user's overall base currency for
@@ -774,17 +778,18 @@ const OnboardingWizard: React.FC = () => {
             ? (brokerageExistingPortfolio.currency?.code ?? brokerageCurrency)
             : brokerageCurrency || baseCurrency
           const brokerageResult = await openBrokerage({
-            broker: { mode: "new", newName: brokerCode },
+            broker: { mode: "new", newName: brokerName },
             portfolio: brokerageExistingPortfolio
               ? {
                   mode: "existing",
                   existingId: brokerageExistingPortfolio.id,
+                  code: brokerageExistingPortfolio.code,
                   currency: brokerageCcy,
                 }
               : {
                   mode: "new",
                   code: brokerCode,
-                  name: `${brokerCode} Portfolio`,
+                  name: `${brokerName} Portfolio`,
                   currency: brokerageCcy,
                   base: baseCurrency,
                 },
@@ -812,7 +817,7 @@ const OnboardingWizard: React.FC = () => {
                         fund.sourcePortfolioId = portfolioId
                       }
                     }
-                    return fund
+                    return [fund]
                   })()
                 : undefined,
           })

--- a/src/components/features/onboarding/steps/BrokerageStep.tsx
+++ b/src/components/features/onboarding/steps/BrokerageStep.tsx
@@ -178,7 +178,7 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
                 htmlFor="ob-currency"
                 className="block text-sm font-medium text-gray-700 mb-1"
               >
-                {"Reporting currency"}
+                {"Default Currency"}
               </label>
               <select
                 id="ob-currency"

--- a/src/components/features/onboarding/steps/__tests__/BrokerageStep.test.tsx
+++ b/src/components/features/onboarding/steps/__tests__/BrokerageStep.test.tsx
@@ -42,8 +42,10 @@ const renderStep = (overrides: Partial<BrokerageStepProps> = {}): void => {
 describe("BrokerageStep portfolio choice", () => {
   it("new mode shows the currency picker, not the existing-portfolio selector", () => {
     renderStep({ portfolioMode: "new" })
-    expect(screen.getByLabelText("Reporting currency")).toBeInTheDocument()
-    expect(screen.queryByLabelText("Existing portfolio")).not.toBeInTheDocument()
+    expect(screen.getByLabelText("Default Currency")).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText("Existing portfolio"),
+    ).not.toBeInTheDocument()
     // Shared chooser is present.
     expect(
       screen.getByRole("radio", {
@@ -59,9 +61,7 @@ describe("BrokerageStep portfolio choice", () => {
     expect(
       Array.from(select.querySelectorAll("option")).map((o) => o.textContent),
     ).toContain("Main (MAIN, SGD)")
-    expect(
-      screen.queryByLabelText("Reporting currency"),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Default Currency")).not.toBeInTheDocument()
   })
 
   it("selecting the existing portfolio reports its id", () => {

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -6,6 +6,7 @@ import {
 } from "@lib/openBrokerage/orchestrate"
 import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
 import PortfolioModeChooser from "@components/features/openBrokerage/PortfolioModeChooser"
+import { deriveBrokerCode } from "@lib/openBrokerage/brokerCode"
 import type { Broker, Currency, Portfolio } from "types/beancounter"
 
 type Step = "broker" | "portfolio" | "funding" | "review" | "done"
@@ -26,9 +27,13 @@ interface PortfolioState {
   existingId: string
 }
 
-interface FundingState {
-  amount: string // free-text input; parsed at submit
-  sourcePortfolioId: string // empty = no source (cash injection)
+// One currency account the user flags to open + fund. The wizard collects a
+// list so the brokerage can span several currencies (e.g. USD + SGD) in one
+// pass. `amount` is free-text and parsed at submit.
+interface FundingRow {
+  currency: string
+  amount: string
+  sourcePortfolioId: string // empty = no source (standalone deposit)
 }
 
 // Fallback list — used only if /api/currencies hasn't returned yet so the
@@ -45,11 +50,9 @@ const FALLBACK_CURRENCIES = [
   "JPY",
 ]
 
-// Portfolio code is derived from the name (uppercased alphanumerics) so the
-// user only types one field — mirrors how onboarding names the brokerage
-// portfolio from the broker name.
-const deriveCode = (name: string): string =>
-  name.replace(/[^A-Za-z0-9]/g, "").toUpperCase()
+// Portfolio code is the abbreviated broker code (deriveBrokerCode) so the
+// user only types one field — "Interactive Brokers" → "IB" — and the code
+// stays compact instead of echoing the full name.
 
 const STEP_TITLES: Record<Exclude<Step, "done">, string> = {
   broker: "Broker",
@@ -94,10 +97,9 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     currency: "USD",
     existingId: "",
   })
-  const [funding, setFunding] = useState<FundingState>({
-    amount: "",
-    sourcePortfolioId: "",
-  })
+  // Currency accounts the user flags to open + fund. Seeded with the
+  // portfolio's default currency on entry to the funding step.
+  const [fundingRows, setFundingRows] = useState<FundingRow[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<OpenBrokerageResult | null>(null)
@@ -118,35 +120,22 @@ export default function OpenBrokerageWizard(): React.ReactElement {
   const portfolios = useMemo(() => portfoliosData?.data ?? [], [portfoliosData])
 
   // The new brokerage portfolio takes its identity from the broker: code is
-  // the broker name uppercased/alphanumeric, the display name appends
-  // "Portfolio". Mirrors the onboarding flow so the two surfaces match.
+  // the abbreviated broker code (Interactive Brokers → IB), the display name
+  // appends "Portfolio". Mirrors the onboarding flow so the two surfaces match.
   const brokerName =
     broker.mode === "new"
       ? broker.newName.trim()
       : (brokers.find((b) => b.id === broker.existingId)?.name ?? "")
-  const derivedCode = deriveCode(brokerName)
+  const derivedCode = deriveBrokerCode(brokerName)
   const derivedName = brokerName ? `${brokerName} Portfolio` : ""
   const currencyCodes = useMemo(() => {
     const codes = currenciesData?.data?.map((c) => c.code)
     return codes && codes.length > 0 ? codes : FALLBACK_CURRENCIES
   }, [currenciesData])
 
-  const sameCurrencySources = useMemo(
-    () => portfolios.filter((p) => p.currency?.code === portfolio.currency),
-    [portfolios, portfolio.currency],
-  )
-
-  // If the user backs up and changes the portfolio currency, drop a
-  // previously-picked source portfolio if it no longer matches.
-  // Otherwise a cross-currency source id would sneak through to submit.
-  // Render-phase reset: the guard is self-terminating (clearing the id makes
-  // the condition false on the next render), so it never loops.
-  if (
-    funding.sourcePortfolioId &&
-    !sameCurrencySources.some((p) => p.id === funding.sourcePortfolioId)
-  ) {
-    setFunding((f) => ({ ...f, sourcePortfolioId: "" }))
-  }
+  // Same-currency source portfolios for a given funding row's currency.
+  const sourcesFor = (currency: string): Portfolio[] =>
+    portfolios.filter((p) => p.currency?.code === currency)
 
   const brokerValid =
     broker.mode === "existing"
@@ -162,16 +151,62 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     if (i > 0) setStep(STEP_ORDER[i - 1])
   }
 
+  // Seed the funding step with the portfolio's default currency the first
+  // time the user lands on it, so there's always one account ready to fund.
+  const seedFundingRows = (): void => {
+    setFundingRows((rows) => {
+      // Re-seed while nothing has been entered yet, so changing the portfolio
+      // default currency (then returning to funding) doesn't leave a stale
+      // row in the old currency. Once the user has typed an amount or picked a
+      // source, their rows are preserved as-is.
+      const untouched = rows.every((r) => !r.amount && !r.sourcePortfolioId)
+      return rows.length === 0 || untouched
+        ? [{ currency: portfolio.currency, amount: "", sourcePortfolioId: "" }]
+        : rows
+    })
+  }
+
   const advance = (): void => {
     const i = STEP_ORDER.indexOf(step as Exclude<Step, "done">)
-    if (i < STEP_ORDER.length - 1) setStep(STEP_ORDER[i + 1])
+    if (i < STEP_ORDER.length - 1) {
+      const next = STEP_ORDER[i + 1]
+      if (next === "funding") seedFundingRows()
+      setStep(next)
+    }
   }
+
+  const updateRow = (idx: number, patch: Partial<FundingRow>): void =>
+    setFundingRows((rows) =>
+      rows.map((r, i) => (i === idx ? { ...r, ...patch } : r)),
+    )
+
+  const addCurrencyRow = (currency: string): void =>
+    setFundingRows((rows) => [
+      ...rows,
+      { currency, amount: "", sourcePortfolioId: "" },
+    ])
+
+  const removeRow = (idx: number): void =>
+    setFundingRows((rows) => rows.filter((_, i) => i !== idx))
+
+  // Currencies not yet opened as accounts — offered in the "add" dropdown.
+  const availableCurrencies = currencyCodes.filter(
+    (c) => !fundingRows.some((r) => r.currency === c),
+  )
+
+  // Funded accounts ready to submit: enabled (amount > 0) rows only.
+  const fundedAccounts = fundingRows
+    .map((r) => ({ ...r, parsed: parseFloat(r.amount) }))
+    .filter((r) => Number.isFinite(r.parsed) && r.parsed > 0)
 
   const submit = async (): Promise<void> => {
     setSubmitting(true)
     setError(null)
     try {
-      const amount = parseFloat(funding.amount)
+      const existingCode =
+        portfolio.mode === "existing"
+          ? (portfolios.find((p) => p.id === portfolio.existingId)?.code ?? "")
+          : ""
       const res = await openBrokerage({
         broker: {
           mode: broker.mode,
@@ -184,6 +219,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
             ? {
                 mode: "existing",
                 existingId: portfolio.existingId,
+                code: existingCode,
                 currency: portfolio.currency,
               }
             : {
@@ -193,14 +229,13 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                 currency: portfolio.currency,
                 base: portfolio.currency,
               },
-        funding:
-          Number.isFinite(amount) && amount > 0
-            ? {
-                amount,
-                currency: portfolio.currency,
-                sourcePortfolioId: funding.sourcePortfolioId || undefined,
-              }
-            : undefined,
+        funding: fundedAccounts.length
+          ? fundedAccounts.map((r) => ({
+              currency: r.currency,
+              amount: r.parsed,
+              sourcePortfolioId: r.sourcePortfolioId || undefined,
+            }))
+          : undefined,
       })
       setResult(res)
       setStep("done")
@@ -224,7 +259,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
             : "No initial deposit posted."}
         </p>
         <a
-          href={`/holdings/${result?.portfolioId ?? ""}`}
+          href={`/holdings/${result?.portfolioCode ?? ""}`}
           className="btn-primary"
         >
           {"View the portfolio"}
@@ -417,7 +452,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                   htmlFor="pf-ccy"
                   className="block text-sm font-medium text-gray-700 mb-1"
                 >
-                  {"Currency"}
+                  {"Default Currency"}
                 </label>
                 <select
                   id="pf-ccy"
@@ -442,51 +477,108 @@ export default function OpenBrokerageWizard(): React.ReactElement {
       {step === "funding" && (
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
-            {`Optional — fund the new portfolio in ${portfolio.currency}. Pick a source portfolio (must be in ${portfolio.currency}) to record a matching withdrawal, or leave blank for a standalone deposit.`}
+            {
+              "Optional — flag the currency accounts to open and how much to deposit in each. Pick a same-currency source portfolio to record a matching withdrawal, or leave blank for a standalone deposit."
+            }
           </p>
-          <div>
-            <label
-              htmlFor="fund-amount"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              {"Amount"}
-            </label>
-            <input
-              id="fund-amount"
-              type="number"
-              inputMode="decimal"
-              min="0"
-              value={funding.amount}
-              onChange={(e) =>
-                setFunding({ ...funding, amount: e.target.value })
-              }
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
-              placeholder="0"
-            />
+
+          <div className="space-y-3">
+            {fundingRows.map((row, idx) => {
+              const sources = sourcesFor(row.currency)
+              return (
+                <div
+                  key={row.currency}
+                  className="rounded-lg border border-gray-200 p-3 space-y-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-semibold text-gray-900">
+                      {`${row.currency} account`}
+                    </span>
+                    {fundingRows.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => removeRow(idx)}
+                        className="text-xs text-gray-400 hover:text-red-600"
+                      >
+                        {"Remove"}
+                      </button>
+                    )}
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <label
+                        htmlFor={`fund-amount-${row.currency}`}
+                        className="block text-xs font-medium text-gray-600 mb-1"
+                      >
+                        {`Deposit (${row.currency})`}
+                      </label>
+                      <input
+                        id={`fund-amount-${row.currency}`}
+                        type="number"
+                        inputMode="decimal"
+                        min="0"
+                        value={row.amount}
+                        onChange={(e) =>
+                          updateRow(idx, { amount: e.target.value })
+                        }
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                        placeholder="0"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        htmlFor={`fund-source-${row.currency}`}
+                        className="block text-xs font-medium text-gray-600 mb-1"
+                      >
+                        {"Source portfolio (optional)"}
+                      </label>
+                      <select
+                        id={`fund-source-${row.currency}`}
+                        value={row.sourcePortfolioId}
+                        onChange={(e) =>
+                          updateRow(idx, { sourcePortfolioId: e.target.value })
+                        }
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                      >
+                        <option value="">— None (deposit only) —</option>
+                        {sources.map((p) => (
+                          <option key={p.id} value={p.id}>
+                            {p.name} ({p.code})
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
           </div>
-          <div>
-            <label
-              htmlFor="fund-source"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              {"Source portfolio (optional)"}
-            </label>
-            <select
-              id="fund-source"
-              value={funding.sourcePortfolioId}
-              onChange={(e) =>
-                setFunding({ ...funding, sourcePortfolioId: e.target.value })
-              }
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
-            >
-              <option value="">— None (deposit only) —</option>
-              {sameCurrencySources.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name} ({p.code})
-                </option>
-              ))}
-            </select>
-          </div>
+
+          {availableCurrencies.length > 0 && (
+            <div>
+              <label
+                htmlFor="fund-add-ccy"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {"Add another currency account"}
+              </label>
+              <select
+                id="fund-add-ccy"
+                value=""
+                onChange={(e) => {
+                  if (e.target.value) addCurrencyRow(e.target.value)
+                }}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              >
+                <option value="">— Add currency —</option>
+                {availableCurrencies.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
       )}
 
@@ -509,13 +601,21 @@ export default function OpenBrokerageWizard(): React.ReactElement {
               </dd>
               <dt className="text-gray-500">Funding</dt>
               <dd className="col-span-2 text-gray-900">
-                {funding.amount && parseFloat(funding.amount) > 0
-                  ? `${parseFloat(funding.amount).toLocaleString()} ${portfolio.currency} ${
-                      funding.sourcePortfolioId
-                        ? `from ${portfolios.find((p) => p.id === funding.sourcePortfolioId)?.name}`
-                        : "(standalone deposit)"
-                    }`
-                  : "None"}
+                {fundedAccounts.length ? (
+                  <ul className="space-y-1">
+                    {fundedAccounts.map((r) => (
+                      <li key={r.currency}>
+                        {`${r.parsed.toLocaleString()} ${r.currency} ${
+                          r.sourcePortfolioId
+                            ? `from ${portfolios.find((p) => p.id === r.sourcePortfolioId)?.name}`
+                            : "(standalone deposit)"
+                        }`}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  "None"
+                )}
               </dd>
             </dl>
           </div>
@@ -536,7 +636,13 @@ export default function OpenBrokerageWizard(): React.ReactElement {
             <button
               type="button"
               onClick={() => {
-                setFunding({ amount: "", sourcePortfolioId: "" })
+                setFundingRows((rows) =>
+                  rows.map((r) => ({
+                    ...r,
+                    amount: "",
+                    sourcePortfolioId: "",
+                  })),
+                )
                 advance()
               }}
               className="px-4 py-2 text-sm text-gray-700 hover:text-gray-900"
@@ -546,7 +652,6 @@ export default function OpenBrokerageWizard(): React.ReactElement {
             <button
               type="button"
               onClick={advance}
-              disabled={!funding.amount || parseFloat(funding.amount) <= 0}
               className="btn-primary btn-primary--sm disabled:opacity-50"
             >
               {"Next →"}

--- a/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
@@ -117,7 +117,7 @@ describe("<OpenBrokerageWizard />", () => {
     // Step 2 — portfolio: no inputs in new mode; code + name derive from the
     // broker name entered in step 1.
     await screen.findByRole("heading", { name: /Portfolio/i })
-    expect(screen.getByText(/code BRANDNEWBROKER/i)).toBeInTheDocument()
+    expect(screen.getByText(/code BNB/i)).toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 3 — funding: skip
@@ -127,7 +127,7 @@ describe("<OpenBrokerageWizard />", () => {
     // Step 4 — review
     await screen.findByRole("heading", { name: /Review/i })
     expect(screen.getByText(/Brand New Broker \(new\)/)).toBeInTheDocument()
-    expect(screen.getByText(/BRANDNEWBROKER/)).toBeInTheDocument()
+    expect(screen.getByText(/BNB/)).toBeInTheDocument()
     await user.click(
       screen.getByRole("button", { name: /Create|Confirm|Open Brokerage/i }),
     )
@@ -162,7 +162,7 @@ describe("<OpenBrokerageWizard />", () => {
 
     // Step 3 — funding: enter amount + source
     await screen.findByRole("heading", { name: /Funding|Deposit/i })
-    await user.type(screen.getByLabelText(/Amount/i), "5000")
+    await user.type(screen.getByLabelText(/Deposit/i), "5000")
     await user.selectOptions(
       screen.getByLabelText(/Source portfolio/i),
       "src-pf",
@@ -265,7 +265,7 @@ describe("<OpenBrokerageWizard />", () => {
 
     // Step 3 — funding: standalone deposit (no source)
     await screen.findByRole("heading", { name: /Funding|Deposit/i })
-    await user.type(screen.getByLabelText(/Amount/i), "1000")
+    await user.type(screen.getByLabelText(/Deposit/i), "1000")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 4 — review + submit
@@ -299,6 +299,74 @@ describe("<OpenBrokerageWizard />", () => {
     expect(brokerCashAsset).toBeDefined()
   })
 
+  test("opens and funds multiple currency accounts in one pass", async () => {
+    const user = userEvent.setup()
+    render(<OpenBrokerageWizard />)
+
+    // Step 1 — broker
+    await screen.findByRole("heading", { name: /Broker/i })
+    await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 2 — portfolio (new mode, default currency USD)
+    await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 3 — funding: fund the default USD account, then add + fund SGD
+    await screen.findByRole("heading", { name: /Funding|Deposit/i })
+    await user.type(screen.getByLabelText(/Deposit \(USD\)/i), "5000")
+    await user.selectOptions(
+      screen.getByLabelText(/Add another currency account/i),
+      "SGD",
+    )
+    await user.type(screen.getByLabelText(/Deposit \(SGD\)/i), "3000")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 4 — review + submit
+    await screen.findByRole("heading", { name: /Review/i })
+    await user.click(
+      screen.getByRole("button", { name: /Create|Confirm|Open Brokerage/i }),
+    )
+    await screen.findByRole("heading", { name: /Done|Complete|Success/i })
+
+    // Two DEPOSITs expected — one per currency
+    const trnPosts = fetchMock.mock.calls.filter((c) => {
+      const url = c[0] as string
+      const method = (c[1] as RequestInit | undefined)?.method ?? "GET"
+      return method === "POST" && url.includes("/api/trns")
+    })
+    const depositCurrencies = trnPosts
+      .map((c) => JSON.parse((c[1] as RequestInit).body as string))
+      .flatMap((b) => b.data)
+      .filter((d: { trnType: string }) => d.trnType === "DEPOSIT")
+      .map((d: { cashCurrency: string }) => d.cashCurrency)
+    expect(depositCurrencies).toContain("USD")
+    expect(depositCurrencies).toContain("SGD")
+  })
+
+  test("links to the new portfolio by code, not id", async () => {
+    const user = userEvent.setup()
+    render(<OpenBrokerageWizard />)
+
+    await screen.findByRole("heading", { name: /Broker/i })
+    await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+    await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+    await screen.findByRole("heading", { name: /Funding|Deposit/i })
+    await user.click(screen.getByRole("button", { name: /Skip|No deposit/i }))
+    await screen.findByRole("heading", { name: /Review/i })
+    await user.click(
+      screen.getByRole("button", { name: /Create|Confirm|Open Brokerage/i }),
+    )
+    await screen.findByRole("heading", { name: /Done|Complete|Success/i })
+
+    // Single-word broker → code "IBKR"; the link must use the code, never the
+    // backend id "pf-new".
+    const link = screen.getByRole("link", { name: /View the portfolio/i })
+    expect(link).toHaveAttribute("href", "/holdings/IBKR")
+  })
+
   test("derives the portfolio code from the broker; blocks Next only when attaching without a pick", async () => {
     const user = userEvent.setup()
     render(<OpenBrokerageWizard />)
@@ -311,7 +379,7 @@ describe("<OpenBrokerageWizard />", () => {
 
     await screen.findByRole("heading", { name: /Portfolio/i })
     // New mode: code derives from the broker name → Next enabled.
-    expect(screen.getByText(/code TESTBROKER/i)).toBeInTheDocument()
+    expect(screen.getByText(/code TB/i)).toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: /Next|Continue/i }),
     ).not.toBeDisabled()

--- a/src/lib/utils/openBrokerage/brokerCode.test.ts
+++ b/src/lib/utils/openBrokerage/brokerCode.test.ts
@@ -1,0 +1,36 @@
+import { deriveBrokerCode } from "./brokerCode"
+
+describe("deriveBrokerCode", () => {
+  it("collapses a multi-word broker name to its word initials", () => {
+    expect(deriveBrokerCode("Interactive Brokers")).toBe("IB")
+    expect(deriveBrokerCode("Charles Schwab")).toBe("CS")
+    expect(deriveBrokerCode("Morgan Stanley")).toBe("MS")
+  })
+
+  it("keeps a single-word name as its full alphanumeric uppercase form", () => {
+    expect(deriveBrokerCode("Fidelity")).toBe("FIDELITY")
+    expect(deriveBrokerCode("DBS")).toBe("DBS")
+  })
+
+  it("prefers the curated house abbreviation where initials would be wrong", () => {
+    expect(deriveBrokerCode("JP Morgan")).toBe("JPM")
+    expect(deriveBrokerCode("TD Ameritrade")).toBe("TDA")
+  })
+
+  it("is case-insensitive for the curated map", () => {
+    expect(deriveBrokerCode("jp morgan")).toBe("JPM")
+  })
+
+  it("strips punctuation from initials", () => {
+    expect(deriveBrokerCode("Smith & Co")).toBe("SC")
+  })
+
+  it("trims and tolerates extra whitespace", () => {
+    expect(deriveBrokerCode("  Interactive   Brokers  ")).toBe("IB")
+  })
+
+  it("returns empty string for a blank name", () => {
+    expect(deriveBrokerCode("")).toBe("")
+    expect(deriveBrokerCode("   ")).toBe("")
+  })
+})

--- a/src/lib/utils/openBrokerage/brokerCode.ts
+++ b/src/lib/utils/openBrokerage/brokerCode.ts
@@ -1,0 +1,43 @@
+/**
+ * Derive a short, stable CODE from a broker's display name. Used for the
+ * brokerage portfolio code (new-portfolio path) and the per-broker cash
+ * asset code (existing-portfolio path, e.g. `IB-SGD`) so the codes stay
+ * compact instead of echoing the full name ("INTERACTIVE BROKERS-SGD").
+ *
+ * Rules:
+ *   1. A curated map wins for well-known brokers whose initials would be
+ *      ambiguous or whose house abbreviation differs (e.g. JP Morgan → JPM).
+ *   2. Multi-word names collapse to their word initials (Interactive
+ *      Brokers → IB, Charles Schwab → CS).
+ *   3. Single-word names keep their full alphanumeric uppercase form
+ *      (Fidelity → FIDELITY, DBS → DBS).
+ */
+
+// Lower-cased name → house abbreviation. Keep this small: only entries the
+// initials/single-word fallback would get wrong belong here.
+const KNOWN_BROKER_CODES: Record<string, string> = {
+  "jp morgan": "JPM",
+  "j.p. morgan": "JPM",
+  "td ameritrade": "TDA",
+  "bank of america": "BOA",
+}
+
+const alnum = (s: string): string => s.replace(/[^A-Za-z0-9]/g, "")
+
+export function deriveBrokerCode(name: string): string {
+  const trimmed = name.trim()
+  if (!trimmed) return ""
+
+  const known = KNOWN_BROKER_CODES[trimmed.toLowerCase()]
+  if (known) return known
+
+  const words = trimmed.split(/\s+/).filter(Boolean)
+  if (words.length > 1) {
+    // Word initials. Strip any stray punctuation a word might start with
+    // (e.g. "&" in "Smith & Co") so the code stays clean.
+    const initials = words.map((w) => alnum(w).charAt(0)).join("")
+    if (initials) return initials.toUpperCase()
+  }
+
+  return alnum(trimmed).toUpperCase()
+}

--- a/src/lib/utils/openBrokerage/orchestrate.ts
+++ b/src/lib/utils/openBrokerage/orchestrate.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Broker } from "types/beancounter"
+import { deriveBrokerCode } from "@lib/openBrokerage/brokerCode"
 
 // Local-date YYYY-MM-DD so tradeDate matches the user's calendar day,
 // not UTC's. `new Date().toISOString()` would mis-report the day for any
@@ -28,36 +29,43 @@ interface BrokerStep {
 
 interface PortfolioStep {
   mode: "new" | "existing"
-  // Required when mode === "new"
+  // Required when mode === "new". `currency` is the portfolio's default
+  // (reporting/base) currency.
   code?: string
   name?: string
   currency: string
   base?: string
-  // Required when mode === "existing"
+  // Required when mode === "existing". `code` lets the orchestrator return a
+  // portfolioCode for navigation without a round-trip to look it up.
   existingId?: string
 }
 
-interface FundingStep {
+// One currency account to open in the brokerage, with its opening deposit.
+// The wizard collects a list of these so a brokerage can be funded across
+// several currencies in a single pass (e.g. an IB account holding USD + SGD).
+interface FundingAccount {
+  currency: string
   amount: number
-  // Either side may be omitted (no WITHDRAWAL leg = standalone deposit).
-  // When both are given, sourceAssetId takes precedence — use it when the
-  // source is a specific PRIVATE asset (e.g. a bank-account line inside
+  // Either source side may be omitted (no WITHDRAWAL leg = standalone
+  // deposit). When both are given, sourceAssetId takes precedence — use it
+  // when the source is a specific PRIVATE asset (e.g. a bank-account line in
   // the same portfolio); fall back to ensureCashAsset(currency) when only
   // sourcePortfolioId is set.
   sourcePortfolioId?: string
   sourceAssetId?: string
-  currency: string
 }
 
 export interface OpenBrokerageRequest {
   broker: BrokerStep
   portfolio: PortfolioStep
-  funding?: FundingStep
+  funding?: FundingAccount[]
 }
 
 export interface OpenBrokerageResult {
   broker: Broker
   portfolioId: string
+  // Portfolio CODE (not id) — callers navigate to /holdings/{code}.
+  portfolioCode: string
   trnIds: string[]
 }
 
@@ -79,7 +87,19 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
 async function ensureBroker(step: BrokerStep): Promise<Broker> {
   if (step.mode === "existing") {
     if (!step.existingId) throw new Error("Existing broker id required")
-    return { id: step.existingId, name: "" }
+    // Resolve the broker's name so the per-broker cash asset code
+    // (deriveBrokerCode(name)) is correct for existing brokers too — without
+    // this the code would collapse to "-{ccy}" on the existing-broker path.
+    const existingId = step.existingId
+    const found = await fetch("/api/brokers")
+      .then((r) => (r.ok ? (r.json() as Promise<{ data: Broker[] }>) : null))
+      .then((j) => j?.data.find((b) => b.id === existingId))
+      .catch(() => undefined)
+    // Fail fast rather than degrade to an empty name: an empty name collapses
+    // the per-broker cash code to "-{ccy}", which two unresolved brokers would
+    // then share, mixing their balances.
+    if (!found) throw new Error("Could not resolve the selected broker")
+    return found
   }
   if (!step.newName) throw new Error("Broker name required")
   // Reuse any existing broker with the same name so retrying the wizard
@@ -98,10 +118,12 @@ async function ensureBroker(step: BrokerStep): Promise<Broker> {
   return resp.data
 }
 
-async function resolvePortfolio(step: PortfolioStep): Promise<string> {
+async function resolvePortfolio(
+  step: PortfolioStep,
+): Promise<{ id: string; code: string }> {
   if (step.mode === "existing") {
     if (!step.existingId) throw new Error("Existing portfolio id required")
-    return step.existingId
+    return { id: step.existingId, code: step.code ?? "" }
   }
   if (!step.code || !step.name || !step.base) {
     throw new Error("New portfolio requires code, name and base currency")
@@ -120,7 +142,7 @@ async function resolvePortfolio(step: PortfolioStep): Promise<string> {
     },
   )
   if (!resp.data?.[0]?.id) throw new Error("Portfolio creation returned no id")
-  return resp.data[0].id
+  return { id: resp.data[0].id, code: step.code }
 }
 
 async function ensureAsset(payload: {
@@ -147,18 +169,21 @@ async function ensureAsset(payload: {
 const ensureCashAsset = (currency: string): Promise<string> =>
   ensureAsset({ code: currency, market: "CASH" })
 
-// Per-broker PRIVATE cash asset like "IBRK-USD" / "DBS-SGD". Used when the
+// Per-broker PRIVATE cash asset like "IB-USD" / "CS-SGD". Used when the
 // brokerage attaches to an EXISTING portfolio so the broker's cash is
-// visible as a distinct line ("IBRK USD Balance") alongside any pre-existing
-// generic-cash holdings in the same portfolio. PRIVATE assets MUST carry an
+// visible as a distinct line ("Interactive Brokers USD Balance") alongside
+// any pre-existing generic-cash holdings in the same portfolio. The CODE is
+// the abbreviated broker code (deriveBrokerCode) so it stays compact; the
+// display NAME keeps the full broker name. PRIVATE assets MUST carry an
 // explicit `currency` and `category` per svc-data's AssetController
 // validation ("Currency required for private asset {code}").
 const ensureBrokerCashAsset = (
+  brokerCode: string,
   brokerName: string,
   currency: string,
 ): Promise<string> =>
   ensureAsset({
-    code: `${brokerName}-${currency}`,
+    code: `${brokerCode}-${currency}`,
     market: "PRIVATE",
     name: `${brokerName} ${currency} Balance`,
     currency,
@@ -216,18 +241,25 @@ export async function openBrokerage(
   req: OpenBrokerageRequest,
 ): Promise<OpenBrokerageResult> {
   const broker = await ensureBroker(req.broker)
-  const portfolioId = await resolvePortfolio(req.portfolio)
+  const { id: portfolioId, code: portfolioCode } = await resolvePortfolio(
+    req.portfolio,
+  )
+  const brokerCode = deriveBrokerCode(broker.name)
 
+  // Each funded currency account is opened independently so a single pass can
+  // span several currencies (e.g. an IB account holding USD + SGD). Sequential
+  // — see the function doc on idempotency.
   const trnIds: string[] = []
-  if (req.funding && req.funding.amount > 0) {
-    // Attach-to-existing-portfolio path uses a per-broker PRIVATE cash
-    // asset so the brokerage cash is visible as a distinct line in the
-    // existing portfolio's holdings; the new-portfolio path uses the
-    // generic per-currency CASH asset (the portfolio itself segregates).
+  for (const account of req.funding ?? []) {
+    if (account.amount <= 0) continue
+    // Attach-to-existing-portfolio path uses a per-broker PRIVATE cash asset
+    // so the brokerage cash is visible as a distinct line in the existing
+    // portfolio's holdings; the new-portfolio path uses the generic
+    // per-currency CASH asset (the portfolio itself segregates).
     const depositAssetId =
       req.portfolio.mode === "existing"
-        ? await ensureBrokerCashAsset(broker.name, req.funding.currency)
-        : await ensureCashAsset(req.funding.currency)
+        ? await ensureBrokerCashAsset(brokerCode, broker.name, account.currency)
+        : await ensureCashAsset(account.currency)
     // Order matters: DEPOSIT first into the freshly-created portfolio
     // (always succeeds — no balance/code constraints), then WITHDRAWAL
     // from the source. If WITHDRAWAL fails afterwards the worst-case
@@ -238,34 +270,33 @@ export async function openBrokerage(
         portfolioId,
         trnType: "DEPOSIT",
         assetId: depositAssetId,
-        currency: req.funding.currency,
-        amount: req.funding.amount,
+        currency: account.currency,
+        amount: account.amount,
       }),
     )
-    if (req.funding.sourcePortfolioId || req.funding.sourceAssetId) {
+    if (account.sourcePortfolioId || account.sourceAssetId) {
       // Withdraw from either the specific source asset (e.g. a bank-account
       // PRIVATE line) when provided, or fall back to the portfolio's
       // generic CASH/{ccy} asset. Broker-tagged cash only exists on the
       // destination, never the source.
       const sourceAssetId =
-        req.funding.sourceAssetId ??
-        (await ensureCashAsset(req.funding.currency))
+        account.sourceAssetId ?? (await ensureCashAsset(account.currency))
       // If sourceAssetId is supplied without an explicit sourcePortfolioId,
       // assume the asset lives on the same portfolio the wizard is
       // attaching the broker to (true for the onboarding flow's
       // bank-account-on-default-portfolio case).
-      const sourcePortfolioId = req.funding.sourcePortfolioId ?? portfolioId
+      const sourcePortfolioId = account.sourcePortfolioId ?? portfolioId
       trnIds.push(
         await postTrn({
           portfolioId: sourcePortfolioId,
           trnType: "WITHDRAWAL",
           assetId: sourceAssetId,
-          currency: req.funding.currency,
-          amount: req.funding.amount,
+          currency: account.currency,
+          amount: account.amount,
         }),
       )
     }
   }
 
-  return { broker, portfolioId, trnIds }
+  return { broker, portfolioId, portfolioCode, trnIds }
 }


### PR DESCRIPTION
Addresses four brokerage-flow issues.

## 1. Abbreviated broker code
`deriveBrokerCode` turns a broker name into a compact code — `Interactive Brokers` → `IB`, `Charles Schwab` → `CS`, single words kept whole (`Fidelity`), curated overrides for `JP Morgan`→`JPM` etc. Drives the new-portfolio code and the per-broker cash asset code, so the line is `IB-SGD` instead of `INTERACTIVE BROKERS-SGD`. Applied in both the standalone wizard and onboarding.

## 2. Transfer button stayed disabled (DBS → IB-SGD)
Root cause: the **Target Portfolio `<select>` had no placeholder**. When the source portfolio id didn't reach the dialog, `targetPortfolioId` was `""` but the browser still *displayed* the only portfolio — and re-picking an already-shown option fires no `onChange`, so it could never be set. `isTargetValid` stayed false → Transfer disabled with no error (matches the screenshot).
Fix: add a `Select target portfolio…` placeholder so the empty state is visible and selecting a portfolio is a real change. Also harden `isTargetValid` to a boolean and reset `isSubmitting` on the resolve-asset early return (a leak that could keep Transfer disabled for the rest of the session).

## 3. Open-portfolio passed the id, not the code
`openBrokerage` now returns `portfolioCode`; the "View the portfolio" link uses `/holdings/{code}` instead of `/holdings/{id}`.

## 4. Multi-currency funding
The funding step now opens **multiple currency accounts**, each with its own deposit and optional same-currency source. New portfolio → generic `CASH/{ccy}`; existing portfolio → `IB-{ccy}` PRIVATE asset. The new-portfolio currency label reads **Default Currency**. Onboarding stays single-currency by design (compact teaser).

## Tests
- `brokerCode.test.ts` — abbreviation rules
- `OpenBrokerageWizard.test.tsx` — multi-currency funding + code-based link
- `CashTransferDialog.test.tsx` — placeholder + enablement regression
- Full suite green (1612 tests), lint + typecheck clean.

@coderabbitai ignore