### PR TITLE
feat(holdings): rename Rebalance button to Invest

### DIFF
--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -528,9 +528,9 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
             colorClass="bg-emerald-500 hover:bg-emerald-600 shadow-sm shadow-emerald-500/20"
             items={tradeItems}
           />
-          {/* Rebalance Dropdown */}
+          {/* Invest (rebalance) Dropdown */}
           <DropdownMenu
-            label="Rebalance"
+            label="Invest"
             icon="fa-balance-scale"
             colorClass="bg-blue-500 hover:bg-blue-600 shadow-sm shadow-blue-500/20"
             items={rebalanceItems}

--- a/src/components/features/holdings/__tests__/HoldingActions.test.tsx
+++ b/src/components/features/holdings/__tests__/HoldingActions.test.tsx
@@ -158,12 +158,12 @@ describe("HoldingActions Mobile Portrait Tests (TDD)", () => {
       setupMatchMedia(375, 667)
     })
 
-    // Mobile-portrait parity: Copy / Trade / Rebalance / Share must all render
+    // Mobile-portrait parity: Copy / Trade / Invest / Share must all render
     // and must NOT sit inside a `mobile-portrait:hidden` ancestor. Labels may
     // collapse to icon-only via `hidden sm:inline`, but the actions stay
     // reachable. Locate by aria-label since the visible text label is
     // CSS-hidden in this viewport.
-    it.each([["Copy Holdings"], ["Trade"], ["Rebalance"]])(
+    it.each([["Copy Holdings"], ["Trade"], ["Invest"]])(
       "renders %s reachable on mobile portrait (no hidden ancestor)",
       (label) => {
         render(
@@ -252,7 +252,7 @@ describe("HoldingActions Mobile Portrait Tests (TDD)", () => {
 
       expect(screen.getByLabelText("Copy Holdings")).toBeInTheDocument()
       expect(screen.getByLabelText("Trade")).toBeInTheDocument()
-      expect(screen.getByLabelText("Rebalance")).toBeInTheDocument()
+      expect(screen.getByLabelText("Invest")).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -585,11 +585,11 @@ function AggregatedHoldingsPage(): React.ReactElement {
                   : ""
                 router.push(`/rebalance/wizard${portfolioParams}`)
               }}
-              aria-label="Rebalance"
-              title="Rebalance"
+              aria-label="Invest"
+              title="Invest"
             >
               <i className="fas fa-balance-scale sm:mr-2"></i>
-              <span className="hidden sm:inline">Rebalance</span>
+              <span className="hidden sm:inline">Invest</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
Renames the holdings toolbar **Rebalance** button to **Invest** on both the per-portfolio holdings page (`HoldingActions` dropdown) and the aggregated holdings page. Label/aria/title only — routing and dropdown items (incl. admin "Rebalance Model") unchanged. Tests updated to assert the new label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated action button labels in the holdings toolbar from "Rebalance" to "Invest" for improved naming clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->