### PR TITLE
feat(holdings): add Exchange Cash action (FX from a holding)

### DIFF
--- a/src/components/features/holdings/ActionsMenus.tsx
+++ b/src/components/features/holdings/ActionsMenus.tsx
@@ -365,7 +365,12 @@ export interface CashActionsMenuProps {
   tradeCurrency?: { code: string; symbol: string; name: string }
   onSetCashBalance?: (data: SetCashBalanceData) => void
   onCashTransfer?: (data: CashTransferData) => void
-  onCashTransaction?: (assetCode: string) => void
+  /**
+   * Open the cash transaction dialog for this asset. `initialType` pre-selects
+   * the transaction type — "Exchange Cash" passes "FX" so the dialog opens
+   * ready to sell from this holding.
+   */
+  onCashTransaction?: (assetCode: string, initialType?: string) => void
   onRecordIncome?: (data: QuickSellData) => void
   onRecordExpense?: (data: QuickSellData) => void
   onEditAsset?: (asset: Asset) => void
@@ -456,6 +461,13 @@ export const CashActionsMenu: React.FC<CashActionsMenuProps> = ({
                       currentBalance: marketValue,
                     })
                   })}
+                />
+              )}
+              {onCashTransaction && (
+                <MenuItem
+                  iconClass="fas fa-right-left text-blue-500 w-4"
+                  label="Exchange Cash"
+                  onClick={handle(() => onCashTransaction(assetCode, "FX"))}
                 />
               )}
               {onCashTransaction && (

--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -53,7 +53,7 @@ interface SharedActionHandlers {
   onRecordExpense?: (data: QuickSellData) => void
   onSetCashBalance?: (data: SetCashBalanceData) => void
   onCashTransfer?: (data: CashTransferData) => void
-  onCashTransaction?: (assetCode: string) => void
+  onCashTransaction?: (assetCode: string, initialType?: string) => void
   onPriceChart?: (data: PriceChartData) => void
   onPortfolioBreakdown?: (data: PortfolioBreakdownData) => void
   onEditAsset?: (asset: Asset) => void

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -57,7 +57,7 @@ interface RowsProps extends HoldingValues {
   onSetBalance?: (data: SetBalanceData) => void
   onSectorWeightings?: (data: SectorWeightingsData) => void
   onCashTransfer?: (data: CashTransferData) => void
-  onCashTransaction?: (assetCode: string) => void
+  onCashTransaction?: (assetCode: string, initialType?: string) => void
   onCostAdjust?: (data: CostAdjustData) => void
   onMovePosition?: (data: MovePositionData) => void
   onRecordIncome?: (data: QuickSellData) => void

--- a/src/components/features/holdings/__tests__/ActionsMenus.test.tsx
+++ b/src/components/features/holdings/__tests__/ActionsMenus.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
-import { ActionsMenu } from "../ActionsMenus"
+import { ActionsMenu, CashActionsMenu } from "../ActionsMenus"
 import { makeAsset } from "@test-fixtures/beancounter"
 
 const asset = makeAsset({ id: "asset-aapl", code: "AAPL" })
@@ -46,5 +46,38 @@ describe("ActionsMenu", () => {
     expect(
       screen.queryByRole("button", { name: "Go to portfolio" }),
     ).not.toBeInTheDocument()
+  })
+})
+
+describe("CashActionsMenu", () => {
+  const cashAsset = makeAsset({ id: "asset-dbs", code: "DBS" })
+  const cashProps = {
+    asset: cashAsset,
+    portfolio: { id: "p1", code: "SGD" },
+    marketValue: 1000,
+    tradeCurrency: { code: "SGD", symbol: "$", name: "Singapore Dollar" },
+  }
+  const openCashMenu = (): void => {
+    fireEvent.click(screen.getByRole("button", { name: /Actions DBS/i }))
+  }
+
+  it("renders Exchange Cash and opens the cash transaction seeded with FX", () => {
+    const onCashTransaction = jest.fn()
+    render(
+      <CashActionsMenu {...cashProps} onCashTransaction={onCashTransaction} />,
+    )
+    openCashMenu()
+    fireEvent.click(screen.getByRole("button", { name: "Exchange Cash" }))
+    expect(onCashTransaction).toHaveBeenCalledWith("DBS", "FX")
+  })
+
+  it("Cash Transaction opens with no preset type (default deposit)", () => {
+    const onCashTransaction = jest.fn()
+    render(
+      <CashActionsMenu {...cashProps} onCashTransaction={onCashTransaction} />,
+    )
+    openCashMenu()
+    fireEvent.click(screen.getByRole("button", { name: "Cash Transaction" }))
+    expect(onCashTransaction).toHaveBeenCalledWith("DBS")
   })
 })

--- a/src/components/features/transactions/CashInputForm.tsx
+++ b/src/components/features/transactions/CashInputForm.tsx
@@ -105,7 +105,9 @@ const CashInputForm: React.FC<{
   modalOpen: boolean
   setModalOpen: (open: boolean) => void
   initialAsset?: string
-}> = ({ portfolio, modalOpen, setModalOpen, initialAsset }) => {
+  /** Pre-select the transaction type (e.g. "FX" for Exchange Cash). */
+  initialType?: string
+}> = ({ portfolio, modalOpen, setModalOpen, initialAsset, initialType }) => {
   const {
     control,
     handleSubmit,
@@ -130,9 +132,12 @@ const CashInputForm: React.FC<{
       reset({
         ...defaultValues,
         asset: initialAsset || defaultValues.asset,
+        type: initialType
+          ? { value: initialType, label: initialType }
+          : defaultValues.type,
       })
     }
-  }, [modalOpen, reset, initialAsset])
+  }, [modalOpen, reset, initialAsset, initialType])
 
   // Focus type select when modal opens
   useEffect(() => {

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -196,6 +196,11 @@ function HoldingsPage(): React.ReactElement {
   const [cashTransactionAsset, setCashTransactionAsset] = useState<
     string | undefined
   >(undefined)
+  // Pre-selected transaction type for the cash dialog (e.g. "FX" for Exchange
+  // Cash); undefined opens with the default deposit type.
+  const [cashTransactionType, setCashTransactionType] = useState<
+    string | undefined
+  >(undefined)
   const [editAsset, setEditAsset] = useState<Asset | undefined>(undefined)
   const [adminEditAsset, setAdminEditAsset] = useState<Asset | undefined>(
     undefined,
@@ -430,16 +435,23 @@ function HoldingsPage(): React.ReactElement {
     mutate()
   }, [mutate])
 
-  // Handle cash transaction from cash row menu
-  const handleCashTransaction = useCallback((assetCode: string) => {
-    setCashTransactionAsset(assetCode)
-  }, [])
+  // Handle cash transaction from cash row menu. `initialType` pre-selects the
+  // dialog's transaction type — "Exchange Cash" passes "FX" so the dialog opens
+  // ready to sell from the chosen holding.
+  const handleCashTransaction = useCallback(
+    (assetCode: string, initialType?: string) => {
+      setCashTransactionAsset(assetCode)
+      setCashTransactionType(initialType)
+    },
+    [],
+  )
 
   // Close cash transaction modal and refresh
   const handleCashTransactionClose = useCallback(
     (open: boolean) => {
       if (!open) {
         setCashTransactionAsset(undefined)
+        setCashTransactionType(undefined)
         mutate()
       }
     },
@@ -875,6 +887,7 @@ function HoldingsPage(): React.ReactElement {
           modalOpen={true}
           setModalOpen={handleCashTransactionClose}
           initialAsset={cashTransactionAsset}
+          initialType={cashTransactionType}
         />
       )}
       {/* Rebalance Dialogs (managed at page level for feature isolation) */}


### PR DESCRIPTION
## What

Adds an **Exchange Cash** item to the cash row actions menu, beside **Transfer Cash**. It opens the existing Cash Transaction dialog pre-seeded in **FX** mode with the clicked holding as the sell side — so exchanging a balance into another currency is one click instead of: open Cash Transaction → switch type to FX → re-pick the sell account.

## How

- `CashActionsMenu` (`ActionsMenus.tsx`): new "Exchange Cash" item reuses the existing `onCashTransaction` callback with an optional second arg — `onCashTransaction(assetCode, "FX")`. No new prop drilled through `Rows`/`CardView`; their signatures just widen to `(assetCode, initialType?)`.
- `[code].tsx`: `handleCashTransaction` accepts `initialType`, stored alongside the asset and passed to the dialog; cleared on close.
- `CashInputForm`: new optional `initialType` prop seeds the type field on open (defaults to deposit when absent).

## Tests

- `ActionsMenus.test.tsx`: Exchange Cash fires `onCashTransaction("DBS", "FX")`; plain Cash Transaction still fires with no preset type.
- Full holdings + transactions + trns suites green (447 tests); typecheck/lint clean.

## Notes

- Builds on the FX Market-column fix (#930) so the FX buy-into-cash leg actually resolves a balance.
- Sell side = the clicked holding (intra-portfolio). Cross-portfolio FX (Private Bank acct → acct) is still out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added "Exchange Cash" menu option in holdings management for streamlined currency exchange transactions
- Cash transaction forms now support pre-selecting transaction type, enabling faster form completion when initiated from menu actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->