### PR TITLE
test(trns): lock trnType preservation on composite/CPF trn edit

### DIFF
--- a/src/components/features/transactions/__tests__/SubAccountTrnEditModal.test.tsx
+++ b/src/components/features/transactions/__tests__/SubAccountTrnEditModal.test.tsx
@@ -9,7 +9,7 @@ jest.mock("swr", () => ({
   useSWRConfig: () => ({ mutate: jest.fn() }),
 }))
 
-const makeTrn = (): Transaction =>
+const makeTrn = (overrides: Partial<Transaction> = {}): Transaction =>
   ({
     id: "trn-1",
     trnType: "BALANCE",
@@ -33,6 +33,7 @@ const makeTrn = (): Transaction =>
     tax: 0,
     comments: "",
     subAccounts: { OA: 60000, SA: 20000, MA: 20000 },
+    ...overrides,
   }) as unknown as Transaction
 
 const mockFetch = (): void => {
@@ -94,4 +95,29 @@ describe("SubAccountTrnEditModal", () => {
     expect(body.quantity).toBe(110000)
     expect(body.trnType).toBe("BALANCE")
   })
+
+  it.each(["BALANCE", "ADD"] as const)(
+    "preserves the %s transaction type on save",
+    async (trnType) => {
+      render(
+        <SubAccountTrnEditModal trn={makeTrn({ trnType })} onClose={jest.fn()} />,
+      )
+      await screen.findByLabelText("Ordinary")
+      fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+      await waitFor(() => {
+        const patch = (global.fetch as jest.Mock).mock.calls.find(
+          (c) =>
+            String(c[0]).includes("/api/trns/trn-1") &&
+            c[1]?.method === "PATCH",
+        )
+        expect(patch).toBeDefined()
+      })
+      const patch = (global.fetch as jest.Mock).mock.calls.find(
+        (c) =>
+          String(c[0]).includes("/api/trns/trn-1") && c[1]?.method === "PATCH",
+      )!
+      expect(JSON.parse(patch[1].body).trnType).toBe(trnType)
+    },
+  )
 })


### PR DESCRIPTION
Holding branch for small tidy-up work.

## First item

Adds a regression test locking **trnType preservation** when editing a composite-policy (CPF) transaction via the sub-account bucket editor: an `ADD` stays `ADD` and a `BALANCE` stays `BALANCE` through the edit/PATCH round-trip, so a bucket-split edit can't silently rewrite the transaction type.

Guards the merged composite-edit feature (#906). Test-only — no production change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced transaction test suite with improved test coverage for transaction type handling and PATCH request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->