### PR TITLE
fix(offboarding): stop wealth/account delete race, surface failures, fix summary overflow

### DIFF
--- a/src/components/features/offboarding/OffboardingWizard.tsx
+++ b/src/components/features/offboarding/OffboardingWizard.tsx
@@ -93,6 +93,13 @@ export default function OffboardingWizard(): React.ReactElement {
         if (response.ok) {
           const result = await response.json()
           newResults.push(result)
+        } else {
+          newResults.push({
+            success: false,
+            deletedCount: 0,
+            type: "wealth",
+            message: `Delete failed (${response.status})`,
+          })
         }
       }
 
@@ -103,6 +110,13 @@ export default function OffboardingWizard(): React.ReactElement {
         if (response.ok) {
           const result = await response.json()
           newResults.push(result)
+        } else {
+          newResults.push({
+            success: false,
+            deletedCount: 0,
+            type: "plans",
+            message: `Delete failed (${response.status})`,
+          })
         }
       }
 
@@ -113,29 +127,56 @@ export default function OffboardingWizard(): React.ReactElement {
         if (response.ok) {
           const result = await response.json()
           newResults.push(result)
+        } else {
+          newResults.push({
+            success: false,
+            deletedCount: 0,
+            type: "models",
+            message: `Delete failed (${response.status})`,
+          })
         }
       }
 
       if (deleteAccount) {
-        // Delete from all services when deleting account
-        const [wealthRes, plansRes, modelsRes, accountRes] = await Promise.all([
-          fetch("/api/offboard/wealth", { method: "DELETE" }),
+        // Bug A fix: /api/offboard/account already deletes portfolios + assets +
+        // brokers + tax rates + the user (it is the superset). Do NOT call
+        // /api/offboard/wealth here — that would race against account on the
+        // same rows and cause an optimistic-lock collision.
+        const [plansRes, modelsRes, accountRes] = await Promise.all([
           fetch("/api/offboard/plans", { method: "DELETE" }).catch(() => null),
           fetch("/api/offboard/models", { method: "DELETE" }).catch(() => null),
           fetch("/api/offboard/account", { method: "DELETE" }),
         ])
 
-        if (wealthRes.ok) {
-          newResults.push(await wealthRes.json())
-        }
         if (plansRes?.ok) {
           newResults.push(await plansRes.json())
+        } else if (plansRes != null) {
+          newResults.push({
+            success: false,
+            deletedCount: 0,
+            type: "plans",
+            message: `Delete failed (${plansRes.status})`,
+          })
         }
         if (modelsRes?.ok) {
           newResults.push(await modelsRes.json())
+        } else if (modelsRes != null) {
+          newResults.push({
+            success: false,
+            deletedCount: 0,
+            type: "models",
+            message: `Delete failed (${modelsRes.status})`,
+          })
         }
         if (accountRes.ok) {
           newResults.push(await accountRes.json())
+        } else {
+          newResults.push({
+            success: false,
+            deletedCount: 0,
+            type: "account",
+            message: `Delete failed (${accountRes.status})`,
+          })
         }
       }
 
@@ -143,6 +184,14 @@ export default function OffboardingWizard(): React.ReactElement {
       setCurrentStep(5) // Move to complete step
     } catch (error) {
       console.error("Deletion failed:", error)
+      newResults.push({
+        success: false,
+        deletedCount: 0,
+        type: "unknown",
+        message: "An unexpected error occurred",
+      })
+      setResults(newResults)
+      setCurrentStep(5)
     } finally {
       setIsDeleting(false)
     }
@@ -196,8 +245,16 @@ export default function OffboardingWizard(): React.ReactElement {
             hasSelections={hasSelections}
           />
         )
-      case 5:
-        return <CompleteStep results={results} accountDeleted={deleteAccount} />
+      case 5: {
+        // Bug B fix: accountDeleted must be true only when the account DELETE
+        // actually succeeded, not merely when the user requested it.
+        const accountSucceeded = results.some(
+          (r) => r.type === "account" && r.success,
+        )
+        return (
+          <CompleteStep results={results} accountDeleted={accountSucceeded} />
+        )
+      }
       default:
         return <div>Unknown step</div>
     }

--- a/src/components/features/offboarding/__tests__/OffboardingWizard.test.tsx
+++ b/src/components/features/offboarding/__tests__/OffboardingWizard.test.tsx
@@ -1,0 +1,238 @@
+import React from "react"
+import { render, screen, waitFor, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import OffboardingWizard from "../OffboardingWizard"
+
+// next/link mocked globally in jest.setup.js
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SUMMARY_RESPONSE = {
+  portfolioCount: 2,
+  assetCount: 1,
+  taxRateCount: 3,
+  brokerCount: 2,
+}
+
+const PLANS_RESPONSE = {
+  data: [{ id: "plan-1" }, { id: "plan-2" }],
+  sharedPlanIds: [],
+}
+
+const MODELS_RESPONSE = {
+  data: [{ id: "model-1", isOwner: true }],
+}
+
+/** Build a minimal ok fetch response */
+function okResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response
+}
+
+/** Build a minimal non-ok fetch response */
+function errorResponse(status = 500): Response {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: "server error" }),
+  } as unknown as Response
+}
+
+/**
+ * Default fetch mock that handles the three summary fetches on mount.
+ * Individual tests can override specific URLs by overwriting `global.fetch`.
+ */
+function setupDefaultFetch(
+  overrides: Record<string, () => Response> = {},
+): jest.Mock {
+  const mockFetch = jest.fn((input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string" ? input : ((input as Request).url ?? "")
+
+    if (overrides[url]) {
+      return Promise.resolve(overrides[url]())
+    }
+
+    // Mount-time summary fetches
+    if (url.includes("/api/offboard/summary")) {
+      return Promise.resolve(okResponse(SUMMARY_RESPONSE))
+    }
+    if (url.includes("/api/independence/plans")) {
+      return Promise.resolve(okResponse(PLANS_RESPONSE))
+    }
+    if (url.includes("/api/rebalance/models")) {
+      return Promise.resolve(okResponse(MODELS_RESPONSE))
+    }
+    // Auth permissions — handled by jest.setup.js global default, but
+    // replicated here so our mock doesn't break it.
+    if (url.includes("/api/auth/permissions")) {
+      return Promise.resolve(
+        okResponse({ ai: true, preview: true, admin: true }),
+      )
+    }
+
+    // Default: generic ok
+    return Promise.resolve(okResponse({ data: [] }))
+  })
+
+  global.fetch = mockFetch
+  return mockFetch
+}
+
+// ---------------------------------------------------------------------------
+// Navigate the wizard to the deletion confirmation step (step 4) and tick
+// the "Delete my entire account" checkbox, then click "Delete Selected".
+// ---------------------------------------------------------------------------
+async function driveToAccountDeletion(mockFetch: jest.Mock): Promise<void> {
+  render(<OffboardingWizard />)
+
+  // Wait for summary fetch to complete and step 1 (SummaryStep) to render
+  await waitFor(() =>
+    expect(screen.getByText("Your Data Summary")).toBeInTheDocument(),
+  )
+
+  // Step 1 → 2: click Continue
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+  // Step 2 (WealthStep) → 3: click Continue (don't select wealth)
+  await waitFor(() =>
+    expect(screen.getByText("Delete Wealth Data")).toBeInTheDocument(),
+  )
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+  // Step 3 (PlanningStep) → 4: click Continue (don't select plans/models)
+  await waitFor(() =>
+    expect(screen.getByText("Delete Planning Data")).toBeInTheDocument(),
+  )
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+  // Step 4 (ConfirmAccountStep): check "Delete my entire account"
+  await waitFor(() =>
+    expect(screen.getByText("Delete Account")).toBeInTheDocument(),
+  )
+
+  const accountCheckbox = screen.getByRole("checkbox", {
+    name: /delete my entire account/i,
+  })
+  fireEvent.click(accountCheckbox)
+
+  // Clear recorded calls so only DELETE calls from handleDelete show up
+  mockFetch.mockClear()
+
+  // Click "Delete Selected" to trigger handleDelete
+  fireEvent.click(screen.getByRole("button", { name: /delete selected/i }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("OffboardingWizard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // ---- Bug A: /api/offboard/wealth must NOT be called in deleteAccount path --
+
+  it("Bug A: does not call /api/offboard/wealth when deleteAccount is selected", async () => {
+    const accountResult = {
+      success: true,
+      deletedCount: 1,
+      type: "account",
+    }
+    const mockFetch = setupDefaultFetch({
+      "/api/offboard/account": () => okResponse(accountResult),
+      "/api/offboard/plans": () =>
+        okResponse({ success: true, deletedCount: 2, type: "plans" }),
+      "/api/offboard/models": () =>
+        okResponse({ success: true, deletedCount: 1, type: "models" }),
+    })
+
+    await driveToAccountDeletion(mockFetch)
+
+    // Wait for CompleteStep to appear
+    await waitFor(() =>
+      expect(screen.getByText(/deletion complete/i)).toBeInTheDocument(),
+    )
+
+    // Verify /api/offboard/wealth was never called
+    const wealthCalls = mockFetch.mock.calls.filter(([input]) => {
+      const url =
+        typeof input === "string" ? input : ((input as Request).url ?? "")
+      return url.includes("/api/offboard/wealth")
+    })
+    expect(wealthCalls).toHaveLength(0)
+
+    // Verify /api/offboard/account WAS called
+    const accountCalls = mockFetch.mock.calls.filter(([input]) => {
+      const url =
+        typeof input === "string" ? input : ((input as Request).url ?? "")
+      return url.includes("/api/offboard/account")
+    })
+    expect(accountCalls).toHaveLength(1)
+    expect(accountCalls[0][1]).toMatchObject({ method: "DELETE" })
+  })
+
+  // ---- Bug B: failed account DELETE must NOT show the success / log-out UI --
+
+  it("Bug B: shows failure state and no logout link when account DELETE returns non-ok", async () => {
+    const mockFetch = setupDefaultFetch({
+      "/api/offboard/account": () => errorResponse(500),
+      "/api/offboard/plans": () =>
+        okResponse({ success: true, deletedCount: 0, type: "plans" }),
+      "/api/offboard/models": () =>
+        okResponse({ success: true, deletedCount: 0, type: "models" }),
+    })
+
+    await driveToAccountDeletion(mockFetch)
+
+    // Wait for CompleteStep
+    await waitFor(() =>
+      expect(
+        screen.getByText(/deletion partially failed/i),
+      ).toBeInTheDocument(),
+    )
+
+    // The happy-path copy must NOT appear
+    expect(
+      screen.queryByText(/your account has been deleted/i),
+    ).not.toBeInTheDocument()
+
+    // The Log Out link must NOT appear
+    expect(screen.queryByText(/log out/i)).not.toBeInTheDocument()
+
+    // The error banner must be visible
+    expect(
+      screen.getByText(/one or more deletions failed/i),
+    ).toBeInTheDocument()
+  })
+
+  // ---- Sanity: success path still shows logout when account DELETE succeeds --
+
+  it("shows logout link and success copy when account DELETE succeeds", async () => {
+    const accountResult = { success: true, deletedCount: 1, type: "account" }
+    const mockFetch = setupDefaultFetch({
+      "/api/offboard/account": () => okResponse(accountResult),
+      "/api/offboard/plans": () =>
+        okResponse({ success: true, deletedCount: 0, type: "plans" }),
+      "/api/offboard/models": () =>
+        okResponse({ success: true, deletedCount: 0, type: "models" }),
+    })
+
+    await driveToAccountDeletion(mockFetch)
+
+    await waitFor(() =>
+      expect(screen.getByText("Deletion Complete")).toBeInTheDocument(),
+    )
+
+    expect(
+      screen.getByText(/your account has been deleted/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText("Log Out")).toBeInTheDocument()
+  })
+})

--- a/src/components/features/offboarding/steps/CompleteStep.tsx
+++ b/src/components/features/offboarding/steps/CompleteStep.tsx
@@ -11,19 +11,40 @@ export default function CompleteStep({
   results,
   accountDeleted,
 }: CompleteStepProps): React.ReactElement {
+  const hasFailures = results.some((r) => !r.success)
+
   return (
     <div className="bg-white rounded-lg shadow-md p-6">
       <div className="text-center mb-6">
-        <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-          <i className="fas fa-check text-2xl text-green-600"></i>
+        <div
+          className={`w-16 h-16 ${hasFailures ? "bg-red-100" : "bg-green-100"} rounded-full flex items-center justify-center mx-auto mb-4`}
+        >
+          <i
+            className={`fas ${hasFailures ? "fa-exclamation-circle text-2xl text-red-600" : "fa-check text-2xl text-green-600"}`}
+          ></i>
         </div>
         <h2 className="text-xl font-semibold text-gray-900">
-          {"Deletion Complete"}
+          {hasFailures ? "Deletion Partially Failed" : "Deletion Complete"}
         </h2>
         <p className="text-gray-600 mt-2">
-          {"The selected data has been successfully removed from Beancounter."}
+          {hasFailures
+            ? "Some items could not be deleted. Please retry or contact support."
+            : "The selected data has been successfully removed from Beancounter."}
         </p>
       </div>
+
+      {hasFailures && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+          <div className="flex items-start">
+            <i className="fas fa-exclamation-circle text-red-500 mr-3 mt-1"></i>
+            <p className="text-red-700 text-sm">
+              {
+                "One or more deletions failed. Your data may be partially deleted. Please retry or contact support if the issue persists."
+              }
+            </p>
+          </div>
+        </div>
+      )}
 
       <div className="space-y-4 mb-8">
         {results.map((result, index) => (

--- a/src/components/features/offboarding/steps/SummaryStep.tsx
+++ b/src/components/features/offboarding/steps/SummaryStep.tsx
@@ -37,7 +37,7 @@ export default function SummaryStep({
         }
       </p>
 
-      <div className="space-y-4 mb-8">
+      <div className="space-y-4 mb-8 max-h-64 overflow-y-auto pr-1">
         <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
           <div className="flex items-center">
             <i className="fas fa-folder text-blue-500 mr-3"></i>


### PR DESCRIPTION
## Problem
Closing an account deleted the independence plan but left portfolios + brokers behind, and falsely reported success.

Three bugs in the offboarding wizard:
- **A — race / data loss:** the `deleteAccount` path fired `/offboard/wealth` AND `/offboard/account` in parallel. Both delete the same portfolios on svc-data → optimistic-lock collision → rollback. Plans (separate service) committed → plan gone, portfolios/brokers survived.
- **B — silent failure:** non-ok DELETEs were dropped and the flow always advanced to a 'Deletion Complete' screen, so a failed account close looked successful.
- **C — overflow:** the step-1 summary (6 rows + warning + Continue) didn't fit a typical viewport; the Continue button sat below the fold.

## Fix
- **A:** `/offboard/account` is the superset (portfolios + assets + brokers + tax rates + user) — drop the redundant `/offboard/wealth` call from the account path.
- **B:** record every non-ok/throwing DELETE as a failure result; derive `accountDeleted` from the actual account-DELETE result; `CompleteStep` shows a red 'Deletion Partially Failed' state + retry banner and gates the log-out copy on real success.
- **C:** bound the summary list with `max-h-64 overflow-y-auto`; header/warning/Continue stay in view.

## Tests
`OffboardingWizard.test.tsx`: race guard (`/offboard/wealth` never called in account path), failure-surfacing guard, success path. Offboarding jest 13/13, eslint + typecheck green.

Backend half (idempotent deletes) is beancounter PR #977.

🤖 Generated with [Claude Code](https://claude.com/claude-code)