### PR TITLE
feat(brokers): per-broker reconcile icon on broker list

### DIFF
--- a/src/components/features/transactions/__tests__/SubAccountTrnEditModal.test.tsx
+++ b/src/components/features/transactions/__tests__/SubAccountTrnEditModal.test.tsx
@@ -9,7 +9,7 @@ jest.mock("swr", () => ({
   useSWRConfig: () => ({ mutate: jest.fn() }),
 }))
 
-const makeTrn = (): Transaction =>
+const makeTrn = (overrides: Partial<Transaction> = {}): Transaction =>
   ({
     id: "trn-1",
     trnType: "BALANCE",
@@ -33,6 +33,7 @@ const makeTrn = (): Transaction =>
     tax: 0,
     comments: "",
     subAccounts: { OA: 60000, SA: 20000, MA: 20000 },
+    ...overrides,
   }) as unknown as Transaction
 
 const mockFetch = (): void => {
@@ -94,4 +95,29 @@ describe("SubAccountTrnEditModal", () => {
     expect(body.quantity).toBe(110000)
     expect(body.trnType).toBe("BALANCE")
   })
+
+  it.each(["BALANCE", "ADD"] as const)(
+    "preserves the %s transaction type on save",
+    async (trnType) => {
+      render(
+        <SubAccountTrnEditModal trn={makeTrn({ trnType })} onClose={jest.fn()} />,
+      )
+      await screen.findByLabelText("Ordinary")
+      fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+      await waitFor(() => {
+        const patch = (global.fetch as jest.Mock).mock.calls.find(
+          (c) =>
+            String(c[0]).includes("/api/trns/trn-1") &&
+            c[1]?.method === "PATCH",
+        )
+        expect(patch).toBeDefined()
+      })
+      const patch = (global.fetch as jest.Mock).mock.calls.find(
+        (c) =>
+          String(c[0]).includes("/api/trns/trn-1") && c[1]?.method === "PATCH",
+      )!
+      expect(JSON.parse(patch[1].body).trnType).toBe(trnType)
+    },
+  )
 })

--- a/src/pages/brokers/index.tsx
+++ b/src/pages/brokers/index.tsx
@@ -477,6 +477,15 @@ export default withPageAuthRequired(function Brokers(): React.ReactElement {
                   </button>
                   <div className="flex items-center space-x-2 ml-4">
                     <button
+                      onClick={() =>
+                        router.push(`/brokers/${broker.id}/holdings`)
+                      }
+                      className="text-gray-400 hover:text-green-600 p-2 transition-colors"
+                      title={"Reconcile Holdings"}
+                    >
+                      <i className="fas fa-balance-scale"></i>
+                    </button>
+                    <button
                       onClick={() => handleEdit(broker)}
                       className="text-gray-400 hover:text-blue-600 p-2 transition-colors"
                       title={"Edit"}


### PR DESCRIPTION
## What
Add a reconcile (⚖ balance-scale) icon to each broker row on `/brokers`.

## Why
Clicking a broker opened the edit modal — no direct path to reconcile a *specific* broker. The existing top-bar "Reconcile Holdings" button only targets `NO_BROKER` (unassigned). New per-row icon routes to `/brokers/[brokerId]/holdings`.

## Scope
- `src/pages/brokers/index.tsx` — one button in the row action group; mirrors existing Edit/Transfer/Delete pattern. No data/logic change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Reconcile Holdings** action to each broker card in the broker list.
  * Selecting it opens the broker’s holdings page directly from the list view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->