### PR TITLE
feat(offboarding): force logout after account closure

### DIFF
--- a/src/components/features/offboarding/__tests__/CompleteStep.test.tsx
+++ b/src/components/features/offboarding/__tests__/CompleteStep.test.tsx
@@ -3,14 +3,22 @@ import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import CompleteStep from "../steps/CompleteStep"
 import { OffboardingResult } from "types/beancounter"
+import { forceLogout } from "@utils/offboarding"
 
 // next/link mocked globally in jest.setup.js
+jest.mock("@utils/offboarding")
+
+const mockForceLogout = forceLogout as jest.Mock
 
 describe("CompleteStep", () => {
   const mockResults: OffboardingResult[] = [
     { success: true, deletedCount: 3, type: "portfolios" },
     { success: true, deletedCount: 2, type: "assets" },
   ]
+
+  beforeEach(() => {
+    mockForceLogout.mockClear()
+  })
 
   it("renders completion title", () => {
     render(<CompleteStep results={mockResults} accountDeleted={false} />)
@@ -30,12 +38,29 @@ describe("CompleteStep", () => {
   it("shows logout button when account is deleted", () => {
     render(<CompleteStep results={mockResults} accountDeleted={true} />)
 
-    expect(screen.getByText("Log Out")).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        "Your account has been deleted. Please log out to complete the process.",
-      ),
-    ).toBeInTheDocument()
+    expect(screen.getByText("Log Out Now")).toBeInTheDocument()
+    expect(screen.getByText(/Your account has been closed/)).toBeInTheDocument()
+  })
+
+  it("forces logout shortly after the account is closed", () => {
+    jest.useFakeTimers()
+    render(<CompleteStep results={mockResults} accountDeleted={true} />)
+
+    expect(mockForceLogout).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(3000)
+    expect(mockForceLogout).toHaveBeenCalledTimes(1)
+
+    jest.useRealTimers()
+  })
+
+  it("does not force logout when the account was not closed", () => {
+    jest.useFakeTimers()
+    render(<CompleteStep results={mockResults} accountDeleted={false} />)
+
+    jest.advanceTimersByTime(5000)
+    expect(mockForceLogout).not.toHaveBeenCalled()
+
+    jest.useRealTimers()
   })
 
   it("shows return home button when account is not deleted", () => {

--- a/src/components/features/offboarding/__tests__/OffboardingWizard.test.tsx
+++ b/src/components/features/offboarding/__tests__/OffboardingWizard.test.tsx
@@ -231,8 +231,8 @@ describe("OffboardingWizard", () => {
     )
 
     expect(
-      screen.getByText(/your account has been deleted/i),
+      screen.getByText(/your account has been closed/i),
     ).toBeInTheDocument()
-    expect(screen.getByText("Log Out")).toBeInTheDocument()
+    expect(screen.getByText("Log Out Now")).toBeInTheDocument()
   })
 })

--- a/src/components/features/offboarding/steps/CompleteStep.tsx
+++ b/src/components/features/offboarding/steps/CompleteStep.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { OffboardingResult } from "types/beancounter"
 import Link from "next/link"
+import { forceLogout } from "@utils/offboarding"
 
 interface CompleteStepProps {
   results: OffboardingResult[]
@@ -12,6 +13,16 @@ export default function CompleteStep({
   accountDeleted,
 }: CompleteStepProps): React.ReactElement {
   const hasFailures = results.some((r) => !r.success)
+
+  // Force logout once the account is closed. The session is dead server-side
+  // (the user is deactivated), so don't leave them sitting in a stale app —
+  // redirect to the Auth0 logout flow after a short beat so they see the
+  // confirmation. Full-page navigation is required for Auth0 logout.
+  React.useEffect(() => {
+    if (!accountDeleted) return undefined
+    const timer = setTimeout(forceLogout, 3000)
+    return () => clearTimeout(timer)
+  }, [accountDeleted])
 
   return (
     <div className="bg-white rounded-lg shadow-md p-6">
@@ -71,7 +82,7 @@ export default function CompleteStep({
         <div className="text-center">
           <p className="text-gray-600 mb-4">
             {
-              "Your account has been deleted. Please log out to complete the process."
+              "Your account has been closed and your data removed. Logging you out… Sign in again any time to reactivate it."
             }
           </p>
           {/* Using <a> intentionally - /auth/logout requires full page navigation for Auth0 logout flow */}
@@ -80,7 +91,7 @@ export default function CompleteStep({
             className="inline-flex items-center px-6 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
           >
             <i className="fas fa-sign-out-alt mr-2"></i>
-            {"Log Out"}
+            {"Log Out Now"}
           </a>
         </div>
       ) : (

--- a/src/lib/utils/offboarding.ts
+++ b/src/lib/utils/offboarding.ts
@@ -1,0 +1,8 @@
+/**
+ * Full-page redirect into the Auth0 logout flow. Extracted into its own module
+ * so the offboarding force-logout can be mocked in tests — jsdom locks
+ * window.location and its methods against redefinition.
+ */
+export function forceLogout(): void {
+  window.location.assign("/auth/logout")
+}


### PR DESCRIPTION
## What
After a successful account close, the wizard now **auto-redirects to `/auth/logout`** (3s grace so the confirmation is visible) instead of relying on the user clicking "Log Out".

## Why
With backend soft-delete (beancounter #982), the offboarded user is deactivated — `getActiveUser` no longer resolves them, so their session is dead server-side. Don't strand them in a stale app; force the logout. Signing in again reactivates the account.

## Changes
- `src/lib/utils/offboarding.ts` — `forceLogout()` (full-page `window.location.assign('/auth/logout')`), extracted so it's mockable (jsdom locks `window.location`).
- `CompleteStep` — `useEffect` fires `forceLogout` 3s after mount when `accountDeleted`; cleared on unmount. Copy updated: "Your account has been closed… Logging you out… Sign in again any time to reactivate it."; button "Log Out Now".

## Tests
- `forces logout shortly after the account is closed` / `does not force logout when the account was not closed` (fake timers + mocked `forceLogout`).
- Updated existing CompleteStep + OffboardingWizard copy assertions.
- Offboarding suite 15/15, eslint + typecheck clean.

Pairs with beancounter #982 (soft-delete + reactivate + getActiveUser active-filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)