### PR TITLE
chore: migrate from CodeRabbit to Graphite

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,0 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-reviews:
-  review_status: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,8 +151,8 @@ Rules for new code:
 - Never `@lib/utils/...` — double-`utils`; the alias already points
   inside `src/lib/utils/`.
 
-CodeRabbit gets this wrong; reject any suggestion that rewrites
-`@utils/api/*` to `@lib/api/*`.
+AI reviewers (e.g. Graphite Agent) get this wrong; reject any suggestion that
+rewrites `@utils/api/*` to `@lib/api/*`.
 
 ## API Routes
 

--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -935,13 +935,19 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                         setConfig((prev) => ({ ...prev, lockedUntilDate: val }))
                       }
                       onSubAccountsChange={(accounts) =>
-                        setConfig((prev) => ({ ...prev, subAccounts: accounts }))
+                        setConfig((prev) => ({
+                          ...prev,
+                          subAccounts: accounts,
+                        }))
                       }
                       onCpfLifePlanChange={(val) =>
                         setConfig((prev) => ({ ...prev, cpfLifePlan: val }))
                       }
                       onCpfPayoutStartAgeChange={(val) =>
-                        setConfig((prev) => ({ ...prev, cpfPayoutStartAge: val }))
+                        setConfig((prev) => ({
+                          ...prev,
+                          cpfPayoutStartAge: val,
+                        }))
                       }
                     />
                   </div>

--- a/src/components/features/openBrokerage/PortfolioModeChooser.tsx
+++ b/src/components/features/openBrokerage/PortfolioModeChooser.tsx
@@ -49,8 +49,8 @@ const PortfolioModeChooser: React.FC<PortfolioModeChooserProps> = ({
           </span>
           <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
             Its own space with its own objectives, kept apart from your
-            non-investment assets — cash, savings, property. Choose this when you
-            want to judge the brokerage on its own goals.
+            non-investment assets — cash, savings, property. Choose this when
+            you want to judge the brokerage on its own goals.
           </span>
         </span>
       </label>
@@ -80,8 +80,9 @@ const PortfolioModeChooser: React.FC<PortfolioModeChooserProps> = ({
             )}
           </span>
           <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
-            Fold these holdings in beside assets you already track — one combined
-            view. Choose this when you think of everything as a single pot.
+            Fold these holdings in beside assets you already track — one
+            combined view. Choose this when you think of everything as a single
+            pot.
           </span>
         </span>
       </label>
@@ -89,8 +90,8 @@ const PortfolioModeChooser: React.FC<PortfolioModeChooserProps> = ({
 
     <p className="text-xs text-gray-500 leading-relaxed">
       Either way, Beancounter totals your net worth across every portfolio —
-      this only decides how you{"’"}d like to view these assets, not what you can
-      see.
+      this only decides how you{"’"}d like to view these assets, not what you
+      can see.
     </p>
   </div>
 )

--- a/src/components/features/openBrokerage/__tests__/PortfolioModeChooser.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/PortfolioModeChooser.test.tsx
@@ -42,11 +42,7 @@ describe("PortfolioModeChooser", () => {
 
   it("disables the existing option when there is nothing to attach to", () => {
     render(
-      <PortfolioModeChooser
-        mode="new"
-        onSelect={jest.fn()}
-        existingDisabled
-      />,
+      <PortfolioModeChooser mode="new" onSelect={jest.fn()} existingDisabled />,
     )
     expect(
       screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),

--- a/src/components/features/transactions/PayslipModal.tsx
+++ b/src/components/features/transactions/PayslipModal.tsx
@@ -110,8 +110,9 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
     modalOpen ? plansKey : null,
     simpleFetcher(plansKey),
   )
-  const scenarioIncome = scenariosData?.data?.find((s) => s.isCurrent)
-    ?.workingIncomeMonthly
+  const scenarioIncome = scenariosData?.data?.find(
+    (s) => s.isCurrent,
+  )?.workingIncomeMonthly
   const planIncome = plansData?.data?.[0]?.workingIncomeMonthly
   const income = scenarioIncome ?? planIncome
   const defaultGross = income && income > 0 ? String(income) : ""
@@ -262,7 +263,10 @@ const PayslipModal: React.FC<PayslipModalProps> = ({ modalOpen, onClose }) => {
   // Portfolio default order: explicit pick → CPF-holding portfolio → saved
   // pref. CPF wins over the generic saved default so contributions land right.
   const effectivePortfolioId =
-    portfolioId || cpfPortfolioId || preferences?.defaultPayslipPortfolioId || ""
+    portfolioId ||
+    cpfPortfolioId ||
+    preferences?.defaultPayslipPortfolioId ||
+    ""
 
   const selectedCashCurrency = useMemo(() => {
     const opt = [...cashOptions, ...accountOptions].find(

--- a/src/components/features/transactions/SubAccountTrnEditModal.tsx
+++ b/src/components/features/transactions/SubAccountTrnEditModal.tsx
@@ -32,9 +32,9 @@ export default function SubAccountTrnEditModal({
   const currency = getAssetCurrency(trn.asset) || trn.tradeCurrency.code
 
   const [date, setDate] = useState<string>(trn.tradeDate)
-  const [values, setValues] = useState<Record<string, number>>(
-    () => ({ ...(trn.subAccounts ?? {}) }),
-  )
+  const [values, setValues] = useState<Record<string, number>>(() => ({
+    ...(trn.subAccounts ?? {}),
+  }))
   // Canonical sub-account rows (code + displayName + order) come from the asset
   // config; fall back to the codes carried on the transaction itself.
   const [configRows, setConfigRows] = useState<SubAccountRow[] | null>(null)


### PR DESCRIPTION
## What
- Remove CodeRabbit: delete `.coderabbit.yaml`, generalize the AI-reviewer note in `CLAUDE.md` to Graphite Agent.
- `style:` commit: Prettier reformat of 5 account/brokerage/transaction components (no logic change).

## Why
Stack-wide migration off CodeRabbit to Graphite (Graphite Agent AI review + `gt` stacked PRs + merge queue).

## Tests
Docs/config + formatting only; pre-commit hooks (import-path check, eslint --fix, lint-staged) pass. No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated review configuration file entry.
  * Updated guidance text to reflect the current AI review workflow.

* **Style**
  * Cleaned up formatting in several account, portfolio, payslip, and transaction dialogs for improved readability.

* **Tests**
  * Adjusted an existing portfolio mode test to match the updated JSX formatting, with no change in coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->