### PR TITLE
feat(assets): MathInput for composite bucket balances + hide liquid flag

### DIFF
--- a/src/components/features/assets/CompositeAssetEditor.tsx
+++ b/src/components/features/assets/CompositeAssetEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo } from "react"
 import { PolicyType, SubAccountRequest } from "types/beancounter"
 import TouchDatePicker from "@components/ui/TouchDatePicker"
+import MathInput from "@components/ui/MathInput"
 
 /**
  * CPF default sub-accounts with Board-published interest rates (as of 2024).
@@ -300,9 +301,6 @@ export default function CompositeAssetEditor({
                   <th className="text-right px-3 py-2 font-medium text-gray-600">
                     Fee %
                   </th>
-                  <th className="text-center px-3 py-2 font-medium text-gray-600">
-                    Liquid
-                  </th>
                   <th className="px-3 py-2"></th>
                 </tr>
               </thead>
@@ -322,16 +320,12 @@ export default function CompositeAssetEditor({
                       </div>
                     </td>
                     <td className="px-3 py-2">
-                      <input
-                        type="number"
+                      <MathInput
+                        aria-label={`${account.code} balance`}
                         step="100"
                         value={account.balance || ""}
-                        onChange={(e) =>
-                          handleSubAccountChange(
-                            index,
-                            "balance",
-                            parseFloat(e.target.value) || 0,
-                          )
+                        onChange={(val) =>
+                          handleSubAccountChange(index, "balance", val)
                         }
                         placeholder="0"
                         className="w-full min-w-[6rem] text-right border-gray-300 rounded px-2 py-1.5 border focus:ring-indigo-500 focus:border-indigo-500"
@@ -383,20 +377,6 @@ export default function CompositeAssetEditor({
                         }
                         placeholder="--"
                         className="w-full min-w-[4.5rem] text-right border-gray-300 rounded px-2 py-1.5 border focus:ring-indigo-500 focus:border-indigo-500"
-                      />
-                    </td>
-                    <td className="px-3 py-2 text-center">
-                      <input
-                        type="checkbox"
-                        checked={account.liquid !== false}
-                        onChange={(e) =>
-                          handleSubAccountChange(
-                            index,
-                            "liquid",
-                            e.target.checked,
-                          )
-                        }
-                        className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                       />
                     </td>
                     <td className="px-3 py-2">

--- a/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
+++ b/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
@@ -102,6 +102,51 @@ describe("CompositeAssetEditor — CPF LIFE plan default", () => {
     expect(onCpfLifePlanChange).toHaveBeenCalledWith(undefined)
   })
 
+  it("does not render a Liquid checkbox — liquidity is template-driven, not user-chosen", () => {
+    render(
+      <CompositeAssetEditor
+        policyType="CPF"
+        lockedUntilDate=""
+        subAccounts={[
+          { code: "OA", balance: 0, liquid: true },
+          { code: "MA", balance: 0, liquid: false },
+        ]}
+        cpfLifePlan="STANDARD"
+        onPolicyTypeChange={jest.fn()}
+        onLockedUntilDateChange={jest.fn()}
+        onSubAccountsChange={jest.fn()}
+        onCpfLifePlanChange={jest.fn()}
+        onCpfPayoutStartAgeChange={jest.fn()}
+      />,
+    )
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Liquid$/)).not.toBeInTheDocument()
+  })
+
+  it("evaluates a math expression in a bucket balance via MathInput", () => {
+    const onSubAccountsChange = jest.fn()
+    render(
+      <CompositeAssetEditor
+        policyType="CPF"
+        lockedUntilDate=""
+        subAccounts={[{ code: "OA", balance: 0, liquid: true }]}
+        cpfLifePlan="STANDARD"
+        onPolicyTypeChange={jest.fn()}
+        onLockedUntilDateChange={jest.fn()}
+        onSubAccountsChange={onSubAccountsChange}
+        onCpfLifePlanChange={jest.fn()}
+        onCpfPayoutStartAgeChange={jest.fn()}
+      />,
+    )
+    const balance = screen.getByLabelText(/OA balance/i)
+    fireEvent.change(balance, { target: { value: "1k*2" } })
+    fireEvent.blur(balance)
+    // MathInput expands shorthand + evaluates: 1k*2 -> 2000.
+    expect(onSubAccountsChange).toHaveBeenCalledWith([
+      { code: "OA", balance: 2000, liquid: true },
+    ])
+  })
+
   it("hides the locked-date picker and the add-sub-account row for CPF", () => {
     render(
       <CompositeAssetEditor

--- a/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
+++ b/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { render, screen, fireEvent } from "@testing-library/react"
 import CompositeAssetEditor from "../CompositeAssetEditor"
+import { makeSubAccount } from "@test-fixtures/beancounter"
 
 /**
  * Regression: a fresh CPF asset must default to the STANDARD CPF LIFE plan
@@ -84,8 +85,8 @@ describe("CompositeAssetEditor — CPF LIFE plan default", () => {
         policyType="CPF"
         lockedUntilDate=""
         subAccounts={[
-          { code: "OA", balance: 1000, liquid: true },
-          { code: "MA", balance: 500, liquid: false },
+          makeSubAccount({ code: "OA", balance: 1000 }),
+          makeSubAccount({ code: "MA", balance: 500, liquid: false }),
         ]}
         cpfLifePlan="STANDARD"
         onPolicyTypeChange={jest.fn()}
@@ -108,8 +109,8 @@ describe("CompositeAssetEditor — CPF LIFE plan default", () => {
         policyType="CPF"
         lockedUntilDate=""
         subAccounts={[
-          { code: "OA", balance: 0, liquid: true },
-          { code: "MA", balance: 0, liquid: false },
+          makeSubAccount({ code: "OA" }),
+          makeSubAccount({ code: "MA", liquid: false }),
         ]}
         cpfLifePlan="STANDARD"
         onPolicyTypeChange={jest.fn()}
@@ -129,7 +130,7 @@ describe("CompositeAssetEditor — CPF LIFE plan default", () => {
       <CompositeAssetEditor
         policyType="CPF"
         lockedUntilDate=""
-        subAccounts={[{ code: "OA", balance: 0, liquid: true }]}
+        subAccounts={[makeSubAccount({ code: "OA" })]}
         cpfLifePlan="STANDARD"
         onPolicyTypeChange={jest.fn()}
         onLockedUntilDateChange={jest.fn()}
@@ -143,7 +144,7 @@ describe("CompositeAssetEditor — CPF LIFE plan default", () => {
     fireEvent.blur(balance)
     // MathInput expands shorthand + evaluates: 1k*2 -> 2000.
     expect(onSubAccountsChange).toHaveBeenCalledWith([
-      { code: "OA", balance: 2000, liquid: true },
+      makeSubAccount({ code: "OA", balance: 2000 }),
     ])
   })
 
@@ -153,8 +154,8 @@ describe("CompositeAssetEditor — CPF LIFE plan default", () => {
         policyType="CPF"
         lockedUntilDate=""
         subAccounts={[
-          { code: "OA", balance: 0, liquid: true },
-          { code: "MA", balance: 0, liquid: false },
+          makeSubAccount({ code: "OA" }),
+          makeSubAccount({ code: "MA", liquid: false }),
         ]}
         cpfLifePlan="STANDARD"
         onPolicyTypeChange={jest.fn()}

--- a/src/test-fixtures/beancounter.ts
+++ b/src/test-fixtures/beancounter.ts
@@ -19,6 +19,7 @@ import {
   PortfolioBreakdown,
   Position,
   QuantityValues,
+  SubAccountRequest,
 } from "types/beancounter"
 import { ValueIn } from "@components/features/holdings/GroupByOptions"
 
@@ -97,6 +98,18 @@ export function makeMoneyValues(overrides: Partial<Money> = {}): Money {
     },
     ...rest,
   } as Money
+}
+
+export function makeSubAccount(
+  overrides: Partial<SubAccountRequest> = {},
+): SubAccountRequest {
+  return {
+    code: "OA",
+    displayName: "Ordinary Account",
+    balance: 0,
+    liquid: true,
+    ...overrides,
+  }
 }
 
 export function makeQuantityValues(


### PR DESCRIPTION
## What
Aligns composite/CPF bucket entry with the rest of the app:

- **Bucket balances use `MathInput`** — accept math + shorthand (`1k*2` → 2000, `1.5m+500k`, comma-paste), same component the pension/independence forms already use.
- **Removed the per-row Liquid checkbox.** Liquidity is template-driven (CPF: OA/SA/RA liquid, MA not; non-CPF buckets default liquid) — not a user choice. The "Liquid Balance" summary line still renders from the underlying flags.

## Surfaces
Shared `CompositeAssetEditor` → Add Asset (`/assets/account?category=POLICY`) and the onboarding/independence asset steps.

## Verify
- 7/7 unit tests (2 new: no checkbox rendered; `1k*2` evaluates to 2000)
- Live-checked on the CPF Add Asset surface: `1k*2` → 2000, no Liquid column
- prettier + lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sub-account balances can now be edited with the math-friendly input, including simple expressions that resolve automatically.
  * The sub-accounts table now reflects policy-driven liquidity settings more consistently and no longer shows unnecessary liquid toggles.
  * Non-CPF policies still support removing sub-accounts, while the table layout has been cleaned up for better alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->