### PR TITLE
feat(open-brokerage): open currency accounts at zero balance; drop source portfolio

### DIFF
--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -6,6 +6,7 @@ import {
 } from "@lib/openBrokerage/orchestrate"
 import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
 import PortfolioModeChooser from "@components/features/openBrokerage/PortfolioModeChooser"
+import DecimalInput from "@components/ui/DecimalInput"
 import { deriveBrokerCode } from "@lib/openBrokerage/brokerCode"
 import type { Broker, Currency, Portfolio } from "types/beancounter"
 
@@ -27,13 +28,13 @@ interface PortfolioState {
   existingId: string
 }
 
-// One currency account the user flags to open + fund. The wizard collects a
-// list so the brokerage can span several currencies (e.g. USD + SGD) in one
-// pass. `amount` is free-text and parsed at submit.
+// One currency account the user flags to open. The wizard collects a list so
+// the brokerage can span several currencies (e.g. USD + SGD) in one pass. The
+// account is opened even with a zero balance; `amount` is an optional opening
+// deposit (0 when unfunded).
 interface FundingRow {
   currency: string
-  amount: string
-  sourcePortfolioId: string // empty = no source (standalone deposit)
+  amount: number
 }
 
 // Fallback list — used only if /api/currencies hasn't returned yet so the
@@ -133,10 +134,6 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     return codes && codes.length > 0 ? codes : FALLBACK_CURRENCIES
   }, [currenciesData])
 
-  // Same-currency source portfolios for a given funding row's currency.
-  const sourcesFor = (currency: string): Portfolio[] =>
-    portfolios.filter((p) => p.currency?.code === currency)
-
   const brokerValid =
     broker.mode === "existing"
       ? !!broker.existingId
@@ -155,13 +152,15 @@ export default function OpenBrokerageWizard(): React.ReactElement {
   // time the user lands on it, so there's always one account ready to fund.
   const seedFundingRows = (): void => {
     setFundingRows((rows) => {
-      // Re-seed while nothing has been entered yet, so changing the portfolio
-      // default currency (then returning to funding) doesn't leave a stale
-      // row in the old currency. Once the user has typed an amount or picked a
-      // source, their rows are preserved as-is.
-      const untouched = rows.every((r) => !r.amount && !r.sourcePortfolioId)
-      return rows.length === 0 || untouched
-        ? [{ currency: portfolio.currency, amount: "", sourcePortfolioId: "" }]
+      // Re-seed when there's nothing yet, or when the only row is the lone
+      // untouched default — so changing the portfolio currency (then returning
+      // to funding) refreshes that single row instead of leaving it stale.
+      // Once the user has added a second currency or typed an amount, their
+      // selection is preserved as-is (a deliberate multi-currency choice must
+      // survive a Back/Next round-trip, even when every row is zero-balance).
+      const onlyUntouchedDefault = rows.length === 1 && !rows[0].amount
+      return rows.length === 0 || onlyUntouchedDefault
+        ? [{ currency: portfolio.currency, amount: 0 }]
         : rows
     })
   }
@@ -181,10 +180,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     )
 
   const addCurrencyRow = (currency: string): void =>
-    setFundingRows((rows) => [
-      ...rows,
-      { currency, amount: "", sourcePortfolioId: "" },
-    ])
+    setFundingRows((rows) => [...rows, { currency, amount: 0 }])
 
   const removeRow = (idx: number): void =>
     setFundingRows((rows) => rows.filter((_, i) => i !== idx))
@@ -194,10 +190,12 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     (c) => !fundingRows.some((r) => r.currency === c),
   )
 
-  // Funded accounts ready to submit: enabled (amount > 0) rows only.
-  const fundedAccounts = fundingRows
-    .map((r) => ({ ...r, parsed: parseFloat(r.amount) }))
-    .filter((r) => Number.isFinite(r.parsed) && r.parsed > 0)
+  // Accounts to open: every listed currency, even with no opening deposit.
+  // `amount` is the opening deposit (0 when unfunded).
+  const accountsToOpen = fundingRows.map((r) => ({
+    currency: r.currency,
+    amount: r.amount,
+  }))
 
   const submit = async (): Promise<void> => {
     setSubmitting(true)
@@ -229,13 +227,9 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                 currency: portfolio.currency,
                 base: portfolio.currency,
               },
-        funding: fundedAccounts.length
-          ? fundedAccounts.map((r) => ({
-              currency: r.currency,
-              amount: r.parsed,
-              sourcePortfolioId: r.sourcePortfolioId || undefined,
-            }))
-          : undefined,
+        // Empty list and undefined are equivalent downstream (orchestrate
+        // iterates `funding ?? []`), so pass the mapped list as-is.
+        funding: accountsToOpen,
       })
       setResult(res)
       setStep("done")
@@ -254,9 +248,14 @@ export default function OpenBrokerageWizard(): React.ReactElement {
         </h1>
         <p className="text-gray-600 mb-6">
           {`Portfolio ${portfolio.mode === "existing" ? (portfolios.find((p) => p.id === portfolio.existingId)?.code ?? "") : derivedCode} ready. `}
+          {result?.accountIds.length
+            ? `${result.accountIds.length} currency account(s) opened. `
+            : ""}
           {result?.trnIds.length
             ? `${result.trnIds.length} cash transaction(s) posted.`
-            : "No initial deposit posted."}
+            : result?.accountIds.length
+              ? "No opening deposit — accounts start empty."
+              : "No initial deposit posted."}
         </p>
         <a
           href={`/holdings/${result?.portfolioCode ?? ""}`}
@@ -478,80 +477,46 @@ export default function OpenBrokerageWizard(): React.ReactElement {
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
             {
-              "Optional — flag the currency accounts to open and how much to deposit in each. Pick a same-currency source portfolio to record a matching withdrawal, or leave blank for a standalone deposit."
+              "Open a cash account for each currency you'll hold in this brokerage. Accounts open even with a zero balance — add an opening deposit if you want to seed cash now. Remove any you don't need."
             }
           </p>
 
           <div className="space-y-3">
-            {fundingRows.map((row, idx) => {
-              const sources = sourcesFor(row.currency)
-              return (
-                <div
-                  key={row.currency}
-                  className="rounded-lg border border-gray-200 p-3 space-y-3"
-                >
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-semibold text-gray-900">
-                      {`${row.currency} account`}
-                    </span>
-                    {fundingRows.length > 1 && (
-                      <button
-                        type="button"
-                        onClick={() => removeRow(idx)}
-                        className="text-xs text-gray-400 hover:text-red-600"
-                      >
-                        {"Remove"}
-                      </button>
-                    )}
-                  </div>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <div>
-                      <label
-                        htmlFor={`fund-amount-${row.currency}`}
-                        className="block text-xs font-medium text-gray-600 mb-1"
-                      >
-                        {`Deposit (${row.currency})`}
-                      </label>
-                      <input
-                        id={`fund-amount-${row.currency}`}
-                        type="number"
-                        inputMode="decimal"
-                        min="0"
-                        value={row.amount}
-                        onChange={(e) =>
-                          updateRow(idx, { amount: e.target.value })
-                        }
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                        placeholder="0"
-                      />
-                    </div>
-                    <div>
-                      <label
-                        htmlFor={`fund-source-${row.currency}`}
-                        className="block text-xs font-medium text-gray-600 mb-1"
-                      >
-                        {"Source portfolio (optional)"}
-                      </label>
-                      <select
-                        id={`fund-source-${row.currency}`}
-                        value={row.sourcePortfolioId}
-                        onChange={(e) =>
-                          updateRow(idx, { sourcePortfolioId: e.target.value })
-                        }
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                      >
-                        <option value="">— None (deposit only) —</option>
-                        {sources.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.name} ({p.code})
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  </div>
+            {fundingRows.map((row, idx) => (
+              <div
+                key={row.currency}
+                className="rounded-lg border border-gray-200 p-3 space-y-3"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-gray-900">
+                    {`${row.currency} account`}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeRow(idx)}
+                    className="text-xs text-gray-400 hover:text-red-600"
+                  >
+                    {"Remove"}
+                  </button>
                 </div>
-              )
-            })}
+                <div>
+                  <label
+                    htmlFor={`fund-amount-${row.currency}`}
+                    className="block text-xs font-medium text-gray-600 mb-1"
+                  >
+                    {`Opening deposit (${row.currency}) — optional`}
+                  </label>
+                  <DecimalInput
+                    id={`fund-amount-${row.currency}`}
+                    min="0"
+                    value={row.amount}
+                    onChange={(amount) => updateRow(idx, { amount })}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="0"
+                  />
+                </div>
+              </div>
+            ))}
           </div>
 
           {availableCurrencies.length > 0 && (
@@ -599,17 +564,15 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                   ? `${portfolios.find((p) => p.id === portfolio.existingId)?.name ?? "?"} (existing, ${portfolio.currency})`
                   : `${derivedCode} — ${derivedName} (new, ${portfolio.currency})`}
               </dd>
-              <dt className="text-gray-500">Funding</dt>
+              <dt className="text-gray-500">Accounts</dt>
               <dd className="col-span-2 text-gray-900">
-                {fundedAccounts.length ? (
+                {accountsToOpen.length ? (
                   <ul className="space-y-1">
-                    {fundedAccounts.map((r) => (
+                    {accountsToOpen.map((r) => (
                       <li key={r.currency}>
-                        {`${r.parsed.toLocaleString()} ${r.currency} ${
-                          r.sourcePortfolioId
-                            ? `from ${portfolios.find((p) => p.id === r.sourcePortfolioId)?.name}`
-                            : "(standalone deposit)"
-                        }`}
+                        {r.amount > 0
+                          ? `${r.currency} — opening deposit ${r.amount.toLocaleString()}`
+                          : `${r.currency} — account only (no opening balance)`}
                       </li>
                     ))}
                   </ul>
@@ -636,18 +599,14 @@ export default function OpenBrokerageWizard(): React.ReactElement {
             <button
               type="button"
               onClick={() => {
-                setFundingRows((rows) =>
-                  rows.map((r) => ({
-                    ...r,
-                    amount: "",
-                    sourcePortfolioId: "",
-                  })),
-                )
+                // Skip = open no accounts at all; clear the list so nothing
+                // is created downstream.
+                setFundingRows([])
                 advance()
               }}
               className="px-4 py-2 text-sm text-gray-700 hover:text-gray-900"
             >
-              {"Skip — no deposit"}
+              {"Skip — no accounts"}
             </button>
             <button
               type="button"

--- a/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
@@ -147,7 +147,7 @@ describe("<OpenBrokerageWizard />", () => {
     expect(posts.some((c) => c.url.includes("/api/trns"))).toBe(false)
   })
 
-  test("posts DEPOSIT + WITHDRAWAL pair when user funds from a source portfolio", async () => {
+  test("posts a single DEPOSIT (no source/WITHDRAWAL leg) when an opening amount is entered", async () => {
     const user = userEvent.setup()
     render(<OpenBrokerageWizard />)
 
@@ -160,13 +160,11 @@ describe("<OpenBrokerageWizard />", () => {
     await screen.findByRole("heading", { name: /Portfolio/i })
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 3 — funding: enter amount + source
+    // Step 3 — funding: enter an opening amount. No source portfolio — the
+    // funding step no longer offers one.
     await screen.findByRole("heading", { name: /Funding|Deposit/i })
-    await user.type(screen.getByLabelText(/Deposit/i), "5000")
-    await user.selectOptions(
-      screen.getByLabelText(/Source portfolio/i),
-      "src-pf",
-    )
+    await user.type(screen.getByLabelText(/deposit/i), "5000")
+    expect(screen.queryByLabelText(/Source portfolio/i)).not.toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 4 — review
@@ -177,23 +175,59 @@ describe("<OpenBrokerageWizard />", () => {
 
     await screen.findByRole("heading", { name: /Done|Complete|Success/i })
 
-    // Two trn POSTs expected (WITHDRAWAL + DEPOSIT)
+    // Exactly one trn POST — a DEPOSIT, no WITHDRAWAL.
     const trnPosts = fetchMock.mock.calls.filter((c) => {
       const url = c[0] as string
       const method = (c[1] as RequestInit | undefined)?.method ?? "GET"
       return method === "POST" && url.includes("/api/trns")
     })
-    expect(trnPosts.length).toBeGreaterThanOrEqual(2)
-
-    // Inspect trn bodies for the type pair
-    const bodies = trnPosts.map((c) =>
-      JSON.parse((c[1] as RequestInit).body as string),
-    )
-    const types = bodies.flatMap((b) =>
-      b.data.map((d: { trnType: string }) => d.trnType),
-    )
+    const types = trnPosts
+      .map((c) => JSON.parse((c[1] as RequestInit).body as string))
+      .flatMap((b) => b.data.map((d: { trnType: string }) => d.trnType))
     expect(types).toContain("DEPOSIT")
-    expect(types).toContain("WITHDRAWAL")
+    expect(types).not.toContain("WITHDRAWAL")
+  })
+
+  test("opens a zero-balance account (asset created, no DEPOSIT) when no amount is entered", async () => {
+    const user = userEvent.setup()
+    render(<OpenBrokerageWizard />)
+
+    // Step 1 — broker
+    await screen.findByRole("heading", { name: /Broker/i })
+    await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 2 — portfolio (new mode, default currency USD)
+    await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 3 — funding: leave the seeded USD account at zero, advance with Next
+    // (not Skip) so the account still opens.
+    await screen.findByRole("heading", { name: /Funding|Deposit/i })
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Step 4 — review + submit
+    await screen.findByRole("heading", { name: /Review/i })
+    await user.click(
+      screen.getByRole("button", { name: /Create|Confirm|Open Brokerage/i }),
+    )
+    await screen.findByRole("heading", { name: /Done|Complete|Success/i })
+
+    // The cash account asset is created even with a zero opening balance...
+    const assetPosts = fetchMock.mock.calls.filter((c) => {
+      const url = c[0] as string
+      const method = (c[1] as RequestInit | undefined)?.method ?? "GET"
+      return method === "POST" && url.includes("/api/assets")
+    })
+    expect(assetPosts.length).toBeGreaterThan(0)
+
+    // ...but no DEPOSIT transaction is posted (nothing to fund).
+    const trnPosts = fetchMock.mock.calls.filter((c) => {
+      const url = c[0] as string
+      const method = (c[1] as RequestInit | undefined)?.method ?? "GET"
+      return method === "POST" && url.includes("/api/trns")
+    })
+    expect(trnPosts).toHaveLength(0)
   })
 
   test("reuses an existing broker by name instead of POSTing a duplicate", async () => {

--- a/src/lib/utils/openBrokerage/__tests__/orchestrate.test.ts
+++ b/src/lib/utils/openBrokerage/__tests__/orchestrate.test.ts
@@ -1,0 +1,148 @@
+import { enableFetchMocks } from "jest-fetch-mock"
+import { openBrokerage } from "../orchestrate"
+
+enableFetchMocks()
+
+interface AssetPostBody {
+  data?: Record<string, { market?: string; currency?: string; code?: string }>
+}
+interface TrnPostBody {
+  data: Array<{ trnType: string; cashCurrency: string }>
+}
+
+function handleMock(req: Request): Promise<string> {
+  const url = req.url
+  const method = req.method
+  if (url.includes("/api/brokers") && method === "GET") {
+    // No existing broker by that name → ensureBroker takes the POST branch.
+    return Promise.resolve(JSON.stringify({ data: [] }))
+  }
+  if (url.includes("/api/brokers") && method === "POST") {
+    return req
+      .clone()
+      .json()
+      .then((body: { name?: string }) =>
+        JSON.stringify({
+          data: { id: "broker-new", name: body.name ?? "Broker" },
+        }),
+      )
+  }
+  if (url.includes("/api/portfolios") && method === "POST") {
+    return Promise.resolve(JSON.stringify({ data: [{ id: "pf-new" }] }))
+  }
+  if (url.includes("/api/assets") && method === "POST") {
+    return req
+      .clone()
+      .json()
+      .then((body: AssetPostBody) => {
+        const code = Object.keys(body.data ?? {})[0] ?? "USD"
+        return JSON.stringify({
+          data: { [code]: { id: `asset-${code}`, code } },
+        })
+      })
+  }
+  if (url.includes("/api/trns") && method === "POST") {
+    return Promise.resolve(
+      JSON.stringify({ data: { trns: [{ id: "trn-1" }] } }),
+    )
+  }
+  return Promise.resolve(JSON.stringify({}))
+}
+
+function trnPosts(): TrnPostBody[] {
+  return fetchMock.mock.calls
+    .filter((c) => {
+      const url = c[0] as string
+      const m = (c[1] as RequestInit | undefined)?.method ?? "GET"
+      return m === "POST" && url.includes("/api/trns")
+    })
+    .map((c) => JSON.parse((c[1] as RequestInit).body as string) as TrnPostBody)
+}
+
+function assetPosts(): AssetPostBody[] {
+  return fetchMock.mock.calls
+    .filter((c) => {
+      const url = c[0] as string
+      const m = (c[1] as RequestInit | undefined)?.method ?? "GET"
+      return m === "POST" && url.includes("/api/assets")
+    })
+    .map(
+      (c) => JSON.parse((c[1] as RequestInit).body as string) as AssetPostBody,
+    )
+}
+
+describe("openBrokerage", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    fetchMock.mockResponse((req) => handleMock(req))
+  })
+
+  // The wizard no longer offers a source portfolio, but the onboarding flow
+  // still passes one — so the DEPOSIT + matching WITHDRAWAL pair must stay
+  // covered at the orchestrator level.
+  test("posts a DEPOSIT + WITHDRAWAL pair when a source portfolio is given", async () => {
+    const res = await openBrokerage({
+      broker: { mode: "new", newName: "IBKR" },
+      portfolio: {
+        mode: "new",
+        code: "IBKR",
+        name: "IBKR Portfolio",
+        currency: "USD",
+        base: "USD",
+      },
+      funding: [{ currency: "USD", amount: 5000, sourcePortfolioId: "src-pf" }],
+    })
+
+    const types = trnPosts().flatMap((b) => b.data.map((d) => d.trnType))
+    expect(types).toContain("DEPOSIT")
+    expect(types).toContain("WITHDRAWAL")
+    expect(res.accountIds).toHaveLength(1)
+    expect(res.trnIds.length).toBeGreaterThanOrEqual(2)
+  })
+
+  // Zero-balance account, attach-to-existing mode: the per-broker PRIVATE cash
+  // asset is created (so the currency bucket exists), but no DEPOSIT is posted.
+  test("opens a zero-balance PRIVATE broker cash account in existing mode without a deposit", async () => {
+    const res = await openBrokerage({
+      broker: { mode: "new", newName: "IBKR" },
+      portfolio: {
+        mode: "existing",
+        existingId: "pf-existing",
+        code: "SAVINGS",
+        currency: "USD",
+      },
+      funding: [{ currency: "USD", amount: 0 }],
+    })
+
+    const privateAsset = assetPosts().find(
+      (b) => b.data?.["IBKR-USD"]?.market === "PRIVATE",
+    )
+    expect(privateAsset).toBeDefined()
+    expect(res.accountIds).toHaveLength(1)
+    expect(res.trnIds).toHaveLength(0)
+    expect(trnPosts()).toHaveLength(0)
+  })
+
+  // Zero-balance account, new dedicated portfolio: generic CASH asset created,
+  // still no deposit.
+  test("opens a zero-balance CASH account in new mode without a deposit", async () => {
+    const res = await openBrokerage({
+      broker: { mode: "new", newName: "IBKR" },
+      portfolio: {
+        mode: "new",
+        code: "IBKR",
+        name: "IBKR Portfolio",
+        currency: "USD",
+        base: "USD",
+      },
+      funding: [{ currency: "USD", amount: 0 }],
+    })
+
+    const cashAsset = assetPosts().find(
+      (b) => b.data?.["USD"]?.market === "CASH",
+    )
+    expect(cashAsset).toBeDefined()
+    expect(res.accountIds).toHaveLength(1)
+    expect(res.trnIds).toHaveLength(0)
+  })
+})

--- a/src/lib/utils/openBrokerage/orchestrate.ts
+++ b/src/lib/utils/openBrokerage/orchestrate.ts
@@ -40,9 +40,12 @@ interface PortfolioStep {
   existingId?: string
 }
 
-// One currency account to open in the brokerage, with its opening deposit.
-// The wizard collects a list of these so a brokerage can be funded across
+// One currency account to open in the brokerage, with an optional opening
+// deposit. The wizard collects a list of these so a brokerage can span
 // several currencies in a single pass (e.g. an IB account holding USD + SGD).
+// The cash account (asset) is ALWAYS created, even when `amount` is 0 — the
+// brokerage opens with the currency buckets the user selected. An opening
+// DEPOSIT (and optional matching WITHDRAWAL) is posted only when amount > 0.
 interface FundingAccount {
   currency: string
   amount: number
@@ -66,6 +69,10 @@ export interface OpenBrokerageResult {
   portfolioId: string
   // Portfolio CODE (not id) — callers navigate to /holdings/{code}.
   portfolioCode: string
+  // Cash-asset ids opened — one per selected currency account, including any
+  // opened with a zero balance.
+  accountIds: string[]
+  // Trn ids for opening deposits — only currencies funded with amount > 0.
   trnIds: string[]
 }
 
@@ -249,17 +256,21 @@ export async function openBrokerage(
   // Each funded currency account is opened independently so a single pass can
   // span several currencies (e.g. an IB account holding USD + SGD). Sequential
   // — see the function doc on idempotency.
+  const accountIds: string[] = []
   const trnIds: string[] = []
   for (const account of req.funding ?? []) {
-    if (account.amount <= 0) continue
-    // Attach-to-existing-portfolio path uses a per-broker PRIVATE cash asset
-    // so the brokerage cash is visible as a distinct line in the existing
-    // portfolio's holdings; the new-portfolio path uses the generic
-    // per-currency CASH asset (the portfolio itself segregates).
+    // Open the account regardless of balance. Attach-to-existing-portfolio
+    // path uses a per-broker PRIVATE cash asset so the brokerage cash is
+    // visible as a distinct line in the existing portfolio's holdings; the
+    // new-portfolio path uses the generic per-currency CASH asset (the
+    // portfolio itself segregates).
     const depositAssetId =
       req.portfolio.mode === "existing"
         ? await ensureBrokerCashAsset(brokerCode, broker.name, account.currency)
         : await ensureCashAsset(account.currency)
+    accountIds.push(depositAssetId)
+    // Zero-balance account: created above, but no cash to move.
+    if (account.amount <= 0) continue
     // Order matters: DEPOSIT first into the freshly-created portfolio
     // (always succeeds — no balance/code constraints), then WITHDRAWAL
     // from the source. If WITHDRAWAL fails afterwards the worst-case
@@ -298,5 +309,5 @@ export async function openBrokerage(
     }
   }
 
-  return { broker, portfolioId, portfolioCode, trnIds }
+  return { broker, portfolioId, portfolioCode, accountIds, trnIds }
 }


### PR DESCRIPTION
## What

Open Brokerage wizard — step 3 (funding) rework.

- **Drop source portfolio** from the funding step UI and payload. No WITHDRAWAL leg from the wizard. (`orchestrate.ts` keeps the source/WITHDRAWAL path intact — the onboarding flow still uses it.)
- **Accounts open even at zero balance** — every selected currency creates a cash account (asset); an opening DEPOSIT is posted only when amount > 0. Zen mode (one portfolio) opens all selected currency buckets up front.
- **Remove any account** — Remove now available on every row, including the seeded base-currency row.
- Skip → "Skip — no accounts" (opens nothing); Next → opens accounts for the listed currencies.
- Result gains `accountIds[]`; done screen reports "N currency account(s) opened".

## Review fixes (high-effort code review)

- Fix seed logic discarding a multi-currency selection on Back→Next.
- Switch the deposit input to shared `DecimalInput` (strips thousands commas; fixes `parseFloat("4,000")=4`).
- Add `orchestrate.test.ts` covering the now-wizard-orphaned DEPOSIT+WITHDRAWAL path and zero-balance new/existing modes.
- Done-page messaging no longer reads as a half-failure when accounts open unfunded.

## Out of scope / flagged

- Onboarding still gates `funding` on `amount > 0`, so it never opens a zero-balance account — now inconsistent with the wizard. Left unchanged pending a product decision.

## Test

22 tests pass; typecheck, lint, prettier clean. Live-verified end-to-end locally (two zero-balance accounts opened, no deposits).


🤖 Generated with [Claude Code](https://claude.com/claude-code)