### PR TITLE
feat(zen): single-portfolio/broker auto-select + smart settlement defaults

### DIFF
--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -120,6 +120,19 @@ export default function OpenBrokerageWizard(): React.ReactElement {
   const brokers = useMemo(() => brokersData?.data ?? [], [brokersData])
   const portfolios = useMemo(() => portfoliosData?.data ?? [], [portfoliosData])
 
+  // Auto-select when there's only one portfolio to pick — nothing to choose,
+  // so treat the lone portfolio as the selection. Derived during render (not
+  // stored via an effect) so it can't trigger cascading renders; an explicit
+  // pick still wins. In attach mode the brokerage currency follows the chosen
+  // portfolio, so a new-mode currency choice is never clobbered.
+  const soleExistingId = portfolios.length === 1 ? portfolios[0].id : ""
+  const existingId = portfolio.existingId || soleExistingId
+  const existingCurrency =
+    portfolios.find((p) => p.id === existingId)?.currency?.code ??
+    portfolio.currency
+  const effectiveCurrency =
+    portfolio.mode === "existing" ? existingCurrency : portfolio.currency
+
   // The new brokerage portfolio takes its identity from the broker: code is
   // the abbreviated broker code (Interactive Brokers → IB), the display name
   // appends "Portfolio". Mirrors the onboarding flow so the two surfaces match.
@@ -139,9 +152,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
       ? !!broker.existingId
       : broker.newName.trim().length > 0
   const portfolioValid =
-    portfolio.mode === "existing"
-      ? !!portfolio.existingId
-      : derivedCode.length > 0
+    portfolio.mode === "existing" ? !!existingId : derivedCode.length > 0
 
   const back = (): void => {
     const i = STEP_ORDER.indexOf(step as Exclude<Step, "done">)
@@ -160,7 +171,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
       // survive a Back/Next round-trip, even when every row is zero-balance).
       const onlyUntouchedDefault = rows.length === 1 && !rows[0].amount
       return rows.length === 0 || onlyUntouchedDefault
-        ? [{ currency: portfolio.currency, amount: 0 }]
+        ? [{ currency: effectiveCurrency, amount: 0 }]
         : rows
     })
   }
@@ -203,7 +214,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     try {
       const existingCode =
         portfolio.mode === "existing"
-          ? (portfolios.find((p) => p.id === portfolio.existingId)?.code ?? "")
+          ? (portfolios.find((p) => p.id === existingId)?.code ?? "")
           : ""
       const res = await openBrokerage({
         broker: {
@@ -216,9 +227,9 @@ export default function OpenBrokerageWizard(): React.ReactElement {
           portfolio.mode === "existing"
             ? {
                 mode: "existing",
-                existingId: portfolio.existingId,
+                existingId,
                 code: existingCode,
-                currency: portfolio.currency,
+                currency: existingCurrency,
               }
             : {
                 mode: "new",
@@ -247,7 +258,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
           {"Done — brokerage opened"}
         </h1>
         <p className="text-gray-600 mb-6">
-          {`Portfolio ${portfolio.mode === "existing" ? (portfolios.find((p) => p.id === portfolio.existingId)?.code ?? "") : derivedCode} ready. `}
+          {`Portfolio ${portfolio.mode === "existing" ? (portfolios.find((p) => p.id === existingId)?.code ?? "") : derivedCode} ready. `}
           {result?.accountIds.length
             ? `${result.accountIds.length} currency account(s) opened. `
             : ""}
@@ -375,22 +386,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
         <div className="space-y-6">
           <PortfolioModeChooser
             mode={portfolio.mode}
-            onSelect={(mode) =>
-              setPortfolio((prev) => {
-                // Re-sync currency to the still-selected existing portfolio so
-                // a currency changed while in "new" mode can't leak into the
-                // existing-mode submit / source filter.
-                if (mode === "existing" && prev.existingId) {
-                  const pf = portfolios.find((p) => p.id === prev.existingId)
-                  return {
-                    ...prev,
-                    mode,
-                    currency: pf?.currency?.code ?? prev.currency,
-                  }
-                }
-                return { ...prev, mode }
-              })
-            }
+            onSelect={(mode) => setPortfolio((prev) => ({ ...prev, mode }))}
             existingDisabled={portfolios.length === 0}
           />
 
@@ -405,16 +401,10 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                 </label>
                 <select
                   id="pf-existing"
-                  value={portfolio.existingId}
-                  onChange={(e) => {
-                    const id = e.target.value
-                    const pf = portfolios.find((p) => p.id === id)
-                    setPortfolio({
-                      ...portfolio,
-                      existingId: id,
-                      currency: pf?.currency?.code ?? portfolio.currency,
-                    })
-                  }}
+                  value={existingId}
+                  onChange={(e) =>
+                    setPortfolio({ ...portfolio, existingId: e.target.value })
+                  }
                   className="w-full px-3 py-2 border border-gray-300 rounded-md"
                 >
                   <option value="">— Select —</option>
@@ -425,7 +415,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                   ))}
                 </select>
                 <p className="text-xs text-gray-500 mt-1">
-                  {`Deposits will land on a per-broker cash line (e.g. ${broker.newName || "BROKER"}-${portfolio.currency}) so the brokerage cash stays separate from any existing cash on this portfolio.`}
+                  {`Deposits will land on a per-broker cash line (e.g. ${broker.newName || "BROKER"}-${effectiveCurrency}) so the brokerage cash stays separate from any existing cash on this portfolio.`}
                 </p>
               </div>
             ) : (
@@ -561,7 +551,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
               <dt className="text-gray-500">Portfolio</dt>
               <dd className="col-span-2 text-gray-900">
                 {portfolio.mode === "existing"
-                  ? `${portfolios.find((p) => p.id === portfolio.existingId)?.name ?? "?"} (existing, ${portfolio.currency})`
+                  ? `${portfolios.find((p) => p.id === existingId)?.name ?? "?"} (existing, ${effectiveCurrency})`
                   : `${derivedCode} — ${derivedName} (new, ${portfolio.currency})`}
               </dd>
               <dt className="text-gray-500">Accounts</dt>

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -127,9 +127,12 @@ export default function OpenBrokerageWizard(): React.ReactElement {
   // portfolio, so a new-mode currency choice is never clobbered.
   const soleExistingId = portfolios.length === 1 ? portfolios[0].id : ""
   const existingId = portfolio.existingId || soleExistingId
+  const selectedExistingPortfolio = useMemo(
+    () => portfolios.find((p) => p.id === existingId),
+    [portfolios, existingId],
+  )
   const existingCurrency =
-    portfolios.find((p) => p.id === existingId)?.currency?.code ??
-    portfolio.currency
+    selectedExistingPortfolio?.currency?.code ?? portfolio.currency
   const effectiveCurrency =
     portfolio.mode === "existing" ? existingCurrency : portfolio.currency
 
@@ -214,7 +217,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     try {
       const existingCode =
         portfolio.mode === "existing"
-          ? (portfolios.find((p) => p.id === existingId)?.code ?? "")
+          ? (selectedExistingPortfolio?.code ?? "")
           : ""
       const res = await openBrokerage({
         broker: {
@@ -258,7 +261,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
           {"Done — brokerage opened"}
         </h1>
         <p className="text-gray-600 mb-6">
-          {`Portfolio ${portfolio.mode === "existing" ? (portfolios.find((p) => p.id === existingId)?.code ?? "") : derivedCode} ready. `}
+          {`Portfolio ${portfolio.mode === "existing" ? (selectedExistingPortfolio?.code ?? "") : derivedCode} ready. `}
           {result?.accountIds.length
             ? `${result.accountIds.length} currency account(s) opened. `
             : ""}
@@ -551,7 +554,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
               <dt className="text-gray-500">Portfolio</dt>
               <dd className="col-span-2 text-gray-900">
                 {portfolio.mode === "existing"
-                  ? `${portfolios.find((p) => p.id === existingId)?.name ?? "?"} (existing, ${effectiveCurrency})`
+                  ? `${selectedExistingPortfolio?.name ?? "?"} (existing, ${effectiveCurrency})`
                   : `${derivedCode} — ${derivedName} (new, ${portfolio.currency})`}
               </dd>
               <dt className="text-gray-500">Accounts</dt>

--- a/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { enableFetchMocks } from "jest-fetch-mock"
+import { SWRConfig } from "swr"
 import OpenBrokerageWizard from "../OpenBrokerageWizard"
 import type { Broker, Portfolio } from "types/beancounter"
 
@@ -12,6 +13,8 @@ const existingBrokers: Broker[] = [
   { id: "broker-dbs", name: "DBS Vickers" },
 ]
 
+// Two portfolios so the "attach without a pick" path has a genuine unpicked
+// state. The single-portfolio auto-select case overrides this per-test.
 const existingPortfolios: Pick<
   Portfolio,
   "id" | "code" | "name" | "currency"
@@ -20,6 +23,12 @@ const existingPortfolios: Pick<
     id: "src-pf",
     code: "SAVINGS",
     name: "Savings",
+    currency: { code: "USD", name: "US Dollar", symbol: "$" },
+  },
+  {
+    id: "pf-2",
+    code: "GROWTH",
+    name: "Growth",
     currency: { code: "USD", name: "US Dollar", symbol: "$" },
   },
 ]
@@ -425,5 +434,59 @@ describe("<OpenBrokerageWizard />", () => {
     expect(
       screen.getByRole("button", { name: /Next|Continue/i }),
     ).toBeDisabled()
+  })
+
+  test("auto-selects the sole existing portfolio so no manual pick is needed", async () => {
+    // Override the portfolios endpoint to return exactly one.
+    fetchMock.resetMocks()
+    const onlyPf = [
+      {
+        id: "only-pf",
+        code: "ONLY",
+        name: "Only One",
+        currency: { code: "USD", name: "US Dollar", symbol: "$" },
+      },
+    ]
+    fetchMock.mockResponse((req) => {
+      if (req.url.includes("/api/portfolios") && req.method === "GET") {
+        return Promise.resolve(JSON.stringify({ data: onlyPf }))
+      }
+      return handleMock(req)
+    })
+
+    const user = userEvent.setup()
+    // Fresh SWR cache so the sole-portfolio response isn't shadowed by the
+    // two-portfolio data other tests primed into the shared global cache.
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <OpenBrokerageWizard />
+      </SWRConfig>,
+    )
+
+    await screen.findByRole("heading", { name: /Broker/i })
+    await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
+    await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
+
+    // Switch to attach-to-existing — the lone portfolio is already selected.
+    await screen.findByRole("heading", { name: /Portfolio/i })
+    await waitFor(() =>
+      expect(
+        screen.getByRole("radio", {
+          name: /Attach to an existing portfolio/i,
+        }),
+      ).not.toBeDisabled(),
+    )
+    await user.click(
+      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
+    )
+
+    const select = (await screen.findByLabelText(
+      "Existing portfolio",
+    )) as HTMLSelectElement
+    await waitFor(() => expect(select.value).toBe("only-pf"))
+    // No pick required → Next is enabled straight away.
+    expect(
+      screen.getByRole("button", { name: /Next|Continue/i }),
+    ).not.toBeDisabled()
   })
 })

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -556,16 +556,18 @@ const TradeInputForm: React.FC<{
   ])
 
   // Auto-select the broker when there's only one — nothing to choose, and it
-  // lets the broker's settlement account resolve without a manual pick. Only
-  // on create (never override an edited trn) and only while the field is
-  // empty, so an explicit "-- No broker --" choice is respected.
+  // lets the broker's settlement account resolve without a manual pick. Fires
+  // once (guarded by a ref) so that a later explicit "-- No broker --" choice
+  // sticks instead of being re-filled. Create-mode only — never an edited trn.
+  const brokerAutoSelectedRef = useRef(false)
   useEffect(() => {
+    if (brokerAutoSelectedRef.current || isEditMode) return
     if (
-      !isEditMode &&
       acceptsBroker(type?.value) &&
       brokers.length === 1 &&
       !watch("brokerId")
     ) {
+      brokerAutoSelectedRef.current = true
       setValue("brokerId", brokers[0].id)
     }
   }, [isEditMode, type?.value, brokers, setValue, watch])

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -555,6 +555,21 @@ const TradeInputForm: React.FC<{
     setValue,
   ])
 
+  // Auto-select the broker when there's only one — nothing to choose, and it
+  // lets the broker's settlement account resolve without a manual pick. Only
+  // on create (never override an edited trn) and only while the field is
+  // empty, so an explicit "-- No broker --" choice is respected.
+  useEffect(() => {
+    if (
+      !isEditMode &&
+      acceptsBroker(type?.value) &&
+      brokers.length === 1 &&
+      !watch("brokerId")
+    ) {
+      setValue("brokerId", brokers[0].id)
+    }
+  }, [isEditMode, type?.value, brokers, setValue, watch])
+
   const cashAmountField = watch("cashAmount")
   const market = watch("market")
 

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -832,8 +832,11 @@ const TradeInputForm: React.FC<{
                     </div>
                   )}
 
-                  {/* Portfolio Selection */}
-                  {portfolios.length > 0 && (
+                  {/* Portfolio Selection — only when there's a choice to make.
+                      With a single portfolio it's already the selection
+                      (selectedPortfolioId defaults to it), so the dropdown is
+                      noise. */}
+                  {portfolios.length > 1 && (
                     <div>
                       <label className={labelClass}>{"Portfolio"}</label>
                       <select

--- a/src/components/features/transactions/__tests__/SubAccountTrnEditModal.test.tsx
+++ b/src/components/features/transactions/__tests__/SubAccountTrnEditModal.test.tsx
@@ -100,7 +100,10 @@ describe("SubAccountTrnEditModal", () => {
     "preserves the %s transaction type on save",
     async (trnType) => {
       render(
-        <SubAccountTrnEditModal trn={makeTrn({ trnType })} onClose={jest.fn()} />,
+        <SubAccountTrnEditModal
+          trn={makeTrn({ trnType })}
+          onClose={jest.fn()}
+        />,
       )
       await screen.findByLabelText("Ordinary")
       fireEvent.click(screen.getByRole("button", { name: "Save" }))

--- a/src/lib/utils/openBrokerage/__tests__/orchestrate.test.ts
+++ b/src/lib/utils/openBrokerage/__tests__/orchestrate.test.ts
@@ -123,6 +123,56 @@ describe("openBrokerage", () => {
     expect(trnPosts()).toHaveLength(0)
   })
 
+  // The opened cash accounts become the broker's per-currency settlement
+  // default (PATCH /api/brokers/{id}), so a later trade settles to the
+  // broker's own cash line rather than a generic CASH/ccy.
+  test("registers opened accounts as the broker's settlement default per currency", async () => {
+    await openBrokerage({
+      broker: { mode: "new", newName: "IBKR" },
+      portfolio: {
+        mode: "existing",
+        existingId: "pf-existing",
+        code: "SAVINGS",
+        currency: "USD",
+      },
+      funding: [
+        { currency: "USD", amount: 0 },
+        { currency: "SGD", amount: 1000 },
+      ],
+    })
+
+    const patch = fetchMock.mock.calls.find((c) => {
+      const url = c[0] as string
+      const m = (c[1] as RequestInit | undefined)?.method
+      return m === "PATCH" && url.includes("/api/brokers/")
+    })
+    expect(patch).toBeDefined()
+    const body = JSON.parse((patch![1] as RequestInit).body as string) as {
+      settlementAccounts: Record<string, string>
+    }
+    expect(body.settlementAccounts.USD).toBe("asset-IBKR-USD")
+    expect(body.settlementAccounts.SGD).toBe("asset-IBKR-SGD")
+  })
+
+  // No accounts opened → no settlement registration.
+  test("does not PATCH the broker when no accounts are opened", async () => {
+    await openBrokerage({
+      broker: { mode: "new", newName: "IBKR" },
+      portfolio: {
+        mode: "new",
+        code: "IBKR",
+        name: "IBKR Portfolio",
+        currency: "USD",
+        base: "USD",
+      },
+    })
+    const patched = fetchMock.mock.calls.some((c) => {
+      const m = (c[1] as RequestInit | undefined)?.method
+      return m === "PATCH" && (c[0] as string).includes("/api/brokers/")
+    })
+    expect(patched).toBe(false)
+  })
+
   // Zero-balance account, new dedicated portfolio: generic CASH asset created,
   // still no deposit.
   test("opens a zero-balance CASH account in new mode without a deposit", async () => {

--- a/src/lib/utils/openBrokerage/orchestrate.ts
+++ b/src/lib/utils/openBrokerage/orchestrate.ts
@@ -5,7 +5,7 @@
  * component so it can be unit-tested or reused.
  */
 
-import type { Broker } from "types/beancounter"
+import type { Broker, BrokerWithAccounts } from "types/beancounter"
 import { deriveBrokerCode } from "@lib/openBrokerage/brokerCode"
 
 // Local-date YYYY-MM-DD so tradeDate matches the user's calendar day,
@@ -89,6 +89,49 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
     )
   }
   return (await res.json()) as T
+}
+
+// Register the just-opened cash accounts as the broker's default settlement
+// account per currency, so settling a trade through this broker defaults to
+// its own cash line (e.g. IB-USD) instead of a generic CASH/USD. Merges with
+// any existing mappings — PATCH replaces the whole map, so we must preserve
+// other currencies. Non-fatal: a failure here doesn't undo the brokerage.
+async function registerBrokerSettlementAccounts(
+  broker: Broker,
+  byCurrency: Record<string, string>,
+): Promise<void> {
+  if (Object.keys(byCurrency).length === 0) return
+  try {
+    const existing = await fetch("/api/brokers?includeAccounts=true")
+      .then((r) =>
+        r.ok ? (r.json() as Promise<{ data: BrokerWithAccounts[] }>) : null,
+      )
+      .then((j) => j?.data.find((b) => b.id === broker.id))
+      .catch(() => undefined)
+    const merged: Record<string, string> = {}
+    existing?.settlementAccounts?.forEach((sa) => {
+      merged[sa.currencyCode] = sa.accountId
+    })
+    // Newly-opened accounts win for their currency.
+    Object.assign(merged, byCurrency)
+    const res = await fetch(`/api/brokers/${broker.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: broker.name,
+        accountNumber: broker.accountNumber,
+        notes: broker.notes,
+        settlementAccounts: merged,
+      }),
+    })
+    if (!res.ok) {
+      console.warn(
+        `registerBrokerSettlementAccounts: PATCH failed (${res.status})`,
+      )
+    }
+  } catch (e) {
+    console.warn("registerBrokerSettlementAccounts: skipped", e)
+  }
 }
 
 async function ensureBroker(step: BrokerStep): Promise<Broker> {
@@ -258,6 +301,9 @@ export async function openBrokerage(
   // — see the function doc on idempotency.
   const accountIds: string[] = []
   const trnIds: string[] = []
+  // currency → opened cash-asset id, registered as the broker's default
+  // settlement account once all accounts are open.
+  const settlementByCurrency: Record<string, string> = {}
   for (const account of req.funding ?? []) {
     // Open the account regardless of balance. Attach-to-existing-portfolio
     // path uses a per-broker PRIVATE cash asset so the brokerage cash is
@@ -269,6 +315,8 @@ export async function openBrokerage(
         ? await ensureBrokerCashAsset(brokerCode, broker.name, account.currency)
         : await ensureCashAsset(account.currency)
     accountIds.push(depositAssetId)
+    // Last opened account for a currency is the broker's settlement default.
+    settlementByCurrency[account.currency] = depositAssetId
     // Zero-balance account: created above, but no cash to move.
     if (account.amount <= 0) continue
     // Order matters: DEPOSIT first into the freshly-created portfolio
@@ -308,6 +356,10 @@ export async function openBrokerage(
       )
     }
   }
+
+  // Make these accounts the broker's per-currency settlement default so a
+  // later trade settles to the broker's own cash line, not a generic CASH/ccy.
+  await registerBrokerSettlementAccounts(broker, settlementByCurrency)
 
   return { broker, portfolioId, portfolioCode, accountIds, trnIds }
 }

--- a/src/pages/trns/proposed.tsx
+++ b/src/pages/trns/proposed.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/router"
 import useSwr, { mutate } from "swr"
-import {
-  fetcher,
-  simpleFetcher,
-  portfoliosKey,
-} from "@utils/api/fetchHelper"
+import { fetcher, simpleFetcher, portfoliosKey } from "@utils/api/fetchHelper"
 import { rootLoader } from "@components/ui/PageLoader"
 import { Broker, Portfolio, Transaction, TrnStatus } from "types/beancounter"
 import { ProposedTransaction, AggregatedTransaction } from "types/proposed"
@@ -37,19 +33,6 @@ const getAssetDisplayCode = (asset: { code: string }): string => {
 export default function ProposedTransactions(): React.JSX.Element {
   const { user, isLoading: userLoading } = useUser()
   const router = useRouter()
-
-  // Portfolios — used to offer a "go to your portfolio" shortcut when there's
-  // nothing to review and the user has a single portfolio (zen mode).
-  const { data: portfoliosData } = useSwr<{ data: Portfolio[] }>(
-    user ? portfoliosKey : null,
-    simpleFetcher(portfoliosKey),
-  )
-  const solePortfolio = useMemo(() => {
-    const active = (portfoliosData?.data ?? []).filter(
-      (p) => p.active !== false,
-    )
-    return active.length === 1 ? active[0] : null
-  }, [portfoliosData])
 
   const [transactions, setTransactions] = useState<ProposedTransaction[]>([])
   const [isSaving, setIsSaving] = useState(false)
@@ -137,6 +120,21 @@ export default function ProposedTransactions(): React.JSX.Element {
   const { data: proposedData, error: fetchError } = useSwr<{
     data: Transaction[]
   }>(proposedKey, fetcher, { refreshInterval: 0 })
+
+  // Portfolios — only to offer a "go to your portfolio" shortcut when there's
+  // nothing to review. Fetched solely on the empty path (when proposed has
+  // loaded and is empty) so the common case doesn't pay for an unused list.
+  const proposedEmpty = (proposedData?.data?.length ?? 1) === 0
+  const { data: portfoliosData } = useSwr<{ data: Portfolio[] }>(
+    user && proposedEmpty ? portfoliosKey : null,
+    simpleFetcher(portfoliosKey),
+  )
+  const solePortfolio = useMemo(() => {
+    const active = (portfoliosData?.data ?? []).filter(
+      (p) => p.active !== false,
+    )
+    return active.length === 1 ? active[0] : null
+  }, [portfoliosData])
 
   // Fetch brokers for dropdown
   const { data: brokersData } = useSwr(
@@ -889,9 +887,7 @@ export default function ProposedTransactions(): React.JSX.Element {
               <div className="space-y-3">
                 <p>{"No proposed transactions — you're all caught up."}</p>
                 <button
-                  onClick={() =>
-                    router.push(`/holdings/${solePortfolio.code}`)
-                  }
+                  onClick={() => router.push(`/holdings/${solePortfolio.code}`)}
                   className="btn-primary btn-primary--sm"
                 >
                   {`View ${solePortfolio.name} holdings`}

--- a/src/pages/trns/proposed.tsx
+++ b/src/pages/trns/proposed.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/router"
 import useSwr, { mutate } from "swr"
-import { fetcher, simpleFetcher } from "@utils/api/fetchHelper"
+import {
+  fetcher,
+  simpleFetcher,
+  portfoliosKey,
+} from "@utils/api/fetchHelper"
 import { rootLoader } from "@components/ui/PageLoader"
-import { Broker, Transaction, TrnStatus } from "types/beancounter"
+import { Broker, Portfolio, Transaction, TrnStatus } from "types/beancounter"
 import { ProposedTransaction, AggregatedTransaction } from "types/proposed"
 import Head from "next/head"
 import { useUser } from "@auth0/nextjs-auth0/client"
@@ -33,6 +37,19 @@ const getAssetDisplayCode = (asset: { code: string }): string => {
 export default function ProposedTransactions(): React.JSX.Element {
   const { user, isLoading: userLoading } = useUser()
   const router = useRouter()
+
+  // Portfolios — used to offer a "go to your portfolio" shortcut when there's
+  // nothing to review and the user has a single portfolio (zen mode).
+  const { data: portfoliosData } = useSwr<{ data: Portfolio[] }>(
+    user ? portfoliosKey : null,
+    simpleFetcher(portfoliosKey),
+  )
+  const solePortfolio = useMemo(() => {
+    const active = (portfoliosData?.data ?? []).filter(
+      (p) => p.active !== false,
+    )
+    return active.length === 1 ? active[0] : null
+  }, [portfoliosData])
 
   const [transactions, setTransactions] = useState<ProposedTransaction[]>([])
   const [isSaving, setIsSaving] = useState(false)
@@ -868,7 +885,21 @@ export default function ProposedTransactions(): React.JSX.Element {
 
         {!fetchError && transactions.length === 0 && (
           <div className="bg-gray-50 border border-gray-200 text-gray-600 px-4 py-8 rounded text-center">
-            No proposed transactions found. All caught up!
+            {solePortfolio ? (
+              <div className="space-y-3">
+                <p>{"No proposed transactions — you're all caught up."}</p>
+                <button
+                  onClick={() =>
+                    router.push(`/holdings/${solePortfolio.code}`)
+                  }
+                  className="btn-primary btn-primary--sm"
+                >
+                  {`View ${solePortfolio.name} holdings`}
+                </button>
+              </div>
+            ) : (
+              "No proposed transactions found. All caught up!"
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## What

\"Zen mode\" UX for users with a single portfolio / single broker — stop asking them to pick when there's only one choice, and make a brokerage's own cash account the settlement default.

- **Auto-select the sole portfolio** in pickers (Open Brokerage wizard + Trade Input). Derived during render (no setState-in-effect).
- **Proposed transactions empty state**: when the user has one active portfolio, offer a \"View {portfolio} holdings\" shortcut instead of a dead-end \"all caught up\".
- **Invest/trade auto-selects the sole broker** (create mode, ref-guarded to fire once so an explicit \"— No broker —\" choice sticks).
- **Settlement default**: opening a brokerage cash account now registers it as the broker's per-currency settlement account (PATCH /api/brokers, merging existing). A later trade through that broker settles to its own cash line (e.g. IB-USD) instead of generic CASH/USD. Runs in the shared onboarding path too — fixes the \"settled to generic USD\" report.

## Out of scope

- Zen vs Master as a **persisted** user preference — deferred. The \"1 active portfolio = zen\" heuristic drives the behavior above for now.

## Review fixes folded in

- Gated the portfolios fetch on the empty path (no fetch on the hot path).
- Memoized the selected existing-portfolio lookup (was repeated 4×).
- Broker auto-select ref-guarded so it can't re-fill a cleared field.

## Test

openBrokerage 25 + broader transactions/holdings/trns suites — 272 pass; typecheck, lint, prettier clean. Local high-effort review run; no Critical/Bug findings (only the perf/DRY cleanups above).

Includes one swept-in prettier-only reflow of an unrelated SubAccountTrnEditModal test (per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)