### PR TITLE
fix(invest-cash): settle into the broker's own cash account, not generic CASH/ccy

### DIFF
--- a/src/components/features/rebalance/execution/InvestCashDialog.tsx
+++ b/src/components/features/rebalance/execution/InvestCashDialog.tsx
@@ -3,7 +3,8 @@ import useSWR from "swr"
 import { useRouter } from "next/router"
 import Dialog from "@components/ui/Dialog"
 import Spinner from "@components/ui/Spinner"
-import { simpleFetcher } from "@utils/api/fetchHelper"
+import { simpleFetcher, accountsKey } from "@utils/api/fetchHelper"
+import { resolveBrokerCashAssetId } from "@utils/trns/tradeFormHelpers"
 import {
   parseShorthandAmount,
   hasShorthandSuffix,
@@ -14,7 +15,7 @@ import {
   ExecutionItemDto,
   PlanDto,
 } from "types/rebalance"
-import { Broker } from "types/beancounter"
+import { BrokerWithAccounts } from "types/beancounter"
 
 interface InvestCashDialogProps {
   modalOpen: boolean
@@ -66,12 +67,24 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
 
   const router = useRouter()
 
-  // Fetch brokers
+  // Fetch brokers (with settlement accounts) + the account assets, so the
+  // commit can route cash into the selected broker's own cash line.
   const { data: brokersData } = useSWR(
-    modalOpen ? "/api/brokers" : null,
-    simpleFetcher("/api/brokers"),
+    modalOpen ? "/api/brokers?includeAccounts=true" : null,
+    simpleFetcher("/api/brokers?includeAccounts=true"),
   )
-  const brokers: Broker[] = brokersData?.data || []
+  const brokers: BrokerWithAccounts[] = brokersData?.data || []
+  const { data: accountAssetsData } = useSWR(
+    modalOpen ? accountsKey : null,
+    simpleFetcher(accountsKey),
+  )
+  const accountAssets = useMemo(
+    () =>
+      accountAssetsData?.data
+        ? (Object.values(accountAssetsData.data) as any[])
+        : [],
+    [accountAssetsData],
+  )
 
   // Convenience: if the user has exactly one broker, pre-select it
   // when the dialog opens. Skip if user already chose (or cleared it).
@@ -238,6 +251,17 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
         }
       }
 
+      // Route settlement into the selected broker's own cash line (e.g.
+      // IBRK-USD) when resolvable; otherwise omit so the backend falls back
+      // to the generic CASH/{ccy} for the execution currency.
+      const cashAssetId =
+        resolveBrokerCashAssetId({
+          brokerId: selectedBrokerId,
+          currency: execution.currency,
+          brokers,
+          accountAssets,
+        }) ?? undefined
+
       // Commit to create transactions
       const response = await fetch(
         `/api/rebalance/executions/${execution.id}/commit`,
@@ -248,6 +272,7 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
             portfolioId: portfolioId,
             transactionStatus,
             brokerId: selectedBrokerId,
+            cashAssetId,
           }),
         },
       )

--- a/src/lib/utils/trns/tradeFormHelpers.test.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.test.ts
@@ -12,6 +12,7 @@ import {
   buildDefaultCashAsset,
   resolveBrokerSettlementAccount,
   brokerHasSettlementForCurrency,
+  resolveBrokerCashAssetId,
 } from "./tradeFormHelpers"
 import { Transaction } from "types/beancounter"
 
@@ -626,6 +627,78 @@ describe("tradeFormHelpers", () => {
         allBankAccounts,
       })
       expect(result).toBeNull()
+    })
+  })
+
+  describe("resolveBrokerCashAssetId", () => {
+    // IBRK has no explicit mapping (the real-world case for brokers created
+    // before settlement mappings existed); SCB has an explicit one.
+    const brokers = [
+      { id: "ibrk", name: "IBRK", settlementAccounts: [] },
+      {
+        id: "scb",
+        name: "SCB",
+        settlementAccounts: [{ currencyCode: "USD", accountId: "scb-usd-id" }],
+      },
+    ]
+    // Asset codes carry an owner-id prefix, as the API returns them.
+    const accountAssets = [
+      {
+        id: "ibrk-usd-id",
+        code: "2xstJu-9QzaiX_Ou1U2Ssw.IBRK-USD",
+        name: "IBRK USD",
+        market: { code: "PRIVATE" },
+      },
+      {
+        id: "scb-usd-id",
+        code: "2xstJu-9QzaiX_Ou1U2Ssw.SCB-USD",
+        name: "SCB USD Trade Account",
+        market: { code: "PRIVATE" },
+      },
+    ]
+
+    test("uses the explicit settlement mapping when present", () => {
+      expect(
+        resolveBrokerCashAssetId({
+          brokerId: "scb",
+          currency: "USD",
+          brokers: brokers as any,
+          accountAssets: accountAssets as any,
+        }),
+      ).toBe("scb-usd-id")
+    })
+
+    test("falls back to the broker's own {code}-{ccy} cash line by convention", () => {
+      expect(
+        resolveBrokerCashAssetId({
+          brokerId: "ibrk",
+          currency: "USD",
+          brokers: brokers as any,
+          accountAssets: accountAssets as any,
+        }),
+      ).toBe("ibrk-usd-id")
+    })
+
+    test("returns null when no broker selected", () => {
+      expect(
+        resolveBrokerCashAssetId({
+          brokerId: undefined,
+          currency: "USD",
+          brokers: brokers as any,
+          accountAssets: accountAssets as any,
+        }),
+      ).toBeNull()
+    })
+
+    test("returns null when no account matches the convention", () => {
+      expect(
+        resolveBrokerCashAssetId({
+          brokerId: "ibrk",
+          currency: "SGD", // no IBRK-SGD account exists
+          brokers: brokers as any,
+          accountAssets: accountAssets as any,
+        }),
+      ).toBeNull()
     })
   })
 

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -10,7 +10,8 @@ import {
   calculateNewPositionWeight,
   getAssetCurrency,
 } from "./tradeUtils"
-import { getDisplayCode } from "@lib/assets/assetUtils"
+import { getDisplayCode, stripOwnerPrefix } from "@lib/assets/assetUtils"
+import { deriveBrokerCode } from "@lib/openBrokerage/brokerCode"
 
 // --- Weight and position calculations ---
 
@@ -375,4 +376,39 @@ export const brokerHasSettlementForCurrency = (params: {
       (sa) => sa.currencyCode === tradeCurrency,
     ) ?? false
   )
+}
+
+/**
+ * Resolve the cash asset id to settle a broker's trade into, for a currency.
+ * Prefers the broker's explicit settlement mapping; otherwise falls back to
+ * the broker's own cash line by code convention (`{brokerCode}-{currency}`,
+ * a PRIVATE/ACCOUNT asset) so brokers created before settlement-mapping
+ * existed (or never configured) still route to their own cash, not a generic
+ * CASH/{ccy}. Returns null when neither resolves — caller should then let the
+ * backend pick its default. Asset codes carry an owner-id prefix, so match on
+ * the stripped code.
+ */
+export const resolveBrokerCashAssetId = (params: {
+  brokerId: string | undefined
+  currency: string
+  brokers: BrokerWithAccounts[]
+  accountAssets: AssetLike[]
+}): string | null => {
+  const { brokerId, currency, brokers, accountAssets } = params
+  if (!brokerId) return null
+  const broker = brokers.find((b) => b.id === brokerId)
+  if (!broker) return null
+
+  // 1. Explicit per-currency settlement mapping.
+  const mapped = broker.settlementAccounts?.find(
+    (sa) => sa.currencyCode === currency,
+  )?.accountId
+  if (mapped) return mapped
+
+  // 2. Convention: the broker's own {code}-{currency} cash line.
+  const brokerCode = deriveBrokerCode(broker.name)
+  if (!brokerCode) return null
+  const target = `${brokerCode}-${currency}`
+  const conv = accountAssets.find((a) => stripOwnerPrefix(a.code) === target)
+  return conv?.id ?? null
 }


### PR DESCRIPTION
## Problem

In the **Invest Cash** flow (rebalance `InvestCashDialog`), committing defaulted the cash settlement leg to generic `CASH/USD` ("USD Balance") instead of the selected broker's own cash line (e.g. `IBRK USD`). A simple trade works because TradeInputForm resolves the settlement asset on the frontend and submits it; the invest-cash commit sent only `brokerId` and let the backend pick — and svc-rebalance has no broker concept, so it always used generic `CASH/{ccy}`.

The commit endpoint already accepts an optional `cashAssetId` (`request.cashAssetId ?: generic`) — it's the designed override. The fix is to resolve and pass it from the client.

## Fix

- New `resolveBrokerCashAssetId(brokerId, currency, brokers, accountAssets)` in `tradeFormHelpers`: prefers the broker's explicit settlement mapping, else falls back to its own `{brokerCode}-{currency}` PRIVATE/ACCOUNT cash line by code convention (owner-prefix-aware). Returns null when neither resolves.
- `InvestCashDialog` fetches brokers `?includeAccounts=true` + ACCOUNT assets and passes the resolved `cashAssetId` in the commit body. When unresolved, omits it so the backend keeps its generic fallback.

The convention fallback matters because existing brokers (IBRK, DBS) have **empty** settlement mappings — only newly-created brokerages get one (PR #942). This routes them correctly without a data migration.

## Verified

- Unit tests for `resolveBrokerCashAssetId` (explicit mapping, convention fallback, no-broker, no-match) — 59 tests pass in the touched suites; typecheck/lint/prettier clean.
- Validated against live data (no transactions created): IBRK has no explicit mapping, but the convention resolves to the real "IBRK USD" asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)