### PR TITLE
fix(wealth): stop net-worth value flicker by gating render on holdings

### DIFF
--- a/src/pages/wealth.tsx
+++ b/src/pages/wealth.tsx
@@ -225,7 +225,12 @@ function WealthDashboard(): React.ReactElement {
     return errorOut("Error retrieving portfolios", portfolioError)
   }
 
-  if (portfolioLoading || !fxReady) {
+  // Wait for aggregated holdings too: customAssetTotals' double-count guard
+  // keys off portfolioAssetIds (derived from holdings). Rendering before
+  // holdings arrive counts a composite (e.g. CPF) that the portfolio already
+  // includes, so the headline value flickers high then corrects down once
+  // holdings load. Gating here renders the final value once.
+  if (portfolioLoading || !fxReady || holdingsLoading) {
     return rootLoader("Loading...")
   }
 


### PR DESCRIPTION
## Problem

On /wealth the headline Net Worth flickered high then dropped (~309k → 209k) on load.

## Cause

`customAssetTotals` (composite assets like CPF) uses a double-count guard keyed off `portfolioAssetIds`, which is derived from the **aggregated holdings**. The page rendered as soon as `portfolios` + FX were ready, but **not** holdings. With holdings still loading, `portfolioAssetIds` is empty → every composite's `parentInPortfolio` is false → its balance is added to the total (the high value). Once holdings arrive, `parentInPortfolio` becomes true and the composite (already counted inside `portfolio.marketValue`) is dropped — correcting the total downward. That correction is the flicker.

## Fix

Add `holdingsLoading` to the page's loading gate so the headline renders once, with the final reconciled value, instead of painting the over-counted figure first.

## Verified

Typecheck/lint/prettier clean. Rendered /wealth locally — loads straight to the final value (no intermediate). Slightly longer loader while aggregated holdings resolve, which is the intended trade-off ("render after the data is retrieved").

🤖 Generated with [Claude Code](https://claude.com/claude-code)