### PR TITLE
feat(onboarding): Zen/Master brokerage modes + default independence plan

### DIFF
--- a/__tests__/pages/independence/setup.test.tsx
+++ b/__tests__/pages/independence/setup.test.tsx
@@ -37,7 +37,7 @@ describe("/independence/setup", () => {
       screen.getByText(/set up your independence plan/i),
     ).toBeInTheDocument()
     expect(screen.getByText(/independence settings/i)).toBeInTheDocument()
-    expect(screen.getByText(/my work scenario/i)).toBeInTheDocument()
+    expect(screen.getByText(/working situation/i)).toBeInTheDocument()
   })
 
   test("shows date of birth and target age inputs", async () => {

--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -134,7 +134,7 @@ const OnboardingWizard: React.FC = () => {
 
   // Independence plan state
   const currentYear = new Date().getFullYear()
-  const [independencePlanEnabled, setIndependencePlanEnabled] = useState(false)
+  const [independencePlanEnabled, setIndependencePlanEnabled] = useState(true)
   const [independenceYearOfBirth, setIndependenceYearOfBirth] = useState(
     currentYear - 55,
   )
@@ -158,11 +158,11 @@ const OnboardingWizard: React.FC = () => {
   const [brokerageSource, setBrokerageSource] = useState<SourceValue>("")
   const [brokerageAmount, setBrokerageAmount] = useState("")
   const [brokerageCurrency, setBrokerageCurrency] = useState("")
-  // Portfolio choice for the brokerage — mirrors the standalone wizard so
-  // onboarding can also attach the brokerage to an existing portfolio.
+  // Zen vs Master for the brokerage. Default to Zen — attach to the default
+  // portfolio created during onboarding (the single-pot path). Master gives
+  // the brokerage its own dedicated portfolio + opening deposit.
   const [brokeragePortfolioMode, setBrokeragePortfolioMode] =
-    useState<PortfolioMode>("new")
-  const [brokerageExistingId, setBrokerageExistingId] = useState("")
+    useState<PortfolioMode>("existing")
   const [brokerageCreated, setBrokerageCreated] = useState(false)
 
   // Pre-fill fields from user preferences or Auth0 profile (render-phase
@@ -690,7 +690,7 @@ const OnboardingWizard: React.FC = () => {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              name: "My Work Scenario",
+              name: "Working Situation",
               currency: baseCurrency,
               workingIncomeMonthly,
               workingExpensesMonthly,
@@ -748,16 +748,10 @@ const OnboardingWizard: React.FC = () => {
       // Use the local `portfolioId` variable (set just above), not the
       // React state `createdPortfolioId` — setState hasn't flushed inside
       // the same async function call.
-      const brokerageExistingPortfolio =
-        brokeragePortfolioMode === "existing"
-          ? existingPortfolios.find((p) => p.id === brokerageExistingId)
-          : undefined
-      if (
-        brokerageEnabled &&
-        brokerageBrokerName.trim() &&
-        portfolioId &&
-        (brokeragePortfolioMode === "new" || !!brokerageExistingPortfolio)
-      ) {
+      // Zen Mode attaches the brokerage to the default portfolio just created
+      // above; Master Mode gives it a new dedicated portfolio.
+      const isZen = brokeragePortfolioMode === "existing"
+      if (brokerageEnabled && brokerageBrokerName.trim() && portfolioId) {
         const amt = parseFloat(brokerageAmount)
         try {
           // Brokerage gets its own dedicated portfolio (named after the
@@ -770,31 +764,36 @@ const OnboardingWizard: React.FC = () => {
           // Abbreviated code (Interactive Brokers → IB) for the portfolio
           // code; the display name keeps the full broker name.
           const brokerCode = deriveBrokerCode(brokerName)
-          // Reporting currency for the brokerage portfolio. User-picked in
-          // step 7; falls back to baseCurrency if they didn't touch the
-          // dropdown. `base` stays as the user's overall base currency for
-          // consolidated reporting upstream.
-          const brokerageCcy = brokerageExistingPortfolio
-            ? (brokerageExistingPortfolio.currency?.code ?? brokerageCurrency)
-            : brokerageCurrency || baseCurrency
+          // Currency the user picked next to the broker name (step 6); falls
+          // back to baseCurrency if untouched. Drives the brokerage cash
+          // account code ({brokerCode}-{ccy}). `base` stays the user's overall
+          // base currency for consolidated reporting upstream.
+          const brokerageCcy = brokerageCurrency || baseCurrency
+          // Portfolio code used for the brokerage — Zen reuses the default
+          // portfolio's code, Master coins a new one from the broker. Drives
+          // both the openBrokerage payload and the post-create valuation fetch
+          // below so the two can't drift.
+          const usedPortfolioCode = isZen ? portfolioCode : brokerCode
           const brokerageResult = await openBrokerage({
             broker: { mode: "new", newName: brokerName },
-            portfolio: brokerageExistingPortfolio
+            portfolio: isZen
               ? {
                   mode: "existing",
-                  existingId: brokerageExistingPortfolio.id,
-                  code: brokerageExistingPortfolio.code,
+                  existingId: portfolioId,
+                  code: usedPortfolioCode,
                   currency: brokerageCcy,
                 }
               : {
                   mode: "new",
-                  code: brokerCode,
+                  code: usedPortfolioCode,
                   name: `${brokerName} Portfolio`,
                   currency: brokerageCcy,
                   base: baseCurrency,
                 },
+            // Opening deposit + source are Master-only (the Zen step hides
+            // them), so only build funding for the new-portfolio path.
             funding:
-              Number.isFinite(amt) && amt > 0
+              !isZen && Number.isFinite(amt) && amt > 0
                 ? (() => {
                     const fund: {
                       amount: number
@@ -827,7 +826,7 @@ const OnboardingWizard: React.FC = () => {
           // portfolios list shows it with no market value until the user
           // opens it.
           try {
-            const valuationCode = brokerageExistingPortfolio?.code ?? brokerCode
+            const valuationCode = usedPortfolioCode
             await fetch(`/api/holdings/${valuationCode}?asAt=${today}`, {
               credentials: "include",
             })
@@ -953,36 +952,18 @@ const OnboardingWizard: React.FC = () => {
             bankAccounts={bankAccounts}
             defaultPortfolioName={portfolioName}
             portfolioMode={brokeragePortfolioMode}
-            existingPortfolioId={brokerageExistingId}
             onEnabledChange={setBrokerageEnabled}
             onBrokerNameChange={setBrokerageBrokerName}
             onSourceChange={setBrokerageSource}
             onAmountChange={setBrokerageAmount}
-            onCurrencyChange={setBrokerageCurrency}
-            onPortfolioModeChange={(mode) => {
-              setBrokeragePortfolioMode(mode)
-              // Re-sync currency to the still-selected existing portfolio so a
-              // currency changed while in "new" mode can't leave the source
-              // filter / deposit on a stale currency.
-              if (mode === "existing" && brokerageExistingId) {
-                const pf = existingPortfolios.find(
-                  (p) => p.id === brokerageExistingId,
-                )
-                const nextCurrency = pf?.currency?.code
-                if (nextCurrency && nextCurrency !== brokerageCurrency) {
-                  setBrokerageCurrency(nextCurrency)
-                  setBrokerageSource("")
-                }
-              }
+            onCurrencyChange={(c) => {
+              setBrokerageCurrency(c)
+              // The source dropdown filters to same-currency options, so a
+              // previously-picked source no longer matches — clear it to avoid
+              // a stale cross-currency WITHDRAWAL against the wrong line.
+              setBrokerageSource("")
             }}
-            onExistingPortfolioChange={(id) => {
-              setBrokerageExistingId(id)
-              // Sync the brokerage currency to the chosen portfolio so the
-              // source filter + deposit stay same-currency (mirrors the
-              // standalone wizard).
-              const pf = existingPortfolios.find((p) => p.id === id)
-              if (pf?.currency?.code) setBrokerageCurrency(pf.currency.code)
-            }}
+            onPortfolioModeChange={setBrokeragePortfolioMode}
           />
         )
       case 7:
@@ -1016,17 +997,17 @@ const OnboardingWizard: React.FC = () => {
       title: "Set your currencies",
       lead: "Base currency tracks costs; reporting currency displays values. Default to the same one — they can differ.",
     },
-    4: {
+    3: {
       title: "Add your accounts",
       lead: "Tell us about your assets to get a complete picture of your wealth. Optional.",
     },
-    6: {
+    5: {
       title: "Quick Independence Check",
       lead: "Want to see how your finances might look in retirement? Just three quick questions.",
     },
-    7: {
+    6: {
       title: "Brokerage account",
-      lead: "Optional — set up a broker, a brokerage portfolio, and your opening cash deposit.",
+      lead: "Optional — set up a broker, attach it to a portfolio, and add an opening cash deposit.",
     },
   }
   const intro = stepIntro[currentStep]

--- a/src/components/features/onboarding/steps/BrokerageStep.tsx
+++ b/src/components/features/onboarding/steps/BrokerageStep.tsx
@@ -4,6 +4,10 @@ import MathInput from "@components/ui/MathInput"
 import PortfolioModeChooser, {
   type PortfolioMode,
 } from "@components/features/openBrokerage/PortfolioModeChooser"
+import {
+  deriveBrokerCode,
+  brokerCashAssetCode,
+} from "@lib/openBrokerage/brokerCode"
 import type { Portfolio } from "types/beancounter"
 import type { BankAccount } from "../OnboardingWizard"
 
@@ -38,17 +42,17 @@ export interface BrokerageStepProps {
   // bank-account line on the default portfolio.
   bankAccounts: BankAccount[]
   defaultPortfolioName: string
-  // Portfolio choice — same new-vs-existing decision as the standalone
-  // /tools/open-brokerage wizard, so onboarding behaves identically.
+  // Zen vs Master — same decision as the standalone /tools/open-brokerage
+  // wizard. Zen attaches to the user's main (default) portfolio; Master gives
+  // the brokerage its own dedicated portfolio. Opening deposit + source are
+  // Master-only — Zen is the lightweight "just register the broker" path.
   portfolioMode: PortfolioMode
-  existingPortfolioId: string
   onEnabledChange: (v: boolean) => void
   onBrokerNameChange: (v: string) => void
   onSourceChange: (v: SourceValue) => void
   onAmountChange: (v: string) => void
   onCurrencyChange: (v: string) => void
   onPortfolioModeChange: (v: PortfolioMode) => void
-  onExistingPortfolioChange: (id: string) => void
 }
 
 /**
@@ -68,14 +72,12 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
   bankAccounts,
   defaultPortfolioName,
   portfolioMode,
-  existingPortfolioId,
   onEnabledChange,
   onBrokerNameChange,
   onSourceChange,
   onAmountChange,
   onCurrencyChange,
   onPortfolioModeChange,
-  onExistingPortfolioChange,
 }) => {
   // Filter source options to the chosen currency (same-currency v1).
   const sameCurrencyPortfolios = existingPortfolios.filter(
@@ -93,6 +95,10 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
   const showFxNotice =
     sameCurrencyBankAccounts.length === 0 &&
     otherCurrencyBankAccounts.length > 0
+  // Abbreviated broker code (Interactive Brokers → IB) shown live so the user
+  // sees the code and the resulting cash-account name ({code}-{ccy}) they'll
+  // get before submitting.
+  const brokerCode = deriveBrokerCode(brokerName)
   return (
     <div className="py-2">
       <p className="text-gray-500 text-xs mb-3">
@@ -119,66 +125,31 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
 
       {enabled && (
         <div className="space-y-3 max-w-md">
-          <div>
-            <label
-              htmlFor="ob-broker"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              {"Broker name"}
-            </label>
-            <input
-              id="ob-broker"
-              type="text"
-              value={brokerName}
-              onChange={(e) => onBrokerNameChange(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
-              placeholder="e.g. IBRK"
-            />
-            {portfolioMode === "new" && (
-              <p className="text-xs text-gray-500 mt-1">
-                {`A new portfolio "${brokerName || "BROKER"} Portfolio" will be created for your brokerage, keeping its cash and trades separate from your "${defaultPortfolioName}" bank-account portfolio.`}
-              </p>
-            )}
-          </div>
-
-          <PortfolioModeChooser
-            mode={portfolioMode}
-            onSelect={onPortfolioModeChange}
-            existingDisabled={existingPortfolios.length === 0}
-          />
-
-          {portfolioMode === "existing" ? (
-            <div>
+          {/* Broker name + default currency sit side by side: the currency
+              drives the brokerage cash-account code ({broker.code}-{ccy}). */}
+          <div className="flex gap-3">
+            <div className="flex-1">
               <label
-                htmlFor="ob-existing"
+                htmlFor="ob-broker"
                 className="block text-sm font-medium text-gray-700 mb-1"
               >
-                {"Existing portfolio"}
+                {"Broker name"}
               </label>
-              <select
-                id="ob-existing"
-                value={existingPortfolioId}
-                onChange={(e) => onExistingPortfolioChange(e.target.value)}
+              <input
+                id="ob-broker"
+                type="text"
+                value={brokerName}
+                onChange={(e) => onBrokerNameChange(e.target.value)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md"
-              >
-                <option value="">— Select —</option>
-                {existingPortfolios.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name} ({p.code}, {p.currency?.code})
-                  </option>
-                ))}
-              </select>
-              <p className="text-xs text-gray-500 mt-1">
-                {`The brokerage's cash lands on a per-broker line (e.g. ${brokerName || "BROKER"}-${currency}) so it stays separate from any existing cash on this portfolio.`}
-              </p>
+                placeholder="e.g. Interactive Brokers"
+              />
             </div>
-          ) : (
-            <div>
+            <div className="w-28">
               <label
                 htmlFor="ob-currency"
                 className="block text-sm font-medium text-gray-700 mb-1"
               >
-                {"Default Currency"}
+                {"Currency"}
               </label>
               <select
                 id="ob-currency"
@@ -192,78 +163,128 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
                   </option>
                 ))}
               </select>
-              <p className="text-xs text-gray-500 mt-1">
-                {`Cash and trades in this brokerage portfolio will report in ${currency}. Picking a different currency from the bank-account source needs FX (not handled in v1 — same-currency source only).`}
-              </p>
             </div>
+          </div>
+
+          {brokerName.trim() && (
+            <p className="text-xs text-gray-500">
+              {"Brokerage code "}
+              <span className="font-mono font-medium text-gray-700">
+                {brokerCode}
+              </span>
+              {" · cash account "}
+              <span className="font-mono font-medium text-gray-700">
+                {brokerCashAssetCode(brokerCode, currency)}
+              </span>
+            </p>
           )}
 
-          <div>
-            <label
-              htmlFor="ob-amount"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              {`Opening deposit (${currency})`}
-            </label>
-            <MathInput
-              id="ob-amount"
-              value={amount}
-              onChange={(v) => onAmountChange(v === 0 ? "" : String(v))}
-              min={0}
-              placeholder="0"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
-            />
-          </div>
+          <PortfolioModeChooser
+            mode={portfolioMode}
+            onSelect={onPortfolioModeChange}
+            existingDisabled={false}
+          />
 
-          <div>
-            <label
-              htmlFor="ob-source"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              {"Source (optional)"}
-            </label>
-            {showFxNotice && (
-              <div className="mb-2 px-3 py-2 rounded bg-amber-50 border border-amber-200 text-xs text-amber-800">
-                {`You have bank accounts in ${otherCurrencyBankAccounts
-                  .map((b) => b.currency)
-                  .filter((c, i, a) => a.indexOf(c) === i)
-                  .join(
-                    ", ",
-                  )} but the brokerage currency is ${currency}. Cross-currency funding (FX) isn't supported yet — the opening deposit will be recorded as a standalone cash injection on the new portfolio with no matching withdrawal.`}
-              </div>
-            )}
-            <select
-              id="ob-source"
-              value={source}
-              onChange={(e) => onSourceChange(e.target.value as SourceValue)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
-            >
-              <option value="">— None (standalone deposit) —</option>
-              {sameCurrencyBankAccounts.length > 0 && (
-                <optgroup label={`Bank accounts on "${defaultPortfolioName}"`}>
-                  {sameCurrencyBankAccounts.map((b) => (
-                    <option key={`b-${b.name}`} value={`bankAccount:${b.name}`}>
-                      {b.name}
-                    </option>
-                  ))}
-                </optgroup>
-              )}
-              {sameCurrencyPortfolios.length > 0 && (
-                <optgroup label="Other portfolios">
-                  {sameCurrencyPortfolios.map((p) => (
-                    <option key={`p-${p.id}`} value={`portfolio:${p.id}`}>
-                      {p.name} ({p.code})
-                    </option>
-                  ))}
-                </optgroup>
-              )}
-            </select>
-            <p className="text-xs text-gray-500 mt-1">
-              {
-                "Picking a source posts a matching withdrawal so the source's cash stays accurate."
-              }
+          {portfolioMode === "existing" ? (
+            <p className="text-xs text-gray-500">
+              {`Attaches to your main portfolio ("${defaultPortfolioName}"). Trades settle to a per-broker cash line (${brokerCashAssetCode(brokerCode || "BROKER", currency)}). Want a dedicated portfolio or an opening deposit now? Switch to Master Mode.`}
             </p>
-          </div>
+          ) : (
+            <>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm">
+                <p className="text-gray-500">{"New portfolio"}</p>
+                {brokerName.trim() ? (
+                  <p className="font-medium text-gray-900">
+                    {`${brokerName} Portfolio`}
+                    <span className="ml-1 font-normal text-gray-500">
+                      {`(code ${brokerCode})`}
+                    </span>
+                  </p>
+                ) : (
+                  <p className="text-gray-400">
+                    {"Name your broker first — the portfolio takes its name."}
+                  </p>
+                )}
+                <p className="text-gray-500 mt-1">
+                  {`Kept separate from your "${defaultPortfolioName}" portfolio so its cash and trades stand on their own.`}
+                </p>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="ob-amount"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  {`Opening deposit (${currency})`}
+                </label>
+                <MathInput
+                  id="ob-amount"
+                  value={amount}
+                  onChange={(v) => onAmountChange(v === 0 ? "" : String(v))}
+                  min={0}
+                  placeholder="0"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="ob-source"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  {"Source (optional)"}
+                </label>
+                {showFxNotice && (
+                  <div className="mb-2 px-3 py-2 rounded bg-amber-50 border border-amber-200 text-xs text-amber-800">
+                    {`You have bank accounts in ${otherCurrencyBankAccounts
+                      .map((b) => b.currency)
+                      .filter((c, i, a) => a.indexOf(c) === i)
+                      .join(
+                        ", ",
+                      )} but the brokerage currency is ${currency}. Cross-currency funding (FX) isn't supported yet — the opening deposit will be recorded as a standalone cash injection on the new portfolio with no matching withdrawal.`}
+                  </div>
+                )}
+                <select
+                  id="ob-source"
+                  value={source}
+                  onChange={(e) =>
+                    onSourceChange(e.target.value as SourceValue)
+                  }
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                >
+                  <option value="">— None (standalone deposit) —</option>
+                  {sameCurrencyBankAccounts.length > 0 && (
+                    <optgroup
+                      label={`Bank accounts on "${defaultPortfolioName}"`}
+                    >
+                      {sameCurrencyBankAccounts.map((b) => (
+                        <option
+                          key={`b-${b.name}`}
+                          value={`bankAccount:${b.name}`}
+                        >
+                          {b.name}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )}
+                  {sameCurrencyPortfolios.length > 0 && (
+                    <optgroup label="Other portfolios">
+                      {sameCurrencyPortfolios.map((p) => (
+                        <option key={`p-${p.id}`} value={`portfolio:${p.id}`}>
+                          {p.name} ({p.code})
+                        </option>
+                      ))}
+                    </optgroup>
+                  )}
+                </select>
+                <p className="text-xs text-gray-500 mt-1">
+                  {
+                    "Picking a source posts a matching withdrawal so the source's cash stays accurate."
+                  }
+                </p>
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/components/features/onboarding/steps/IndependencePlanStep.tsx
+++ b/src/components/features/onboarding/steps/IndependencePlanStep.tsx
@@ -222,10 +222,10 @@ const IndependencePlanStep: React.FC<IndependencePlanStepProps> = ({
             </div>
           </div>
 
-          {/* Section 2: My Work Scenario */}
+          {/* Section 2: Working Situation */}
           <div className="bg-gray-50 rounded-lg p-6 space-y-4">
             <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
-              {"My Work Scenario"}
+              {"Working Situation"}
             </h3>
             <p className="text-xs text-gray-500">
               {

--- a/src/components/features/onboarding/steps/__tests__/BrokerageStep.test.tsx
+++ b/src/components/features/onboarding/steps/__tests__/BrokerageStep.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import BrokerageStep from "../BrokerageStep"
 import type { BrokerageStepProps } from "../BrokerageStep"
@@ -25,14 +25,12 @@ const baseProps: BrokerageStepProps = {
   bankAccounts: [],
   defaultPortfolioName: "Cash",
   portfolioMode: "new",
-  existingPortfolioId: "",
   onEnabledChange: jest.fn(),
   onBrokerNameChange: jest.fn(),
   onSourceChange: jest.fn(),
   onAmountChange: jest.fn(),
   onCurrencyChange: jest.fn(),
   onPortfolioModeChange: jest.fn(),
-  onExistingPortfolioChange: jest.fn(),
 }
 
 const renderStep = (overrides: Partial<BrokerageStepProps> = {}): void => {
@@ -40,36 +38,40 @@ const renderStep = (overrides: Partial<BrokerageStepProps> = {}): void => {
 }
 
 describe("BrokerageStep portfolio choice", () => {
-  it("new mode shows the currency picker, not the existing-portfolio selector", () => {
+  it("shows the currency picker next to the broker name in both modes", () => {
     renderStep({ portfolioMode: "new" })
-    expect(screen.getByLabelText("Default Currency")).toBeInTheDocument()
+    expect(screen.getByLabelText("Currency")).toBeInTheDocument()
+    expect(screen.getByLabelText("Broker name")).toBeInTheDocument()
+    // Shared chooser offers Zen + Master.
     expect(
-      screen.queryByLabelText("Existing portfolio"),
-    ).not.toBeInTheDocument()
-    // Shared chooser is present.
-    expect(
-      screen.getByRole("radio", {
-        name: /Create a new portfolio for this brokerage/i,
-      }),
+      screen.getByRole("radio", { name: /Master Mode/i }),
     ).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: /Zen Mode/i })).toBeInTheDocument()
   })
 
-  it("existing mode shows the existing-portfolio selector, not the currency picker", () => {
-    renderStep({ portfolioMode: "existing" })
-    const select = screen.getByLabelText("Existing portfolio")
-    expect(select).toBeInTheDocument()
+  it("surfaces the computed brokerage code and cash-account name", () => {
+    renderStep({ brokerName: "Interactive Brokers", currency: "USD" })
+    // deriveBrokerCode("Interactive Brokers") === "IB"
+    expect(screen.getByText("IB")).toBeInTheDocument()
+    expect(screen.getByText("IB-USD")).toBeInTheDocument()
+  })
+
+  it("new (Master) mode shows the new-portfolio box plus opening deposit + source", () => {
+    renderStep({ portfolioMode: "new", brokerName: "Interactive Brokers" })
     expect(
-      Array.from(select.querySelectorAll("option")).map((o) => o.textContent),
-    ).toContain("Main (MAIN, SGD)")
-    expect(screen.queryByLabelText("Default Currency")).not.toBeInTheDocument()
+      screen.getByText("Interactive Brokers Portfolio"),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText(/Opening deposit/i)).toBeInTheDocument()
+    expect(screen.getByLabelText("Source (optional)")).toBeInTheDocument()
   })
 
-  it("selecting the existing portfolio reports its id", () => {
-    const onExistingPortfolioChange = jest.fn()
-    renderStep({ portfolioMode: "existing", onExistingPortfolioChange })
-    fireEvent.change(screen.getByLabelText("Existing portfolio"), {
-      target: { value: "pf-1" },
-    })
-    expect(onExistingPortfolioChange).toHaveBeenCalledWith("pf-1")
+  it("existing (Zen) mode hides deposit + source and shows the attach note", () => {
+    renderStep({ portfolioMode: "existing", brokerName: "Interactive Brokers" })
+    expect(screen.queryByLabelText(/Opening deposit/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Source (optional)")).not.toBeInTheDocument()
+    // Zen attaches to the user's main portfolio — no portfolio picker.
+    expect(
+      screen.getByText(/attaches to your main portfolio/i),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -5,10 +5,14 @@ import {
   type OpenBrokerageResult,
 } from "@lib/openBrokerage/orchestrate"
 import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
-import PortfolioModeChooser from "@components/features/openBrokerage/PortfolioModeChooser"
 import DecimalInput from "@components/ui/DecimalInput"
 import { deriveBrokerCode } from "@lib/openBrokerage/brokerCode"
-import { solePortfolioId } from "@lib/user/zenMode"
+import {
+  deriveZenModeFromPreferences,
+  solePortfolio,
+  solePortfolioId,
+} from "@lib/user/zenMode"
+import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import type { Broker, Currency, Portfolio } from "types/beancounter"
 
 type Step = "broker" | "portfolio" | "funding" | "review" | "done"
@@ -95,12 +99,15 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     newAccountNumber: "",
   })
   const [portfolio, setPortfolio] = useState<PortfolioState>({
-    mode: "new",
+    // Master users toggle this; for Zen users the effective mode is derived
+    // from their posture (see effMode below), so this is just the Master
+    // default — attach to an existing portfolio.
+    mode: "existing",
     currency: "USD",
     existingId: "",
   })
-  // Currency accounts the user flags to open + fund. Seeded with the
-  // portfolio's default currency on entry to the funding step.
+  // Currency accounts the user flags to open + fund. Starts empty — nothing is
+  // opened until the user explicitly adds a currency on the funding step.
   const [fundingRows, setFundingRows] = useState<FundingRow[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -121,30 +128,48 @@ export default function OpenBrokerageWizard(): React.ReactElement {
   const brokers = useMemo(() => brokersData?.data ?? [], [brokersData])
   const portfolios = useMemo(() => portfoliosData?.data ?? [], [portfoliosData])
 
-  // Auto-select when there's only one portfolio to pick — nothing to choose,
-  // so treat the lone portfolio as the selection. Derived during render (not
-  // stored via an effect) so it can't trigger cascading renders; an explicit
-  // pick still wins. In attach mode the brokerage currency follows the chosen
-  // portfolio, so a new-mode currency choice is never clobbered.
+  const { preferences } = useUserPreferences()
+
+  // The user's existing posture decides how the brokerage attaches:
+  //  • Zen user with a sole portfolio   → fold into it, no chooser.
+  //  • Zen user with no portfolio yet   → create their first one, coded/named
+  //    after the broker (stays single-pot).
+  //  • Master user (several portfolios) → plain attach-existing / create-new
+  //    toggle, without the Zen/Master framing.
+  const zen = deriveZenModeFromPreferences(portfolios.length, preferences)
+  const sole = solePortfolio(portfolios)
+  const masterUser = !zen
+
+  // Auto-select the sole portfolio for attach mode; an explicit pick wins.
   const existingId = portfolio.existingId || solePortfolioId(portfolios)
   const selectedExistingPortfolio = useMemo(
     () => portfolios.find((p) => p.id === existingId),
     [portfolios, existingId],
   )
-  const existingCurrency =
-    selectedExistingPortfolio?.currency?.code ?? portfolio.currency
-  const effectiveCurrency =
-    portfolio.mode === "existing" ? existingCurrency : portfolio.currency
 
-  // The new brokerage portfolio takes its identity from the broker: code is
-  // the abbreviated broker code (Interactive Brokers → IB), the display name
-  // appends "Portfolio". Mirrors the onboarding flow so the two surfaces match.
+  // The new brokerage portfolio takes its identity from the broker: code is the
+  // abbreviated broker code (Interactive Brokers → IB). Master mode appends
+  // "Portfolio"; a zero-portfolio Zen user's first portfolio is named after the
+  // broker outright.
   const brokerName =
     broker.mode === "new"
       ? broker.newName.trim()
       : (brokers.find((b) => b.id === broker.existingId)?.name ?? "")
   const derivedCode = deriveBrokerCode(brokerName)
   const derivedName = brokerName ? `${brokerName} Portfolio` : ""
+
+  // Effective portfolio decision after applying the zen posture. Zen+sole folds
+  // into the lone portfolio; Zen+none creates the first portfolio; Master lets
+  // the user toggle existing-vs-new.
+  const effMode: "existing" | "new" =
+    zen && sole ? "existing" : zen && !sole ? "new" : portfolio.mode
+  const newPortfolioName = zen && !sole ? brokerName : derivedName
+
+  const existingCurrency =
+    selectedExistingPortfolio?.currency?.code ?? portfolio.currency
+  const effectiveCurrency =
+    effMode === "existing" ? existingCurrency : portfolio.currency
+
   const currencyCodes = useMemo(() => {
     const codes = currenciesData?.data?.map((c) => c.code)
     return codes && codes.length > 0 ? codes : FALLBACK_CURRENCIES
@@ -155,36 +180,19 @@ export default function OpenBrokerageWizard(): React.ReactElement {
       ? !!broker.existingId
       : broker.newName.trim().length > 0
   const portfolioValid =
-    portfolio.mode === "existing" ? !!existingId : derivedCode.length > 0
+    effMode === "existing" ? !!existingId : derivedCode.length > 0
 
   const back = (): void => {
     const i = STEP_ORDER.indexOf(step as Exclude<Step, "done">)
     if (i > 0) setStep(STEP_ORDER[i - 1])
   }
 
-  // Seed the funding step with the portfolio's default currency the first
-  // time the user lands on it, so there's always one account ready to fund.
-  const seedFundingRows = (): void => {
-    setFundingRows((rows) => {
-      // Re-seed when there's nothing yet, or when the only row is the lone
-      // untouched default — so changing the portfolio currency (then returning
-      // to funding) refreshes that single row instead of leaving it stale.
-      // Once the user has added a second currency or typed an amount, their
-      // selection is preserved as-is (a deliberate multi-currency choice must
-      // survive a Back/Next round-trip, even when every row is zero-balance).
-      const onlyUntouchedDefault = rows.length === 1 && !rows[0].amount
-      return rows.length === 0 || onlyUntouchedDefault
-        ? [{ currency: effectiveCurrency, amount: 0 }]
-        : rows
-    })
-  }
-
   const advance = (): void => {
     const i = STEP_ORDER.indexOf(step as Exclude<Step, "done">)
     if (i < STEP_ORDER.length - 1) {
-      const next = STEP_ORDER[i + 1]
-      if (next === "funding") seedFundingRows()
-      setStep(next)
+      // No cash account is seeded — the funding step opens empty and the user
+      // explicitly adds each currency they want via "Add a currency account".
+      setStep(STEP_ORDER[i + 1])
     }
   }
 
@@ -216,9 +224,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
     setError(null)
     try {
       const existingCode =
-        portfolio.mode === "existing"
-          ? (selectedExistingPortfolio?.code ?? "")
-          : ""
+        effMode === "existing" ? (selectedExistingPortfolio?.code ?? "") : ""
       const res = await openBrokerage({
         broker: {
           mode: broker.mode,
@@ -227,7 +233,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
           newAccountNumber: broker.newAccountNumber || undefined,
         },
         portfolio:
-          portfolio.mode === "existing"
+          effMode === "existing"
             ? {
                 mode: "existing",
                 existingId,
@@ -237,7 +243,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
             : {
                 mode: "new",
                 code: derivedCode,
-                name: derivedName,
+                name: newPortfolioName,
                 currency: portfolio.currency,
                 base: portfolio.currency,
               },
@@ -261,7 +267,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
           {"Done — brokerage opened"}
         </h1>
         <p className="text-gray-600 mb-6">
-          {`Portfolio ${portfolio.mode === "existing" ? (selectedExistingPortfolio?.code ?? "") : derivedCode} ready. `}
+          {`Portfolio ${effMode === "existing" ? (selectedExistingPortfolio?.code ?? "") : derivedCode} ready. `}
           {result?.accountIds.length
             ? `${result.accountIds.length} currency account(s) opened. `
             : ""}
@@ -387,80 +393,124 @@ export default function OpenBrokerageWizard(): React.ReactElement {
 
       {step === "portfolio" && (
         <div className="space-y-6">
-          <PortfolioModeChooser
-            mode={portfolio.mode}
-            onSelect={(mode) => setPortfolio((prev) => ({ ...prev, mode }))}
-            existingDisabled={portfolios.length === 0}
-          />
+          {masterUser ? (
+            // Master user: plain attach-vs-create toggle, no Zen/Master cards.
+            <fieldset className="space-y-3">
+              <legend className="text-sm text-gray-700 mb-1">
+                {"How would you like to track this brokerage?"}
+              </legend>
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="pf-mode"
+                  checked={portfolio.mode === "existing"}
+                  onChange={() =>
+                    setPortfolio((prev) => ({ ...prev, mode: "existing" }))
+                  }
+                />
+                <span>Attach to an existing portfolio</span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="pf-mode"
+                  checked={portfolio.mode === "new"}
+                  onChange={() =>
+                    setPortfolio((prev) => ({ ...prev, mode: "new" }))
+                  }
+                />
+                <span>Create a new portfolio</span>
+              </label>
+            </fieldset>
+          ) : effMode === "existing" ? (
+            // Zen user with a sole portfolio: fold in, no chooser.
+            <p className="text-sm text-gray-600">
+              {`This brokerage folds into your portfolio "${sole?.name ?? ""}" — one combined view. Its cash lands on a per-broker line (${derivedCode || "BROKER"}-${effectiveCurrency}).`}
+            </p>
+          ) : (
+            // Zen user with no portfolio yet: create their first, named after
+            // the broker.
+            <p className="text-sm text-gray-600">
+              {`We'll create your "${brokerName || "broker"}" portfolio to hold this brokerage. Pick its currency below.`}
+            </p>
+          )}
 
           <div className="space-y-4 pt-4 border-t border-gray-100">
-            {portfolio.mode === "existing" ? (
-              <div>
-                <label
-                  htmlFor="pf-existing"
-                  className="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  {"Existing portfolio"}
-                </label>
-                <select
-                  id="pf-existing"
-                  value={existingId}
-                  onChange={(e) =>
-                    setPortfolio({ ...portfolio, existingId: e.target.value })
-                  }
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                >
-                  <option value="">— Select —</option>
-                  {portfolios.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name} ({p.code}, {p.currency?.code})
-                    </option>
-                  ))}
-                </select>
-                <p className="text-xs text-gray-500 mt-1">
-                  {`Deposits will land on a per-broker cash line (e.g. ${broker.newName || "BROKER"}-${effectiveCurrency}) so the brokerage cash stays separate from any existing cash on this portfolio.`}
-                </p>
-              </div>
+            {effMode === "existing" ? (
+              masterUser && (
+                <div>
+                  <label
+                    htmlFor="pf-existing"
+                    className="block text-sm font-medium text-gray-700 mb-1"
+                  >
+                    {"Existing portfolio"}
+                  </label>
+                  <select
+                    id="pf-existing"
+                    value={existingId}
+                    onChange={(e) =>
+                      setPortfolio({
+                        ...portfolio,
+                        existingId: e.target.value,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  >
+                    <option value="">— Select —</option>
+                    {portfolios.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.name} ({p.code}, {p.currency?.code})
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-gray-500 mt-1">
+                    {`Deposits land on a per-broker cash line (e.g. ${derivedCode || "BROKER"}-${effectiveCurrency}) so the brokerage cash stays separate from any existing cash on this portfolio.`}
+                  </p>
+                </div>
+              )
             ) : (
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm">
-                <p className="text-gray-500">New portfolio</p>
-                {derivedCode ? (
-                  <p className="font-medium text-gray-900">
-                    {derivedName}
-                    <span className="ml-1 font-normal text-gray-500">
-                      {`(code ${derivedCode})`}
-                    </span>
-                  </p>
-                ) : (
-                  <p className="text-gray-400">
-                    Name your broker first — the portfolio takes its name.
-                  </p>
-                )}
-              </div>
-            )}
-            {portfolio.mode === "new" && (
-              <div>
-                <label
-                  htmlFor="pf-ccy"
-                  className="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  {"Default Currency"}
-                </label>
-                <select
-                  id="pf-ccy"
-                  value={portfolio.currency}
-                  onChange={(e) =>
-                    setPortfolio({ ...portfolio, currency: e.target.value })
-                  }
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                >
-                  {currencyCodes.map((c) => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <>
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm">
+                  <p className="text-gray-500">New portfolio</p>
+                  {derivedCode ? (
+                    <p className="font-medium text-gray-900">
+                      {newPortfolioName}
+                      <span className="ml-1 font-normal text-gray-500">
+                        {`(code ${derivedCode})`}
+                      </span>
+                    </p>
+                  ) : (
+                    <p className="text-gray-400">
+                      Name your broker first — the portfolio takes its name.
+                    </p>
+                  )}
+                </div>
+                <div>
+                  <label
+                    htmlFor="pf-ccy"
+                    className="block text-sm font-medium text-gray-700 mb-1"
+                  >
+                    {"Default Currency"}
+                  </label>
+                  <select
+                    id="pf-ccy"
+                    value={portfolio.currency}
+                    onChange={(e) =>
+                      setPortfolio({
+                        ...portfolio,
+                        currency: e.target.value,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  >
+                    {currencyCodes.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </>
             )}
           </div>
         </div>
@@ -470,7 +520,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
             {
-              "Open a cash account for each currency you'll hold in this brokerage. Accounts open even with a zero balance — add an opening deposit if you want to seed cash now. Remove any you don't need."
+              "Add a cash account for each currency you'll hold in this brokerage. Nothing is opened by default — add only what you need, with an optional opening deposit to seed cash now."
             }
           </p>
 
@@ -518,7 +568,9 @@ export default function OpenBrokerageWizard(): React.ReactElement {
                 htmlFor="fund-add-ccy"
                 className="block text-sm font-medium text-gray-700 mb-1"
               >
-                {"Add another currency account"}
+                {fundingRows.length === 0
+                  ? "Add a currency account"
+                  : "Add another currency account"}
               </label>
               <select
                 id="fund-add-ccy"
@@ -553,9 +605,9 @@ export default function OpenBrokerageWizard(): React.ReactElement {
               </dd>
               <dt className="text-gray-500">Portfolio</dt>
               <dd className="col-span-2 text-gray-900">
-                {portfolio.mode === "existing"
+                {effMode === "existing"
                   ? `${selectedExistingPortfolio?.name ?? "?"} (existing, ${effectiveCurrency})`
-                  : `${derivedCode} — ${derivedName} (new, ${portfolio.currency})`}
+                  : `${derivedCode} — ${newPortfolioName} (new, ${portfolio.currency})`}
               </dd>
               <dt className="text-gray-500">Accounts</dt>
               <dd className="col-span-2 text-gray-900">

--- a/src/components/features/openBrokerage/PortfolioModeChooser.tsx
+++ b/src/components/features/openBrokerage/PortfolioModeChooser.tsx
@@ -30,32 +30,6 @@ const PortfolioModeChooser: React.FC<PortfolioModeChooserProps> = ({
       <legend className="sr-only">Choose how to track this brokerage</legend>
 
       <label
-        className={`flex items-start gap-3 rounded-xl border p-4 cursor-pointer transition-colors ${
-          mode === "new"
-            ? "border-blue-300 bg-blue-50/50 ring-1 ring-blue-300"
-            : "border-gray-200 hover:border-gray-300"
-        }`}
-      >
-        <input
-          type="radio"
-          name="portfolio-mode"
-          className="mt-1"
-          checked={mode === "new"}
-          onChange={() => onSelect("new")}
-        />
-        <span className="flex-1">
-          <span className="block font-medium text-gray-900">
-            Create a new portfolio for this brokerage
-          </span>
-          <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
-            Its own space with its own objectives, kept apart from your
-            non-investment assets — cash, savings, property. Choose this when
-            you want to judge the brokerage on its own goals.
-          </span>
-        </span>
-      </label>
-
-      <label
         className={`flex items-start gap-3 rounded-xl border p-4 transition-colors ${
           existingDisabled
             ? "border-gray-200 opacity-50 cursor-not-allowed"
@@ -74,15 +48,41 @@ const PortfolioModeChooser: React.FC<PortfolioModeChooserProps> = ({
         />
         <span className="flex-1">
           <span className="block font-medium text-gray-900">
-            Attach to an existing portfolio{" "}
+            Zen Mode — keep one portfolio{" "}
             {existingDisabled && (
               <span className="font-normal text-gray-400">(none yet)</span>
             )}
           </span>
           <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
-            Fold these holdings in beside assets you already track — one
-            combined view. Choose this when you think of everything as a single
-            pot.
+            Fold this brokerage into a portfolio you already have — one combined
+            view, one number to watch. The simplest way to track everything as a
+            single pot.
+          </span>
+        </span>
+      </label>
+
+      <label
+        className={`flex items-start gap-3 rounded-xl border p-4 cursor-pointer transition-colors ${
+          mode === "new"
+            ? "border-blue-300 bg-blue-50/50 ring-1 ring-blue-300"
+            : "border-gray-200 hover:border-gray-300"
+        }`}
+      >
+        <input
+          type="radio"
+          name="portfolio-mode"
+          className="mt-1"
+          checked={mode === "new"}
+          onChange={() => onSelect("new")}
+        />
+        <span className="flex-1">
+          <span className="block font-medium text-gray-900">
+            Master Mode — a dedicated portfolio
+          </span>
+          <span className="block text-sm text-gray-500 mt-1 leading-relaxed">
+            Give this brokerage its own space with its own objectives, kept
+            apart from your other assets. Choose this when you want to judge it
+            on its own goals.
           </span>
         </span>
       </label>

--- a/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/OpenBrokerageWizard.test.tsx
@@ -126,6 +126,10 @@ describe("<OpenBrokerageWizard />", () => {
     // Step 2 — portfolio: no inputs in new mode; code + name derive from the
     // broker name entered in step 1.
     await screen.findByRole("heading", { name: /Portfolio/i })
+    // Default is Zen (attach to existing); switch to Master for a new portfolio.
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new portfolio/i }),
+    )
     expect(screen.getByText(/code BNB/i)).toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
@@ -165,14 +169,21 @@ describe("<OpenBrokerageWizard />", () => {
     await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 2 — portfolio (new mode derives code/name from the broker)
+    // Step 2 — portfolio: Master mode derives code/name from the broker
     await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new portfolio/i }),
+    )
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 3 — funding: enter an opening amount. No source portfolio — the
-    // funding step no longer offers one.
+    // Step 3 — funding: nothing seeded, so add a USD account then fund it. No
+    // source portfolio — the funding step no longer offers one.
     await screen.findByRole("heading", { name: /Funding|Deposit/i })
-    await user.type(screen.getByLabelText(/deposit/i), "5000")
+    await user.selectOptions(
+      screen.getByLabelText(/Add a currency account/i),
+      "USD",
+    )
+    await user.type(screen.getByLabelText(/Deposit \(USD\)/i), "5000")
     expect(screen.queryByLabelText(/Source portfolio/i)).not.toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
@@ -206,13 +217,20 @@ describe("<OpenBrokerageWizard />", () => {
     await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 2 — portfolio (new mode, default currency USD)
+    // Step 2 — portfolio: Master mode, default currency USD
     await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new portfolio/i }),
+    )
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 3 — funding: leave the seeded USD account at zero, advance with Next
-    // (not Skip) so the account still opens.
+    // Step 3 — funding: add a USD account but leave it at zero, then advance
+    // with Next (not Skip) so the account still opens.
     await screen.findByRole("heading", { name: /Funding|Deposit/i })
+    await user.selectOptions(
+      screen.getByLabelText(/Add a currency account/i),
+      "USD",
+    )
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 4 — review + submit
@@ -254,8 +272,11 @@ describe("<OpenBrokerageWizard />", () => {
     )
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 2 — portfolio (new mode derives code/name from the broker)
+    // Step 2 — portfolio: Master mode derives code/name from the broker
     await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new portfolio/i }),
+    )
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 3 — skip funding
@@ -292,9 +313,7 @@ describe("<OpenBrokerageWizard />", () => {
     await screen.findByRole("heading", { name: /Portfolio/i })
     await waitFor(() =>
       expect(
-        screen.getByRole("radio", {
-          name: /Attach to an existing portfolio/i,
-        }),
+        screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
       ).not.toBeDisabled(),
     )
     await user.click(
@@ -306,9 +325,13 @@ describe("<OpenBrokerageWizard />", () => {
     )
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 3 — funding: standalone deposit (no source)
+    // Step 3 — funding: add a USD account + standalone deposit (no source)
     await screen.findByRole("heading", { name: /Funding|Deposit/i })
-    await user.type(screen.getByLabelText(/Deposit/i), "1000")
+    await user.selectOptions(
+      screen.getByLabelText(/Add a currency account/i),
+      "USD",
+    )
+    await user.type(screen.getByLabelText(/Deposit \(USD\)/i), "1000")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     // Step 4 — review + submit
@@ -351,12 +374,19 @@ describe("<OpenBrokerageWizard />", () => {
     await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 2 — portfolio (new mode, default currency USD)
+    // Step 2 — portfolio: Master mode, default currency USD
     await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new portfolio/i }),
+    )
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Step 3 — funding: fund the default USD account, then add + fund SGD
+    // Step 3 — funding: add + fund USD, then add + fund SGD
     await screen.findByRole("heading", { name: /Funding|Deposit/i })
+    await user.selectOptions(
+      screen.getByLabelText(/Add a currency account/i),
+      "USD",
+    )
     await user.type(screen.getByLabelText(/Deposit \(USD\)/i), "5000")
     await user.selectOptions(
       screen.getByLabelText(/Add another currency account/i),
@@ -395,6 +425,9 @@ describe("<OpenBrokerageWizard />", () => {
     await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
     await screen.findByRole("heading", { name: /Portfolio/i })
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new portfolio/i }),
+    )
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
     await screen.findByRole("heading", { name: /Funding|Deposit/i })
     await user.click(screen.getByRole("button", { name: /Skip|No deposit/i }))
@@ -421,13 +454,16 @@ describe("<OpenBrokerageWizard />", () => {
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
     await screen.findByRole("heading", { name: /Portfolio/i })
-    // New mode: code derives from the broker name → Next enabled.
+    // Master mode: code derives from the broker name → Next enabled.
+    await user.click(
+      screen.getByRole("radio", { name: /Create a new portfolio/i }),
+    )
     expect(screen.getByText(/code TB/i)).toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: /Next|Continue/i }),
     ).not.toBeDisabled()
 
-    // Switch to attach-to-existing without choosing one → Next blocked.
+    // Switch to Zen (attach to existing) without choosing one → Next blocked.
     await user.click(
       screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
     )
@@ -436,8 +472,8 @@ describe("<OpenBrokerageWizard />", () => {
     ).toBeDisabled()
   })
 
-  test("auto-selects the sole existing portfolio so no manual pick is needed", async () => {
-    // Override the portfolios endpoint to return exactly one.
+  test("zen user with a sole portfolio folds in with no chooser", async () => {
+    // Override the portfolios endpoint to return exactly one → zen + sole.
     fetchMock.resetMocks()
     const onlyPf = [
       {
@@ -467,24 +503,20 @@ describe("<OpenBrokerageWizard />", () => {
     await user.type(screen.getByLabelText(/Broker name/i), "IBKR")
     await user.click(screen.getByRole("button", { name: /Next|Continue/i }))
 
-    // Switch to attach-to-existing — the lone portfolio is already selected.
+    // Zen user with a sole portfolio: no Zen/Master chooser, no picker — the
+    // brokerage just folds into the one portfolio and Next is enabled.
     await screen.findByRole("heading", { name: /Portfolio/i })
     await waitFor(() =>
       expect(
-        screen.getByRole("radio", {
-          name: /Attach to an existing portfolio/i,
-        }),
-      ).not.toBeDisabled(),
+        screen.getByText(/folds into your portfolio/i),
+      ).toBeInTheDocument(),
     )
-    await user.click(
-      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
-    )
-
-    const select = (await screen.findByLabelText(
-      "Existing portfolio",
-    )) as HTMLSelectElement
-    await waitFor(() => expect(select.value).toBe("only-pf"))
-    // No pick required → Next is enabled straight away.
+    expect(
+      screen.queryByRole("radio", { name: /Create a new portfolio/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText("Existing portfolio"),
+    ).not.toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: /Next|Continue/i }),
     ).not.toBeDisabled()

--- a/src/components/features/openBrokerage/__tests__/PortfolioModeChooser.test.tsx
+++ b/src/components/features/openBrokerage/__tests__/PortfolioModeChooser.test.tsx
@@ -4,21 +4,17 @@ import "@testing-library/jest-dom"
 import PortfolioModeChooser from "../PortfolioModeChooser"
 
 describe("PortfolioModeChooser", () => {
-  it("renders both options and the net-worth reassurance", () => {
+  it("renders both options (Zen first) and the net-worth reassurance", () => {
     render(
       <PortfolioModeChooser
-        mode="new"
+        mode="existing"
         onSelect={jest.fn()}
         existingDisabled={false}
       />,
     )
+    expect(screen.getByRole("radio", { name: /Zen Mode/i })).toBeChecked()
     expect(
-      screen.getByRole("radio", {
-        name: /Create a new portfolio for this brokerage/i,
-      }),
-    ).toBeChecked()
-    expect(
-      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
+      screen.getByRole("radio", { name: /Master Mode/i }),
     ).not.toBeChecked()
     expect(
       screen.getByText(/totals your net worth across every portfolio/i),
@@ -29,24 +25,20 @@ describe("PortfolioModeChooser", () => {
     const onSelect = jest.fn()
     render(
       <PortfolioModeChooser
-        mode="new"
+        mode="existing"
         onSelect={onSelect}
         existingDisabled={false}
       />,
     )
-    fireEvent.click(
-      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
-    )
-    expect(onSelect).toHaveBeenCalledWith("existing")
+    fireEvent.click(screen.getByRole("radio", { name: /Master Mode/i }))
+    expect(onSelect).toHaveBeenCalledWith("new")
   })
 
-  it("disables the existing option when there is nothing to attach to", () => {
+  it("disables the Zen (existing) option when there is nothing to attach to", () => {
     render(
       <PortfolioModeChooser mode="new" onSelect={jest.fn()} existingDisabled />,
     )
-    expect(
-      screen.getByRole("radio", { name: /Attach to an existing portfolio/i }),
-    ).toBeDisabled()
+    expect(screen.getByRole("radio", { name: /Zen Mode/i })).toBeDisabled()
     expect(screen.getByText(/\(none yet\)/i)).toBeInTheDocument()
   })
 })

--- a/src/lib/utils/openBrokerage/__tests__/orchestrate.test.ts
+++ b/src/lib/utils/openBrokerage/__tests__/orchestrate.test.ts
@@ -173,9 +173,10 @@ describe("openBrokerage", () => {
     expect(patched).toBe(false)
   })
 
-  // Zero-balance account, new dedicated portfolio: generic CASH asset created,
-  // still no deposit.
-  test("opens a zero-balance CASH account in new mode without a deposit", async () => {
+  // Zero-balance account, new dedicated portfolio: the brokerage cash uses the
+  // per-broker PRIVATE line ({brokerCode}-{ccy}) in this mode too, so the cash
+  // shows as a broker-coded account regardless of which portfolio holds it.
+  test("opens a zero-balance per-broker PRIVATE cash account in new mode without a deposit", async () => {
     const res = await openBrokerage({
       broker: { mode: "new", newName: "IBKR" },
       portfolio: {
@@ -188,10 +189,10 @@ describe("openBrokerage", () => {
       funding: [{ currency: "USD", amount: 0 }],
     })
 
-    const cashAsset = assetPosts().find(
-      (b) => b.data?.["USD"]?.market === "CASH",
+    const privateAsset = assetPosts().find(
+      (b) => b.data?.["IBKR-USD"]?.market === "PRIVATE",
     )
-    expect(cashAsset).toBeDefined()
+    expect(privateAsset).toBeDefined()
     expect(res.accountIds).toHaveLength(1)
     expect(res.trnIds).toHaveLength(0)
   })

--- a/src/lib/utils/openBrokerage/brokerCode.ts
+++ b/src/lib/utils/openBrokerage/brokerCode.ts
@@ -24,6 +24,18 @@ const KNOWN_BROKER_CODES: Record<string, string> = {
 
 const alnum = (s: string): string => s.replace(/[^A-Za-z0-9]/g, "")
 
+/**
+ * The per-broker cash asset code: `{brokerCode}-{currency}` (e.g. `IB-USD`).
+ * Single source of truth so the onboarding/wizard preview and the asset the
+ * orchestrator actually creates can never drift apart.
+ */
+export function brokerCashAssetCode(
+  brokerCode: string,
+  currency: string,
+): string {
+  return `${brokerCode}-${currency}`
+}
+
 export function deriveBrokerCode(name: string): string {
   const trimmed = name.trim()
   if (!trimmed) return ""

--- a/src/lib/utils/openBrokerage/orchestrate.ts
+++ b/src/lib/utils/openBrokerage/orchestrate.ts
@@ -6,7 +6,10 @@
  */
 
 import type { Broker, BrokerWithAccounts } from "types/beancounter"
-import { deriveBrokerCode } from "@lib/openBrokerage/brokerCode"
+import {
+  deriveBrokerCode,
+  brokerCashAssetCode,
+} from "@lib/openBrokerage/brokerCode"
 
 // Local-date YYYY-MM-DD so tradeDate matches the user's calendar day,
 // not UTC's. `new Date().toISOString()` would mis-report the day for any
@@ -233,7 +236,7 @@ const ensureBrokerCashAsset = (
   currency: string,
 ): Promise<string> =>
   ensureAsset({
-    code: `${brokerCode}-${currency}`,
+    code: brokerCashAssetCode(brokerCode, currency),
     market: "PRIVATE",
     name: `${brokerName} ${currency} Balance`,
     currency,
@@ -305,15 +308,16 @@ export async function openBrokerage(
   // settlement account once all accounts are open.
   const settlementByCurrency: Record<string, string> = {}
   for (const account of req.funding ?? []) {
-    // Open the account regardless of balance. Attach-to-existing-portfolio
-    // path uses a per-broker PRIVATE cash asset so the brokerage cash is
-    // visible as a distinct line in the existing portfolio's holdings; the
-    // new-portfolio path uses the generic per-currency CASH asset (the
-    // portfolio itself segregates).
-    const depositAssetId =
-      req.portfolio.mode === "existing"
-        ? await ensureBrokerCashAsset(brokerCode, broker.name, account.currency)
-        : await ensureCashAsset(account.currency)
+    // Open the account regardless of balance. Both paths use a per-broker
+    // PRIVATE cash asset (e.g. `IB-USD`) so the brokerage's cash always shows
+    // as a distinct, broker-coded line — whether it's folded into an existing
+    // portfolio (Zen) or sitting in its own dedicated one (Master). Keeps the
+    // settlement default and holdings label consistent across both modes.
+    const depositAssetId = await ensureBrokerCashAsset(
+      brokerCode,
+      broker.name,
+      account.currency,
+    )
     accountIds.push(depositAssetId)
     // Last opened account for a currency is the broker's settlement default.
     settlementByCurrency[account.currency] = depositAssetId

--- a/src/pages/independence/setup.tsx
+++ b/src/pages/independence/setup.tsx
@@ -81,7 +81,7 @@ function IndependenceSetupPage(): React.ReactElement {
       })
 
       const workPayload = {
-        name: "My Work Scenario",
+        name: "Working Situation",
         currency: baseCurrency,
         workingIncomeMonthly,
         workingExpensesMonthly,


### PR DESCRIPTION
## Onboarding Step 5 — Independence
- Default to "Yes, let's do it" (plan + work scenario created by default).
- Rename "My Work Scenario" → "Working Situation" (onboarding + /independence/setup).

## Onboarding Step 6 — Brokerage (Zen / Master)
- Zen Mode (attach to main portfolio) first + default; Master Mode (dedicated portfolio) second, with narratives.
- Zen hides the portfolio picker / opening deposit / source — those are Master-only.
- Currency shown next to the broker name; live computed brokerage code + `{code}-{ccy}` cash-line preview.
- Brokerage cash uses a per-broker PRIVATE `{code}-{ccy}` line in both modes.

## Tools → Open Brokerage (kept aligned)
- Master users: plain attach-existing / create-new toggle, no Zen/Master cards.
- Zen user with a sole portfolio: folds into it, no chooser.
- Zero-portfolio user: stays zen, creates a portfolio named/coded after the broker in the chosen currency.
- No cash account seeded until the user adds one.

## Fixes from local review
- Clear the funding source on currency change (no stale cross-currency withdrawal).
- `setup.tsx` scenario name aligned to "Working Situation".
- Shared `brokerCashAssetCode` helper (was duplicated 3×).
- Corrected off-by-one onboarding step-intro headers.

Tests: 1671 pass · typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
