### PR TITLE
feat(brokerage): per-currency settlement accounts + FX_BUY cash-balance fix

### DIFF
--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -17,7 +17,6 @@ import ReviewStep from "./steps/ReviewStep"
 import CompleteStep from "./steps/CompleteStep"
 import IndependencePlanStep from "./steps/IndependencePlanStep"
 import BrokerageStep from "./steps/BrokerageStep"
-import type { SourceValue } from "./steps/BrokerageStep"
 import { type PortfolioMode } from "@components/features/openBrokerage/PortfolioModeChooser"
 import { openBrokerage } from "@lib/openBrokerage/orchestrate"
 import { buildBrokerageFunding } from "@lib/openBrokerage/buildBrokerageFunding"
@@ -156,12 +155,12 @@ const OnboardingWizard: React.FC = () => {
   // Brokerage step (optional, post-default-portfolio creation)
   const [brokerageEnabled, setBrokerageEnabled] = useState(false)
   const [brokerageBrokerName, setBrokerageBrokerName] = useState("")
-  const [brokerageSource, setBrokerageSource] = useState<SourceValue>("")
-  const [brokerageAmount, setBrokerageAmount] = useState("")
-  const [brokerageCurrency, setBrokerageCurrency] = useState("")
+  // Currencies the user expects to trade — one per-broker cash account + default
+  // settlement mapping is opened for each. Opening balances are recorded later.
+  const [brokerageCurrencies, setBrokerageCurrencies] = useState<string[]>([])
   // Zen vs Master for the brokerage. Default to Zen — attach to the default
   // portfolio created during onboarding (the single-pot path). Master gives
-  // the brokerage its own dedicated portfolio + opening deposit.
+  // the brokerage its own dedicated portfolio.
   const [brokeragePortfolioMode, setBrokeragePortfolioMode] =
     useState<PortfolioMode>("existing")
   const [brokerageCreated, setBrokerageCreated] = useState(false)
@@ -655,10 +654,7 @@ const OnboardingWizard: React.FC = () => {
       }
       setCreatedPortfolioId(portfolioId ?? null)
 
-      // Create assets if any. The returned bankAccountAssetIds map is
-      // used below to wire the optional brokerage step's source to a
-      // specific bank-account asset.
-      let bankAccountAssetIds: Record<string, string> = {}
+      // Create assets if any (bank accounts, properties, pensions, insurances).
       if (
         portfolioId &&
         (bankAccounts.length > 0 ||
@@ -666,8 +662,7 @@ const OnboardingWizard: React.FC = () => {
           pensions.length > 0 ||
           insurances.length > 0)
       ) {
-        const created = await createAssets(portfolioId)
-        bankAccountAssetIds = created.bankAccountAssetIds
+        await createAssets(portfolioId)
       }
 
       // Trigger portfolio valuation by fetching holdings
@@ -752,24 +747,24 @@ const OnboardingWizard: React.FC = () => {
       // Zen Mode attaches the brokerage to the default portfolio just created
       // above; Master Mode gives it a new dedicated portfolio.
       const isZen = brokeragePortfolioMode === "existing"
+      // Currencies the user expects to trade — fall back to base currency so a
+      // broker is never registered with zero settlement accounts.
+      const brokerageCcys =
+        brokerageCurrencies.length > 0 ? brokerageCurrencies : [baseCurrency]
       if (brokerageEnabled && brokerageBrokerName.trim() && portfolioId) {
-        const amt = parseFloat(brokerageAmount)
         try {
           // Brokerage gets its own dedicated portfolio (named after the
           // broker) so its cash + future trades stay separate from the
-          // user's day-to-day bank-account portfolio. Source still
-          // resolves to a bank-account asset on the default portfolio
-          // when the user picked one, so a paired WITHDRAWAL hits the
-          // right line.
+          // user's day-to-day bank-account portfolio.
           const brokerName = brokerageBrokerName.trim()
           // Abbreviated code (Interactive Brokers → IB) for the portfolio
           // code; the display name keeps the full broker name.
           const brokerCode = deriveBrokerCode(brokerName)
-          // Currency the user picked next to the broker name (step 6); falls
-          // back to baseCurrency if untouched. Drives the brokerage cash
-          // account code ({brokerCode}-{ccy}). `base` stays the user's overall
-          // base currency for consolidated reporting upstream.
-          const brokerageCcy = brokerageCurrency || baseCurrency
+          // First picked currency is the dedicated portfolio's reporting
+          // currency; the portfolio still holds every selected currency's cash
+          // line. `base` stays the user's overall base for consolidated
+          // reporting upstream.
+          const brokerageCcy = brokerageCcys[0] || baseCurrency
           // Portfolio code used for the brokerage — Zen reuses the default
           // portfolio's code, Master coins a new one from the broker. Drives
           // both the openBrokerage payload and the post-create valuation fetch
@@ -791,19 +786,10 @@ const OnboardingWizard: React.FC = () => {
                   currency: brokerageCcy,
                   base: baseCurrency,
                 },
-            // Always open the broker's cash account (e.g. IB-USD) in the
-            // chosen currency so its settlement mapping exists — even in Zen
-            // mode or with a zero opening deposit. The opening deposit + source
-            // (Master-only; the Zen step hides them) only post a trn when
-            // amount > 0.
-            funding: buildBrokerageFunding({
-              isZen,
-              currency: brokerageCcy,
-              amount: amt,
-              source: brokerageSource,
-              defaultPortfolioId: portfolioId,
-              bankAccountAssetIds,
-            }),
+            // Open one broker cash account (e.g. IB-USD) per selected currency
+            // so its settlement mapping exists — Zen or Master. Opening balances
+            // are recorded later, so every row is amount 0 (no trn posted).
+            funding: buildBrokerageFunding(brokerageCcys),
           })
           setBrokerageCreated(true)
           // Trigger valuation for the new brokerage portfolio (same as we
@@ -925,29 +911,24 @@ const OnboardingWizard: React.FC = () => {
           <BrokerageStep
             enabled={brokerageEnabled}
             brokerName={brokerageBrokerName}
-            source={brokerageSource}
-            amount={brokerageAmount}
-            currency={brokerageCurrency || baseCurrency || "USD"}
+            currencies={brokerageCurrencies}
             currencyCodes={
               currencies.length > 0
                 ? currencies.map((c) => c.code)
                 : [baseCurrency || "USD"]
             }
-            existingPortfolios={existingPortfolios}
-            bankAccounts={bankAccounts}
             defaultPortfolioName={portfolioName}
             portfolioMode={brokeragePortfolioMode}
-            onEnabledChange={setBrokerageEnabled}
-            onBrokerNameChange={setBrokerageBrokerName}
-            onSourceChange={setBrokerageSource}
-            onAmountChange={setBrokerageAmount}
-            onCurrencyChange={(c) => {
-              setBrokerageCurrency(c)
-              // The source dropdown filters to same-currency options, so a
-              // previously-picked source no longer matches — clear it to avoid
-              // a stale cross-currency WITHDRAWAL against the wrong line.
-              setBrokerageSource("")
+            onEnabledChange={(v) => {
+              setBrokerageEnabled(v)
+              // Seed the user's base currency so enabling the step always has at
+              // least one account to open; they can add/remove from there.
+              if (v && brokerageCurrencies.length === 0 && baseCurrency) {
+                setBrokerageCurrencies([baseCurrency])
+              }
             }}
+            onBrokerNameChange={setBrokerageBrokerName}
+            onCurrenciesChange={setBrokerageCurrencies}
             onPortfolioModeChange={setBrokeragePortfolioMode}
           />
         )

--- a/src/components/features/onboarding/steps/BrokerageStep.tsx
+++ b/src/components/features/onboarding/steps/BrokerageStep.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import Link from "next/link"
-import MathInput from "@components/ui/MathInput"
 import PortfolioModeChooser, {
   type PortfolioMode,
 } from "@components/features/openBrokerage/PortfolioModeChooser"
@@ -8,97 +7,64 @@ import {
   deriveBrokerCode,
   brokerCashAssetCode,
 } from "@lib/openBrokerage/brokerCode"
-import type { Portfolio } from "types/beancounter"
-import type { BankAccount } from "../OnboardingWizard"
-
-// The source dropdown's value encodes WHICH backend object the WITHDRAWAL
-// should hit: a portfolio (uses its generic cash asset) or a specific
-// bank-account asset on the default portfolio (e.g. the "DBS" PRIVATE
-// line the user just added in step 4). Format keeps both shapes in a
-// single <select> value string.
-//   ""                              → no source (standalone deposit)
-//   "portfolio:{id}"                → withdraw from portfolio's CASH/{ccy}
-//   "bankAccount:{name}"            → withdraw from bank-account asset
-export type SourceValue = "" | `portfolio:${string}` | `bankAccount:${string}`
 
 export interface BrokerageStepProps {
   enabled: boolean
   brokerName: string
-  source: SourceValue
-  amount: string // free text; parsed at submit
-  // User-chosen reporting currency for the new brokerage portfolio.
-  // Defaults to the user's baseCurrency but they can pick any code from
-  // `currencyCodes` (e.g. USD broker funded from SGD bank balances).
-  currency: string
+  // Currencies the user expects to trade. One per-broker cash account
+  // ({code}-{ccy}) is opened for each and registered as the broker's default
+  // settlement account for that currency. Opening balances are recorded later
+  // (Tools → Open Brokerage, or a normal cash deposit) — this step never moves
+  // cash, it just stands the accounts up.
+  currencies: string[]
   currencyCodes: string[]
-  // Portfolios the user already has — used to populate the source dropdown.
-  // The default portfolio created earlier in this onboarding is NOT in this
-  // list because it lives in component state, not the backend yet; we expose
-  // it as a synthetic "Default portfolio" option via the defaultPortfolioName
-  // prop instead.
-  existingPortfolios: Portfolio[]
-  // Bank accounts the user added in step 4 — surfaced as additional source
-  // options so the brokerage deposit can be funded from a specific
-  // bank-account line on the default portfolio.
-  bankAccounts: BankAccount[]
   defaultPortfolioName: string
   // Zen vs Master — same decision as the standalone /tools/open-brokerage
-  // wizard. Zen attaches to the user's main (default) portfolio; Master gives
-  // the brokerage its own dedicated portfolio. Opening deposit + source are
-  // Master-only — Zen is the lightweight "just register the broker" path.
+  // wizard. Zen attaches the broker to the user's main (default) portfolio;
+  // Master gives it a dedicated portfolio. Both open the same per-broker,
+  // per-currency cash lines.
   portfolioMode: PortfolioMode
   onEnabledChange: (v: boolean) => void
   onBrokerNameChange: (v: string) => void
-  onSourceChange: (v: SourceValue) => void
-  onAmountChange: (v: string) => void
-  onCurrencyChange: (v: string) => void
+  onCurrenciesChange: (v: string[]) => void
   onPortfolioModeChange: (v: PortfolioMode) => void
 }
 
 /**
- * Optional brokerage setup as a step inside the onboarding wizard.
- * Compact form — only the fields needed to drive the openBrokerage
- * orchestrator. Reuses the orchestrator from the standalone wizard at
- * /tools/open-brokerage so the two surfaces stay consistent.
+ * Optional brokerage setup as a step inside the onboarding wizard. The user
+ * names the broker and picks the currencies they expect to trade; on submit the
+ * wizard opens one per-broker cash account per currency and registers each as
+ * the broker's default settlement account. Reuses the orchestrator from the
+ * standalone wizard at /tools/open-brokerage so the two surfaces stay consistent.
  */
 const BrokerageStep: React.FC<BrokerageStepProps> = ({
   enabled,
   brokerName,
-  source,
-  amount,
-  currency,
+  currencies,
   currencyCodes,
-  existingPortfolios,
-  bankAccounts,
   defaultPortfolioName,
   portfolioMode,
   onEnabledChange,
   onBrokerNameChange,
-  onSourceChange,
-  onAmountChange,
-  onCurrencyChange,
+  onCurrenciesChange,
   onPortfolioModeChange,
 }) => {
-  // Filter source options to the chosen currency (same-currency v1).
-  const sameCurrencyPortfolios = existingPortfolios.filter(
-    (p) => p.currency?.code === currency,
-  )
-  const sameCurrencyBankAccounts = bankAccounts.filter(
-    (b) => b.currency === currency,
-  )
-  // If the user has bank accounts but none in the chosen currency, they
-  // probably expected to fund from a different-currency balance. Surface
-  // it explicitly so they don't end up with a silent standalone deposit.
-  const otherCurrencyBankAccounts = bankAccounts.filter(
-    (b) => b.currency !== currency,
-  )
-  const showFxNotice =
-    sameCurrencyBankAccounts.length === 0 &&
-    otherCurrencyBankAccounts.length > 0
   // Abbreviated broker code (Interactive Brokers → IB) shown live so the user
-  // sees the code and the resulting cash-account name ({code}-{ccy}) they'll
-  // get before submitting.
+  // sees the code and the resulting cash-account names ({code}-{ccy}) before
+  // submitting.
   const brokerCode = deriveBrokerCode(brokerName)
+  // Reporting currency of the dedicated (Master) portfolio — the first picked
+  // currency. The portfolio still holds every selected currency's cash line.
+  const primaryCurrency = currencies[0] || currencyCodes[0]
+
+  const toggleCurrency = (code: string): void => {
+    if (currencies.includes(code)) {
+      onCurrenciesChange(currencies.filter((c) => c !== code))
+    } else {
+      onCurrenciesChange([...currencies, code])
+    }
+  }
+
   return (
     <div className="py-2">
       <p className="text-gray-500 text-xs mb-3">
@@ -125,56 +91,67 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
 
       {enabled && (
         <div className="space-y-3 max-w-md">
-          {/* Broker name + default currency sit side by side: the currency
-              drives the brokerage cash-account code ({broker.code}-{ccy}). */}
-          <div className="flex gap-3">
-            <div className="flex-1">
-              <label
-                htmlFor="ob-broker"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                {"Broker name"}
-              </label>
-              <input
-                id="ob-broker"
-                type="text"
-                value={brokerName}
-                onChange={(e) => onBrokerNameChange(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                placeholder="e.g. Interactive Brokers"
-              />
-            </div>
-            <div className="w-28">
-              <label
-                htmlFor="ob-currency"
-                className="block text-sm font-medium text-gray-700 mb-1"
-              >
-                {"Currency"}
-              </label>
-              <select
-                id="ob-currency"
-                value={currency}
-                onChange={(e) => onCurrencyChange(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md"
-              >
-                {currencyCodes.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
-                  </option>
-                ))}
-              </select>
-            </div>
+          <div>
+            <label
+              htmlFor="ob-broker"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              {"Broker name"}
+            </label>
+            <input
+              id="ob-broker"
+              type="text"
+              value={brokerName}
+              onChange={(e) => onBrokerNameChange(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              placeholder="e.g. Interactive Brokers"
+            />
           </div>
 
-          {brokerName.trim() && (
+          <fieldset>
+            <legend className="block text-sm font-medium text-gray-700 mb-1">
+              {"Currencies you expect to trade"}
+            </legend>
+            <p className="text-xs text-gray-500 mb-2">
+              {
+                "We'll open a cash account for each and make it the broker's default settlement account for that currency."
+              }
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {currencyCodes.map((code) => {
+                const checked = currencies.includes(code)
+                return (
+                  <label
+                    key={code}
+                    className={`flex items-center gap-2 px-3 py-2 rounded-md border cursor-pointer text-sm ${
+                      checked
+                        ? "border-purple-400 bg-purple-50 text-purple-800"
+                        : "border-gray-300 text-gray-700"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleCurrency(code)}
+                    />
+                    {code}
+                  </label>
+                )
+              })}
+            </div>
+          </fieldset>
+
+          {brokerName.trim() && currencies.length > 0 && (
             <p className="text-xs text-gray-500">
               {"Brokerage code "}
               <span className="font-mono font-medium text-gray-700">
                 {brokerCode}
               </span>
-              {" · cash account "}
+              {" · cash accounts "}
               <span className="font-mono font-medium text-gray-700">
-                {brokerCashAssetCode(brokerCode, currency)}
+                {currencies
+                  .map((c) => brokerCashAssetCode(brokerCode, c))
+                  .join(", ")}
               </span>
             </p>
           )}
@@ -187,103 +164,27 @@ const BrokerageStep: React.FC<BrokerageStepProps> = ({
 
           {portfolioMode === "existing" ? (
             <p className="text-xs text-gray-500">
-              {`Attaches to your main portfolio ("${defaultPortfolioName}"). Trades settle to a per-broker cash line (${brokerCashAssetCode(brokerCode || "BROKER", currency)}). Want a dedicated portfolio or an opening deposit now? Switch to Master Mode.`}
+              {`Attaches to your main portfolio ("${defaultPortfolioName}"). Trades settle to per-broker cash lines (e.g. ${brokerCashAssetCode(brokerCode || "BROKER", primaryCurrency)}). Want a dedicated portfolio? Switch to Master Mode.`}
             </p>
           ) : (
-            <>
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm">
-                <p className="text-gray-500">{"New portfolio"}</p>
-                {brokerName.trim() ? (
-                  <p className="font-medium text-gray-900">
-                    {`${brokerName} Portfolio`}
-                    <span className="ml-1 font-normal text-gray-500">
-                      {`(code ${brokerCode})`}
-                    </span>
-                  </p>
-                ) : (
-                  <p className="text-gray-400">
-                    {"Name your broker first — the portfolio takes its name."}
-                  </p>
-                )}
-                <p className="text-gray-500 mt-1">
-                  {`Kept separate from your "${defaultPortfolioName}" portfolio so its cash and trades stand on their own.`}
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm">
+              <p className="text-gray-500">{"New portfolio"}</p>
+              {brokerName.trim() ? (
+                <p className="font-medium text-gray-900">
+                  {`${brokerName} Portfolio`}
+                  <span className="ml-1 font-normal text-gray-500">
+                    {`(code ${brokerCode}, ${primaryCurrency})`}
+                  </span>
                 </p>
-              </div>
-
-              <div>
-                <label
-                  htmlFor="ob-amount"
-                  className="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  {`Opening deposit (${currency})`}
-                </label>
-                <MathInput
-                  id="ob-amount"
-                  value={amount}
-                  onChange={(v) => onAmountChange(v === 0 ? "" : String(v))}
-                  min={0}
-                  placeholder="0"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="ob-source"
-                  className="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  {"Source (optional)"}
-                </label>
-                {showFxNotice && (
-                  <div className="mb-2 px-3 py-2 rounded bg-amber-50 border border-amber-200 text-xs text-amber-800">
-                    {`You have bank accounts in ${otherCurrencyBankAccounts
-                      .map((b) => b.currency)
-                      .filter((c, i, a) => a.indexOf(c) === i)
-                      .join(
-                        ", ",
-                      )} but the brokerage currency is ${currency}. Cross-currency funding (FX) isn't supported yet — the opening deposit will be recorded as a standalone cash injection on the new portfolio with no matching withdrawal.`}
-                  </div>
-                )}
-                <select
-                  id="ob-source"
-                  value={source}
-                  onChange={(e) =>
-                    onSourceChange(e.target.value as SourceValue)
-                  }
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
-                >
-                  <option value="">— None (standalone deposit) —</option>
-                  {sameCurrencyBankAccounts.length > 0 && (
-                    <optgroup
-                      label={`Bank accounts on "${defaultPortfolioName}"`}
-                    >
-                      {sameCurrencyBankAccounts.map((b) => (
-                        <option
-                          key={`b-${b.name}`}
-                          value={`bankAccount:${b.name}`}
-                        >
-                          {b.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                  {sameCurrencyPortfolios.length > 0 && (
-                    <optgroup label="Other portfolios">
-                      {sameCurrencyPortfolios.map((p) => (
-                        <option key={`p-${p.id}`} value={`portfolio:${p.id}`}>
-                          {p.name} ({p.code})
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                </select>
-                <p className="text-xs text-gray-500 mt-1">
-                  {
-                    "Picking a source posts a matching withdrawal so the source's cash stays accurate."
-                  }
+              ) : (
+                <p className="text-gray-400">
+                  {"Name your broker first — the portfolio takes its name."}
                 </p>
-              </div>
-            </>
+              )}
+              <p className="text-gray-500 mt-1">
+                {`Kept separate from your "${defaultPortfolioName}" portfolio so its cash and trades stand on their own.`}
+              </p>
+            </div>
           )}
         </div>
       )}

--- a/src/components/features/onboarding/steps/__tests__/BrokerageStep.test.tsx
+++ b/src/components/features/onboarding/steps/__tests__/BrokerageStep.test.tsx
@@ -1,35 +1,19 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import BrokerageStep from "../BrokerageStep"
 import type { BrokerageStepProps } from "../BrokerageStep"
-import type { Portfolio } from "types/beancounter"
-
-const existingPortfolios = [
-  {
-    id: "pf-1",
-    code: "MAIN",
-    name: "Main",
-    currency: { code: "SGD" },
-  },
-] as unknown as Portfolio[]
 
 const baseProps: BrokerageStepProps = {
   enabled: true,
   brokerName: "IBKR",
-  source: "",
-  amount: "",
-  currency: "SGD",
+  currencies: ["SGD"],
   currencyCodes: ["SGD", "USD"],
-  existingPortfolios,
-  bankAccounts: [],
   defaultPortfolioName: "Cash",
   portfolioMode: "new",
   onEnabledChange: jest.fn(),
   onBrokerNameChange: jest.fn(),
-  onSourceChange: jest.fn(),
-  onAmountChange: jest.fn(),
-  onCurrencyChange: jest.fn(),
+  onCurrenciesChange: jest.fn(),
   onPortfolioModeChange: jest.fn(),
 }
 
@@ -37,10 +21,11 @@ const renderStep = (overrides: Partial<BrokerageStepProps> = {}): void => {
   render(<BrokerageStep {...baseProps} {...overrides} />)
 }
 
-describe("BrokerageStep portfolio choice", () => {
-  it("shows the currency picker next to the broker name in both modes", () => {
+describe("BrokerageStep", () => {
+  it("offers a currency toggle per available code in both modes", () => {
     renderStep({ portfolioMode: "new" })
-    expect(screen.getByLabelText("Currency")).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "SGD" })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "USD" })).toBeInTheDocument()
     expect(screen.getByLabelText("Broker name")).toBeInTheDocument()
     // Shared chooser offers Zen + Master.
     expect(
@@ -49,27 +34,52 @@ describe("BrokerageStep portfolio choice", () => {
     expect(screen.getByRole("radio", { name: /Zen Mode/i })).toBeInTheDocument()
   })
 
-  it("surfaces the computed brokerage code and cash-account name", () => {
-    renderStep({ brokerName: "Interactive Brokers", currency: "USD" })
-    // deriveBrokerCode("Interactive Brokers") === "IB"
-    expect(screen.getByText("IB")).toBeInTheDocument()
-    expect(screen.getByText("IB-USD")).toBeInTheDocument()
+  it("reflects the selected currencies as checked", () => {
+    renderStep({ currencies: ["SGD", "USD"] })
+    expect(screen.getByRole("checkbox", { name: "SGD" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "USD" })).toBeChecked()
   })
 
-  it("new (Master) mode shows the new-portfolio box plus opening deposit + source", () => {
+  it("adds a currency on toggle", () => {
+    const onCurrenciesChange = jest.fn()
+    renderStep({ currencies: ["SGD"], onCurrenciesChange })
+    fireEvent.click(screen.getByRole("checkbox", { name: "USD" }))
+    expect(onCurrenciesChange).toHaveBeenCalledWith(["SGD", "USD"])
+  })
+
+  it("removes a currency on toggle", () => {
+    const onCurrenciesChange = jest.fn()
+    renderStep({ currencies: ["SGD", "USD"], onCurrenciesChange })
+    fireEvent.click(screen.getByRole("checkbox", { name: "SGD" }))
+    expect(onCurrenciesChange).toHaveBeenCalledWith(["USD"])
+  })
+
+  it("previews the broker code and a cash account per selected currency", () => {
+    renderStep({
+      brokerName: "Interactive Brokers",
+      currencies: ["USD", "SGD"],
+    })
+    // deriveBrokerCode("Interactive Brokers") === "IB"
+    expect(screen.getByText("IB")).toBeInTheDocument()
+    expect(screen.getByText(/IB-USD/)).toBeInTheDocument()
+    expect(screen.getByText(/IB-SGD/)).toBeInTheDocument()
+  })
+
+  it("never shows an opening-deposit or source field (balances recorded later)", () => {
+    renderStep({ portfolioMode: "new", brokerName: "Interactive Brokers" })
+    expect(screen.queryByLabelText(/Opening deposit/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Source/i)).not.toBeInTheDocument()
+  })
+
+  it("Master mode shows the dedicated-portfolio box", () => {
     renderStep({ portfolioMode: "new", brokerName: "Interactive Brokers" })
     expect(
       screen.getByText("Interactive Brokers Portfolio"),
     ).toBeInTheDocument()
-    expect(screen.getByLabelText(/Opening deposit/i)).toBeInTheDocument()
-    expect(screen.getByLabelText("Source (optional)")).toBeInTheDocument()
   })
 
-  it("existing (Zen) mode hides deposit + source and shows the attach note", () => {
+  it("Zen mode shows the attach note", () => {
     renderStep({ portfolioMode: "existing", brokerName: "Interactive Brokers" })
-    expect(screen.queryByLabelText(/Opening deposit/i)).not.toBeInTheDocument()
-    expect(screen.queryByLabelText("Source (optional)")).not.toBeInTheDocument()
-    // Zen attaches to the user's main portfolio — no portfolio picker.
     expect(
       screen.getByText(/attaches to your main portfolio/i),
     ).toBeInTheDocument()

--- a/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
+++ b/src/components/features/openBrokerage/OpenBrokerageWizard.tsx
@@ -520,7 +520,7 @@ export default function OpenBrokerageWizard(): React.ReactElement {
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
             {
-              "Add a cash account for each currency you'll hold in this brokerage. Nothing is opened by default — add only what you need, with an optional opening deposit to seed cash now."
+              "Add a cash account for each currency you expect to trade. Each becomes the broker's default settlement account for that currency. Nothing is opened by default — add only what you need, with an optional opening deposit to seed cash now."
             }
           </p>
 

--- a/src/components/features/transactions/CashInputForm.tsx
+++ b/src/components/features/transactions/CashInputForm.tsx
@@ -62,7 +62,7 @@ const defaultValues = {
   market: "CASH",
   tradeDate: new Date().toISOString().split("T")[0],
   tradeCurrency: { value: "USD", label: "USD" },
-  cashCurrency: { value: "USD", label: "USD" },
+  cashCurrency: { value: "USD", label: "USD", market: "CASH" },
   quantity: 0,
   price: 1,
   tradeAmount: 0,

--- a/src/lib/utils/openBrokerage/__tests__/buildBrokerageFunding.test.ts
+++ b/src/lib/utils/openBrokerage/__tests__/buildBrokerageFunding.test.ts
@@ -1,88 +1,24 @@
 import { buildBrokerageFunding } from "../buildBrokerageFunding"
 
 describe("buildBrokerageFunding", () => {
-  it("always opens the broker cash account in Zen mode, even with no deposit", () => {
-    // The original bug: Zen mode passed `undefined`, so openBrokerage never
-    // minted the per-broker cash asset (e.g. IB-USD). The row must always
-    // exist so ensureBrokerCashAsset + settlement mapping run.
-    const funding = buildBrokerageFunding({
-      isZen: true,
-      currency: "USD",
-      amount: NaN,
-      source: "",
-      defaultPortfolioId: "pf-1",
-      bankAccountAssetIds: {},
-    })
-    expect(funding).toEqual([{ currency: "USD", amount: 0 }])
-  })
-
-  it("opens a zero-balance account for a Master broker with no opening deposit", () => {
-    const funding = buildBrokerageFunding({
-      isZen: false,
-      currency: "SGD",
-      amount: 0,
-      source: "",
-      defaultPortfolioId: "pf-1",
-      bankAccountAssetIds: {},
-    })
-    expect(funding).toEqual([{ currency: "SGD", amount: 0 }])
-  })
-
-  it("funds a Master deposit from a bank-account source on the default portfolio", () => {
-    const funding = buildBrokerageFunding({
-      isZen: false,
-      currency: "USD",
-      amount: 1000,
-      source: "bankAccount:DBS",
-      defaultPortfolioId: "pf-1",
-      bankAccountAssetIds: { DBS: "asset-dbs" },
-    })
-    expect(funding).toEqual([
-      {
-        currency: "USD",
-        amount: 1000,
-        sourceAssetId: "asset-dbs",
-        sourcePortfolioId: "pf-1",
-      },
+  it("opens one zero-balance account per currency", () => {
+    // Onboarding records opening balances later, so every row is amount 0 —
+    // openBrokerage still mints the per-broker cash asset ({code}-{ccy}) and
+    // registers it as the broker's settlement default for that currency.
+    expect(buildBrokerageFunding(["USD", "SGD"])).toEqual([
+      { currency: "USD", amount: 0 },
+      { currency: "SGD", amount: 0 },
     ])
   })
 
-  it("funds a Master deposit from a portfolio source", () => {
-    const funding = buildBrokerageFunding({
-      isZen: false,
-      currency: "USD",
-      amount: 500,
-      source: "portfolio:pf-other",
-      defaultPortfolioId: "pf-1",
-      bankAccountAssetIds: {},
-    })
-    expect(funding).toEqual([
-      { currency: "USD", amount: 500, sourcePortfolioId: "pf-other" },
+  it("dedupes and trims, ignoring blanks", () => {
+    expect(buildBrokerageFunding(["USD", "USD", "", " SGD "])).toEqual([
+      { currency: "USD", amount: 0 },
+      { currency: "SGD", amount: 0 },
     ])
   })
 
-  it("ignores a bank-account source whose asset id is unknown", () => {
-    const funding = buildBrokerageFunding({
-      isZen: false,
-      currency: "USD",
-      amount: 500,
-      source: "bankAccount:Missing",
-      defaultPortfolioId: "pf-1",
-      bankAccountAssetIds: {},
-    })
-    expect(funding).toEqual([{ currency: "USD", amount: 500 }])
-  })
-
-  it("never attaches a withdrawal source in Zen mode", () => {
-    const funding = buildBrokerageFunding({
-      isZen: true,
-      currency: "USD",
-      amount: 1000,
-      source: "bankAccount:DBS",
-      defaultPortfolioId: "pf-1",
-      bankAccountAssetIds: { DBS: "asset-dbs" },
-    })
-    expect(funding[0].sourceAssetId).toBeUndefined()
-    expect(funding[0].sourcePortfolioId).toBeUndefined()
+  it("returns no rows for an empty selection", () => {
+    expect(buildBrokerageFunding([])).toEqual([])
   })
 })

--- a/src/lib/utils/openBrokerage/buildBrokerageFunding.ts
+++ b/src/lib/utils/openBrokerage/buildBrokerageFunding.ts
@@ -1,50 +1,23 @@
 import type { FundingAccount } from "./orchestrate"
 
-export interface BrokerageFundingInput {
-  // Zen attaches the broker to the existing default portfolio; Master gives it
-  // a dedicated one. Zen hides the deposit/source fields, so funding there is
-  // always a zero-balance account opening.
-  isZen: boolean
-  // Currency the user picked for the brokerage (drives the {code}-{ccy} asset).
-  currency: string
-  // Parsed opening deposit. NaN or <= 0 means "open the account, post no trn".
-  amount: number
-  // Encoded source for the paired WITHDRAWAL: "", "portfolio:{id}" or
-  // "bankAccount:{name}". Only honoured for a funded Master deposit.
-  source: string
-  // Portfolio the user's bank-account assets live on (the default portfolio).
-  defaultPortfolioId: string
-  // name → asset id for bank accounts added earlier in onboarding.
-  bankAccountAssetIds: Record<string, string>
-}
-
 /**
- * Build the `funding` rows for openBrokerage from the onboarding wizard's
- * brokerage step. Always emits exactly one row for the chosen currency so the
- * per-broker cash asset (e.g. IB-USD) and its settlement mapping are created
- * even when no opening deposit is made. The DEPOSIT/WITHDRAWAL only posts when
- * `amount > 0` (orchestrate skips zero-amount rows), and a withdrawal source is
- * attached only for a funded Master deposit — Zen never moves cash.
+ * Build the `funding` rows for openBrokerage from the onboarding brokerage
+ * step — one account per currency the user expects to trade. openBrokerage
+ * opens the per-broker cash asset ({code}-{ccy}) for each and registers it as
+ * the broker's default settlement account for that currency.
+ *
+ * Opening balances are recorded later (Tools → Open Brokerage, or a normal cash
+ * deposit), so no DEPOSIT is posted here — every row is amount 0. Currencies are
+ * trimmed and de-duplicated so a repeated pick can't open the same account twice.
  */
-export function buildBrokerageFunding(
-  input: BrokerageFundingInput,
-): FundingAccount[] {
-  const amount =
-    Number.isFinite(input.amount) && input.amount > 0 ? input.amount : 0
-  const fund: FundingAccount = { currency: input.currency, amount }
-  if (!input.isZen && amount > 0) {
-    if (input.source.startsWith("portfolio:")) {
-      fund.sourcePortfolioId = input.source.slice("portfolio:".length)
-    } else if (input.source.startsWith("bankAccount:")) {
-      const name = input.source.slice("bankAccount:".length)
-      const assetId = input.bankAccountAssetIds[name]
-      if (assetId) {
-        fund.sourceAssetId = assetId
-        // Bank-account assets live on the default portfolio, not the new
-        // brokerage portfolio being created — pin the WITHDRAWAL there.
-        fund.sourcePortfolioId = input.defaultPortfolioId
-      }
-    }
+export function buildBrokerageFunding(currencies: string[]): FundingAccount[] {
+  const seen = new Set<string>()
+  const rows: FundingAccount[] = []
+  for (const code of currencies) {
+    const ccy = code.trim()
+    if (!ccy || seen.has(ccy)) continue
+    seen.add(ccy)
+    rows.push({ currency: ccy, amount: 0 })
   }
-  return [fund]
+  return rows
 }

--- a/src/lib/utils/trns/tradeUtils.test.ts
+++ b/src/lib/utils/trns/tradeUtils.test.ts
@@ -416,6 +416,40 @@ describe("TradeUtils", () => {
     expect(result).toContain("Buy USD/Sell SGD")
   })
 
+  test("FX buy with no buy-side market falls back to CASH, not the sell market", () => {
+    // User leaves the default Buy Currency (no market set) and sells from a
+    // PRIVATE bank account. The buy side must still resolve to a CASH balance —
+    // falling back to the sell market produced a phantom PRIVATE/USD equity
+    // asset and no USD balance appeared.
+    const data: TradeFormData = {
+      type: { value: "FX", label: "FX" },
+      asset: "DBS-SGD",
+      market: "PRIVATE", // Sell side market
+      tradeDate: "2026-06-27",
+      quantity: 5000, // Sell SGD
+      price: 1,
+      tradeCurrency: {
+        value: "SGD",
+        label: "SGD",
+        currency: "SGD",
+        market: "PRIVATE",
+      },
+      cashCurrency: {
+        value: "USD", // Default buy option — note: NO market field
+        label: "USD",
+        currency: "USD",
+      },
+      cashAmount: 3863.39, // Buy USD
+      fees: 0,
+      tax: 0,
+      comments: undefined,
+    }
+    const result = getCashRow(data)
+
+    // Must be CASH, not the sell side's PRIVATE.
+    expect(result).toContain("FX_BUY,CASH,USD,,DBS-SGD,SGD,")
+  })
+
   test("tradeCurrency defaults to cashCurrency if missing", () => {
     const data: TradeFormData = {
       type: { value: "DIVI", label: "Dividend" },

--- a/src/lib/utils/trns/tradeUtils.ts
+++ b/src/lib/utils/trns/tradeUtils.ts
@@ -281,8 +281,10 @@ export const getCashRow = (data: TradeFormData): string => {
     // come from the buy side, not tradeImport.market (the sell side). Using the
     // sell market resolved a phantom <sellMarket>/<buyCode> asset (e.g.
     // PRIVATE/USD) when buying into a different-market account, so the buy-side
-    // balance never appeared. Fall back to the sell market only if absent.
-    const buyMarket = data.cashCurrency?.market || tradeImport.market
+    // balance never appeared. When the buy option carries no market (user left
+    // the default Buy Currency), fall back to CASH — buying a currency lands in
+    // a generic cash balance — NEVER the sell market.
+    const buyMarket = data.cashCurrency?.market || "CASH"
 
     const comment = `Buy ${buyCurrency}/Sell ${sellCurrency}`
     return `${tradeImport.batchId},,FX_BUY,${buyMarket},${buyAssetCode},,${sellAssetCode},${sellCurrency},${tradeImport.tradeDate},${buyAmount},,${buyCurrency},1,${tradeImport.fees},,,-${sellAmount},${comment},${tradeImport.status},${tradeImport.brokerId}`


### PR DESCRIPTION
- onboarding BrokerageStep: pick the currencies you trade; open one
  per-broker cash account + default settlement mapping per currency
- fix FX_BUY into a generic balance defaulting to the sell market
  (phantom PRIVATE/USD asset, no cash balance)