### PR TITLE
feat(onboarding): capture medical expenses separately so phases ramp it up

### DIFF
--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -143,6 +143,8 @@ const OnboardingWizard: React.FC = () => {
   const [independenceMonthOfBirth, setIndependenceMonthOfBirth] = useState(1)
   const [independenceMonthlyExpenses, setIndependenceMonthlyExpenses] =
     useState(0)
+  const [independenceMedicalExpenses, setIndependenceMedicalExpenses] =
+    useState(0)
   const [independenceTargetAge, setIndependenceTargetAge] = useState(65)
   const [independencePlanCreated, setIndependencePlanCreated] = useState(false)
 
@@ -710,7 +712,8 @@ const OnboardingWizard: React.FC = () => {
               yearOfBirth: independenceYearOfBirth,
               planningHorizonYears: 90 - independenceTargetAge,
               lifeExpectancy: 90,
-              monthlyExpenses: independenceMonthlyExpenses,
+              monthlyExpenses:
+                independenceMonthlyExpenses + independenceMedicalExpenses,
               expensesCurrency: baseCurrency,
               cashReturnRate: 0.03,
               equityReturnRate: 0.08,
@@ -731,8 +734,10 @@ const OnboardingWizard: React.FC = () => {
           })
           if (planResponse.ok) {
             setIndependencePlanCreated(true)
-            // Persist the lump-sum retirement expenses as a categorised
-            // plan_expense row so the new plan opens with a real expense line.
+            // Persist the retirement expenses as categorised plan_expense rows
+            // (general under "Other", medical under "Healthcare") so the plan
+            // opens with real expense lines AND the phased generator can ramp
+            // medical separately from discretionary spend.
             try {
               const planBody = await planResponse.json()
               const planId = planBody?.data?.id
@@ -740,6 +745,7 @@ const OnboardingWizard: React.FC = () => {
                 await saveOnboardingExpenses(
                   planId,
                   independenceMonthlyExpenses,
+                  independenceMedicalExpenses,
                   baseCurrency,
                 )
                 // Convert the base plan into the default phased trio
@@ -916,6 +922,7 @@ const OnboardingWizard: React.FC = () => {
             yearOfBirth={independenceYearOfBirth}
             monthOfBirth={independenceMonthOfBirth}
             monthlyExpenses={independenceMonthlyExpenses}
+            medicalExpenses={independenceMedicalExpenses}
             targetRetirementAge={independenceTargetAge}
             workingIncomeMonthly={workingIncomeMonthly}
             workingExpensesMonthly={workingExpensesMonthly}
@@ -926,6 +933,7 @@ const OnboardingWizard: React.FC = () => {
             onYearOfBirthChange={setIndependenceYearOfBirth}
             onMonthOfBirthChange={setIndependenceMonthOfBirth}
             onMonthlyExpensesChange={setIndependenceMonthlyExpenses}
+            onMedicalExpensesChange={setIndependenceMedicalExpenses}
             onTargetRetirementAgeChange={setIndependenceTargetAge}
             onWorkingIncomeMonthlyChange={setWorkingIncomeMonthly}
             onWorkingExpensesMonthlyChange={setWorkingExpensesMonthly}

--- a/src/components/features/onboarding/steps/IndependencePlanStep.tsx
+++ b/src/components/features/onboarding/steps/IndependencePlanStep.tsx
@@ -28,6 +28,7 @@ export interface IndependencePlanStepProps {
   yearOfBirth: number
   monthOfBirth: number
   monthlyExpenses: number
+  medicalExpenses: number
   targetRetirementAge: number
   workingIncomeMonthly: number
   workingExpensesMonthly: number
@@ -38,6 +39,7 @@ export interface IndependencePlanStepProps {
   onYearOfBirthChange: (year: number) => void
   onMonthOfBirthChange: (month: number) => void
   onMonthlyExpensesChange: (amount: number) => void
+  onMedicalExpensesChange: (amount: number) => void
   onTargetRetirementAgeChange: (age: number) => void
   onWorkingIncomeMonthlyChange: (amount: number) => void
   onWorkingExpensesMonthlyChange: (amount: number) => void
@@ -65,6 +67,7 @@ const IndependencePlanStep: React.FC<IndependencePlanStepProps> = ({
   yearOfBirth,
   monthOfBirth,
   monthlyExpenses,
+  medicalExpenses,
   targetRetirementAge,
   workingIncomeMonthly,
   workingExpensesMonthly,
@@ -75,6 +78,7 @@ const IndependencePlanStep: React.FC<IndependencePlanStepProps> = ({
   onYearOfBirthChange,
   onMonthOfBirthChange,
   onMonthlyExpensesChange,
+  onMedicalExpensesChange,
   onTargetRetirementAgeChange,
   onWorkingIncomeMonthlyChange,
   onWorkingExpensesMonthlyChange,
@@ -202,7 +206,7 @@ const IndependencePlanStep: React.FC<IndependencePlanStepProps> = ({
                 htmlFor="independenceMonthlyExpenses"
                 className="block text-sm font-medium text-gray-700 mb-1"
               >
-                {`Estimated Monthly Expenses in Retirement (${baseCurrency})`}
+                {`General Monthly Expenses in Retirement (${baseCurrency})`}
               </label>
               <input
                 id="independenceMonthlyExpenses"
@@ -219,6 +223,38 @@ const IndependencePlanStep: React.FC<IndependencePlanStepProps> = ({
                 }
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
               />
+              <p className="mt-1 text-xs text-gray-500">
+                {"Day-to-day living costs, excluding healthcare."}
+              </p>
+            </div>
+
+            <div>
+              <label
+                htmlFor="independenceMedicalExpenses"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {`Monthly Healthcare / Medical (${baseCurrency})`}
+              </label>
+              <input
+                id="independenceMedicalExpenses"
+                type="number"
+                aria-label="Monthly medical expenses"
+                value={medicalExpenses || ""}
+                min={0}
+                step={50}
+                placeholder={"e.g. 300"}
+                onChange={(e) =>
+                  onMedicalExpensesChange(
+                    e.target.value === "" ? 0 : Number(e.target.value),
+                  )
+                }
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                {
+                  "Tracked separately so later retirement phases can ramp it up as other spending eases."
+                }
+              </p>
             </div>
           </div>
 

--- a/src/components/features/onboarding/steps/__tests__/IndependencePlanStep.test.tsx
+++ b/src/components/features/onboarding/steps/__tests__/IndependencePlanStep.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import IndependencePlanStep from "../IndependencePlanStep"
 
@@ -8,6 +8,7 @@ const baseProps = {
   yearOfBirth: 1981,
   monthOfBirth: 1,
   monthlyExpenses: 0,
+  medicalExpenses: 0,
   targetRetirementAge: 65,
   workingIncomeMonthly: 0,
   workingExpensesMonthly: 0,
@@ -18,6 +19,7 @@ const baseProps = {
   onYearOfBirthChange: jest.fn(),
   onMonthOfBirthChange: jest.fn(),
   onMonthlyExpensesChange: jest.fn(),
+  onMedicalExpensesChange: jest.fn(),
   onTargetRetirementAgeChange: jest.fn(),
   onWorkingIncomeMonthlyChange: jest.fn(),
   onWorkingExpensesMonthlyChange: jest.fn(),
@@ -53,5 +55,30 @@ describe("IndependencePlanStep — CPF date-of-birth requirement", () => {
     expect(
       screen.queryByText(/required to calculate your CPF contributions/i),
     ).not.toBeInTheDocument()
+  })
+})
+
+describe("IndependencePlanStep — retirement expenses capture", () => {
+  it("captures general and medical expenses as separate inputs", () => {
+    const onMonthlyExpensesChange = jest.fn()
+    const onMedicalExpensesChange = jest.fn()
+    render(
+      <IndependencePlanStep
+        {...baseProps}
+        enabled
+        onMonthlyExpensesChange={onMonthlyExpensesChange}
+        onMedicalExpensesChange={onMedicalExpensesChange}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText("Monthly retirement expenses"), {
+      target: { value: "3000" },
+    })
+    fireEvent.change(screen.getByLabelText("Monthly medical expenses"), {
+      target: { value: "300" },
+    })
+
+    expect(onMonthlyExpensesChange).toHaveBeenCalledWith(3000)
+    expect(onMedicalExpensesChange).toHaveBeenCalledWith(300)
   })
 })

--- a/src/lib/utils/onboarding/__tests__/saveIndependenceExpenses.test.ts
+++ b/src/lib/utils/onboarding/__tests__/saveIndependenceExpenses.test.ts
@@ -21,74 +21,102 @@ const okResponse = (): Response => ({ ok: true }) as unknown as Response
 const errorResponse = (status: number): Response =>
   ({ ok: false, status }) as unknown as Response
 
+const systemLabels = [
+  { id: "housing-1", name: "Housing" },
+  { id: "other-99", name: "Other" },
+  { id: "health-7", name: "Healthcare" },
+]
+
 describe("saveOnboardingExpenses", () => {
-  it("does not POST when the lump sum is zero", async () => {
+  it("does not fetch or POST when both amounts are zero", async () => {
     const fetchMock = jest.fn()
-    await saveOnboardingExpenses("plan-1", 0, "USD", fetchMock)
+    await saveOnboardingExpenses("plan-1", 0, 0, "USD", fetchMock)
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it("posts the lump sum against the shared Other category id", async () => {
+  it("posts the general amount under Other and the medical amount under Healthcare", async () => {
     const fetchMock = jest
       .fn()
-      .mockResolvedValueOnce(
-        categoriesResponse([
-          { id: "housing-1", name: "Housing" },
-          { id: "other-99", name: "Other" },
-        ]),
-      )
+      .mockResolvedValueOnce(categoriesResponse(systemLabels))
+      .mockResolvedValueOnce(okResponse())
       .mockResolvedValueOnce(okResponse())
 
-    await saveOnboardingExpenses("plan-1", 2500, "SGD", fetchMock)
+    await saveOnboardingExpenses("plan-1", 2500, 300, "SGD", fetchMock)
 
     expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/independence/categories")
-    const [url, init] = fetchMock.mock.calls[1]
-    expect(url).toBe("/api/independence/plans/plan-1/expenses")
-    expect(init.method).toBe("POST")
-    expect(JSON.parse(init.body)).toEqual({
+    const general = JSON.parse(fetchMock.mock.calls[1][1].body)
+    const medical = JSON.parse(fetchMock.mock.calls[2][1].body)
+    expect(general).toEqual({
       categoryLabelId: "other-99",
       categoryName: "Other",
       monthlyAmount: 2500,
       currency: "SGD",
       expensePhase: "RETIREMENT",
     })
+    expect(medical).toEqual({
+      categoryLabelId: "health-7",
+      categoryName: "Healthcare",
+      monthlyAmount: 300,
+      currency: "SGD",
+      expensePhase: "RETIREMENT",
+    })
   })
 
-  it("falls back to a custom Other label when the category is missing", async () => {
+  it("posts only the medical row when the general amount is zero", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(categoriesResponse(systemLabels))
+      .mockResolvedValueOnce(okResponse())
+
+    await saveOnboardingExpenses("plan-1", 0, 300, "USD", fetchMock)
+
+    const expensePosts = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes("/expenses"),
+    )
+    expect(expensePosts).toHaveLength(1)
+    expect(JSON.parse(expensePosts[0][1].body).categoryName).toBe("Healthcare")
+  })
+
+  it("falls back to custom labels when the seeded categories are missing", async () => {
     const fetchMock = jest
       .fn()
       .mockResolvedValueOnce(
         categoriesResponse([{ id: "housing-1", name: "Housing" }]),
       )
       .mockResolvedValueOnce(okResponse())
+      .mockResolvedValueOnce(okResponse())
 
-    await saveOnboardingExpenses("plan-1", 1000, "USD", fetchMock)
+    await saveOnboardingExpenses("plan-1", 1000, 200, "USD", fetchMock)
 
-    const [, init] = fetchMock.mock.calls[1]
-    expect(JSON.parse(init.body).categoryLabelId).toBe("custom-other")
-    expect(JSON.parse(init.body).categoryName).toBe("Other")
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).categoryLabelId).toBe(
+      "custom-other",
+    )
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body).categoryLabelId).toBe(
+      "custom-healthcare",
+    )
   })
 
-  it("falls back to a custom Other label when the categories fetch fails", async () => {
+  it("falls back to custom labels when the categories fetch fails", async () => {
     const fetchMock = jest
       .fn()
       .mockRejectedValueOnce(new Error("network"))
       .mockResolvedValueOnce(okResponse())
 
-    await saveOnboardingExpenses("plan-1", 1000, "USD", fetchMock)
+    await saveOnboardingExpenses("plan-1", 1000, 0, "USD", fetchMock)
 
-    const [, init] = fetchMock.mock.calls[1]
-    expect(JSON.parse(init.body).categoryLabelId).toBe("custom-other")
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).categoryLabelId).toBe(
+      "custom-other",
+    )
   })
 
-  it("throws when the expense POST returns a non-ok status", async () => {
+  it("throws, naming the category, when an expense POST returns a non-ok status", async () => {
     const fetchMock = jest
       .fn()
-      .mockResolvedValueOnce(categoriesResponse([{ id: "other-1", name: "Other" }]))
+      .mockResolvedValueOnce(categoriesResponse(systemLabels))
       .mockResolvedValueOnce(errorResponse(500))
 
     await expect(
-      saveOnboardingExpenses("plan-1", 1000, "USD", fetchMock),
-    ).rejects.toThrow("Failed to save onboarding expense: 500")
+      saveOnboardingExpenses("plan-1", 1000, 0, "USD", fetchMock),
+    ).rejects.toThrow("Failed to save onboarding expense (Other): 500")
   })
 })

--- a/src/lib/utils/onboarding/saveIndependenceExpenses.ts
+++ b/src/lib/utils/onboarding/saveIndependenceExpenses.ts
@@ -1,68 +1,113 @@
 /**
- * Persists the onboarding retirement-expenses lump sum as a categorised
- * plan_expense row. The onboarding wizard collects a single "monthly expenses
- * in retirement" figure but previously only stored it on the plan total — no
- * `plan_expense` rows were written, so the categorised expense breakdown was
- * empty. This saves that lump sum under the shared "Other" category so the
- * plan opens with a real, editable expense line.
+ * Persists the onboarding retirement-expenses figures as categorised
+ * `plan_expense` rows. The onboarding wizard collects a general living-cost
+ * figure plus a separate healthcare/medical figure; without these rows the
+ * categorised breakdown is empty AND the phased generator can't tell medical
+ * (which ramps up with age) apart from discretionary spend (which tapers).
  *
- * Kept out of the wizard component so it can be unit-tested in isolation.
+ * Writes one row per positive amount: the general figure under "Other", the
+ * medical figure under "Healthcare". Kept out of the wizard component so it can
+ * be unit-tested in isolation.
  */
 
 import type { CategoryLabelsResponse } from "types/independence"
 
 const OTHER_CATEGORY = "Other"
+const HEALTHCARE_CATEGORY = "Healthcare"
 // resolveCategoryLabel (svc-retire) accepts any `custom-` prefixed id without a
-// DB lookup, so this is a safe fallback if the seeded system label is absent.
+// DB lookup, so these are safe fallbacks if the seeded system label is absent.
 const CUSTOM_OTHER_ID = "custom-other"
+const CUSTOM_HEALTHCARE_ID = "custom-healthcare"
 
 /**
  * @param planId           the just-created independence plan
- * @param monthlyExpenses  the onboarding lump-sum retirement expenses
+ * @param generalExpenses  monthly living costs excluding healthcare
+ * @param medicalExpenses  monthly healthcare/medical costs (tracked separately)
  * @param currency         the plan's expense currency
  * @param fetchImpl        injectable for testing; defaults to global fetch
  */
 export async function saveOnboardingExpenses(
   planId: string,
-  monthlyExpenses: number,
+  generalExpenses: number,
+  medicalExpenses: number,
   currency: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<void> {
-  if (!planId || monthlyExpenses <= 0) return
+  if (!planId || (generalExpenses <= 0 && medicalExpenses <= 0)) return
 
-  const categoryLabelId = await resolveOtherCategoryId(fetchImpl)
+  // Resolve both category ids up front from the single categories fetch.
+  const labels = await fetchCategoryLabels(fetchImpl)
 
-  const res = await fetchImpl(`/api/independence/plans/${planId}/expenses`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      categoryLabelId,
+  const rows: Array<{
+    categoryLabelId: string
+    categoryName: string
+    amount: number
+  }> = []
+  if (generalExpenses > 0) {
+    rows.push({
+      categoryLabelId: resolveCategoryId(
+        labels,
+        OTHER_CATEGORY,
+        CUSTOM_OTHER_ID,
+      ),
       categoryName: OTHER_CATEGORY,
-      monthlyAmount: monthlyExpenses,
-      currency,
-      expensePhase: "RETIREMENT",
-    }),
-  })
+      amount: generalExpenses,
+    })
+  }
+  if (medicalExpenses > 0) {
+    rows.push({
+      categoryLabelId: resolveCategoryId(
+        labels,
+        HEALTHCARE_CATEGORY,
+        CUSTOM_HEALTHCARE_ID,
+      ),
+      categoryName: HEALTHCARE_CATEGORY,
+      amount: medicalExpenses,
+    })
+  }
 
-  // Surface a failed save rather than resolving silently — the caller logs it
-  // so the expense isn't lost without a trace while the plan total succeeds.
-  if (!res.ok) {
-    throw new Error(`Failed to save onboarding expense: ${res.status}`)
+  for (const row of rows) {
+    const res = await fetchImpl(`/api/independence/plans/${planId}/expenses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        categoryLabelId: row.categoryLabelId,
+        categoryName: row.categoryName,
+        monthlyAmount: row.amount,
+        currency,
+        expensePhase: "RETIREMENT",
+      }),
+    })
+
+    // Surface a failed save rather than resolving silently — the caller logs it
+    // so the expense isn't lost without a trace while the plan total succeeds.
+    if (!res.ok) {
+      throw new Error(
+        `Failed to save onboarding expense (${row.categoryName}): ${res.status}`,
+      )
+    }
   }
 }
 
-async function resolveOtherCategoryId(
+async function fetchCategoryLabels(
   fetchImpl: typeof fetch,
-): Promise<string> {
+): Promise<CategoryLabelsResponse["data"] | undefined> {
   try {
     const res = await fetchImpl("/api/independence/categories")
     if (res.ok) {
       const body = (await res.json()) as CategoryLabelsResponse
-      const other = body.data?.find((c) => c.name === OTHER_CATEGORY)
-      if (other) return other.id
+      return body.data
     }
   } catch {
-    // fall through to the custom fallback below
+    // fall through to the custom fallbacks
   }
-  return CUSTOM_OTHER_ID
+  return undefined
+}
+
+function resolveCategoryId(
+  labels: CategoryLabelsResponse["data"] | undefined,
+  name: string,
+  fallbackId: string,
+): string {
+  return labels?.find((c) => c.name === name)?.id ?? fallbackId
 }

--- a/src/pages/independence/setup.tsx
+++ b/src/pages/independence/setup.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router"
 import Head from "next/head"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import IndependencePlanStep from "@components/features/onboarding/steps/IndependencePlanStep"
+import { saveOnboardingExpenses } from "@lib/onboarding/saveIndependenceExpenses"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import { WorkScenario } from "types/independence"
 
@@ -16,6 +17,7 @@ function IndependenceSetupPage(): React.ReactElement {
   const [monthOfBirth, setMonthOfBirth] = useState(1)
   const [targetRetirementAge, setTargetRetirementAge] = useState(65)
   const [monthlyExpenses, setMonthlyExpenses] = useState(0)
+  const [medicalExpenses, setMedicalExpenses] = useState(0)
   const [workingIncomeMonthly, setWorkingIncomeMonthly] = useState(0)
   const [workingExpensesMonthly, setWorkingExpensesMonthly] = useState(0)
   const [taxesMonthly, setTaxesMonthly] = useState(0)
@@ -114,7 +116,7 @@ function IndependenceSetupPage(): React.ReactElement {
           yearOfBirth,
           planningHorizonYears: 90 - targetRetirementAge,
           lifeExpectancy: 90,
-          monthlyExpenses,
+          monthlyExpenses: monthlyExpenses + medicalExpenses,
           expensesCurrency: baseCurrency,
           cashReturnRate: 0.03,
           equityReturnRate: 0.08,
@@ -141,6 +143,18 @@ function IndependenceSetupPage(): React.ReactElement {
       const plan = await planResponse.json()
       const planId = plan?.data?.id ?? plan?.id
       if (planId) {
+        // Persist the general + medical figures as categorised expense rows so
+        // the plan opens with real lines and phasing can ramp medical separately.
+        try {
+          await saveOnboardingExpenses(
+            planId,
+            monthlyExpenses,
+            medicalExpenses,
+            baseCurrency,
+          )
+        } catch (expenseErr) {
+          console.warn("Failed to save setup retirement expenses:", expenseErr)
+        }
         await router.push(`/independence/wizard/${planId}`)
       } else {
         await router.push("/independence")
@@ -180,6 +194,7 @@ function IndependenceSetupPage(): React.ReactElement {
               yearOfBirth={yearOfBirth}
               monthOfBirth={monthOfBirth}
               monthlyExpenses={monthlyExpenses}
+              medicalExpenses={medicalExpenses}
               targetRetirementAge={targetRetirementAge}
               workingIncomeMonthly={workingIncomeMonthly}
               workingExpensesMonthly={workingExpensesMonthly}
@@ -190,6 +205,7 @@ function IndependenceSetupPage(): React.ReactElement {
               onYearOfBirthChange={setYearOfBirth}
               onMonthOfBirthChange={setMonthOfBirth}
               onMonthlyExpensesChange={setMonthlyExpenses}
+              onMedicalExpensesChange={setMedicalExpenses}
               onTargetRetirementAgeChange={setTargetRetirementAge}
               onWorkingIncomeMonthlyChange={setWorkingIncomeMonthly}
               onWorkingExpensesMonthlyChange={setWorkingExpensesMonthly}


### PR DESCRIPTION
Onboarding (and the standalone setup page) now collect a general
living-cost figure plus a separate healthcare/medical figure, persisted as
two categorised plan_expense rows (Other + Healthcare). The plan total is
their sum. This gives the phased generator a real medical line to ramp up
in later retirement phases while discretionary spend tapers, instead of
assuming a fixed medical fraction.