### PR TITLE
feat(assets): link CPF pension to a portfolio on create

### DIFF
--- a/__tests__/pages/assets/account.test.tsx
+++ b/__tests__/pages/assets/account.test.tsx
@@ -19,6 +19,11 @@ jest.mock("next/router", () => ({
   }),
 }))
 
+// Mock usePortfolios — the page now reads it to decide zen vs master linking.
+jest.mock("@hooks/usePortfolios", () => ({
+  usePortfolios: () => ({ portfolios: [] }),
+}))
+
 // Mock useUserPreferences
 jest.mock("@contexts/UserPreferencesContext", () => ({
   useUserPreferences: () => ({

--- a/src/components/features/onboarding/buildPensionTrn.ts
+++ b/src/components/features/onboarding/buildPensionTrn.ts
@@ -1,74 +1,30 @@
 import type { Pension } from "./OnboardingWizard"
+import {
+  buildCompositeBalanceTrn,
+  type CompositeBalanceTrnRow,
+} from "@utils/trns/compositeBalanceTrn"
 
 /**
  * Build the `/api/trns` transaction-data row that links a pension asset
- * to the default portfolio during onboarding.
- *
- * Composite pensions (CPF today) hold their balance in `subAccounts`,
- * not in the top-level `balance`. Mirror what LinkCompositeDialog posts:
- * a BALANCE trn carrying the per-sub-account map and a total equal to
- * the sum of sub-account balances, so svc-position's BalanceBehaviour
- * persists the breakdown and svc-data's `whereHeld` resolves a portfolio
- * (no "isn't in a portfolio yet" banner for freshly-onboarded users).
- * BALANCE does not impact the portfolio's cash.
- *
- * Plain pensions keep the prior behaviour: an ADD trn for the top-level
- * balance (also cash-neutral).
- *
- * Returns null when there is nothing to link (no sub-accounts and no
- * positive top-level balance) so the caller can skip the POST.
+ * to the default portfolio during onboarding. Thin adapter over the shared
+ * {@link buildCompositeBalanceTrn} (the single source of truth for the trn
+ * shape) — composite pensions (CPF) post a BALANCE trn with the per-sub-account
+ * map; plain pensions post an ADD for the top-level balance; nothing-to-link
+ * returns null.
  */
-export interface PensionTrnRow {
-  assetId: string
-  trnType: "BALANCE" | "ADD"
-  quantity: number
-  tradeCurrency: string
-  tradeDate: string
-  status: "SETTLED"
-  price?: number
-  tradeAmount?: number
-  cashCurrency?: string
-  comments?: string
-  subAccounts?: Record<string, number>
-}
+export type PensionTrnRow = CompositeBalanceTrnRow
 
 export function buildPensionTrn(
   pension: Pension,
   assetId: string,
   tradeDate: string,
 ): PensionTrnRow | null {
-  const subAccounts = pension.subAccounts ?? []
-
-  if (subAccounts.length > 0) {
-    const total = subAccounts.reduce((sum, sa) => sum + sa.balance, 0)
-    const subAccountsMap = Object.fromEntries(
-      subAccounts.map((sa) => [sa.code, sa.balance]),
-    )
-    return {
-      assetId,
-      trnType: "BALANCE",
-      quantity: total,
-      tradeAmount: total,
-      tradeDate,
-      tradeCurrency: pension.currency,
-      cashCurrency: pension.currency,
-      status: "SETTLED",
-      comments: `Link ${pension.name} balance to portfolio`,
-      subAccounts: subAccountsMap,
-    }
-  }
-
-  if (pension.balance && pension.balance > 0) {
-    return {
-      assetId,
-      trnType: "ADD",
-      quantity: pension.balance,
-      price: 1,
-      tradeCurrency: pension.currency,
-      tradeDate,
-      status: "SETTLED",
-    }
-  }
-
-  return null
+  return buildCompositeBalanceTrn({
+    assetId,
+    assetName: pension.name,
+    currency: pension.currency,
+    tradeDate,
+    subAccounts: pension.subAccounts,
+    balance: pension.balance,
+  })
 }

--- a/src/components/features/portfolios/LinkCompositeDialog.tsx
+++ b/src/components/features/portfolios/LinkCompositeDialog.tsx
@@ -1,16 +1,8 @@
 import React, { useState } from "react"
-import useSwr from "swr"
-import { portfoliosKey, simpleFetcher } from "@utils/api/fetchHelper"
+import { usePortfolios } from "@hooks/usePortfolios"
+import { useUserPreferences } from "@contexts/UserPreferencesContext"
+import { showPortfolioPicker, solePortfolio } from "@lib/user/zenMode"
 import type { StandaloneCompositeConfig } from "@hooks/useStandaloneCompositeAssets"
-
-interface PortfoliosResponse {
-  data: Array<{
-    id: string
-    code: string
-    name: string
-    currency: { code: string }
-  }>
-}
 
 interface Props {
   config: StandaloneCompositeConfig
@@ -28,23 +20,29 @@ export default function LinkCompositeDialog({
   config,
   onClose,
 }: Props): React.ReactElement {
-  const { data: portfoliosData } = useSwr<PortfoliosResponse>(
-    portfoliosKey,
-    simpleFetcher(portfoliosKey),
-  )
+  const { portfolios } = usePortfolios()
+  const { preferences } = useUserPreferences()
   const [portfolioId, setPortfolioId] = useState<string>("")
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
 
-  // Default to first same-currency portfolio once the list arrives.
-  const [prevPortfoliosData, setPrevPortfoliosData] = useState(portfoliosData)
-  if (portfoliosData !== prevPortfoliosData) {
-    setPrevPortfoliosData(portfoliosData)
-    if (!portfolioId && portfoliosData?.data?.length) {
-      const sameCcy = portfoliosData.data.find(
+  // Zen-mode users (sole portfolio) skip the picker entirely — the link
+  // auto-targets that portfolio. Master-mode users keep the dropdown.
+  const needsPick = showPortfolioPicker(portfolios, preferences)
+  const sole = solePortfolio(portfolios)
+
+  // Seed a sensible default once the list arrives: the sole portfolio in zen
+  // mode, otherwise the first same-currency portfolio.
+  const [seeded, setSeeded] = useState(false)
+  if (!seeded && portfolios.length) {
+    setSeeded(true)
+    if (!needsPick && sole) {
+      setPortfolioId(sole.id)
+    } else {
+      const sameCcy = portfolios.find(
         (p) => p.currency.code === config.currency,
       )
-      setPortfolioId((sameCcy ?? portfoliosData.data[0]).id)
+      setPortfolioId((sameCcy ?? portfolios[0]).id)
     }
   }
 
@@ -130,18 +128,27 @@ export default function LinkCompositeDialog({
           >
             Portfolio
           </label>
-          <select
-            id="link-composite-portfolio"
-            value={portfolioId}
-            onChange={(e) => setPortfolioId(e.target.value)}
-            className="w-full rounded-md border border-gray-300 p-2 text-sm"
-          >
-            {portfoliosData?.data?.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.code} — {p.name} ({p.currency.code})
-              </option>
-            ))}
-          </select>
+          {needsPick ? (
+            <select
+              id="link-composite-portfolio"
+              value={portfolioId}
+              onChange={(e) => setPortfolioId(e.target.value)}
+              className="w-full rounded-md border border-gray-300 p-2 text-sm"
+            >
+              {portfolios.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.code} — {p.name} ({p.currency.code})
+                </option>
+              ))}
+            </select>
+          ) : (
+            <p
+              id="link-composite-portfolio"
+              className="rounded-md border border-gray-200 bg-gray-50 p-2 text-sm text-gray-700"
+            >
+              {sole ? `${sole.code} — ${sole.name}` : "—"}
+            </p>
+          )}
         </div>
         {error && (
           <p className="mb-2 text-sm text-red-600" role="alert">

--- a/src/components/features/portfolios/PortfolioPickerDialog.tsx
+++ b/src/components/features/portfolios/PortfolioPickerDialog.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import { Portfolio } from "types/beancounter"
+import Dialog from "@components/ui/Dialog"
+
+interface PortfolioPickerDialogProps {
+  title: string
+  prompt: string
+  portfolios: Portfolio[]
+  onSelect: (portfolio: Portfolio) => void
+  onClose: () => void
+}
+
+/**
+ * Shared "which portfolio?" picker — a Dialog with a button list of
+ * portfolios. Used wherever master-mode users must choose a target portfolio
+ * (asset trade, CPF/composite link-on-create). Zen-mode auto-targeting (sole
+ * portfolio, no prompt) is decided by the caller via `@lib/user/zenMode`;
+ * this component only renders the choice when there genuinely is one.
+ */
+export default function PortfolioPickerDialog({
+  title,
+  prompt,
+  portfolios,
+  onSelect,
+  onClose,
+}: PortfolioPickerDialogProps): React.ReactElement {
+  return (
+    <Dialog title={title} onClose={onClose} maxWidth="md" scrollable>
+      <p className="text-sm text-gray-500">{prompt}</p>
+      <div className="space-y-2 max-h-64 overflow-y-auto">
+        {portfolios.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => onSelect(p)}
+            className="w-full flex items-center justify-between p-3 border border-gray-200 rounded-lg text-left hover:border-invest-300 hover:bg-invest-50 focus:outline-none focus:ring-2 focus:ring-invest-500"
+          >
+            <span>
+              <span className="font-medium text-gray-900">{p.name}</span>
+              <span className="block text-sm text-gray-500">{p.code}</span>
+            </span>
+            <span className="text-sm text-gray-500">{p.currency.code}</span>
+          </button>
+        ))}
+      </div>
+    </Dialog>
+  )
+}

--- a/src/components/features/portfolios/__tests__/LinkCompositeDialog.test.tsx
+++ b/src/components/features/portfolios/__tests__/LinkCompositeDialog.test.tsx
@@ -1,0 +1,54 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { SGD, USD, makePortfolio } from "@test-fixtures/beancounter"
+import LinkCompositeDialog from "@components/features/portfolios/LinkCompositeDialog"
+import type { StandaloneCompositeConfig } from "@hooks/useStandaloneCompositeAssets"
+
+let mockPortfolios = [
+  makePortfolio({ id: "pf-1", code: "MAIN", name: "Main", currency: SGD }),
+]
+jest.mock("@hooks/usePortfolios", () => ({
+  usePortfolios: () => ({ portfolios: mockPortfolios }),
+}))
+
+jest.mock("@contexts/UserPreferencesContext", () => ({
+  useUserPreferences: () => ({ preferences: null }),
+}))
+
+const config: StandaloneCompositeConfig = {
+  assetId: "cpf-1",
+  assetName: "CPF",
+  assetCode: "CPF",
+  currency: "SGD",
+  policyType: "CPF",
+  total: 350,
+  subAccounts: [{ code: "OA", balance: 350, liquid: true }],
+}
+
+describe("LinkCompositeDialog zen-awareness", () => {
+  it("hides the picker and auto-targets the sole portfolio in zen mode", () => {
+    mockPortfolios = [
+      makePortfolio({ id: "pf-1", code: "MAIN", name: "Main", currency: SGD }),
+    ]
+    render(<LinkCompositeDialog config={config} onClose={jest.fn()} />)
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+    expect(screen.getByText("MAIN — Main")).toBeInTheDocument()
+  })
+
+  it("shows the picker dropdown when the user has several portfolios", () => {
+    mockPortfolios = [
+      makePortfolio({ id: "pf-1", code: "MAIN", name: "Main", currency: SGD }),
+      makePortfolio({
+        id: "pf-2",
+        code: "USD",
+        name: "Dollars",
+        currency: USD,
+      }),
+    ]
+    render(<LinkCompositeDialog config={config} onClose={jest.fn()} />)
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: /MAIN/ })).toBeInTheDocument()
+  })
+})

--- a/src/components/features/portfolios/__tests__/PortfolioPickerDialog.test.tsx
+++ b/src/components/features/portfolios/__tests__/PortfolioPickerDialog.test.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { makePortfolio, USD, SGD } from "@test-fixtures/beancounter"
+import PortfolioPickerDialog from "@components/features/portfolios/PortfolioPickerDialog"
+
+describe("PortfolioPickerDialog", () => {
+  const portfolios = [
+    makePortfolio({ id: "p-1", code: "MAIN", name: "Main", currency: USD }),
+    makePortfolio({ id: "p-2", code: "CPF", name: "CPF Fund", currency: SGD }),
+  ]
+
+  it("renders title, prompt and one button per portfolio", () => {
+    render(
+      <PortfolioPickerDialog
+        title="Choose portfolio"
+        prompt="Which portfolio?"
+        portfolios={portfolios}
+        onSelect={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    )
+
+    expect(screen.getByText("Choose portfolio")).toBeInTheDocument()
+    expect(screen.getByText("Which portfolio?")).toBeInTheDocument()
+    expect(screen.getByText("Main")).toBeInTheDocument()
+    expect(screen.getByText("CPF Fund")).toBeInTheDocument()
+  })
+
+  it("fires onSelect with the clicked portfolio", () => {
+    const onSelect = jest.fn()
+    render(
+      <PortfolioPickerDialog
+        title="Choose portfolio"
+        prompt="Which portfolio?"
+        portfolios={portfolios}
+        onSelect={onSelect}
+        onClose={jest.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByText("CPF Fund"))
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "p-2" }),
+    )
+  })
+})

--- a/src/lib/utils/trns/__tests__/compositeBalanceTrn.test.ts
+++ b/src/lib/utils/trns/__tests__/compositeBalanceTrn.test.ts
@@ -1,0 +1,63 @@
+import { buildCompositeBalanceTrn } from "@utils/trns/compositeBalanceTrn"
+
+describe("buildCompositeBalanceTrn", () => {
+  const base = {
+    assetId: "asset-1",
+    assetName: "CPF",
+    currency: "SGD",
+    tradeDate: "2026-06-28",
+  }
+
+  it("builds a BALANCE trn carrying the sub-account map for composites", () => {
+    const row = buildCompositeBalanceTrn({
+      ...base,
+      subAccounts: [
+        { code: "OA", balance: 100 },
+        { code: "SA", balance: 250 },
+      ],
+    })
+
+    expect(row).toMatchObject({
+      assetId: "asset-1",
+      trnType: "BALANCE",
+      quantity: 350,
+      tradeAmount: 350,
+      tradeCurrency: "SGD",
+      cashCurrency: "SGD",
+      status: "SETTLED",
+      subAccounts: { OA: 100, SA: 250 },
+    })
+    expect(row?.comments).toContain("CPF")
+  })
+
+  it("builds an ADD trn for a plain positive balance", () => {
+    const row = buildCompositeBalanceTrn({ ...base, balance: 500 })
+
+    expect(row).toMatchObject({
+      assetId: "asset-1",
+      trnType: "ADD",
+      quantity: 500,
+      price: 1,
+      tradeCurrency: "SGD",
+      status: "SETTLED",
+    })
+    expect(row?.subAccounts).toBeUndefined()
+  })
+
+  it("prefers sub-accounts over a top-level balance when both are present", () => {
+    const row = buildCompositeBalanceTrn({
+      ...base,
+      subAccounts: [{ code: "OA", balance: 10 }],
+      balance: 999,
+    })
+
+    expect(row?.trnType).toBe("BALANCE")
+    expect(row?.quantity).toBe(10)
+  })
+
+  it("returns null when there is nothing to link", () => {
+    expect(buildCompositeBalanceTrn({ ...base })).toBeNull()
+    expect(buildCompositeBalanceTrn({ ...base, subAccounts: [] })).toBeNull()
+    expect(buildCompositeBalanceTrn({ ...base, balance: 0 })).toBeNull()
+  })
+})

--- a/src/lib/utils/trns/compositeBalanceTrn.ts
+++ b/src/lib/utils/trns/compositeBalanceTrn.ts
@@ -1,0 +1,82 @@
+/**
+ * Build the `/api/trns` transaction-data row that links a composite-policy
+ * (CPF today) or plain pension asset to a portfolio.
+ *
+ * Composite assets hold their balance in `subAccounts`, not in a top-level
+ * `balance`. They post a BALANCE trn carrying the per-sub-account map and a
+ * total equal to the sum of sub-account balances, so svc-position's
+ * BalanceBehaviour persists the breakdown and svc-data's `whereHeld` resolves
+ * a portfolio (no "isn't in a portfolio yet" banner). BALANCE does not impact
+ * the portfolio's cash.
+ *
+ * Plain assets keep an ADD trn for the top-level balance (also cash-neutral).
+ *
+ * Returns null when there is nothing to link (no sub-accounts and no positive
+ * top-level balance) so the caller can skip the POST.
+ *
+ * Single source of truth for onboarding (buildPensionTrn), the Add-Asset
+ * create flow, and the LinkComposite dialog — keep the trn shape here.
+ */
+export interface CompositeBalanceTrnRow {
+  assetId: string
+  trnType: "BALANCE" | "ADD"
+  quantity: number
+  tradeCurrency: string
+  tradeDate: string
+  status: "SETTLED"
+  price?: number
+  tradeAmount?: number
+  cashCurrency?: string
+  comments?: string
+  subAccounts?: Record<string, number>
+}
+
+export interface CompositeBalanceInput {
+  assetId: string
+  assetName: string
+  currency: string
+  tradeDate: string
+  /** Per-sub-account balances; non-empty means "composite" → BALANCE trn. */
+  subAccounts?: Array<{ code: string; balance: number }>
+  /** Top-level balance for plain (non-composite) assets → ADD trn. */
+  balance?: number
+}
+
+export function buildCompositeBalanceTrn(
+  input: CompositeBalanceInput,
+): CompositeBalanceTrnRow | null {
+  const subAccounts = input.subAccounts ?? []
+
+  if (subAccounts.length > 0) {
+    const total = subAccounts.reduce((sum, sa) => sum + sa.balance, 0)
+    const subAccountsMap = Object.fromEntries(
+      subAccounts.map((sa) => [sa.code, sa.balance]),
+    )
+    return {
+      assetId: input.assetId,
+      trnType: "BALANCE",
+      quantity: total,
+      tradeAmount: total,
+      tradeDate: input.tradeDate,
+      tradeCurrency: input.currency,
+      cashCurrency: input.currency,
+      status: "SETTLED",
+      comments: `Link ${input.assetName} balance to portfolio`,
+      subAccounts: subAccountsMap,
+    }
+  }
+
+  if (input.balance && input.balance > 0) {
+    return {
+      assetId: input.assetId,
+      trnType: "ADD",
+      quantity: input.balance,
+      price: 1,
+      tradeCurrency: input.currency,
+      tradeDate: input.tradeDate,
+      status: "SETTLED",
+    }
+  }
+
+  return null
+}

--- a/src/pages/assets/account.tsx
+++ b/src/pages/assets/account.tsx
@@ -21,6 +21,10 @@ import { validateInput } from "@components/errors/validator"
 import { accountInputSchema } from "@lib/account/schema"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import CompositeAssetEditor from "@components/features/assets/CompositeAssetEditor"
+import { usePortfolios } from "@hooks/usePortfolios"
+import { showPortfolioPicker, solePortfolio } from "@lib/user/zenMode"
+import { buildCompositeBalanceTrn } from "@utils/trns/compositeBalanceTrn"
+import PortfolioPickerDialog from "@components/features/portfolios/PortfolioPickerDialog"
 
 interface SectorInfo {
   code: string
@@ -53,6 +57,16 @@ export default withPageAuthRequired(
   function CreateAccount(): React.ReactElement {
     const router = useRouter()
     const { preferences, isLoading: prefsLoading } = useUserPreferences()
+    const { portfolios } = usePortfolios()
+
+    // When a composite policy (CPF) is created in master mode we can't pick the
+    // target portfolio for the user — prompt with the shared picker. Zen-mode
+    // users (sole portfolio) are auto-linked without a prompt. Holds the
+    // already-built BALANCE trn so the picker only has to supply a portfolioId.
+    const [pendingLink, setPendingLink] = useState<{
+      assetName: string
+      trnRow: NonNullable<ReturnType<typeof buildCompositeBalanceTrn>>
+    } | null>(null)
 
     // Get category from query param (e.g., /assets/account?category=POLICY)
     const categoryFromQuery = router.query.category as string | undefined
@@ -137,6 +151,57 @@ export default withPageAuthRequired(
       }
     }, [categoryFromQuery, categoryOptions, setValue])
 
+    const goToAccounts = (): void => {
+      router.push("/accounts").then()
+    }
+
+    const postLink = async (
+      portfolioId: string,
+      trnRow: NonNullable<ReturnType<typeof buildCompositeBalanceTrn>>,
+    ): Promise<void> => {
+      try {
+        await fetch("/api/trns", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ portfolioId, data: [trnRow] }),
+        })
+      } catch (err) {
+        console.error("Failed to link asset to portfolio:", err)
+      }
+    }
+
+    // Link a freshly-created composite policy (CPF) to a portfolio. Zen-mode
+    // users with a sole portfolio are auto-linked; master-mode users are
+    // prompted via PortfolioPickerDialog. Returns true when a prompt is now
+    // pending (caller must not redirect yet).
+    const linkAfterCreate = async (
+      assetId: string,
+      formData: AccountFormInput,
+    ): Promise<boolean> => {
+      const trnRow =
+        formData.category.value === "POLICY" && policyType
+          ? buildCompositeBalanceTrn({
+              assetId,
+              assetName: formData.name,
+              currency: formData.currency.value,
+              tradeDate: new Date().toISOString().slice(0, 10),
+              subAccounts,
+            })
+          : null
+
+      if (!trnRow || portfolios.length === 0) return false
+
+      if (!showPortfolioPicker(portfolios, preferences)) {
+        const sole = solePortfolio(portfolios)
+        if (sole) {
+          await postLink(sole.id, trnRow)
+          return false
+        }
+      }
+      setPendingLink({ assetName: formData.name, trnRow })
+      return true
+    }
+
     const handleSubmit: SubmitHandler<AccountFormInput> = (formData) => {
       validateInput(accountInputSchema, formData)
         .then(() => {
@@ -211,7 +276,8 @@ export default withPageAuthRequired(
                   }
                 }
 
-                router.push("/accounts").then()
+                const pending = await linkAfterCreate(createdAsset.id, formData)
+                if (!pending) goToAccounts()
               }
             })
             .catch((err) => {
@@ -384,6 +450,23 @@ export default withPageAuthRequired(
             </button>
           </div>
         </form>
+
+        {pendingLink && (
+          <PortfolioPickerDialog
+            title={`Add ${pendingLink.assetName} to a portfolio`}
+            prompt="Which portfolio do you want to add this to?"
+            portfolios={portfolios}
+            onClose={() => {
+              setPendingLink(null)
+              goToAccounts()
+            }}
+            onSelect={(p) => {
+              const { trnRow } = pendingLink
+              setPendingLink(null)
+              postLink(p.id, trnRow).finally(goToAccounts)
+            }}
+          />
+        )}
       </div>
     )
   },


### PR DESCRIPTION
Zen mode auto-links the sole portfolio; master mode prompts via a shared
PortfolioPickerDialog. Applies to the Add-Asset create page and the
LinkComposite dialog. Extracts a shared buildCompositeBalanceTrn (onboarding,
create, and link now share one BALANCE/ADD trn builder).