### PR TITLE
fix: expand price chart to all non-cash asset categories

### DIFF
--- a/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
+++ b/src/components/features/independence/composite/tabs/WealthJourneyTab.tsx
@@ -65,8 +65,15 @@ export default function WealthJourneyTab(): React.ReactElement | null {
   // buildWealthJourneyChartData also nets cpfNonLiquidValue out of
   // housingValue so users with no real estate don't see a phantom
   // Housing legend entry from the upstream svc-retire MA bleed.
+  // Prepend accumulation rows so the chart spans current-age → life-expectancy,
+  // matching the single-plan My Path tab. Backend emits accumulationProjections
+  // when the user hasn't yet reached retirement age; empty when already retired.
+  const allRows = [
+    ...(projection.accumulationProjections ?? []),
+    ...projection.yearlyProjections,
+  ]
   const { chartData, hasHousingLayer, hasAnnuitizedLayer } =
-    buildWealthJourneyChartData(projection.yearlyProjections)
+    buildWealthJourneyChartData(allRows)
 
   // First year where housingValue drops to 0 after being > 0 = property sold.
   // CompositeYearlyProjection lacks propertyLiquidated, so we detect from the

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -1236,6 +1236,8 @@ export interface CompositeProjectionResult {
   isSustainable: boolean
   yearlyProjections: CompositeYearlyProjection[]
   warnings: string[]
+  /** Pre-retirement accumulation rows (currentAge → firstPhaseAge-1). Empty when already retired. */
+  accumulationProjections?: CompositeYearlyProjection[]
 }
 
 export interface CompositeScenarioResult {


### PR DESCRIPTION
fix: expand price chart to all non-cash asset categories

feat(composite): prepend accumulation rows to WealthJourneyTab chart

CompositeProjectionResult now exposes accumulationProjections (working
years currentAge → retirementAge-1). Merge them before building chart
data so the consolidated path Wealth Journey chart matches the single-plan
My Path tab — full arc from current age to life expectancy.