### PR TITLE
feat(wealth): rolling 30-day window for Monthly Investment tile

### DIFF
--- a/src/components/features/wealth/IndependenceMetrics.tsx
+++ b/src/components/features/wealth/IndependenceMetrics.tsx
@@ -9,7 +9,8 @@ import Spinner from "@components/ui/Spinner"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
 
 interface MonthlyInvestmentData {
-  yearMonth: string
+  startDate: string
+  endDate: string
   totalInvested: number
   currency?: string
 }
@@ -38,7 +39,7 @@ export default function IndependenceMetrics({
 
   // Fetch transactions only when modal is open
   const investmentTrnsUrl = showInvestmentModal
-    ? "/api/trns/investments/monthly/transactions"
+    ? "/api/trns/investments/monthly/transactions?days=30"
     : null
   const { data: investmentTrnsData } = useSwr<{ data: Transaction[] }>(
     investmentTrnsUrl,
@@ -146,7 +147,7 @@ export default function IndependenceMetrics({
                     </div>
                     <p className="text-xs text-gray-500 mt-2">
                       {isNegative
-                        ? "Net withdrawal this month"
+                        ? "Net withdrawal (last 30 days)"
                         : progress >= 100
                           ? "Target met!"
                           : `${progress.toFixed(0)}% of monthly target`}
@@ -344,7 +345,10 @@ export default function IndependenceMetrics({
                     Monthly Investment Transactions
                   </h3>
                   <p className="text-sm text-gray-500">
-                    {monthlyInvestmentData?.yearMonth || "Current month"}
+                    {monthlyInvestmentData?.startDate &&
+                    monthlyInvestmentData?.endDate
+                      ? `${monthlyInvestmentData.startDate} – ${monthlyInvestmentData.endDate}`
+                      : "Last 30 days"}
                   </p>
                 </div>
                 <button
@@ -364,7 +368,7 @@ export default function IndependenceMetrics({
                   </div>
                 ) : investmentTrnsData.data.length === 0 ? (
                   <p className="text-center text-gray-500 py-8">
-                    No investment transactions this month
+                    No investment transactions in the last 30 days
                   </p>
                 ) : (
                   <table className="min-w-full">

--- a/src/components/features/wealth/__tests__/IndependenceMetrics.test.tsx
+++ b/src/components/features/wealth/__tests__/IndependenceMetrics.test.tsx
@@ -60,7 +60,11 @@ const render_ = (
       primaryPlan={maryPlan}
       projectionData={projectionData}
       projectionLoading={false}
-      monthlyInvestmentData={{ yearMonth: "2026-06", totalInvested }}
+      monthlyInvestmentData={{
+        startDate: "2026-06-01",
+        endDate: "2026-07-01",
+        totalInvested,
+      }}
       displayCurrency={usd}
       collapsed={false}
       onToggle={jest.fn()}

--- a/src/pages/api/trns/investments/monthly.ts
+++ b/src/pages/api/trns/investments/monthly.ts
@@ -4,8 +4,8 @@ import { getDataUrl } from "@utils/api/bcConfig"
 export default createApiHandler({
   url: (req) => {
     const params = new URLSearchParams()
-    const { yearMonth, currency, portfolioIds } = req.query
-    if (yearMonth) params.append("yearMonth", yearMonth as string)
+    const { days, currency, portfolioIds } = req.query
+    if (days) params.append("days", days as string)
     if (currency) params.append("currency", currency as string)
     if (portfolioIds) params.append("portfolioIds", portfolioIds as string)
     const qs = params.toString()

--- a/src/pages/api/trns/investments/monthly/transactions.ts
+++ b/src/pages/api/trns/investments/monthly/transactions.ts
@@ -4,9 +4,9 @@ import { transformTrnEnvelopeJson } from "@utils/trns/trnsSelectors"
 
 export default createApiHandler({
   url: (req) => {
-    const yearMonth = req.query.yearMonth as string | undefined
+    const days = req.query.days as string | undefined
     const params = new URLSearchParams()
-    if (yearMonth) params.append("yearMonth", yearMonth)
+    if (days) params.append("days", days)
     const qs = params.toString()
     return getDataUrl(
       `/trns/investments/monthly/transactions${qs ? `?${qs}` : ""}`,

--- a/src/pages/wealth.tsx
+++ b/src/pages/wealth.tsx
@@ -178,12 +178,13 @@ function WealthDashboard(): React.ReactElement {
     sourceCurrencyCodes,
   )
 
-  // Fetch monthly investment for current month (depends on display currency)
+  // Fetch investment over the rolling 30-day window (depends on display currency)
   const monthlyInvestmentUrl = displayCurrency
-    ? `/api/trns/investments/monthly?currency=${displayCurrency.code}`
+    ? `/api/trns/investments/monthly?currency=${displayCurrency.code}&days=30`
     : null
   const { data: monthlyInvestmentData } = useSwr<{
-    yearMonth: string
+    startDate: string
+    endDate: string
     totalInvested: number
     currency?: string
   }>(


### PR DESCRIPTION
Consume the svc-data rolling-window API: proxies forward a days param instead of yearMonth; the tile reads startDate/endDate; modal header and copy reflect the trailing 30-day window.