### PR TITLE
fix(rebalance): Add Asset 'All Markets' searches like header

### DIFF
--- a/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
+++ b/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
@@ -174,7 +174,7 @@ const AddAssetToModelDialog: React.FC<AddAssetToModelDialogProps> = ({
           <div className="flex-1">
             <AssetSearch
               key={`${selectedMarket}-${existingAssetIds.join(",")}`}
-              market={selectedMarket}
+              market={selectedMarket === "LOCAL" ? undefined : selectedMarket}
               knownMarkets={knownMarkets}
               value={selectedAsset}
               onSelect={setSelectedAsset}


### PR DESCRIPTION
Dialog forwarded the UI sentinel "LOCAL" as a real market query param,
so /api/assets/search filtered against a non-existent market and returned
few/no results. Translate LOCAL to undefined (no market) like the header
and admin asset search, so the default 'All Markets' does the broad search.