### PR TITLE
fix(independence): surplus plans no longer report savings running out

### DIFF
--- a/src/lib/utils/independence/journeyRibbon.test.ts
+++ b/src/lib/utils/independence/journeyRibbon.test.ts
@@ -322,6 +322,38 @@ describe("deriveJourneyRibbon", () => {
   })
 
   describe("verdict", () => {
+    it("ignores backend depletionAge when no rendered year is short (surplus plan)", () => {
+      const rows = [
+        makeDrawdownRow(60, { endingBalance: 1_400_000, expenses: 80_000 }),
+        makeDrawdownRow(75, { endingBalance: 1_600_000, expenses: 90_000 }),
+        makeDrawdownRow(90, { endingBalance: 1_800_000, expenses: 100_000 }),
+      ]
+      const result = deriveJourneyRibbon(rows, { depletionAge: 90 })
+      expect(result.verdict).toBe("Money lasts to age 90+")
+      expect(result.verdictTone).toBe("good")
+      expect(result.depletionAge).toBeUndefined()
+    })
+
+    it("falls back to the rendered shortfall age when backend depletionAge is out of range", () => {
+      const rows = [
+        makeDrawdownRow(70, { endingBalance: 100_000, expenses: 80_000 }),
+        makeDrawdownRow(84, { unfundedExpense: 20_000, endingBalance: 0 }),
+        makeDrawdownRow(90, { unfundedExpense: 30_000, endingBalance: 0 }),
+      ]
+      const result = deriveJourneyRibbon(rows, { depletionAge: 95 })
+      expect(result.verdict).toContain("Savings run out at 84")
+    })
+
+    it("omits the years-short suffix when shortfall lands on the final year", () => {
+      const rows = [
+        makeDrawdownRow(89, { endingBalance: 10_000, expenses: 80_000 }),
+        makeDrawdownRow(90, { unfundedExpense: 5_000, endingBalance: 0 }),
+      ]
+      const result = deriveJourneyRibbon(rows)
+      expect(result.verdict).toBe("Savings run out at 90")
+      expect(result.verdict).not.toContain("short")
+    })
+
     it("returns good verdict when no shortfall", () => {
       const rows = [
         makeDrawdownRow(65, {

--- a/src/lib/utils/independence/journeyRibbon.ts
+++ b/src/lib/utils/independence/journeyRibbon.ts
@@ -59,10 +59,6 @@ export function deriveJourneyRibbon(
   // Client-side detection: used for cell status/coloring and "savings run out this year" note
   const clientDepletionAge = rows.find((r) => isShortfallRow(r))?.age
 
-  // Verdict depletion age: backend value takes precedence; client detection is the fallback
-  const verdictDepletionAge =
-    opts?.depletionAge != null ? opts.depletionAge : clientDepletionAge
-
   const currency = opts?.currency ?? ""
 
   const cells: JourneyCell[] = rows.map((row, idx) => {
@@ -136,14 +132,28 @@ export function deriveJourneyRibbon(
     }
   })
 
-  // Verdict
-  if (!verdictDepletionAge) {
+  // Verdict — the rendered rows are the truth: when no year shows a shortfall,
+  // the plan lasts, regardless of the backend depletionAge (its semantics
+  // wobble at the horizon, e.g. surplus plans reporting depletion at life
+  // expectancy).
+  if (clientDepletionAge == null) {
     return {
       cells,
       verdict: `Money lasts to age ${lastAge}+`,
       verdictTone: "good",
     }
   }
+
+  // Rows do show a shortfall — the backend age refines the headline number
+  // when it falls within the rendered age range (it may sit a year before the
+  // first shortfall row: year-end vs year-start semantics).
+  const firstAge = rows[0].age
+  const verdictDepletionAge =
+    opts?.depletionAge != null &&
+    opts.depletionAge >= firstAge &&
+    opts.depletionAge <= lastAge
+      ? opts.depletionAge
+      : clientDepletionAge
 
   // Rows strictly after the verdict depletion age (post-depletion)
   const postDepletionRows = rows.filter(
@@ -166,7 +176,10 @@ export function deriveJourneyRibbon(
 
   // No annuity income post-depletion — classic "N years short" verdict
   const yearsShort = lastAge - verdictDepletionAge
-  const verdictText = `Savings run out at ${verdictDepletionAge} — ${yearsShort} year${yearsShort !== 1 ? "s" : ""} short`
+  const verdictText =
+    yearsShort > 0
+      ? `Savings run out at ${verdictDepletionAge} — ${yearsShort} year${yearsShort !== 1 ? "s" : ""} short`
+      : `Savings run out at ${verdictDepletionAge}`
   const lastRow = rows[rows.length - 1]
   // Warn when shortfall exists but final year balance is positive (lumpy expense / recovery)
   const verdictTone = lastRow.endingBalance > 0 ? "warn" : "bad"


### PR DESCRIPTION
## Summary
- Surplus plans were showing "⚠ Savings run out at 90 — 0 years short" while every ribbon cell was green: the backend `depletionAge` can report life expectancy on plans that never deplete, and the verdict trusted it blindly.
- The rendered rows are now the source of truth: no shortfall rows + positive final balance → "Money lasts to age N+", regardless of backend `depletionAge`. When rows do show a shortfall, the backend age still refines the headline (it may sit a year before the first shortfall row) but only within the rendered age range.
- "— 0 years short" suffix dropped when depletion lands on the final year.
- Regression tests for the surplus case, the out-of-range backend age, and the zero-years-short wording.