### PR TITLE
fix(composite): stack phases card on mobile behind flip card, stop narrative overlap

### DIFF
--- a/src/components/features/independence/PhaseConfigList.tsx
+++ b/src/components/features/independence/PhaseConfigList.tsx
@@ -117,7 +117,9 @@ export default function PhaseConfigList({
             return (
               <div
                 key={phase.planId}
-                className="flex items-center gap-2 px-3 py-2 text-sm"
+                // flex-wrap + min-w-0 let rows reflow on narrow (mobile flip
+                // card) widths; a no-op on desktop where the row fits one line.
+                className="flex flex-wrap items-center gap-2 px-3 py-2 text-sm min-w-0"
               >
                 <span className="font-medium text-gray-700 shrink-0 truncate max-w-[8rem]">
                   {getPlanName(plans, phase.planId)}:

--- a/src/components/features/independence/__tests__/CompositeTab.test.tsx
+++ b/src/components/features/independence/__tests__/CompositeTab.test.tsx
@@ -183,9 +183,10 @@ describe("CompositeTab", () => {
 
   it("renders narrative field in Phases tab", () => {
     render(<CompositeTab plans={plans} settings={settings} />)
-    // Narrative textarea is inside PhasesTab (default tab)
-    const narrativeLabel = screen.getByText(/Plan narrative/)
-    expect(narrativeLabel).toBeInTheDocument()
+    // Narrative textarea is inside PhasesTab (default tab).
+    // PhasesTab renders desktop + mobile copies so there are two labels.
+    const narrativeLabels = screen.getAllByText(/Plan narrative/)
+    expect(narrativeLabels.length).toBeGreaterThanOrEqual(1)
   })
 
   it("renders all sub-tabs in the navigation", () => {

--- a/src/components/features/independence/composite/__tests__/PhasesTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/PhasesTab.test.tsx
@@ -1,0 +1,154 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import type { CompositePhase } from "types/independence"
+import {
+  CompositeProjectionProvider,
+  type CompositeProjectionValue,
+} from "../CompositeProjectionContext"
+
+// Stub PhaseConfigList so we can assert it renders without dragging in
+// MathInput / DOM measurement issues.
+jest.mock(
+  "@components/features/independence/composite/../PhaseConfigList",
+  () => ({
+    __esModule: true,
+    default: (): React.ReactElement => (
+      <div data-testid="phase-config-list">PhaseConfigList stub</div>
+    ),
+  }),
+)
+
+// PhaseConfigList is imported relative from PhasesTab — also cover the
+// relative path the module resolver will use.
+jest.mock("../../PhaseConfigList", () => ({
+  __esModule: true,
+  default: (): React.ReactElement => (
+    <div data-testid="phase-config-list">PhaseConfigList stub</div>
+  ),
+}))
+
+jest.mock("@hooks/usePrivacyMode", () => ({
+  usePrivacyMode: () => ({ hideValues: false }),
+}))
+
+import PhasesTab from "../tabs/PhasesTab"
+
+const defaultPhases: CompositePhase[] = [
+  { planId: "p1", fromAge: 65, toAge: 90 },
+]
+
+function makeCtx(
+  overrides: Partial<CompositeProjectionValue> = {},
+): CompositeProjectionValue {
+  return {
+    plans: [],
+    phases: defaultPhases,
+    setPhases: jest.fn(),
+    displayCurrency: "USD",
+    setDisplayCurrency: jest.fn(),
+    excludedPlanIds: new Set<string>(),
+    toggleExclusion: jest.fn(),
+    compositeNarrative: "My plan narrative",
+    setCompositeNarrative: jest.fn(),
+    compositeWorkScenarioId: undefined,
+    setCompositeWorkScenarioId: jest.fn(),
+    projection: undefined,
+    scenarios: undefined,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  }
+}
+
+function renderWithCtx(
+  ctxOverrides: Partial<CompositeProjectionValue> = {},
+): void {
+  const ctx = makeCtx(ctxOverrides)
+  render(
+    <CompositeProjectionProvider value={ctx}>
+      <PhasesTab />
+    </CompositeProjectionProvider>,
+  )
+}
+
+describe("PhasesTab", () => {
+  it("renders the desktop layout container", () => {
+    renderWithCtx()
+    expect(screen.getByTestId("phases-desktop-layout")).toBeInTheDocument()
+  })
+
+  it("desktop layout contains the narrative textarea with id=composite-narrative", () => {
+    renderWithCtx()
+    const desktopLayout = screen.getByTestId("phases-desktop-layout")
+    // The desktop textarea sits inside the desktop layout div.
+    const desktopTextarea = desktopLayout.querySelector(
+      "textarea#composite-narrative",
+    )
+    expect(desktopTextarea).toBeInTheDocument()
+  })
+
+  it("renders the mobile layout container", () => {
+    renderWithCtx()
+    expect(screen.getByTestId("phases-mobile-layout")).toBeInTheDocument()
+  })
+
+  it("mobile layout contains its own narrative textarea with unique id", () => {
+    renderWithCtx()
+    const mobileLayout = screen.getByTestId("phases-mobile-layout")
+    const mobileTextarea = mobileLayout.querySelector(
+      "textarea#composite-narrative-mobile",
+    )
+    expect(mobileTextarea).toBeInTheDocument()
+  })
+
+  it("both textarea ids are present in the document and are different", () => {
+    renderWithCtx()
+    const desktopTextarea = document.getElementById("composite-narrative")
+    const mobileTextarea = document.getElementById("composite-narrative-mobile")
+
+    expect(desktopTextarea).toBeInTheDocument()
+    expect(mobileTextarea).toBeInTheDocument()
+    expect(desktopTextarea?.id).not.toBe(mobileTextarea?.id)
+  })
+
+  it("both textareas reflect the compositeNarrative value from context", () => {
+    renderWithCtx({ compositeNarrative: "Phase narrative text" })
+
+    const allTextareas = screen.getAllByPlaceholderText(
+      /Overarching goal across all phases/i,
+    )
+    // One from desktop layout, one from mobile flip card
+    expect(allTextareas).toHaveLength(2)
+    allTextareas.forEach((ta) => {
+      expect(ta).toHaveValue("Phase narrative text")
+    })
+  })
+
+  it("renders PhaseConfigList in both desktop and mobile layouts", () => {
+    renderWithCtx()
+    const stubs = screen.getAllByTestId("phase-config-list")
+    // desktop layout + mobile flip card (front face)
+    expect(stubs.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("mobile layout contains a FlipCard flip-card-inner element", () => {
+    renderWithCtx()
+    const mobileLayout = screen.getByTestId("phases-mobile-layout")
+    const inner = mobileLayout.querySelector("[data-testid='flip-card-inner']")
+    expect(inner).toBeInTheDocument()
+  })
+
+  it("shows an error alert when error is set", () => {
+    renderWithCtx({ error: "Something went wrong" })
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument()
+  })
+
+  it("shows a spinner when isLoading is true", () => {
+    renderWithCtx({ isLoading: true })
+    // Spinner renders a visually-hidden label; check for it
+    expect(
+      screen.getByText(/Calculating composite projection/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/features/independence/composite/tabs/PhasesTab.tsx
+++ b/src/components/features/independence/composite/tabs/PhasesTab.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import PhaseConfigList from "../../PhaseConfigList"
+import FlipCard from "@components/ui/FlipCard"
 import Spinner from "@components/ui/Spinner"
 import Alert from "@components/ui/Alert"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
@@ -7,9 +8,46 @@ import { useCompositeProjectionContext } from "../CompositeProjectionContext"
 
 const HIDDEN_VALUE = "****"
 
+/** Shared narrative textarea content — accepts an `id` so desktop and mobile
+ *  copies can each have a unique DOM id while staying controlled from the same
+ *  context value. */
+function NarrativeField({
+  id,
+  value,
+  onChange,
+}: {
+  id: string
+  value: string
+  onChange: (v: string) => void
+}): React.ReactElement {
+  return (
+    <>
+      <label
+        htmlFor={id}
+        className="block text-sm font-medium text-gray-700 mb-1"
+      >
+        Plan narrative
+        <span className="ml-1 text-xs font-normal text-gray-500">
+          (optional)
+        </span>
+      </label>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={7}
+        placeholder="Overarching goal across all phases. Used as context by AI tools."
+        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+      />
+    </>
+  )
+}
+
 /**
- * Phases tab — phase configuration (left) + narrative (right) in a two-column
- * layout, followed by the scenario comparison table.
+ * Phases tab — phase configuration (left) + narrative (right).
+ *
+ * Desktop (`lg+`): unchanged two-column layout — config flex-1, narrative w-72.
+ * Mobile (below `lg`): a flip card — front = PhaseConfigList, back = narrative.
  */
 export default function PhasesTab(): React.ReactElement {
   const { hideValues } = usePrivacyMode()
@@ -26,11 +64,17 @@ export default function PhasesTab(): React.ReactElement {
     setCompositeNarrative,
   } = useCompositeProjectionContext()
 
+  const narrativeValue = compositeNarrative ?? ""
+
   return (
     <div className="space-y-6">
       {/* Phase Configuration + Narrative */}
       <div className="bg-white rounded-xl shadow-md p-4">
-        <div className="flex gap-6">
+        {/* ── Desktop: two-column side-by-side (lg+) ── */}
+        <div
+          className="hidden lg:flex gap-6"
+          data-testid="phases-desktop-layout"
+        >
           <div className="flex-1 min-w-0">
             <PhaseConfigList
               plans={plans}
@@ -41,24 +85,36 @@ export default function PhasesTab(): React.ReactElement {
             />
           </div>
           <div className="w-72 shrink-0">
-            <label
-              htmlFor="composite-narrative"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              Plan narrative
-              <span className="ml-1 text-xs font-normal text-gray-500">
-                (optional)
-              </span>
-            </label>
-            <textarea
+            <NarrativeField
               id="composite-narrative"
-              value={compositeNarrative ?? ""}
-              onChange={(e) => setCompositeNarrative(e.target.value)}
-              rows={7}
-              placeholder="Overarching goal across all phases. Used as context by AI tools."
-              className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+              value={narrativeValue}
+              onChange={setCompositeNarrative}
             />
           </div>
+        </div>
+
+        {/* ── Mobile: flip card (below lg) ── */}
+        <div className="lg:hidden" data-testid="phases-mobile-layout">
+          <FlipCard
+            frontLabel="Phases"
+            backLabel="Narrative"
+            front={
+              <PhaseConfigList
+                plans={plans}
+                phases={phases}
+                onPhaseChange={setPhases}
+                onExclude={toggleExclusion}
+                excludedPlanIds={excludedPlanIds}
+              />
+            }
+            back={
+              <NarrativeField
+                id="composite-narrative-mobile"
+                value={narrativeValue}
+                onChange={setCompositeNarrative}
+              />
+            }
+          />
         </div>
       </div>
 

--- a/src/components/ui/FlipCard.tsx
+++ b/src/components/ui/FlipCard.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from "react"
+
+interface FlipCardProps {
+  /** Content rendered on the front face (shown first). */
+  front: React.ReactNode
+  /** Content rendered on the back face. */
+  back: React.ReactNode
+  /** Short label used in the toggle button on the front face ("→ {backLabel}"). */
+  frontLabel: string
+  /** Short label used in the toggle button on the back face ("← {frontLabel}"). */
+  backLabel: string
+}
+
+/**
+ * Mobile-only flip card. Renders `front` and `back` as two faces of a 3-D
+ * card; a toggle button on each face rotates between them.
+ *
+ * Only active below the `lg` breakpoint. On `lg+` callers should use the
+ * normal two-column layout (`hidden lg:flex`) in parallel with `lg:hidden`
+ * wrapping this component.
+ *
+ * Accessibility:
+ * - The non-visible face carries `aria-hidden="true"` and `inert` so its
+ *   focusable children cannot be tabbed into.
+ * - Toggle buttons carry a descriptive `aria-label`.
+ * - `motion-reduce:transition-none` respects the OS reduced-motion setting.
+ */
+export default function FlipCard({
+  front,
+  back,
+  frontLabel,
+  backLabel,
+}: FlipCardProps): React.ReactElement {
+  const [flipped, setFlipped] = useState(false)
+
+  return (
+    <div
+      className="[perspective:1200px]"
+      // Give the container a stable height equal to whichever face is taller.
+      // Both faces share the same grid cell so the container height is the max.
+      style={{ minHeight: 0 }}
+    >
+      {/* Inner wrapper — both faces share grid-area 1/1 so the container
+          height is the natural max of the two faces. */}
+      <div
+        className={[
+          "grid transition-transform duration-500 motion-reduce:transition-none",
+          "[transform-style:preserve-3d]",
+          flipped ? "[transform:rotateY(180deg)]" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        style={{ gridTemplateAreas: "'card'" }}
+        data-testid="flip-card-inner"
+      >
+        {/* ── Front face ── */}
+        <div
+          className="[grid-area:card] [backface-visibility:hidden]"
+          aria-hidden={flipped ? "true" : undefined}
+          {...(flipped ? { inert: true } : {})}
+        >
+          {front}
+          <div className="flex justify-end mt-2">
+            <button
+              type="button"
+              onClick={() => setFlipped(true)}
+              aria-label={`Show ${backLabel}`}
+              className="inline-flex items-center gap-1 text-xs text-independence-600 hover:text-independence-800 focus:outline-none focus:ring-2 focus:ring-independence-500 rounded px-2 py-1"
+            >
+              {backLabel}
+              <i className="fas fa-rotate-right" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        {/* ── Back face ── */}
+        <div
+          className="[grid-area:card] [backface-visibility:hidden] [transform:rotateY(180deg)]"
+          aria-hidden={!flipped ? "true" : undefined}
+          {...(!flipped ? { inert: true } : {})}
+        >
+          <div className="flex justify-start mb-2">
+            <button
+              type="button"
+              onClick={() => setFlipped(false)}
+              aria-label={`Show ${frontLabel}`}
+              className="inline-flex items-center gap-1 text-xs text-independence-600 hover:text-independence-800 focus:outline-none focus:ring-2 focus:ring-independence-500 rounded px-2 py-1"
+            >
+              <i className="fas fa-rotate-left" aria-hidden="true" />
+              {frontLabel}
+            </button>
+          </div>
+          {back}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/FlipCard.tsx
+++ b/src/components/ui/FlipCard.tsx
@@ -44,7 +44,7 @@ export default function FlipCard({
           height is the natural max of the two faces. */}
       <div
         className={[
-          "grid transition-transform duration-500 motion-reduce:transition-none",
+          "grid w-full transition-transform duration-500 motion-reduce:transition-none",
           "[transform-style:preserve-3d]",
           flipped ? "[transform:rotateY(180deg)]" : "",
         ]
@@ -55,7 +55,7 @@ export default function FlipCard({
       >
         {/* ── Front face ── */}
         <div
-          className="[grid-area:card] [backface-visibility:hidden]"
+          className="[grid-area:card] min-w-0 max-w-full [backface-visibility:hidden]"
           aria-hidden={flipped ? "true" : undefined}
           {...(flipped ? { inert: true } : {})}
         >
@@ -75,7 +75,7 @@ export default function FlipCard({
 
         {/* ── Back face ── */}
         <div
-          className="[grid-area:card] [backface-visibility:hidden] [transform:rotateY(180deg)]"
+          className="[grid-area:card] min-w-0 max-w-full [backface-visibility:hidden] [transform:rotateY(180deg)]"
           aria-hidden={!flipped ? "true" : undefined}
           {...(!flipped ? { inert: true } : {})}
         >

--- a/src/components/ui/__tests__/FlipCard.test.tsx
+++ b/src/components/ui/__tests__/FlipCard.test.tsx
@@ -1,0 +1,105 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import "@testing-library/jest-dom"
+import FlipCard from "../FlipCard"
+
+function renderFlipCard(
+  overrides: Partial<React.ComponentProps<typeof FlipCard>> = {},
+): void {
+  render(
+    <FlipCard
+      front={<div>Front content</div>}
+      back={<div>Back content</div>}
+      frontLabel="Phases"
+      backLabel="Narrative"
+      {...overrides}
+    />,
+  )
+}
+
+describe("FlipCard", () => {
+  it("renders front content and hides back on initial render", () => {
+    renderFlipCard()
+    expect(screen.getByText("Front content")).toBeInTheDocument()
+    expect(screen.getByText("Back content")).toBeInTheDocument()
+
+    // Back face is in the DOM but aria-hidden
+    const backFace = screen.getByText("Back content").closest("[aria-hidden]")
+    expect(backFace).toHaveAttribute("aria-hidden", "true")
+
+    // Front face is NOT aria-hidden
+    const frontFace = screen.getByText("Front content").parentElement
+    expect(frontFace).not.toHaveAttribute("aria-hidden")
+  })
+
+  it("shows the 'Narrative' toggle button on front face initially", () => {
+    renderFlipCard()
+    expect(
+      screen.getByRole("button", { name: /Show Narrative/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("shows the 'Phases' back button once flipped", async () => {
+    const user = userEvent.setup()
+    renderFlipCard()
+
+    await user.click(screen.getByRole("button", { name: /Show Narrative/i }))
+
+    expect(
+      screen.getByRole("button", { name: /Show Phases/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("flips: front becomes aria-hidden after clicking the forward toggle", async () => {
+    const user = userEvent.setup()
+    renderFlipCard()
+
+    await user.click(screen.getByRole("button", { name: /Show Narrative/i }))
+
+    const frontFace = screen.getByText("Front content").closest("[aria-hidden]")
+    expect(frontFace).toHaveAttribute("aria-hidden", "true")
+
+    // Back face is no longer aria-hidden
+    const backFace = screen.getByText("Back content").parentElement
+    expect(backFace).not.toHaveAttribute("aria-hidden")
+  })
+
+  it("flips back: front recovers when back button is clicked", async () => {
+    const user = userEvent.setup()
+    renderFlipCard()
+
+    await user.click(screen.getByRole("button", { name: /Show Narrative/i }))
+    await user.click(screen.getByRole("button", { name: /Show Phases/i }))
+
+    // Front should be visible again (not aria-hidden)
+    const frontFace = screen.getByText("Front content").parentElement
+    expect(frontFace).not.toHaveAttribute("aria-hidden")
+
+    // Back should be aria-hidden again
+    const backFace = screen.getByText("Back content").closest("[aria-hidden]")
+    expect(backFace).toHaveAttribute("aria-hidden", "true")
+  })
+
+  it("renders custom front and back labels in toggle buttons", () => {
+    renderFlipCard({ frontLabel: "Config", backLabel: "Notes" })
+
+    expect(
+      screen.getByRole("button", { name: /Show Notes/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("shows back label button on front face and front label button on back face", async () => {
+    const user = userEvent.setup()
+    renderFlipCard({ frontLabel: "Config", backLabel: "Notes" })
+
+    // Initially: forward button visible ("Show Notes")
+    expect(screen.getByRole("button", { name: /Show Notes/i })).toBeVisible()
+
+    // After flip: back button visible ("Show Config")
+    await user.click(screen.getByRole("button", { name: /Show Notes/i }))
+    expect(
+      screen.getByRole("button", { name: /Show Config/i }),
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Composite Phases tab on mobile: phase config and the "Plan narrative" textarea sat in a fixed two-column flex with no responsive stacking — on phone widths the narrative column overflowed on top of the crushed config (headings interleaved, checkboxes under the textarea).
- Fix: desktop keeps the exact two-column layout (`hidden lg:flex`); below `lg` the card becomes a 3-D flip card (new reusable `ui/FlipCard`) — phase config on the front, narrative on the back, toggle buttons each face. `aria-hidden` + `inert` on the non-visible face, `motion-reduce:transition-none`.
- Follow-up commit constrains face widths (`min-w-0 max-w-full`) and lets PhaseConfigList rows wrap so content fits ~320px cards without horizontal scroll.
- Verified with Playwright at 390x844 (front/back faces fully inside viewport, no h-scroll, a11y attributes held) and desktop 1440 (pixel-identical two-column).