### PR TITLE
feat(independence): account-level Net Worth tab in Composite view

### DIFF
--- a/src/components/features/independence/CompositeTab.tsx
+++ b/src/components/features/independence/CompositeTab.tsx
@@ -37,9 +37,9 @@ interface CompositeSubTabConfig {
 
 const COMPOSITE_SUB_TABS: CompositeSubTabConfig[] = [
   { id: "phases", label: "Phases", icon: "fa-clipboard-list" },
+  { id: "networth", label: "Net Worth", icon: "fa-wallet" },
   { id: "overview", label: "FI Overview", icon: "fa-bullseye" },
   { id: "wealth", label: "Wealth Journey", icon: "fa-chart-line" },
-  { id: "networth", label: "Net Worth", icon: "fa-wallet" },
   { id: "stress", label: "Stress Test", icon: "fa-dice" },
   { id: "timeline", label: "Year-by-Year", icon: "fa-table" },
 ]

--- a/src/components/features/independence/CompositeTab.tsx
+++ b/src/components/features/independence/CompositeTab.tsx
@@ -14,6 +14,7 @@ import WealthJourneyTab from "./composite/tabs/WealthJourneyTab"
 import StressTestTab from "./composite/tabs/StressTestTab"
 import YearByYearTab from "./composite/tabs/YearByYearTab"
 import FiOverviewTab from "./composite/tabs/FiOverviewTab"
+import NetWorthTab from "./composite/tabs/NetWorthTab"
 
 interface CompositeTabProps {
   plans: RetirementPlan[]
@@ -24,6 +25,7 @@ type CompositeSubTabId =
   | "overview"
   | "phases"
   | "wealth"
+  | "networth"
   | "stress"
   | "timeline"
 
@@ -37,6 +39,7 @@ const COMPOSITE_SUB_TABS: CompositeSubTabConfig[] = [
   { id: "phases", label: "Phases", icon: "fa-clipboard-list" },
   { id: "overview", label: "FI Overview", icon: "fa-bullseye" },
   { id: "wealth", label: "Wealth Journey", icon: "fa-chart-line" },
+  { id: "networth", label: "Net Worth", icon: "fa-wallet" },
   { id: "stress", label: "Stress Test", icon: "fa-dice" },
   { id: "timeline", label: "Year-by-Year", icon: "fa-table" },
 ]
@@ -133,6 +136,7 @@ export default function CompositeTab({
         {activeTab === "overview" && <FiOverviewTab />}
         {activeTab === "phases" && <PhasesTab />}
         {activeTab === "wealth" && <WealthJourneyTab />}
+        {activeTab === "networth" && <NetWorthTab />}
         {activeTab === "stress" && <StressTestTab />}
         {activeTab === "timeline" && <YearByYearTab />}
       </div>

--- a/src/components/features/independence/composite/__tests__/NetWorthTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/NetWorthTab.test.tsx
@@ -59,8 +59,11 @@ const defaultNetWorthData: UseNetWorthDataResult = {
 
 let mockNetWorthData: UseNetWorthDataResult = { ...defaultNetWorthData }
 
+// Spy so tests can assert which excludedPortfolioIds were passed
+const mockUseNetWorthData = jest.fn()
+
 jest.mock("@components/features/wealth/useNetWorthData", () => ({
-  useNetWorthData: () => mockNetWorthData,
+  useNetWorthData: (...args: unknown[]) => mockUseNetWorthData(...args),
 }))
 
 // ── useWealthSummary — spy to assert filtered inputs ─────────────────────────
@@ -122,6 +125,7 @@ describe("NetWorthTab", () => {
       ...defaultNetWorthData,
       portfolios: [mockPortfolio1, mockPortfolio2],
     }
+    mockUseNetWorthData.mockImplementation(() => mockNetWorthData)
     mockWealthSummaryFn.mockReturnValue(makeSummary(150000))
   })
 
@@ -222,6 +226,45 @@ describe("NetWorthTab", () => {
       const callArgs = mockWealthSummaryFn.mock.calls[0]
       const portfoliosArg = callArgs[0] as Portfolio[]
       expect(portfoliosArg).toHaveLength(2)
+    })
+  })
+
+  describe("holdings fetch scoping via useNetWorthData", () => {
+    it("passes excluded ids to useNetWorthData so the holdings URL is scoped", () => {
+      mockSettings = { excludedPortfolioIds: JSON.stringify(["pf-1"]) }
+      render(<NetWorthTab />)
+      // The hook receives the excluded list; it builds ids= from portfolios minus this set
+      expect(mockUseNetWorthData).toHaveBeenCalledWith(["pf-1"])
+    })
+
+    it("passes empty excluded ids when no exclusions are configured", () => {
+      mockSettings = {}
+      render(<NetWorthTab />)
+      expect(mockUseNetWorthData).toHaveBeenCalledWith([])
+    })
+
+    it("excluded portfolio id is absent from the list passed to useNetWorthData", () => {
+      mockSettings = { excludedPortfolioIds: JSON.stringify(["pf-2"]) }
+      render(<NetWorthTab />)
+      const args = mockUseNetWorthData.mock.calls[0][0] as string[]
+      // pf-2 is excluded so it should be in the excluded-ids arg, not filtered out here —
+      // the hook is responsible for deriving included from portfolios minus excluded.
+      expect(args).toEqual(["pf-2"])
+    })
+
+    it("toggling exclusion then calling mutateSettings triggers a re-render with updated excluded ids", async () => {
+      mockSettings = {}
+      render(<NetWorthTab />)
+      // Initially no exclusions
+      expect(mockUseNetWorthData).toHaveBeenCalledWith([])
+
+      const alphaCheckbox = screen.getByRole("checkbox", { name: /ALPHA/ })
+      fireEvent.click(alphaCheckbox)
+      await new Promise((r) => setTimeout(r, 0))
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        excludedPortfolioIds: JSON.stringify(["pf-1"]),
+      })
+      expect(mockMutateSettings).toHaveBeenCalled()
     })
   })
 

--- a/src/components/features/independence/composite/__tests__/NetWorthTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/NetWorthTab.test.tsx
@@ -1,0 +1,279 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import type { Portfolio } from "types/beancounter"
+import type { WealthSummary } from "@lib/wealth/liquidityGroups"
+import type { UseNetWorthDataResult } from "@components/features/wealth/useNetWorthData"
+
+// ── Data hooks ───────────────────────────────────────────────────────────────
+
+const mockUpdateSettings = jest.fn().mockResolvedValue({})
+const mockMutateSettings = jest.fn()
+
+let mockSettings: {
+  excludedPortfolioIds?: string | null
+  manualAssets?: string | null
+} = {}
+
+jest.mock("@hooks/useIndependenceSettings", () => ({
+  useIndependenceSettings: () => ({
+    settings: mockSettings,
+    updateSettings: mockUpdateSettings,
+    mutateSettings: mockMutateSettings,
+    isLoading: false,
+  }),
+}))
+
+const mockPortfolio1: Portfolio = {
+  id: "pf-1",
+  code: "ALPHA",
+  name: "Alpha Portfolio",
+  base: { id: "usd", code: "USD", symbol: "$", name: "US Dollar" },
+  currency: { id: "usd", code: "USD", symbol: "$", name: "US Dollar" },
+  marketValue: 100000,
+  irr: 0.05,
+} as unknown as Portfolio
+
+const mockPortfolio2: Portfolio = {
+  id: "pf-2",
+  code: "BETA",
+  name: "Beta Portfolio",
+  base: { id: "usd", code: "USD", symbol: "$", name: "US Dollar" },
+  currency: { id: "usd", code: "USD", symbol: "$", name: "US Dollar" },
+  marketValue: 50000,
+  irr: 0.03,
+} as unknown as Portfolio
+
+const defaultNetWorthData: UseNetWorthDataResult = {
+  portfolios: [mockPortfolio1, mockPortfolio2],
+  holdingsData: undefined,
+  currencies: [{ code: "USD", symbol: "$", name: "US Dollar" }],
+  displayCurrency: { code: "USD", symbol: "$", name: "US Dollar" },
+  setDisplayCurrency: jest.fn(),
+  fxRates: { USD: 1 },
+  fxReady: true,
+  customAssetTotals: {},
+  healthcareReserveTotals: {},
+  isLoading: false,
+}
+
+let mockNetWorthData: UseNetWorthDataResult = { ...defaultNetWorthData }
+
+jest.mock("@components/features/wealth/useNetWorthData", () => ({
+  useNetWorthData: () => mockNetWorthData,
+}))
+
+// ── useWealthSummary — spy to assert filtered inputs ─────────────────────────
+
+const mockWealthSummaryFn = jest.fn()
+
+jest.mock("@components/features/wealth/useWealthSummary", () => ({
+  useWealthSummary: (...args: unknown[]) => mockWealthSummaryFn(...args),
+}))
+
+function makeSummary(totalValue: number): WealthSummary {
+  return {
+    totalValue,
+    totalGainOnDay: 0,
+    portfolioCount: 1,
+    healthcareReserve: 0,
+    classificationBreakdown: [],
+    portfolioBreakdown: [],
+  }
+}
+
+// ── Wealth display components — stub so tests don't need full dep tree ───────
+
+jest.mock("@components/features/wealth/WealthHeroSection", () => ({
+  __esModule: true,
+  default: ({ summary }: { summary: WealthSummary }) => (
+    <div data-testid="wealth-hero">
+      <span data-testid="total-value">{summary.totalValue}</span>
+    </div>
+  ),
+}))
+
+jest.mock("@components/features/wealth/AssetAllocationCharts", () => ({
+  __esModule: true,
+  default: () => <div data-testid="asset-allocation-charts" />,
+}))
+
+jest.mock("@components/features/wealth/PortfolioDetailsTable", () => ({
+  __esModule: true,
+  default: () => <div data-testid="portfolio-details-table" />,
+}))
+
+jest.mock("@components/ui/Spinner", () => ({
+  __esModule: true,
+  default: ({ label }: { label?: string }) => (
+    <div data-testid="spinner">{label}</div>
+  ),
+}))
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+import NetWorthTab from "../tabs/NetWorthTab"
+
+describe("NetWorthTab", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSettings = {}
+    mockNetWorthData = {
+      ...defaultNetWorthData,
+      portfolios: [mockPortfolio1, mockPortfolio2],
+    }
+    mockWealthSummaryFn.mockReturnValue(makeSummary(150000))
+  })
+
+  describe("rendering", () => {
+    it("shows the wealth hero with the summary total", () => {
+      render(<NetWorthTab />)
+      expect(screen.getByTestId("wealth-hero")).toBeInTheDocument()
+      expect(screen.getByTestId("total-value")).toHaveTextContent("150000")
+    })
+
+    it("renders a spinner while data is loading", () => {
+      mockNetWorthData = { ...defaultNetWorthData, isLoading: true }
+      render(<NetWorthTab />)
+      expect(screen.getByTestId("spinner")).toBeInTheDocument()
+      expect(screen.queryByTestId("wealth-hero")).not.toBeInTheDocument()
+    })
+
+    it("renders checkboxes for each portfolio", () => {
+      render(<NetWorthTab />)
+      expect(screen.getByLabelText(/ALPHA/)).toBeInTheDocument()
+      expect(screen.getByLabelText(/BETA/)).toBeInTheDocument()
+    })
+
+    it("all portfolios are checked by default when no exclusions in settings", () => {
+      mockSettings = { excludedPortfolioIds: null }
+      render(<NetWorthTab />)
+      const alphaCheckbox = screen.getByRole("checkbox", { name: /ALPHA/ })
+      const betaCheckbox = screen.getByRole("checkbox", { name: /BETA/ })
+      expect(alphaCheckbox).toBeChecked()
+      expect(betaCheckbox).toBeChecked()
+    })
+
+    it("excluded portfolio checkbox is unchecked when in settings", () => {
+      mockSettings = { excludedPortfolioIds: JSON.stringify(["pf-1"]) }
+      render(<NetWorthTab />)
+      const alphaCheckbox = screen.getByRole("checkbox", { name: /ALPHA/ })
+      const betaCheckbox = screen.getByRole("checkbox", { name: /BETA/ })
+      expect(alphaCheckbox).not.toBeChecked()
+      expect(betaCheckbox).toBeChecked()
+    })
+  })
+
+  describe("portfolio exclusion toggling", () => {
+    it("unchecking a portfolio calls updateSettings with its id in excludedPortfolioIds", () => {
+      mockSettings = {}
+      render(<NetWorthTab />)
+      const alphaCheckbox = screen.getByRole("checkbox", { name: /ALPHA/ })
+      fireEvent.click(alphaCheckbox)
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        excludedPortfolioIds: JSON.stringify(["pf-1"]),
+      })
+    })
+
+    it("re-checking an excluded portfolio removes it from excluded list", () => {
+      mockSettings = { excludedPortfolioIds: JSON.stringify(["pf-1"]) }
+      render(<NetWorthTab />)
+      const alphaCheckbox = screen.getByRole("checkbox", { name: /ALPHA/ })
+      fireEvent.click(alphaCheckbox)
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        excludedPortfolioIds: JSON.stringify([]),
+      })
+    })
+
+    it("adding a second exclusion preserves the first", () => {
+      mockSettings = { excludedPortfolioIds: JSON.stringify(["pf-1"]) }
+      render(<NetWorthTab />)
+      const betaCheckbox = screen.getByRole("checkbox", { name: /BETA/ })
+      fireEvent.click(betaCheckbox)
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        excludedPortfolioIds: JSON.stringify(["pf-1", "pf-2"]),
+      })
+    })
+
+    it("mutateSettings is called after updateSettings", async () => {
+      mockSettings = {}
+      render(<NetWorthTab />)
+      const alphaCheckbox = screen.getByRole("checkbox", { name: /ALPHA/ })
+      fireEvent.click(alphaCheckbox)
+      // Wait for the async chain to settle
+      await new Promise((r) => setTimeout(r, 0))
+      expect(mockMutateSettings).toHaveBeenCalled()
+    })
+  })
+
+  describe("wealth summary filtering", () => {
+    it("passes only included portfolios to useWealthSummary", () => {
+      mockSettings = { excludedPortfolioIds: JSON.stringify(["pf-1"]) }
+      render(<NetWorthTab />)
+      const callArgs = mockWealthSummaryFn.mock.calls[0]
+      const portfoliosArg = callArgs[0] as Portfolio[]
+      expect(portfoliosArg).toHaveLength(1)
+      expect(portfoliosArg[0].id).toBe("pf-2")
+    })
+
+    it("passes all portfolios when no exclusions set", () => {
+      mockSettings = {}
+      render(<NetWorthTab />)
+      const callArgs = mockWealthSummaryFn.mock.calls[0]
+      const portfoliosArg = callArgs[0] as Portfolio[]
+      expect(portfoliosArg).toHaveLength(2)
+    })
+  })
+
+  describe("manual assets editor", () => {
+    it("does NOT show manual assets editor when portfolios have balances", () => {
+      // Both portfolios have non-zero marketValue
+      render(<NetWorthTab />)
+      expect(screen.queryByText(/Estimated Assets/)).not.toBeInTheDocument()
+    })
+
+    it("shows manual assets editor when no portfolios have balances", () => {
+      mockNetWorthData = {
+        ...defaultNetWorthData,
+        portfolios: [
+          { ...mockPortfolio1, marketValue: 0 },
+          { ...mockPortfolio2, marketValue: 0 },
+        ],
+      }
+      render(<NetWorthTab />)
+      expect(screen.getByText(/Estimated Assets/)).toBeInTheDocument()
+    })
+
+    it("shows manual assets editor when portfolio list is empty", () => {
+      mockNetWorthData = { ...defaultNetWorthData, portfolios: [] }
+      render(<NetWorthTab />)
+      expect(screen.getByText(/Estimated Assets/)).toBeInTheDocument()
+    })
+
+    it("manual asset input change calls updateSettings with serialised record", () => {
+      mockNetWorthData = {
+        ...defaultNetWorthData,
+        portfolios: [],
+      }
+      mockSettings = { manualAssets: null }
+      render(<NetWorthTab />)
+      const cashInput = screen.getByLabelText(/Cash & Bank Accounts/)
+      fireEvent.change(cashInput, { target: { value: "10000" } })
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        manualAssets: JSON.stringify({ CASH: 10000 }),
+      })
+    })
+
+    it("pre-populates manual asset inputs from settings", () => {
+      mockNetWorthData = { ...defaultNetWorthData, portfolios: [] }
+      mockSettings = {
+        manualAssets: JSON.stringify({ CASH: 5000, EQUITY: 20000 }),
+      }
+      render(<NetWorthTab />)
+      const cashInput = screen.getByLabelText(
+        /Cash & Bank Accounts/,
+      ) as HTMLInputElement
+      expect(cashInput.value).toBe("5000")
+    })
+  })
+})

--- a/src/components/features/independence/composite/tabs/NetWorthTab.tsx
+++ b/src/components/features/independence/composite/tabs/NetWorthTab.tsx
@@ -1,0 +1,301 @@
+import React, { useMemo, useState } from "react"
+import { Portfolio } from "types/beancounter"
+import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
+import { useNetWorthData } from "@components/features/wealth/useNetWorthData"
+import { useWealthSummary } from "@components/features/wealth/useWealthSummary"
+import WealthHeroSection from "@components/features/wealth/WealthHeroSection"
+import AssetAllocationCharts from "@components/features/wealth/AssetAllocationCharts"
+import PortfolioDetailsTable from "@components/features/wealth/PortfolioDetailsTable"
+import Spinner from "@components/ui/Spinner"
+
+type SortConfig = {
+  key: string | null
+  direction: "asc" | "desc"
+}
+
+/** Manual asset categories matching the wizard's AssetsStep. */
+const MANUAL_ASSET_CATEGORIES: { key: string; label: string }[] = [
+  { key: "CASH", label: "Cash & Bank Accounts" },
+  { key: "EQUITY", label: "Stocks & Shares" },
+  { key: "ETF", label: "ETFs" },
+  { key: "MUTUAL_FUND", label: "Mutual Funds" },
+  { key: "RE", label: "Real Estate" },
+]
+
+function parseJsonStringArray(raw: string | null | undefined): string[] {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as string[]) : []
+  } catch {
+    return []
+  }
+}
+
+function parseJsonStringRecord(
+  raw: string | null | undefined,
+): Record<string, number> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, number>)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * NetWorthTab — account-level Net Worth breakdown within the Composite view.
+ *
+ * Shows the user's wealth from their portfolios (liquid / non-spendable /
+ * CPF / housing) and lets them configure — once, account-wide — which
+ * portfolios count toward FI calculations. The excludedPortfolioIds and
+ * manualAssets settings are persisted to UserIndependenceSettings and
+ * re-derived by svc-retire for every phase's gauge.
+ *
+ * Note on holdingsData filtering: the aggregated holdings endpoint aggregates
+ * positions by asset across all portfolios — per-portfolio filtering of
+ * holdingsData positions is not feasible. The portfolios array IS filtered
+ * (accurate headline total), while holdingsData is passed as-is (the
+ * classification chart will include excluded portfolios' positions, which is
+ * an acceptable approximation for this view).
+ */
+export default function NetWorthTab(): React.ReactElement {
+  const [sortConfig, setSortConfig] = useState<SortConfig>({
+    key: "value",
+    direction: "desc",
+  })
+  const [collapsedSections, setCollapsedSections] = useState({
+    charts: false,
+    portfolioDetails: false,
+  })
+
+  const { settings, updateSettings, mutateSettings } = useIndependenceSettings()
+
+  const {
+    portfolios,
+    holdingsData,
+    currencies,
+    displayCurrency,
+    setDisplayCurrency,
+    fxRates,
+    customAssetTotals,
+    healthcareReserveTotals,
+    isLoading,
+  } = useNetWorthData()
+
+  // Parse account-wide exclusion list from JSON string field
+  const excludedIds: string[] = useMemo(
+    () => parseJsonStringArray(settings?.excludedPortfolioIds),
+    [settings?.excludedPortfolioIds],
+  )
+  const excludedSet = useMemo(() => new Set(excludedIds), [excludedIds])
+
+  // Filter portfolios to include only non-excluded ones for the summary
+  const includedPortfolios: Portfolio[] = useMemo(
+    () => portfolios.filter((p) => !excludedSet.has(p.id)),
+    [portfolios, excludedSet],
+  )
+
+  const summary = useWealthSummary(
+    includedPortfolios,
+    fxRates,
+    sortConfig,
+    holdingsData,
+    customAssetTotals,
+    healthcareReserveTotals,
+  )
+
+  // Gates the manual assets editor — only shown when no balances exist
+  const portfoliosWithBalance: Portfolio[] = useMemo(
+    () => portfolios.filter((p) => (p.marketValue ?? 0) !== 0),
+    [portfolios],
+  )
+
+  // Parse manual asset estimates from JSON string field
+  const manualAssetsRecord: Record<string, number> = useMemo(
+    () => parseJsonStringRecord(settings?.manualAssets),
+    [settings?.manualAssets],
+  )
+
+  const handleSort = (key: string): void => {
+    setSortConfig((prev) => {
+      if (prev.key === key) {
+        return { key, direction: prev.direction === "asc" ? "desc" : "asc" }
+      }
+      return { key, direction: key === "code" ? "asc" : "desc" }
+    })
+  }
+
+  const toggleExclusion = (portfolioId: string): void => {
+    const next = excludedSet.has(portfolioId)
+      ? excludedIds.filter((id) => id !== portfolioId)
+      : [...excludedIds, portfolioId]
+    updateSettings({ excludedPortfolioIds: JSON.stringify(next) })
+      .then(() => mutateSettings())
+      .catch(console.error)
+  }
+
+  const handleManualAssetChange = (key: string, value: number): void => {
+    const next = { ...manualAssetsRecord, [key]: value }
+    updateSettings({ manualAssets: JSON.stringify(next) })
+      .then(() => mutateSettings())
+      .catch(console.error)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Spinner label="Loading wealth data..." size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {/* Account-wide scope notice */}
+      <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg flex items-start gap-3">
+        <i className="fas fa-wallet text-blue-500 mt-0.5 shrink-0"></i>
+        <div>
+          <p className="text-sm font-medium text-blue-800">
+            Account-wide Net Worth
+          </p>
+          <p className="text-sm text-blue-700 mt-0.5">
+            This view reflects your actual portfolio wealth and drives the FI
+            gauge across every phase. Use the settings below to control which
+            portfolios are included.
+          </p>
+        </div>
+      </div>
+
+      {/* Headline wealth summary */}
+      <WealthHeroSection
+        summary={summary}
+        displayCurrency={displayCurrency}
+        currencies={currencies}
+        portfolios={includedPortfolios}
+        onCurrencyChange={setDisplayCurrency}
+        onShareClick={() => {}}
+      />
+
+      {/* Classification breakdown */}
+      <AssetAllocationCharts
+        summary={summary}
+        holdings={holdingsData}
+        fxRates={fxRates}
+        displayCurrency={displayCurrency}
+        collapsed={collapsedSections.charts}
+        onToggle={() =>
+          setCollapsedSections((prev) => ({
+            ...prev,
+            charts: !prev.charts,
+          }))
+        }
+      />
+
+      {/* Per-portfolio breakdown */}
+      {includedPortfolios.length > 1 && (
+        <PortfolioDetailsTable
+          summary={summary}
+          sortConfig={sortConfig}
+          onSort={handleSort}
+          displayCurrency={displayCurrency}
+          collapsed={collapsedSections.portfolioDetails}
+          onToggle={() =>
+            setCollapsedSections((prev) => ({
+              ...prev,
+              portfolioDetails: !prev.portfolioDetails,
+            }))
+          }
+        />
+      )}
+
+      {/* Portfolio inclusion editor */}
+      {portfolios.length > 0 && (
+        <div className="mt-6 bg-white rounded-xl shadow-md overflow-hidden">
+          <div className="px-6 py-4 border-b border-gray-100">
+            <h3 className="text-base font-semibold text-gray-900">
+              Which portfolios count toward your wealth
+            </h3>
+            <p className="text-sm text-gray-500 mt-0.5">
+              Account-wide — affects the FI gauge across all phases.
+            </p>
+          </div>
+          <div className="px-6 py-4 space-y-2">
+            {portfolios.map((portfolio) => (
+              <label
+                key={portfolio.id}
+                className="flex items-center p-3 bg-gray-50 rounded-lg hover:bg-gray-100 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={!excludedSet.has(portfolio.id)}
+                  onChange={() => toggleExclusion(portfolio.id)}
+                  className="h-4 w-4 text-independence-600 focus:ring-independence-500 border-gray-300 rounded"
+                />
+                <div className="ml-3 flex-1">
+                  <span className="font-medium text-gray-900">
+                    {portfolio.code}
+                  </span>
+                  <span className="text-gray-500 ml-2">{portfolio.name}</span>
+                </div>
+                <span className="text-gray-700 font-medium text-sm">
+                  {portfolio.base?.code}{" "}
+                  {Math.round(portfolio.marketValue || 0).toLocaleString()}
+                </span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Manual asset estimates — only when no portfolio balances exist */}
+      {portfoliosWithBalance.length === 0 && (
+        <div className="mt-6 bg-white rounded-xl shadow-md overflow-hidden">
+          <div className="px-6 py-4 border-b border-gray-100">
+            <h3 className="text-base font-semibold text-gray-900">
+              Estimated Assets
+            </h3>
+            <p className="text-sm text-gray-500 mt-0.5">
+              No portfolio balances found. Enter estimated values to drive the
+              FI gauge while you set up your portfolios.
+            </p>
+          </div>
+          <div className="px-6 py-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+            {MANUAL_ASSET_CATEGORIES.map((cat) => (
+              <div key={cat.key}>
+                <label
+                  htmlFor={`manual-asset-${cat.key}`}
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
+                  {cat.label}
+                </label>
+                <div className="relative">
+                  <span className="absolute left-3 top-2.5 text-gray-500 pointer-events-none">
+                    $
+                  </span>
+                  <input
+                    id={`manual-asset-${cat.key}`}
+                    type="number"
+                    min={0}
+                    step={1000}
+                    value={manualAssetsRecord[cat.key] || 0}
+                    onChange={(e) =>
+                      handleManualAssetChange(
+                        cat.key,
+                        Number(e.target.value) || 0,
+                      )
+                    }
+                    className="w-full pl-8 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/independence/composite/tabs/NetWorthTab.tsx
+++ b/src/components/features/independence/composite/tabs/NetWorthTab.tsx
@@ -55,12 +55,12 @@ function parseJsonStringRecord(
  * manualAssets settings are persisted to UserIndependenceSettings and
  * re-derived by svc-retire for every phase's gauge.
  *
- * Note on holdingsData filtering: the aggregated holdings endpoint aggregates
- * positions by asset across all portfolios — per-portfolio filtering of
- * holdingsData positions is not feasible. The portfolios array IS filtered
- * (accurate headline total), while holdingsData is passed as-is (the
- * classification chart will include excluded portfolios' positions, which is
- * an acceptable approximation for this view).
+ * Holdings scoping: excluded portfolio ids are passed to useNetWorthData so
+ * the aggregated-holdings fetch is sent with ids=<included ids> — svc-position
+ * aggregates only those portfolios. This keeps the classification breakdown
+ * (AssetAllocationCharts) consistent with the filtered headline total.
+ * While portfolios are loading the holdings fetch is suppressed (null SWR key)
+ * to prevent svc-position's "no ids = all portfolios" fallback.
  */
 export default function NetWorthTab(): React.ReactElement {
   const [sortConfig, setSortConfig] = useState<SortConfig>({
@@ -74,6 +74,14 @@ export default function NetWorthTab(): React.ReactElement {
 
   const { settings, updateSettings, mutateSettings } = useIndependenceSettings()
 
+  // Parse account-wide exclusion list early — passed to useNetWorthData so
+  // the holdings fetch is scoped to only the included portfolio ids.
+  const excludedIds: string[] = useMemo(
+    () => parseJsonStringArray(settings?.excludedPortfolioIds),
+    [settings?.excludedPortfolioIds],
+  )
+  const excludedSet = useMemo(() => new Set(excludedIds), [excludedIds])
+
   const {
     portfolios,
     holdingsData,
@@ -84,14 +92,7 @@ export default function NetWorthTab(): React.ReactElement {
     customAssetTotals,
     healthcareReserveTotals,
     isLoading,
-  } = useNetWorthData()
-
-  // Parse account-wide exclusion list from JSON string field
-  const excludedIds: string[] = useMemo(
-    () => parseJsonStringArray(settings?.excludedPortfolioIds),
-    [settings?.excludedPortfolioIds],
-  )
-  const excludedSet = useMemo(() => new Set(excludedIds), [excludedIds])
+  } = useNetWorthData(excludedIds)
 
   // Filter portfolios to include only non-excluded ones for the summary
   const includedPortfolios: Portfolio[] = useMemo(

--- a/src/components/features/wealth/__tests__/useNetWorthData.test.ts
+++ b/src/components/features/wealth/__tests__/useNetWorthData.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for useNetWorthData holdings-URL scoping.
+ *
+ * Asserts that the aggregated-holdings SWR key includes ids=<included ids>
+ * when excludedPortfolioIds is provided, and that the excluded portfolio id
+ * is absent from the URL. Also covers the null-key guard that prevents the
+ * svc-position "no ids = all portfolios" fallback while portfolios load.
+ */
+import { renderHook } from "@testing-library/react"
+import useSwr from "swr"
+import { useNetWorthData } from "../useNetWorthData"
+
+jest.mock("swr")
+
+jest.mock("@hooks/useFxRates", () => ({
+  useFxRates: () => ({
+    displayCurrency: { code: "USD", symbol: "$", name: "US Dollar" },
+    setDisplayCurrency: jest.fn(),
+    fxRates: { USD: 1 },
+    fxReady: true,
+  }),
+}))
+
+jest.mock("@utils/assets/usePrivateAssetConfigs", () => ({
+  usePrivateAssetConfigs: () => ({ configs: [] }),
+}))
+
+const mockUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function buildSwrMock(
+  calls: Record<number, Partial<ReturnType<typeof useSwr>>>,
+) {
+  let callIndex = 0
+  mockUseSwr.mockImplementation(() => {
+    const idx = callIndex++
+    const base = {
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    } as unknown as ReturnType<typeof useSwr>
+    return { ...base, ...(calls[idx] ?? {}) } as ReturnType<typeof useSwr>
+  })
+}
+
+type StubPortfolio = {
+  id: string
+  code: string
+  base: { id: string; code: string; symbol: string; name: string }
+  currency: { id: string; code: string; symbol: string; name: string }
+  marketValue: number
+}
+
+function makePortfolio(id: string, code: string): StubPortfolio {
+  const usd = { id: "usd", code: "USD", symbol: "$", name: "US Dollar" }
+  return { id, code, base: usd, currency: usd, marketValue: 10000 }
+}
+
+// SWR call ordering inside useNetWorthData (with useFxRates + usePrivateAssetConfigs mocked):
+//   index 0 → portfoliosKey (portfolios)
+//   index 1 → holdingKeyUrl (aggregated holdings)
+//   index 2 → ccyKey (currencies)
+const HOLDINGS_SWR_CALL_INDEX = 1
+
+describe("useNetWorthData — holdings URL scoping", () => {
+  beforeEach(() => {
+    mockUseSwr.mockReset()
+  })
+
+  describe("when excludedPortfolioIds is not provided", () => {
+    it("uses the unscoped holdings URL (no ids param)", () => {
+      buildSwrMock({
+        0: { data: { data: [makePortfolio("pf-1", "ALPHA")] } },
+      })
+      renderHook(() => useNetWorthData())
+      const holdingsKey = mockUseSwr.mock.calls[HOLDINGS_SWR_CALL_INDEX][0]
+      expect(holdingsKey).toBe("/api/holdings/aggregated?asAt=today")
+    })
+  })
+
+  describe("when excludedPortfolioIds is provided", () => {
+    it("includes only non-excluded portfolio ids in the holdings URL", () => {
+      buildSwrMock({
+        0: {
+          data: {
+            data: [
+              makePortfolio("pf-1", "ALPHA"),
+              makePortfolio("pf-2", "BETA"),
+            ],
+          },
+        },
+      })
+      renderHook(() => useNetWorthData(["pf-1"]))
+
+      const holdingsKey = mockUseSwr.mock.calls[
+        HOLDINGS_SWR_CALL_INDEX
+      ][0] as string
+      // Included id present; excluded id absent
+      expect(holdingsKey).toContain("ids=")
+      const params = new URLSearchParams(holdingsKey.split("?")[1])
+      const ids = (params.get("ids") ?? "").split(",")
+      expect(ids).toContain("pf-2")
+      expect(ids).not.toContain("pf-1")
+    })
+
+    it("uses null key (skips fetch) when all portfolios are excluded", () => {
+      buildSwrMock({
+        0: { data: { data: [makePortfolio("pf-1", "ALPHA")] } },
+      })
+      renderHook(() => useNetWorthData(["pf-1"]))
+      expect(mockUseSwr.mock.calls[HOLDINGS_SWR_CALL_INDEX][0]).toBeNull()
+    })
+
+    it("uses null key while portfolios are still loading (prevents unscoped fallback)", () => {
+      // portfolios loading → portfolios=[] → includedIds=[] → null key
+      buildSwrMock({
+        0: { data: undefined, isLoading: true },
+      })
+      renderHook(() => useNetWorthData(["pf-x"]))
+      expect(mockUseSwr.mock.calls[HOLDINGS_SWR_CALL_INDEX][0]).toBeNull()
+    })
+
+    it("uses null key when excluded ids are empty and no portfolios exist (zero-portfolio path)", () => {
+      // Zero-portfolio: portfolios=[], excluded=[] → includedIds=[] → null key
+      // (avoids sending ids= with empty value; manual-assets fallback takes over)
+      buildSwrMock({
+        0: { data: { data: [] } },
+      })
+      renderHook(() => useNetWorthData([]))
+      expect(mockUseSwr.mock.calls[HOLDINGS_SWR_CALL_INDEX][0]).toBeNull()
+    })
+
+    it("scopes URL to all portfolio ids when excluded list is empty and portfolios exist", () => {
+      buildSwrMock({
+        0: {
+          data: {
+            data: [
+              makePortfolio("pf-1", "ALPHA"),
+              makePortfolio("pf-2", "BETA"),
+            ],
+          },
+        },
+      })
+      renderHook(() => useNetWorthData([]))
+
+      const holdingsKey = mockUseSwr.mock.calls[
+        HOLDINGS_SWR_CALL_INDEX
+      ][0] as string
+      const params = new URLSearchParams(holdingsKey.split("?")[1])
+      const ids = (params.get("ids") ?? "").split(",")
+      expect(ids).toContain("pf-1")
+      expect(ids).toContain("pf-2")
+    })
+  })
+})

--- a/src/components/features/wealth/useNetWorthData.ts
+++ b/src/components/features/wealth/useNetWorthData.ts
@@ -33,17 +33,57 @@ export interface UseNetWorthDataResult {
  * wealth.tsx is NOT refactored to consume this hook — the page has
  * additional state (sort, collapse, TWR visibility) that makes a
  * low-risk extraction harder than it's worth.
+ *
+ * @param excludedPortfolioIds - When provided, the aggregated holdings fetch
+ *   is scoped to only the included portfolios (all minus excluded). Prevents
+ *   the classification breakdown from including positions belonging to
+ *   portfolios the user has deselected. When omitted, all portfolios are
+ *   fetched (existing behaviour, preserves compatibility for other callers).
+ *   While portfolios are still loading the holdings fetch is suppressed
+ *   (null SWR key) to avoid svc-position's "no ids = all portfolios"
+ *   fallback — same guard used in useIndependencePlanData.
  */
-export function useNetWorthData(): UseNetWorthDataResult {
+export function useNetWorthData(
+  excludedPortfolioIds?: string[],
+): UseNetWorthDataResult {
   const { data: portfolioData, isLoading: portfolioLoading } = useSwr(
     portfoliosKey,
     simpleFetcher(portfoliosKey),
   )
 
-  const holdingKeyUrl = holdingKey("aggregated", "today")
+  // Derive portfolios early so the holdings URL can be scoped to included ids.
+  const portfolios: Portfolio[] = useMemo(
+    () => portfolioData?.data || [],
+    [portfolioData?.data],
+  )
+
+  // Build the holdings SWR key.
+  // When excludedPortfolioIds is provided, scope the fetch to the included
+  // subset. While portfolios are loading (portfolios=[]), the included set
+  // is empty — null key suppresses the fetch until the set resolves, avoiding
+  // the svc-position "no ids = all portfolios" fallback.
+  const holdingKeyUrl = useMemo(() => {
+    if (excludedPortfolioIds === undefined) {
+      // Default: unscoped (preserves existing behaviour for callers that do
+      // not pass excluded ids — e.g. wealth.tsx, debug.tsx).
+      return holdingKey("aggregated", "today")
+    }
+    const excludedSet = new Set(excludedPortfolioIds)
+    const includedIds = portfolios
+      .filter((p) => !excludedSet.has(p.id))
+      .map((p) => p.id)
+    if (includedIds.length === 0) {
+      // All portfolios excluded, or portfolios not yet loaded — skip fetch.
+      return null
+    }
+    const params = new URLSearchParams({ asAt: "today" })
+    params.set("ids", includedIds.join(","))
+    return `/api/holdings/aggregated?${params.toString()}`
+  }, [excludedPortfolioIds, portfolios])
+
   const { data: holdingsResponse, isLoading: holdingsLoading } = useSwr<{
     data: HoldingContract
-  }>(holdingKeyUrl, simpleFetcher(holdingKeyUrl), {
+  }>(holdingKeyUrl, holdingKeyUrl ? simpleFetcher(holdingKeyUrl) : null, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
     dedupingInterval: 60000,
@@ -58,10 +98,6 @@ export function useNetWorthData(): UseNetWorthDataResult {
   const currencies = useMemo(
     () => currencyData?.data || [],
     [currencyData?.data],
-  )
-  const portfolios: Portfolio[] = useMemo(
-    () => portfolioData?.data || [],
-    [portfolioData?.data],
   )
 
   // Composite assets (CPF / pensions): same double-count guard as wealth.tsx.

--- a/src/components/features/wealth/useNetWorthData.ts
+++ b/src/components/features/wealth/useNetWorthData.ts
@@ -1,0 +1,150 @@
+import { useMemo } from "react"
+import useSwr from "swr"
+import { Portfolio, Currency, HoldingContract } from "types/beancounter"
+import {
+  portfoliosKey,
+  simpleFetcher,
+  ccyKey,
+  holdingKey,
+} from "@utils/api/fetchHelper"
+import { useFxRates } from "@hooks/useFxRates"
+import { usePrivateAssetConfigs } from "@utils/assets/usePrivateAssetConfigs"
+
+export interface UseNetWorthDataResult {
+  portfolios: Portfolio[]
+  holdingsData: HoldingContract | undefined
+  currencies: Currency[]
+  displayCurrency: Currency | null
+  setDisplayCurrency: (c: Currency) => void
+  fxRates: Record<string, number>
+  fxReady: boolean
+  customAssetTotals: Record<string, number>
+  healthcareReserveTotals: Record<string, number>
+  isLoading: boolean
+}
+
+/**
+ * Fetches all data needed to render a Net Worth breakdown — portfolios,
+ * aggregated holdings, currencies, FX rates, and private-asset configs
+ * (CPF / pension sub-account totals with double-count guard).
+ *
+ * Extracted from wealth.tsx so the composite NetWorthTab can reuse the
+ * same data pipeline without duplicating the double-count guard logic.
+ * wealth.tsx is NOT refactored to consume this hook — the page has
+ * additional state (sort, collapse, TWR visibility) that makes a
+ * low-risk extraction harder than it's worth.
+ */
+export function useNetWorthData(): UseNetWorthDataResult {
+  const { data: portfolioData, isLoading: portfolioLoading } = useSwr(
+    portfoliosKey,
+    simpleFetcher(portfoliosKey),
+  )
+
+  const holdingKeyUrl = holdingKey("aggregated", "today")
+  const { data: holdingsResponse, isLoading: holdingsLoading } = useSwr<{
+    data: HoldingContract
+  }>(holdingKeyUrl, simpleFetcher(holdingKeyUrl), {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    dedupingInterval: 60000,
+  })
+  const holdingsData = holdingsResponse?.data
+
+  const { data: currencyData } = useSwr<{ data: Currency[] }>(
+    ccyKey,
+    simpleFetcher(ccyKey),
+  )
+
+  const currencies = useMemo(
+    () => currencyData?.data || [],
+    [currencyData?.data],
+  )
+  const portfolios: Portfolio[] = useMemo(
+    () => portfolioData?.data || [],
+    [portfolioData?.data],
+  )
+
+  // Composite assets (CPF / pensions): same double-count guard as wealth.tsx.
+  // Parent trn in a portfolio → CompositeValuation already includes balance.
+  // Standalone (no parent trn) → top up via customAssetTotals.
+  // CPF MA (Medisave) is statutory healthcare reserve → healthcareReserveTotals.
+  const { configs: privateAssetConfigs } = usePrivateAssetConfigs()
+  const portfolioAssetIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (holdingsData?.positions) {
+      Object.values(holdingsData.positions).forEach((position) => {
+        const id = position.asset?.id
+        if (id) ids.add(id)
+      })
+    }
+    return ids
+  }, [holdingsData])
+
+  const { customAssetTotals, healthcareReserveTotals } = useMemo(() => {
+    const customTotals: Record<string, number> = {}
+    const reserveTotals: Record<string, number> = {}
+    privateAssetConfigs.forEach((config) => {
+      const subAccounts = config.subAccounts ?? []
+      if (subAccounts.length === 0) return
+      const currency = config.rentalCurrency || "USD"
+      const parentInPortfolio = portfolioAssetIds.has(config.assetId)
+
+      let nonReserve = 0
+      let reserve = 0
+      subAccounts.forEach((sa) => {
+        const balance = sa.balance || 0
+        if (balance === 0) return
+        if (sa.code === "MA") {
+          reserve += balance
+        } else {
+          nonReserve += balance
+        }
+      })
+
+      if (reserve > 0) {
+        reserveTotals[currency] = (reserveTotals[currency] || 0) + reserve
+      }
+      if (!parentInPortfolio && nonReserve > 0) {
+        customTotals[currency] = (customTotals[currency] || 0) + nonReserve
+      }
+    })
+    return {
+      customAssetTotals: customTotals,
+      healthcareReserveTotals: reserveTotals,
+    }
+  }, [privateAssetConfigs, portfolioAssetIds])
+
+  const sourceCurrencyCodes = useMemo(
+    () => [
+      ...portfolios.map((p) => p.base.code),
+      ...portfolios.map((p) => p.currency.code),
+      ...Object.keys(customAssetTotals),
+      ...Object.keys(healthcareReserveTotals),
+    ],
+    [portfolios, customAssetTotals, healthcareReserveTotals],
+  )
+
+  const { displayCurrency, setDisplayCurrency, fxRates, fxReady } = useFxRates(
+    currencies,
+    sourceCurrencyCodes,
+  )
+
+  // Gate on both portfolio and holdings loading: the double-count guard in
+  // customAssetTotals keys off portfolioAssetIds (derived from holdingsData).
+  // Rendering before holdings arrive would temporarily double-count composite
+  // assets already included via portfolio.marketValue.
+  const isLoading = portfolioLoading || holdingsLoading || !fxReady
+
+  return {
+    portfolios,
+    holdingsData,
+    currencies,
+    displayCurrency,
+    setDisplayCurrency,
+    fxRates,
+    fxReady,
+    customAssetTotals,
+    healthcareReserveTotals,
+    isLoading,
+  }
+}

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -1130,6 +1130,19 @@ export interface UserIndependenceSettings {
    */
   compositeNarrative?: string
   compositeWorkScenarioId?: string
+  /**
+   * JSON-serialised string[] of portfolio IDs to exclude from wealth
+   * and FI calculations. e.g. '["pf-id-1","pf-id-2"]'.
+   * Parse with JSON.parse; guard against null/blank.
+   */
+  excludedPortfolioIds?: string | null
+  /**
+   * JSON-serialised Record<string,number> of manual asset estimates
+   * (category → value) used when the user has no portfolio balances.
+   * e.g. '{"CASH":1000,"EQUITY":5000,"RE":200000}'.
+   * Parse with JSON.parse; guard against null/blank.
+   */
+  manualAssets?: string | null
   createdDate: string
   updatedDate: string
 }
@@ -1145,6 +1158,16 @@ export interface UpdateSettingsRequest {
   /** Free-form composite-level narrative. Empty string clears it. */
   compositeNarrative?: string
   compositeWorkScenarioId?: string
+  /**
+   * JSON-serialised string[] of portfolio IDs to exclude from wealth
+   * and FI calculations. e.g. '["pf-id-1","pf-id-2"]'.
+   */
+  excludedPortfolioIds?: string | null
+  /**
+   * JSON-serialised Record<string,number> of manual asset estimates
+   * (category → value). e.g. '{"CASH":1000,"EQUITY":5000,"RE":200000}'.
+   */
+  manualAssets?: string | null
 }
 
 // ============ Phased Plans Types ============


### PR DESCRIPTION
Adds a "Net Worth" sub-tab to the Independence Composite view that surfaces the user's portfolio-derived wealth (liquid / non-spendable / CPF / housing) and lets them configure — once, account-wide — which portfolios count toward FI and (fallback) manual asset estimates. Pairs with svc-retire #121 which moves the exclusion/manual-asset storage to account-level UserIndependenceSettings.

- New composite sub-tab id "networth" (distinct from the projection-based "wealth"/Wealth Journey tab)
- NetWorthTab reuses useWealthSummary + WealthHeroSection / AssetAllocationCharts / PortfolioDetailsTable
- Account-level exclusion + manual-asset editors persist via useIndependenceSettings().updateSettings (JSON-serialised)
- New useNetWorthData hook; aggregated holdings fetched scoped to included portfolio ids so the breakdown respects exclusions, not just the headline
- UserIndependenceSettings / UpdateSettingsRequest types extended
- FI gauge unchanged (svc-retire re-derives from settings)

Follow-up: retire per-plan asset config from the wizard AssetsStep / EditPlanDetailsModal.
