### PR TITLE
feat(independence): make per-plan wealth step read-only, point to Net Worth tab

### DIFF
--- a/src/components/features/independence/EditPlanDetailsModal.tsx
+++ b/src/components/features/independence/EditPlanDetailsModal.tsx
@@ -506,62 +506,21 @@ export default function EditPlanDetailsModal({
             </p>
           </div>
 
-          {/* Portfolios */}
-          {portfolios.length > 0 && (
-            <div className="border-t pt-4 mt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-3">
-                Portfolios
-              </h3>
-              <p className="text-xs text-gray-500 mb-2">
-                Uncheck to exclude a portfolio from this plan
+          {/* Portfolios — selection is account-wide; editing moved to Net Worth tab */}
+          <div className="border-t pt-4 mt-4">
+            <h3 className="text-sm font-medium text-gray-700 mb-3">
+              Portfolios
+            </h3>
+            <div className="flex items-start gap-2 bg-blue-50 border border-blue-200 rounded-lg p-3">
+              <i className="fas fa-info-circle text-blue-500 mt-0.5 flex-shrink-0 text-sm"></i>
+              <p className="text-xs text-blue-800">
+                Portfolio selection is set account-wide on the{" "}
+                <span className="font-medium">Net Worth tab</span> on the
+                Independence page. Open Independence &#8594; Net Worth to change
+                which portfolios count.
               </p>
-              <div className="space-y-2 max-h-40 overflow-y-auto">
-                {portfolios
-                  .filter((p) => p.active !== false)
-                  .map((portfolio) => {
-                    const isExcluded = formData.excludedPortfolioIds.includes(
-                      portfolio.id,
-                    )
-                    return (
-                      <label
-                        key={portfolio.id}
-                        className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors ${
-                          isExcluded
-                            ? "bg-gray-50 text-gray-400"
-                            : "hover:bg-gray-50"
-                        }`}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={!isExcluded}
-                          onChange={() => {
-                            setFormData((prev) => ({
-                              ...prev,
-                              excludedPortfolioIds: isExcluded
-                                ? prev.excludedPortfolioIds.filter(
-                                    (id) => id !== portfolio.id,
-                                  )
-                                : [...prev.excludedPortfolioIds, portfolio.id],
-                            }))
-                          }}
-                          className="w-4 h-4 text-independence-500 rounded border-gray-300 focus:ring-independence-500"
-                        />
-                        <span
-                          className={`text-sm ${isExcluded ? "line-through" : "font-medium text-gray-900"}`}
-                        >
-                          {portfolio.code}
-                        </span>
-                        <span
-                          className={`text-xs ${isExcluded ? "" : "text-gray-500"}`}
-                        >
-                          {portfolio.name}
-                        </span>
-                      </label>
-                    )
-                  })}
-              </div>
             </div>
-          )}
+          </div>
 
           {/* Per-property Rental Income */}
           {rentalProperties.length > 0 && (

--- a/src/components/features/independence/__tests__/AssetsStep.test.tsx
+++ b/src/components/features/independence/__tests__/AssetsStep.test.tsx
@@ -27,6 +27,11 @@ const mockPortfolios = {
   ],
 }
 
+// Mutable reference used inside the SWR mock so individual tests can override
+// the portfolio data without rebuilding the whole mock factory. Starts with
+// "mock" so Jest's Babel hoisting picks it up alongside jest.mock().
+let mockSwrPortfolioData: { data: unknown[] } = mockPortfolios
+
 // AssetsStep calls multiple SWR hooks plus direct fetch() calls. Both
 // produce async state updates that fall outside React Testing Library's
 // implicit act() window and trigger "An update to AssetsStep was not
@@ -35,7 +40,9 @@ const mockPortfolios = {
 jest.mock("swr", () => ({
   __esModule: true,
   default: (key: string) => ({
-    data: key.includes("portfolios") ? mockPortfolios : { data: [] },
+    data: (key as string).includes("portfolios")
+      ? mockSwrPortfolioData
+      : { data: [] },
     error: undefined,
     isLoading: false,
     mutate: jest.fn(),
@@ -50,6 +57,11 @@ beforeAll(() => {
     json: () => Promise.resolve({ data: [] }),
     text: () => Promise.resolve(""),
   }) as unknown as typeof fetch
+})
+
+beforeEach(() => {
+  // Reset to the default (portfolios present) before each test
+  mockSwrPortfolioData = mockPortfolios
 })
 
 const TestWrapper: React.FC<{ children: React.ReactNode }> = () => {
@@ -102,5 +114,43 @@ describe("AssetsStep", () => {
     expect(
       await screen.findByText(/we've selected your portfolios automatically/i),
     ).toBeInTheDocument()
+  })
+
+  it("shows read-only info banner pointing to Net Worth tab", async () => {
+    render(
+      <TestWrapper>
+        <div />
+      </TestWrapper>,
+    )
+
+    expect(await screen.findByText(/net worth tab/i)).toBeInTheDocument()
+  })
+
+  it("renders portfolio checkboxes as disabled", async () => {
+    render(
+      <TestWrapper>
+        <div />
+      </TestWrapper>,
+    )
+
+    // Wait for portfolio rows to appear, then verify all checkboxes are disabled
+    await screen.findByText("TEST")
+    const checkboxes = screen.getAllByRole("checkbox")
+    checkboxes.forEach((cb) => expect(cb).toBeDisabled())
+  })
+
+  it("renders manual asset inputs as disabled when no portfolios", async () => {
+    // Override: no portfolios so the manual-asset fallback branch renders
+    mockSwrPortfolioData = { data: [] }
+
+    render(
+      <TestWrapper>
+        <div />
+      </TestWrapper>,
+    )
+
+    // The manual-asset inputs are type="number" (spinbutton role)
+    const inputs = await screen.findAllByRole("spinbutton")
+    inputs.forEach((input) => expect(input).toBeDisabled())
   })
 })

--- a/src/components/features/independence/__tests__/EditPlanDetailsModal.test.tsx
+++ b/src/components/features/independence/__tests__/EditPlanDetailsModal.test.tsx
@@ -243,6 +243,29 @@ describe("EditPlanDetailsModal", () => {
     expect(inputs[0]).toHaveValue(2000)
   })
 
+  it("shows read-only note for portfolio selection pointing to Net Worth tab", () => {
+    render(<EditPlanDetailsModal {...defaultProps} />)
+
+    expect(screen.getByText(/net worth tab/i)).toBeInTheDocument()
+  })
+
+  it("does not render interactive portfolio checkboxes", () => {
+    // Provide portfolios so the section would previously have shown checkboxes
+    mockedUseSWR.mockReturnValue({
+      data: {
+        data: [{ id: "p1", code: "MY", name: "My Portfolio", active: true }],
+      },
+      error: undefined,
+      isLoading: false,
+      mutate: jest.fn(),
+    } as any)
+
+    render(<EditPlanDetailsModal {...defaultProps} />)
+
+    // No checkboxes — the portfolio section is now a read-only note
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
+  })
+
   it("Use Actual button normalizes CPF-polluted allocation to 100%", async () => {
     // Provide an active portfolio so the button renders
     mockedUseSWR.mockReturnValue({

--- a/src/components/features/independence/steps/AssetsStep.tsx
+++ b/src/components/features/independence/steps/AssetsStep.tsx
@@ -673,6 +673,16 @@ export default function AssetsStep({
         <p className="text-sm text-gray-600">{msg.description}</p>
       </div>
 
+      {/* Wealth definition is account-level — direct the user to Net Worth tab */}
+      <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 flex items-start gap-2">
+        <i className="fas fa-info-circle text-blue-500 mt-0.5 flex-shrink-0 text-sm"></i>
+        <p className="text-sm text-blue-800">
+          Wealth portfolios are set account-wide on the{" "}
+          <span className="font-medium">Net Worth tab</span> on the Independence
+          page. This step is read-only.
+        </p>
+      </div>
+
       {portfoliosWithBalance.length > 0 && !isEditMode && (
         <div className="bg-green-50 border border-green-200 rounded-lg p-4 flex items-start">
           <i className="fas fa-check-circle text-green-600 mt-0.5 mr-3"></i>
@@ -735,10 +745,9 @@ export default function AssetsStep({
                           min={0}
                           step={1000}
                           value={field.value || 0}
-                          onChange={(e) =>
-                            field.onChange(Number(e.target.value) || 0)
-                          }
-                          className="w-full pl-8 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                          onChange={() => undefined}
+                          disabled
+                          className="w-full pl-8 pr-4 py-2 border border-gray-300 rounded-lg opacity-60 cursor-not-allowed bg-gray-50"
                         />
                       )}
                     />
@@ -792,32 +801,13 @@ export default function AssetsStep({
                 name="selectedPortfolioIds"
                 control={control}
                 render={({ field }) => (
-                  <label className="flex items-center p-3 bg-gray-50 rounded-lg hover:bg-gray-100 cursor-pointer">
+                  <label className="flex items-center p-3 bg-gray-50 rounded-lg cursor-not-allowed">
                     <input
                       type="checkbox"
                       checked={field.value?.includes(portfolio.id) || false}
-                      onChange={(e) => {
-                        const current = field.value || []
-                        const currentExcluded = watchedExcludedIds || []
-                        if (e.target.checked) {
-                          field.onChange([...current, portfolio.id])
-                          setValue(
-                            "excludedPortfolioIds",
-                            currentExcluded.filter(
-                              (id: string) => id !== portfolio.id,
-                            ),
-                          )
-                        } else {
-                          field.onChange(
-                            current.filter((id: string) => id !== portfolio.id),
-                          )
-                          setValue("excludedPortfolioIds", [
-                            ...currentExcluded,
-                            portfolio.id,
-                          ])
-                        }
-                      }}
-                      className="h-4 w-4 text-independence-600 focus:ring-independence-500 border-gray-300 rounded"
+                      onChange={() => undefined}
+                      disabled
+                      className="h-4 w-4 text-independence-600 border-gray-300 rounded opacity-60 cursor-not-allowed"
                     />
                     <div className="ml-3 flex-1">
                       <span className="font-medium text-gray-900">


### PR DESCRIPTION
Stacked on #992. Now that portfolio inclusion + manual assets are configured account-wide on the Net Worth tab, the per-phase wizard "Wealth" step and the EditPlanDetailsModal portfolio-exclusion control are made read-only.

- Wizard AssetsStep: info banner + disabled portfolio checkboxes and manual-asset inputs (still shows what's included). RHF/submit payload untouched — per-plan fields remain a legacy fallback.
- EditPlanDetailsModal: interactive exclusion block replaced with a read-only note; excludedPortfolioIds still initialised from the plan and passed through unchanged.
- No deep-link to the Net Worth tab exists (its state is internal to CompositeTab), so the pointer is plain guidance text.
