### PR TITLE
feat(independence): never-force-sell-illiquid toggle on Stress Test (composite + single-plan)

### DIFF
--- a/src/components/features/independence/MonteCarloTab.tsx
+++ b/src/components/features/independence/MonteCarloTab.tsx
@@ -33,6 +33,7 @@ export default function MonteCarloTab({
   displayProjection,
 }: MonteCarloTabProps): React.ReactElement {
   const [iterations, setIterations] = useState(1000)
+  const [neverSellIlliquid, setNeverSellIlliquid] = useState(false)
 
   const { result, isRunning, error, runSimulation } = useMonteCarloSimulation({
     plan,
@@ -41,6 +42,7 @@ export default function MonteCarloTab({
     scenario,
     rentalIncome,
     displayCurrency,
+    neverSellIlliquid,
   })
 
   return (
@@ -88,6 +90,29 @@ export default function MonteCarloTab({
               )}
             </button>
           </div>
+        </div>
+
+        {/* Stress-run modelling assumption */}
+        <div className="mt-4 pt-4 border-t border-gray-100">
+          <label className="flex items-start gap-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={neverSellIlliquid}
+              onChange={(e) => setNeverSellIlliquid(e.target.checked)}
+              disabled={isRunning}
+              aria-label="Never force-sell illiquid"
+              className="mt-0.5 h-4 w-4 rounded border-gray-300 text-independence-500 focus:ring-independence-500"
+            />
+            <span>
+              <span className="text-sm font-medium text-gray-800">
+                Never force-sell illiquid assets
+              </span>
+              <span className="block text-xs text-gray-500 mt-0.5">
+                Keeps your property &amp; real-estate in place — models spending
+                from liquid savings only (CPF is already excluded)
+              </span>
+            </span>
+          </label>
         </div>
 
         {error && (

--- a/src/components/features/independence/__tests__/MonteCarloTab.test.tsx
+++ b/src/components/features/independence/__tests__/MonteCarloTab.test.tsx
@@ -1,20 +1,31 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import "@testing-library/jest-dom"
-import type { RetirementPlan, RetirementProjection } from "types/independence"
+import type {
+  MonteCarloResult,
+  RetirementPlan,
+  RetirementProjection,
+} from "types/independence"
 import type { AssetBreakdown } from "../useAssetBreakdown"
+import type { UseMonteCarloSimulationProps } from "../useMonteCarloSimulation"
 
-// Mock the Monte Carlo hook so the component renders with our deterministic
-// fixture instead of issuing a real API call. The shape MUST match what
-// MonteCarloTab destructures from the hook.
+// Capture the last props passed to the hook so we can assert on them.
+const mockRunSimulation = jest.fn()
+let capturedHookProps: UseMonteCarloSimulationProps | undefined = undefined
+let mockHookResult: MonteCarloResult | null = null
+let mockIsRunning = false
+
 jest.mock("../useMonteCarloSimulation", () => ({
-  useMonteCarloSimulation: jest.fn(() => ({
-    result: jest.requireActual("../__fixtures__/monteCarloResult")
-      .fixtureMonteCarloResult,
-    isRunning: false,
-    error: null,
-    runSimulation: jest.fn(),
-  })),
+  useMonteCarloSimulation: (props: UseMonteCarloSimulationProps) => {
+    capturedHookProps = props
+    return {
+      result: mockHookResult,
+      isRunning: mockIsRunning,
+      error: null,
+      runSimulation: mockRunSimulation,
+    }
+  },
 }))
 
 // Stabilise Recharts: ResponsiveContainer relies on element measurements that
@@ -35,6 +46,7 @@ jest.mock("recharts", () => {
 })
 
 import MonteCarloTab from "../MonteCarloTab"
+import { fixtureMonteCarloResult } from "../__fixtures__/monteCarloResult"
 
 function makePlan(): RetirementPlan {
   return {
@@ -198,8 +210,58 @@ const mockProps = {
 }
 
 describe("MonteCarloTab snapshot baseline", () => {
+  beforeEach(() => {
+    capturedHookProps = undefined
+    mockRunSimulation.mockClear()
+    mockHookResult = fixtureMonteCarloResult
+    mockIsRunning = false
+  })
+
   it("matches snapshot with fixture result", () => {
     const { container } = render(<MonteCarloTab {...mockProps} />)
     expect(container).toMatchSnapshot()
+  })
+})
+
+describe("MonteCarloTab — never-force-sell illiquid toggle", () => {
+  beforeEach(() => {
+    capturedHookProps = undefined
+    mockRunSimulation.mockClear()
+    mockHookResult = null
+    mockIsRunning = false
+  })
+
+  it("renders the toggle unchecked by default", () => {
+    render(<MonteCarloTab {...mockProps} />)
+    const toggle = screen.getByRole("checkbox", {
+      name: /Never force-sell illiquid/i,
+    })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).not.toBeChecked()
+  })
+
+  it("passes neverSellIlliquid as falsy to the hook when toggle is OFF", () => {
+    render(<MonteCarloTab {...mockProps} />)
+    expect(capturedHookProps?.neverSellIlliquid).toBeFalsy()
+  })
+
+  it("passes neverSellIlliquid: true to the hook after toggling ON", async () => {
+    const user = userEvent.setup()
+    render(<MonteCarloTab {...mockProps} />)
+
+    await user.click(
+      screen.getByRole("checkbox", { name: /Never force-sell illiquid/i }),
+    )
+
+    // React re-renders after toggle → hook called with updated props
+    expect(capturedHookProps?.neverSellIlliquid).toBe(true)
+  })
+
+  it("disables the toggle while the simulation is running", () => {
+    mockIsRunning = true
+    render(<MonteCarloTab {...mockProps} />)
+    expect(
+      screen.getByRole("checkbox", { name: /Never force-sell illiquid/i }),
+    ).toBeDisabled()
   })
 })

--- a/src/components/features/independence/__tests__/__snapshots__/MonteCarloTab.test.tsx.snap
+++ b/src/components/features/independence/__tests__/__snapshots__/MonteCarloTab.test.tsx.snap
@@ -64,6 +64,31 @@ exports[`MonteCarloTab snapshot baseline matches snapshot with fixture result 1`
           </button>
         </div>
       </div>
+      <div
+        class="mt-4 pt-4 border-t border-gray-100"
+      >
+        <label
+          class="flex items-start gap-3 cursor-pointer select-none"
+        >
+          <input
+            aria-label="Never force-sell illiquid"
+            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-independence-500 focus:ring-independence-500"
+            type="checkbox"
+          />
+          <span>
+            <span
+              class="text-sm font-medium text-gray-800"
+            >
+              Never force-sell illiquid assets
+            </span>
+            <span
+              class="block text-xs text-gray-500 mt-0.5"
+            >
+              Keeps your property & real-estate in place — models spending from liquid savings only (CPF is already excluded)
+            </span>
+          </span>
+        </label>
+      </div>
     </div>
     <div
       class="rounded-xl shadow-md p-6 border bg-amber-50 border-amber-200"

--- a/src/components/features/independence/composite/__tests__/StressTestTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/StressTestTab.test.tsx
@@ -261,4 +261,53 @@ describe("StressTestTab", () => {
     renderWithCtx()
     expect(screen.getByRole("button", { name: /Running/i })).toBeDisabled()
   })
+
+  describe("Never force-sell illiquid toggle", () => {
+    it("renders the toggle unchecked by default", () => {
+      renderWithCtx()
+      const toggle = screen.getByRole("checkbox", {
+        name: /Never force-sell illiquid/i,
+      })
+      expect(toggle).toBeInTheDocument()
+      expect(toggle).not.toBeChecked()
+    })
+
+    it("does not include neverSellIlliquid in runSimulation args when toggle is OFF", async () => {
+      const user = userEvent.setup()
+      renderWithCtx()
+
+      await user.click(screen.getByRole("button", { name: /Run Stress Test/i }))
+
+      expect(mockRunSimulation).toHaveBeenCalledWith({
+        iterations: 1000,
+        phases: defaultPhases,
+        displayCurrency: "USD",
+      })
+      expect(mockRunSimulation).toHaveBeenCalledWith(
+        expect.not.objectContaining({ neverSellIlliquid: true }),
+      )
+    })
+
+    it("sends neverSellIlliquid: true in runSimulation args when toggle is ON", async () => {
+      const user = userEvent.setup()
+      renderWithCtx()
+
+      await user.click(
+        screen.getByRole("checkbox", { name: /Never force-sell illiquid/i }),
+      )
+      await user.click(screen.getByRole("button", { name: /Run Stress Test/i }))
+
+      expect(mockRunSimulation).toHaveBeenCalledWith(
+        expect.objectContaining({ neverSellIlliquid: true }),
+      )
+    })
+
+    it("disables the toggle while the simulation is running", () => {
+      mockHookState = { result: null, isRunning: true, error: null }
+      renderWithCtx()
+      expect(
+        screen.getByRole("checkbox", { name: /Never force-sell illiquid/i }),
+      ).toBeDisabled()
+    })
+  })
 })

--- a/src/components/features/independence/composite/tabs/StressTestTab.tsx
+++ b/src/components/features/independence/composite/tabs/StressTestTab.tsx
@@ -20,6 +20,7 @@ export default function StressTestTab(): React.ReactElement {
   const { result, isRunning, error, runSimulation } =
     useCompositeMonteCarloSimulation()
   const [iterations, setIterations] = useState(1000)
+  const [neverSellIlliquid, setNeverSellIlliquid] = useState(false)
   const [isStale, setIsStale] = useState(false)
 
   // Mark result stale when user changes phases/currency after a run.
@@ -44,6 +45,7 @@ export default function StressTestTab(): React.ReactElement {
       iterations,
       phases,
       displayCurrency,
+      ...(neverSellIlliquid ? { neverSellIlliquid: true } : {}),
     })
   }
 
@@ -95,6 +97,29 @@ export default function StressTestTab(): React.ReactElement {
               )}
             </button>
           </div>
+        </div>
+
+        {/* Stress-run modelling assumption */}
+        <div className="mt-4 pt-4 border-t border-gray-100">
+          <label className="flex items-start gap-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={neverSellIlliquid}
+              onChange={(e) => setNeverSellIlliquid(e.target.checked)}
+              disabled={isRunning}
+              aria-label="Never force-sell illiquid"
+              className="mt-0.5 h-4 w-4 rounded border-gray-300 text-independence-500 focus:ring-independence-500"
+            />
+            <span>
+              <span className="text-sm font-medium text-gray-800">
+                Never force-sell illiquid assets
+              </span>
+              <span className="block text-xs text-gray-500 mt-0.5">
+                Keeps your property &amp; real-estate in place — models spending
+                from liquid savings only (CPF is already excluded)
+              </span>
+            </span>
+          </label>
         </div>
 
         {isStale && result && (

--- a/src/components/features/independence/useMonteCarloSimulation.ts
+++ b/src/components/features/independence/useMonteCarloSimulation.ts
@@ -12,7 +12,7 @@ import { DEFAULT_SCENARIO_STATE, type ScenarioState } from "./scenario/types"
 import { AssetBreakdown } from "./useAssetBreakdown"
 import { RentalIncomeData } from "./useUnifiedProjection"
 
-interface UseMonteCarloSimulationProps {
+export interface UseMonteCarloSimulationProps {
   plan: RetirementPlan | undefined
   assets: AssetBreakdown
   monthlyInvestment?: number
@@ -20,6 +20,12 @@ interface UseMonteCarloSimulationProps {
   scenario?: ScenarioState
   rentalIncome?: RentalIncomeData
   displayCurrency?: string
+  /**
+   * When true the simulation keeps illiquid assets (property, real-estate)
+   * in place and models spending from liquid savings only. Sent to the
+   * backend as-is; omitted from the request body when false/undefined.
+   */
+  neverSellIlliquid?: boolean
 }
 
 interface UseMonteCarloSimulationResult {
@@ -44,6 +50,7 @@ export function useMonteCarloSimulation({
   scenario = DEFAULT_SCENARIO_STATE,
   rentalIncome,
   displayCurrency,
+  neverSellIlliquid,
 }: UseMonteCarloSimulationProps): UseMonteCarloSimulationResult {
   const [result, setResult] = useState<MonteCarloResult | null>(null)
   const [isRunning, setIsRunning] = useState(false)
@@ -66,9 +73,12 @@ export function useMonteCarloSimulation({
           derivedLiquidAssets: assets.liquidAssets,
           derivedNonSpendableAssets: assets.nonSpendableAssets,
         }
-        const requestBody = {
+        const requestBody: Record<string, unknown> = {
           ...scenarioToPayload(scenario, ctx),
           iterations,
+        }
+        if (neverSellIlliquid) {
+          requestBody.neverSellIlliquid = true
         }
 
         const response = await fetch(
@@ -96,7 +106,15 @@ export function useMonteCarloSimulation({
         setIsRunning(false)
       }
     },
-    [plan, assets, monthlyInvestment, rentalIncome, scenario, displayCurrency],
+    [
+      plan,
+      assets,
+      monthlyInvestment,
+      rentalIncome,
+      scenario,
+      displayCurrency,
+      neverSellIlliquid,
+    ],
   )
 
   return { result, isRunning, error, runSimulation }

--- a/src/hooks/__tests__/useCompositeMonteCarloSimulation.test.ts
+++ b/src/hooks/__tests__/useCompositeMonteCarloSimulation.test.ts
@@ -84,6 +84,68 @@ describe("useCompositeMonteCarloSimulation", () => {
     expect(body).not.toHaveProperty("seed")
   })
 
+  it("includes neverSellIlliquid: true in body when set to true", async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: fixtureMonteCarloResult }),
+    })
+
+    const { result } = renderHook(() => useCompositeMonteCarloSimulation())
+
+    await act(async () => {
+      await result.current.runSimulation({
+        iterations: 1000,
+        phases,
+        displayCurrency: "USD",
+        neverSellIlliquid: true,
+      })
+    })
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body)
+    expect(body.neverSellIlliquid).toBe(true)
+  })
+
+  it("omits neverSellIlliquid from body when not provided", async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: fixtureMonteCarloResult }),
+    })
+
+    const { result } = renderHook(() => useCompositeMonteCarloSimulation())
+
+    await act(async () => {
+      await result.current.runSimulation({
+        iterations: 1000,
+        phases,
+        displayCurrency: "USD",
+      })
+    })
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body)
+    expect(body).not.toHaveProperty("neverSellIlliquid")
+  })
+
+  it("omits neverSellIlliquid from body when explicitly false", async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: fixtureMonteCarloResult }),
+    })
+
+    const { result } = renderHook(() => useCompositeMonteCarloSimulation())
+
+    await act(async () => {
+      await result.current.runSimulation({
+        iterations: 1000,
+        phases,
+        displayCurrency: "USD",
+        neverSellIlliquid: false,
+      })
+    })
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body)
+    expect(body).not.toHaveProperty("neverSellIlliquid")
+  })
+
   it("toggles isRunning around the call", async () => {
     let resolveFetch: (value: unknown) => void = () => undefined
     ;(global.fetch as jest.Mock).mockReturnValueOnce(

--- a/src/hooks/useCompositeMonteCarloSimulation.ts
+++ b/src/hooks/useCompositeMonteCarloSimulation.ts
@@ -12,6 +12,7 @@ export interface CompositeMonteCarloRunArgs {
   phases: CompositePhase[]
   displayCurrency: string
   seed?: number
+  neverSellIlliquid?: boolean
 }
 
 export interface UseCompositeMonteCarloSimulationResult {
@@ -39,6 +40,7 @@ export function useCompositeMonteCarloSimulation(): UseCompositeMonteCarloSimula
       phases,
       displayCurrency,
       seed,
+      neverSellIlliquid,
     }: CompositeMonteCarloRunArgs): Promise<void> => {
       if (phases.length === 0) return
 
@@ -53,6 +55,9 @@ export function useCompositeMonteCarloSimulation(): UseCompositeMonteCarloSimula
         }
         if (seed !== undefined) {
           requestBody.seed = seed
+        }
+        if (neverSellIlliquid) {
+          requestBody.neverSellIlliquid = true
         }
 
         const response = await fetch(COMPOSITE_MONTE_CARLO_URL, {


### PR DESCRIPTION
Adds a "Never force-sell illiquid" toggle to both Monte Carlo Stress Test surfaces. Pairs with svc-retire #122, which accepts neverSellIlliquid on the MC requests — when on, housing/real-estate is never force-sold in the simulation (assets stay, keep growing/earning rent; CPF already never sold).

- Composite StressTestTab + useCompositeMonteCarloSimulation: toggle + field in POST body (omitted when false)
- Single-plan MonteCarloTab + useMonteCarloSimulation: same, as Stress-Test-local state (NOT wired into ScenarioState/What-If sliders per design)
- API routes pass the body through unchanged (createApiHandler) — no route change

Distinct from the existing "Liquid Only" preset (which zeroes non-spendable assets); this keeps them, just refuses forced liquidation.
