### PR TITLE
fix(accounts): stack Set Account Balances rows, enlarge Target input

### DIFF
--- a/src/components/features/accounts/SetAccountBalancesDialog.tsx
+++ b/src/components/features/accounts/SetAccountBalancesDialog.tsx
@@ -344,82 +344,72 @@ const SetAccountBalancesDialog: React.FC<SetAccountBalancesDialogProps> = ({
         </div>
       )}
 
-      {/* Balance Table */}
+      {/* Balance List */}
       {!isLoading && !error && positions.length > 0 && (
-        <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-                  {"Portfolio"}
-                </th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
-                  {"Current"}
-                </th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
-                  {"Target"}
-                </th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
-                  {"Change"}
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {balanceEntries.map((entry) => (
-                <tr key={entry.portfolio.id}>
-                  <td className="px-4 py-3">
-                    <div className="font-medium text-gray-900">
-                      {entry.portfolio.name}
-                    </div>
-                    <div className="text-xs text-gray-500">
-                      {entry.portfolio.code}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-right text-gray-600">
+        <div className="space-y-3">
+          {balanceEntries.map((entry) => (
+            <div
+              key={entry.portfolio.id}
+              className="bg-white border border-gray-200 rounded-lg p-4"
+            >
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <div className="font-medium text-gray-900">
+                    {entry.portfolio.name}
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    {entry.portfolio.code}
+                  </div>
+                </div>
+                {entry.adjustment.amount > 0 && (
+                  <span
+                    className={`font-medium text-sm ${
+                      entry.adjustment.type === "DEPOSIT"
+                        ? "text-green-600"
+                        : "text-red-600"
+                    }`}
+                  >
+                    {entry.adjustment.type === "DEPOSIT" ? "+" : "-"}
                     {currency}{" "}
-                    {entry.currentBalance.toLocaleString(undefined, {
+                    {entry.adjustment.amount.toLocaleString(undefined, {
                       minimumFractionDigits: 2,
                       maximumFractionDigits: 2,
                     })}
-                  </td>
-                  <td className="px-4 py-3">
-                    <MathInput
-                      value={
-                        entry.targetBalance === ""
-                          ? ""
-                          : parseFloat(entry.targetBalance)
-                      }
-                      onChange={(value) =>
-                        handleBalanceChange(entry.portfolio.id, String(value))
-                      }
-                      className="w-full text-right border-gray-300 rounded-md shadow-sm px-2 py-1 border focus:ring-blue-500 focus:border-blue-500"
-                      disabled={isSubmitting || submitSuccess}
-                    />
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    {entry.adjustment.amount > 0 ? (
-                      <span
-                        className={`font-medium ${
-                          entry.adjustment.type === "DEPOSIT"
-                            ? "text-green-600"
-                            : "text-red-600"
-                        }`}
-                      >
-                        {entry.adjustment.type === "DEPOSIT" ? "+" : "-"}
-                        {currency}{" "}
-                        {entry.adjustment.amount.toLocaleString(undefined, {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}
-                      </span>
-                    ) : (
-                      <span className="text-gray-400">-</span>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                  </span>
+                )}
+              </div>
+              <label
+                htmlFor={`target-balance-${entry.portfolio.id}`}
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {"Target"} ({currency})
+              </label>
+              <MathInput
+                id={`target-balance-${entry.portfolio.id}`}
+                aria-label={`Target balance for ${entry.portfolio.name}`}
+                value={
+                  entry.targetBalance === ""
+                    ? ""
+                    : parseFloat(entry.targetBalance)
+                }
+                onChange={(value) =>
+                  handleBalanceChange(entry.portfolio.id, String(value))
+                }
+                className="w-full text-right border-gray-300 rounded-md shadow-sm px-4 py-3 text-lg border focus:ring-blue-500 focus:border-blue-500"
+                disabled={isSubmitting || submitSuccess}
+              />
+              <div className="mt-2 text-sm">
+                <span className="text-gray-500">{"Current Balance"}:</span>{" "}
+                <span className="font-medium text-gray-900">
+                  {currency}{" "}
+                  {entry.currentBalance.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
+                </span>
+              </div>
+            </div>
+          ))}
         </div>
       )}
 

--- a/src/components/features/accounts/__tests__/SetAccountBalancesDialog.test.tsx
+++ b/src/components/features/accounts/__tests__/SetAccountBalancesDialog.test.tsx
@@ -1,0 +1,72 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import SetAccountBalancesDialog from "../SetAccountBalancesDialog"
+import { Asset, Portfolio } from "types/beancounter"
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    data: { data: [] },
+    error: undefined,
+    isLoading: false,
+    mutate: jest.fn(),
+  })),
+  mutate: jest.fn(),
+  SWRConfig: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+jest.mock("@components/ui/DropZone", () => ({
+  postData: jest.fn(),
+}))
+
+const portfolio = {
+  id: "p1",
+  code: "SGD",
+  name: "SGD Portfolio",
+} as Portfolio
+
+const asset = {
+  id: "choc-1",
+  code: "CHOC",
+  name: "Chocolate Finance Balance",
+  assetCategory: { id: "ACCOUNT", name: "Bank Account" },
+  market: { code: "PRIVATE" },
+} as unknown as Asset
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        data: [{ portfolio, position: null, balance: 38797 }],
+      }),
+  }) as unknown as typeof fetch
+})
+
+describe("SetAccountBalancesDialog", () => {
+  it("renders a large per-portfolio Target input with Current Balance shown below it", async () => {
+    render(
+      <SetAccountBalancesDialog
+        asset={asset}
+        onClose={jest.fn()}
+        onComplete={jest.fn()}
+      />,
+    )
+
+    const input = await screen.findByLabelText(/Target.*SGD Portfolio/i)
+    expect(input.className).toContain("text-lg")
+    expect(input.className).toContain("py-3")
+
+    // Not a 4-column table with a separate "Current" header — stacked layout instead
+    expect(
+      screen.queryByRole("columnheader", { name: /current/i }),
+    ).not.toBeInTheDocument()
+
+    const currentBalanceLabel = screen.getByText(/Current Balance/i)
+    expect(
+      input.compareDocumentPosition(currentBalanceLabel) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+})


### PR DESCRIPTION
The 4-column table (Portfolio/Current/Target/Change) squeezed the
Target MathInput to px-2/py-1 and overflowed on mobile. Replaced
with per-portfolio cards: larger Target input (px-4/py-3/text-lg)
with Current Balance shown directly below it instead of in a
separate column.