### PR TITLE
feat(nav): mobile nav drawer + visible holdings settings tab

### DIFF
--- a/src/components/features/holdings/GroupByOptions.tsx
+++ b/src/components/features/holdings/GroupByOptions.tsx
@@ -84,15 +84,17 @@ const GroupByOptions: React.FC<GroupByOptionsProps> = ({
   return (
     <ul className="menu-list">
       {groupOptions.values.map((option) => (
-        <li
-          key={option.value}
-          className="menu-item"
-          onClick={() => handleSelectChange(option)}
-        >
-          {option.label}
-          {holdingState.groupBy.value === option.value && (
-            <span className="check-mark">&#10003;</span>
-          )}
+        <li key={option.value}>
+          <button
+            type="button"
+            className="menu-item"
+            onClick={() => handleSelectChange(option)}
+          >
+            {option.label}
+            {holdingState.groupBy.value === option.value && (
+              <span className="check-mark">&#10003;</span>
+            )}
+          </button>
         </li>
       ))}
     </ul>

--- a/src/components/features/holdings/HoldingMenu.tsx
+++ b/src/components/features/holdings/HoldingMenu.tsx
@@ -10,6 +10,10 @@ interface HoldingMenuOptions {
   showPortfolioSelector?: boolean
 }
 
+// Section label — DESIGN.md Label spec (12px / 500 / 0.04em tracking).
+const sectionLabelClass =
+  "block text-xs font-medium tracking-wide text-gray-500"
+
 const HoldingMenu: React.FC<HoldingMenuOptions> = ({
   portfolio,
   showPortfolioSelector = true,
@@ -36,8 +40,6 @@ const HoldingMenu: React.FC<HoldingMenuOptions> = ({
 
   return (
     <div className="relative">
-      <header className="main-header">{/* Main header content */}</header>
-
       {/* Backdrop overlay - only visible when menu is open */}
       {menuOpen && (
         <div
@@ -47,18 +49,20 @@ const HoldingMenu: React.FC<HoldingMenuOptions> = ({
         />
       )}
 
-      {/* Menu Trigger - with visual cue */}
+      {/* Menu Trigger — a visible pull-tab on the left edge. Click/tap to
+          open (no hover-open: an 8px hover strip fired accidentally and was
+          nearly untappable on mobile). */}
       <button
         aria-label="Open menu"
         aria-expanded={menuOpen}
-        aria-haspopup="true"
-        className="fixed top-0 left-0 h-full w-[8px] bg-gray-800 z-50 cursor-pointer flex items-center justify-center hover:bg-gray-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-        onMouseEnter={() => setMenuOpen(true)}
+        aria-haspopup="dialog"
+        className="fixed left-0 top-1/2 -translate-y-1/2 z-40 flex h-24 w-6 cursor-pointer items-center justify-center rounded-r-lg bg-gray-800 text-white shadow-md transition-colors hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         onClick={toggleMenu}
+        title="View settings"
       >
         {/* Chevron icon */}
         <svg
-          className="w-3 h-3 text-white"
+          className="w-3.5 h-3.5"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -74,67 +78,67 @@ const HoldingMenu: React.FC<HoldingMenuOptions> = ({
 
       {/* Menu Panel */}
       <div
-        className={`fixed top-0 left-0 h-full w-64 bg-white shadow-lg transform transition-transform z-50 ${
+        role="dialog"
+        aria-label="View settings"
+        className={`fixed top-0 left-0 z-50 flex h-full w-72 flex-col border-r border-gray-200 bg-white shadow-[0_2px_10px_rgb(0_0_0/0.1)] transform transition-transform duration-200 ease-out motion-reduce:transition-none ${
           menuOpen ? "translate-x-0" : "-translate-x-full"
         }`}
-        onMouseLeave={closeMenu}
       >
-        {/* Close Button */}
-        <button
-          aria-label="Close menu"
-          className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-          onClick={closeMenu}
-        >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
+        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+          <h2 className="text-sm font-semibold text-gray-900">
+            {"View Settings"}
+          </h2>
+          {/* Close Button */}
+          <button
+            aria-label="Close menu"
+            className="rounded p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+            onClick={closeMenu}
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
 
-        <div className="p-4 mt-8">
+        {/* No overflow-y here: the Portfolios selector opens an absolute
+            dropdown that a scroll container would clip. */}
+        <div className="flex-1 space-y-5 p-4">
           {showPortfolioSelector && (
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700">
-                {"Portfolio"}
-              </label>
-              <div className="mt-1 flex items-center">
+            <div>
+              <label className={sectionLabelClass}>{"Portfolio"}</label>
+              <div className="mt-1.5 flex items-center">
                 <Portfolios {...portfolio} />
               </div>
             </div>
           )}
-          <div className="mb-4">
-            <label className="block text-sm font-medium text-gray-700">
-              {"Value In"}
-            </label>
-            <div className="mt-1">
+          <div>
+            <label className={sectionLabelClass}>{"Value In"}</label>
+            <div className="mt-1.5">
               <ValueInOption portfolio={portfolio} onOptionSelect={closeMenu} />
             </div>
           </div>
-          <div className="mb-4">
-            <label className="block text-sm font-medium text-gray-700">
-              {"Display Currency"}
-            </label>
-            <div className="mt-1">
+          <div>
+            <label className={sectionLabelClass}>{"Display Currency"}</label>
+            <div className="mt-1.5">
               <DisplayCurrencyOption
                 portfolio={portfolio}
                 onOptionSelect={closeMenu}
               />
             </div>
           </div>
-          <div className="mb-4">
-            <label className="block text-sm font-medium text-gray-700">
-              {"Open Only"}
-            </label>
-            <div className="mt-1">
+          <div>
+            <label className={sectionLabelClass}>{"Open Only"}</label>
+            <div className="mt-1.5">
               <HideEmpty />
             </div>
           </div>

--- a/src/components/features/holdings/__tests__/HoldingMenu.test.tsx
+++ b/src/components/features/holdings/__tests__/HoldingMenu.test.tsx
@@ -129,11 +129,13 @@ describe("HoldingMenu Visual Cues and Mobile Support (TDD)", () => {
     fireEvent.click(backdrop)
 
     // Menu should be closed
-    const menu = document.querySelector(".fixed.w-64")
+    const menu = screen.getByRole("dialog", { name: "View settings" })
     expect(menu).toHaveClass("-translate-x-full")
   })
 
-  it("should close menu when mouse leaves the menu panel", () => {
+  it("should keep the menu open when the mouse leaves the panel", () => {
+    // Leaving the panel must not dismiss it — the old hover-close fired
+    // while users reached for controls inside the drawer.
     render(<HoldingMenu portfolio={mockPortfolio} />)
 
     // Open menu
@@ -141,15 +143,34 @@ describe("HoldingMenu Visual Cues and Mobile Support (TDD)", () => {
     fireEvent.click(trigger)
 
     // Verify menu is open
-    const menu = document.querySelector(".fixed.w-64")
+    const menu = screen.getByRole("dialog", { name: "View settings" })
     expect(menu).not.toHaveClass("-translate-x-full")
 
     // Mouse leave from menu panel
-    if (menu) {
-      fireEvent.mouseLeave(menu)
-    }
+    fireEvent.mouseLeave(menu)
 
-    // Menu should be closed
+    // Menu stays open; only backdrop, Escape, or the close button dismiss it
+    expect(menu).not.toHaveClass("-translate-x-full")
+  })
+
+  it("should show a drawer title so the panel is self-describing", () => {
+    render(<HoldingMenu portfolio={mockPortfolio} />)
+
+    const trigger = screen.getByLabelText("Open menu")
+    fireEvent.click(trigger)
+
+    expect(screen.getByText("View Settings")).toBeInTheDocument()
+  })
+
+  it("should close menu when Escape is pressed", () => {
+    render(<HoldingMenu portfolio={mockPortfolio} />)
+
+    const trigger = screen.getByLabelText("Open menu")
+    fireEvent.click(trigger)
+
+    fireEvent.keyDown(document, { key: "Escape" })
+
+    const menu = screen.getByRole("dialog", { name: "View settings" })
     expect(menu).toHaveClass("-translate-x-full")
   })
 })

--- a/src/components/layout/HeaderBrand.tsx
+++ b/src/components/layout/HeaderBrand.tsx
@@ -167,6 +167,76 @@ const defaultSectionColor = {
   text: "text-gray-700",
 }
 
+function filterNavItems(
+  items: NavItem[],
+  isAdmin: boolean,
+  canRunAi: boolean,
+  zenMode: boolean,
+): NavItem[] {
+  return items.filter(
+    (item) =>
+      (!item.adminOnly || isAdmin) &&
+      (!item.aiOnly || canRunAi) &&
+      (!item.zenHidden || !zenMode),
+  )
+}
+
+// One nav entry — shared by the desktop dropdowns and the mobile drawer so
+// both surfaces keep the same vocabulary. `dense` is the desktop dropdown
+// sizing; the drawer gets roomier tap targets.
+function NavItemRow({
+  item,
+  active,
+  colors,
+  dense = false,
+  onNavigate,
+  onAction,
+}: {
+  item: NavItem
+  active: boolean
+  colors: { bg: string; text: string }
+  dense?: boolean
+  onNavigate: () => void
+  onAction: (action: NavAction) => void
+}): React.ReactElement {
+  const rowClass = `flex items-center ${
+    dense ? "gap-2.5 px-3 py-2" : "gap-3 px-4 py-2.5"
+  } text-sm transition-colors ${
+    active
+      ? `${colors.bg} ${colors.text} font-medium`
+      : "text-gray-700 hover:bg-gray-50"
+  }`
+  const icon = (
+    <i
+      className={`fas ${item.icon} ${dense ? "w-4 text-xs" : "w-5 text-sm"} text-center ${
+        active ? colors.text : "text-gray-400"
+      }`}
+    ></i>
+  )
+  if (item.action) {
+    const action = item.action
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          onNavigate()
+          onAction(action)
+        }}
+        className={`${rowClass} w-full text-left`}
+      >
+        {icon}
+        {item.label}
+      </button>
+    )
+  }
+  return (
+    <Link href={item.href} onClick={onNavigate} className={rowClass}>
+      {icon}
+      {item.label}
+    </Link>
+  )
+}
+
 // Desktop dropdown — opens on hover with a close delay, click also toggles
 function DesktopDropdown({
   section,
@@ -218,11 +288,11 @@ function DesktopDropdown({
     return () => document.removeEventListener("mousedown", handleClickOutside)
   }, [isOpen])
 
-  const filteredItems = section.items.filter(
-    (item) =>
-      (!item.adminOnly || isAdmin) &&
-      (!item.aiOnly || canRunAi) &&
-      (!item.zenHidden || !zenMode),
+  const filteredItems = filterNavItems(
+    section.items,
+    isAdmin,
+    canRunAi,
+    zenMode,
   )
   const isActive = filteredItems.some((item) =>
     isActiveRoute(router.pathname, item.href),
@@ -257,9 +327,9 @@ function DesktopDropdown({
         onClick={() => setIsOpen(!isOpen)}
         aria-expanded={isOpen}
         aria-haspopup="true"
-        className={`flex items-center px-3 py-2 text-sm font-medium rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
+        className={`relative flex items-center px-3 py-2 text-sm font-medium rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
           isActive
-            ? "text-white bg-gray-700"
+            ? "text-white bg-gray-700 after:absolute after:inset-x-3 after:bottom-0.5 after:h-0.5 after:rounded-full after:bg-blue-400 after:content-['']"
             : "text-gray-300 hover:text-white hover:bg-gray-700"
         }`}
       >
@@ -270,51 +340,18 @@ function DesktopDropdown({
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 mt-1 w-52 bg-white rounded-lg shadow-lg border border-gray-200 z-50 overflow-hidden py-1 text-gray-800">
-          {filteredItems.map((item) => {
-            const active = isActiveRoute(router.pathname, item.href)
-            const colors = sectionColors[section.title] || defaultSectionColor
-            const itemClass = `flex items-center gap-2.5 px-3 py-2 text-sm transition-colors ${
-              active
-                ? `${colors.bg} ${colors.text} font-medium`
-                : "text-gray-700 hover:bg-gray-50"
-            }`
-            const itemIcon = (
-              <i
-                className={`fas ${item.icon} w-4 text-center text-xs ${
-                  active ? colors.text : "text-gray-400"
-                }`}
-              ></i>
-            )
-            if (item.action) {
-              const action = item.action
-              return (
-                <button
-                  key={item.href}
-                  type="button"
-                  onClick={() => {
-                    setIsOpen(false)
-                    onAction(action)
-                  }}
-                  className={`${itemClass} w-full text-left`}
-                >
-                  {itemIcon}
-                  {item.label}
-                </button>
-              )
-            }
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setIsOpen(false)}
-                className={itemClass}
-              >
-                {itemIcon}
-                {item.label}
-              </Link>
-            )
-          })}
+        <div className="absolute left-0 mt-1 w-52 bg-white rounded-lg shadow-[0_2px_10px_rgb(0_0_0/0.1)] border border-gray-200 z-50 overflow-hidden py-1 text-gray-800 animate-menu-in">
+          {filteredItems.map((item) => (
+            <NavItemRow
+              key={item.href}
+              item={item}
+              active={isActiveRoute(router.pathname, item.href)}
+              colors={sectionColors[section.title] || defaultSectionColor}
+              dense
+              onNavigate={() => setIsOpen(false)}
+              onAction={onAction}
+            />
+          ))}
         </div>
       )}
     </div>
@@ -332,26 +369,28 @@ function HeaderBrand(): React.ReactElement {
   const zenMode = deriveZenModeFromPreferences(portfolios.length, preferences)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [payslipOpen, setPayslipOpen] = useState(false)
-  const mobileMenuRef = useRef<HTMLDivElement>(null)
   const isAuthed = !!user
 
-  const openAction = useCallback((action: NavAction): void => {
-    if (action === "payslip") setPayslipOpen(true)
-  }, [])
+  const openAction = useCallback(
+    (action: NavAction): void => {
+      if (action === "payslip") setPayslipOpen(true)
+    },
+    [setPayslipOpen],
+  )
 
-  // Close mobile menu when clicking outside
+  const closeMobileMenu = useCallback((): void => {
+    setMobileMenuOpen(false)
+  }, [setMobileMenuOpen])
+
+  // Close mobile menu on Escape — document-level so it works regardless of
+  // which element inside the drawer holds focus.
   useEffect(() => {
     if (!mobileMenuOpen) return () => {}
-    function handleClickOutside(event: MouseEvent): void {
-      if (
-        mobileMenuRef.current &&
-        !mobileMenuRef.current.contains(event.target as Node)
-      ) {
-        setMobileMenuOpen(false)
-      }
+    function onKey(event: KeyboardEvent): void {
+      if (event.key === "Escape") setMobileMenuOpen(false)
     }
-    document.addEventListener("mousedown", handleClickOutside)
-    return () => document.removeEventListener("mousedown", handleClickOutside)
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
   }, [mobileMenuOpen])
 
   // Close mobile menu on route change. Subscribe to the router event rather
@@ -391,23 +430,16 @@ function HeaderBrand(): React.ReactElement {
     }
   }, [mobileMenuOpen])
 
-  const handleKeyDown = (e: React.KeyboardEvent): void => {
-    if (e.key === "Escape") {
-      setMobileMenuOpen(false)
-    }
-  }
-
   return (
-    <div className="flex items-center" ref={mobileMenuRef}>
+    <div className="flex items-center">
       {/* Mobile Menu Button — hidden when unauthenticated */}
       {isAuthed && (
-        <div className="relative lg:hidden mr-3">
+        <div className="lg:hidden mr-3">
           <button
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            onKeyDown={handleKeyDown}
             className="p-2 rounded-md hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
             aria-expanded={mobileMenuOpen}
-            aria-haspopup="true"
+            aria-haspopup="dialog"
             aria-label="Navigation menu"
           >
             {mobileMenuOpen ? (
@@ -417,85 +449,65 @@ function HeaderBrand(): React.ReactElement {
             )}
           </button>
 
-          {/* Mobile Dropdown */}
+          {/* Backdrop — tap anywhere outside the drawer to dismiss */}
           {mobileMenuOpen && (
-            <div className="absolute left-0 mt-2 w-64 bg-white rounded-xl shadow-2xl border border-gray-200 z-50 overflow-hidden text-gray-800">
-              <div className="py-2 max-h-[75vh] overflow-y-auto overscroll-contain">
-                {navSections.map((section, sectionIdx) => {
-                  const filteredItems = section.items.filter(
-                    (item) =>
-                      (!item.adminOnly || isAdmin) &&
-                      (!item.aiOnly || canRunAi) &&
-                      (!item.zenHidden || !zenMode),
+            <div
+              data-testid="mobile-nav-backdrop"
+              className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+              onClick={closeMobileMenu}
+            />
+          )}
+
+          {/* Mobile drawer — slides in from the left edge on open; unmounted
+              while closed so its links stay out of the tab order. */}
+          {mobileMenuOpen && (
+            <div
+              role="dialog"
+              aria-label="Navigation"
+              className="fixed inset-y-0 left-0 z-50 flex w-72 max-w-[85vw] flex-col bg-white shadow-[0_2px_10px_rgb(0_0_0/0.1)] lg:hidden animate-drawer-in"
+            >
+              <div className="flex items-center justify-between bg-gray-800 px-4 py-3 text-white">
+                <span className="text-lg font-bold">
+                  Holds<i>worth</i>
+                </span>
+                <button
+                  onClick={closeMobileMenu}
+                  aria-label="Close menu"
+                  className="rounded p-1 text-gray-300 transition-colors hover:bg-gray-700 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+                >
+                  <i className="fas fa-times w-5 text-center text-lg"></i>
+                </button>
+              </div>
+              <nav className="flex-1 overflow-y-auto overscroll-contain py-2">
+                {navSections.map((section) => {
+                  const filteredItems = filterNavItems(
+                    section.items,
+                    isAdmin,
+                    canRunAi,
+                    zenMode,
                   )
                   if (filteredItems.length === 0) return null
                   return (
                     <div key={section.title}>
-                      {sectionIdx > 0 && (
-                        <hr className="my-1.5 border-gray-100" />
-                      )}
-                      <div className="px-3 py-1">
-                        <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
-                          {section.title}
-                        </p>
-                      </div>
-                      {filteredItems.map((item) => {
-                        const active = isActiveRoute(router.pathname, item.href)
-                        const colors =
-                          sectionColors[section.title] || defaultSectionColor
-                        const itemClass = `flex items-center gap-2.5 px-3 py-2 transition-colors ${
-                          active
-                            ? `${colors.bg} ${colors.text} font-medium`
-                            : "text-gray-700 hover:bg-gray-50"
-                        }`
-                        const itemIcon = (
-                          <i
-                            className={`fas ${item.icon} w-4 text-center text-xs ${
-                              active ? colors.text : "text-gray-400"
-                            }`}
-                          ></i>
-                        )
-                        if (item.action) {
-                          const action = item.action
-                          return (
-                            <button
-                              key={item.href}
-                              type="button"
-                              onClick={() => {
-                                setMobileMenuOpen(false)
-                                openAction(action)
-                              }}
-                              className={`${itemClass} w-full text-left`}
-                            >
-                              {itemIcon}
-                              <span className="text-sm">{item.label}</span>
-                            </button>
-                          )
-                        }
-                        return (
-                          <Link
-                            key={item.href}
-                            href={item.href}
-                            className={itemClass}
-                          >
-                            {itemIcon}
-                            <span className="text-sm">{item.label}</span>
-                          </Link>
-                        )
-                      })}
+                      <p className="px-4 pb-1 pt-4 text-xs font-semibold tracking-wide text-gray-500">
+                        {section.title}
+                      </p>
+                      {filteredItems.map((item) => (
+                        <NavItemRow
+                          key={item.href}
+                          item={item}
+                          active={isActiveRoute(router.pathname, item.href)}
+                          colors={
+                            sectionColors[section.title] || defaultSectionColor
+                          }
+                          onNavigate={closeMobileMenu}
+                          onAction={openAction}
+                        />
+                      ))}
                     </div>
                   )
                 })}
-              </div>
-              <div className="bg-gray-50 px-3 py-1.5 border-t border-gray-100">
-                <p className="text-[10px] text-gray-400">
-                  Press{" "}
-                  <kbd className="px-1 bg-gray-200 rounded text-[10px]">
-                    Esc
-                  </kbd>{" "}
-                  to close
-                </p>
-              </div>
+              </nav>
             </div>
           )}
         </div>

--- a/src/components/layout/HeaderUserControls.tsx
+++ b/src/components/layout/HeaderUserControls.tsx
@@ -24,6 +24,13 @@ function Avatar({
   )
 }
 
+const userMenuLinks: { href: string; label: string; icon: string }[] = [
+  { href: "/settings", label: "Settings", icon: "fa-cog" },
+  { href: "/milestones", label: "Milestones", icon: "fa-trophy" },
+  { href: "/brokers", label: "Brokers", icon: "fa-building" },
+  { href: "/shares", label: "Shares", icon: "fa-share-alt" },
+]
+
 export default function HeaderUserControls(): React.ReactElement {
   // Auth0 v4 surfaces 401 from /auth/profile as `error` rather than a clean
   // `user: undefined` — for header UX, treat error the same as unauthenticated
@@ -70,7 +77,7 @@ export default function HeaderUserControls(): React.ReactElement {
       <div className="flex items-center">
         <button
           onClick={toggleHideValues}
-          className="p-2 mr-2 hover:bg-gray-700 rounded transition-colors"
+          className="p-2 mr-2 hover:bg-gray-700 rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
           title={hideValues ? "Show values" : "Hide values"}
           aria-label={hideValues ? "Show values" : "Hide values"}
         >
@@ -78,7 +85,9 @@ export default function HeaderUserControls(): React.ReactElement {
         </button>
         <button
           onClick={() => setDropdownOpen(!dropdownOpen)}
-          className="flex items-center gap-2 hover:bg-gray-700 rounded-md px-2 py-1 transition-colors"
+          aria-expanded={dropdownOpen}
+          aria-haspopup="true"
+          className="flex items-center gap-2 hover:bg-gray-700 rounded-md px-2 py-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         >
           <Avatar user={user} size={28} />
           <span className="hidden sm:inline text-sm">{displayName}</span>
@@ -88,39 +97,20 @@ export default function HeaderUserControls(): React.ReactElement {
         </button>
       </div>
       {dropdownOpen && (
-        <div className="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-50 text-gray-800 overflow-hidden py-1">
-          <Link
-            href="/settings"
-            className="flex items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-            onClick={() => setDropdownOpen(false)}
-          >
-            <i className="fas fa-cog w-4 text-center text-xs text-gray-400"></i>
-            {"Settings"}
-          </Link>
-          <Link
-            href="/milestones"
-            className="flex items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-            onClick={() => setDropdownOpen(false)}
-          >
-            <i className="fas fa-trophy w-4 text-center text-xs text-gray-400"></i>
-            {"Milestones"}
-          </Link>
-          <Link
-            href="/brokers"
-            className="flex items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-            onClick={() => setDropdownOpen(false)}
-          >
-            <i className="fas fa-building w-4 text-center text-xs text-gray-400"></i>
-            {"Brokers"}
-          </Link>
-          <Link
-            href="/shares"
-            className="flex items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-            onClick={() => setDropdownOpen(false)}
-          >
-            <i className="fas fa-share-alt w-4 text-center text-xs text-gray-400"></i>
-            {"Shares"}
-          </Link>
+        <div className="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-lg shadow-[0_2px_10px_rgb(0_0_0/0.1)] z-50 text-gray-800 overflow-hidden py-1 animate-menu-in">
+          {userMenuLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="flex items-center gap-2.5 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+              onClick={() => setDropdownOpen(false)}
+            >
+              <i
+                className={`fas ${link.icon} w-4 text-center text-xs text-gray-400`}
+              ></i>
+              {link.label}
+            </Link>
+          ))}
           <hr className="my-1 border-gray-100" />
           <a
             href="/auth/logout"

--- a/src/components/layout/__tests__/HeaderBrand.test.tsx
+++ b/src/components/layout/__tests__/HeaderBrand.test.tsx
@@ -81,6 +81,34 @@ describe("HeaderBrand", () => {
     expect(document.body.style.overflow).toBe("")
   })
 
+  it("opens the mobile drawer and closes it via the backdrop", () => {
+    window.scrollTo = jest.fn()
+    render(<HeaderBrand />)
+    expect(
+      screen.queryByRole("dialog", { name: "Navigation" }),
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: /Navigation menu/i }))
+    expect(
+      screen.getByRole("dialog", { name: "Navigation" }),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId("mobile-nav-backdrop"))
+    expect(
+      screen.queryByRole("dialog", { name: "Navigation" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("closes the mobile drawer on Escape", () => {
+    window.scrollTo = jest.fn()
+    render(<HeaderBrand />)
+    fireEvent.click(screen.getByRole("button", { name: /Navigation menu/i }))
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(
+      screen.queryByRole("dialog", { name: "Navigation" }),
+    ).not.toBeInTheDocument()
+  })
+
   it("hides nav dropdowns when unauthenticated", () => {
     mockUseUser.mockReturnValueOnce({
       user: undefined,

--- a/src/components/ui/DisplayCurrencyOption.tsx
+++ b/src/components/ui/DisplayCurrencyOption.tsx
@@ -50,9 +50,15 @@ const DisplayCurrencyOption: React.FC<DisplayCurrencyOptionProps> = ({
     <div className="space-y-2">
       <ul className="menu-list max-h-48 overflow-y-auto">
         {/* None option - clears custom display currency */}
-        <li className="menu-item" onClick={handleClearDisplayCurrency}>
-          {"None"}
-          {!isCustomSelected && <span className="check-mark">&#10003;</span>}
+        <li>
+          <button
+            type="button"
+            className="menu-item"
+            onClick={handleClearDisplayCurrency}
+          >
+            {"None"}
+            {!isCustomSelected && <span className="check-mark">&#10003;</span>}
+          </button>
         </li>
         {/* Separator */}
         <li className="border-t border-gray-200 my-1" />
@@ -61,16 +67,18 @@ const DisplayCurrencyOption: React.FC<DisplayCurrencyOptionProps> = ({
           {"Cost/Gains will be approximate"} ⚠
         </li>
         {availableCurrencies.map((currency) => (
-          <li
-            key={currency.code}
-            className="menu-item"
-            onClick={() => handleCurrencySelect(currency.code)}
-          >
-            {currency.code} ({currency.symbol})
-            {isCustomSelected &&
-              displayCurrency.customCode === currency.code && (
-                <span className="check-mark">&#10003;</span>
-              )}
+          <li key={currency.code}>
+            <button
+              type="button"
+              className="menu-item"
+              onClick={() => handleCurrencySelect(currency.code)}
+            >
+              {currency.code} ({currency.symbol})
+              {isCustomSelected &&
+                displayCurrency.customCode === currency.code && (
+                  <span className="check-mark">&#10003;</span>
+                )}
+            </button>
           </li>
         ))}
       </ul>

--- a/src/components/ui/ValueIn.tsx
+++ b/src/components/ui/ValueIn.tsx
@@ -59,15 +59,17 @@ const ValueInOption: React.FC<ValueInOptionProps> = ({
   return (
     <ul className="menu-list">
       {options.map((option) => (
-        <li
-          key={option.value}
-          className="menu-item"
-          onClick={() => handleSelectChange(option)}
-        >
-          {option.label}
-          {holdingState.valueIn.value === option.value && (
-            <span className="check-mark">&#10003;</span>
-          )}
+        <li key={option.value}>
+          <button
+            type="button"
+            className="menu-item"
+            onClick={() => handleSelectChange(option)}
+          >
+            {option.label}
+            {holdingState.valueIn.value === option.value && (
+              <span className="check-mark">&#10003;</span>
+            )}
+          </button>
         </li>
       ))}
     </ul>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -144,7 +144,6 @@ body {
 
 .holding-row:hover {
   background-color: #eff6ff !important; /* wealth-50 */
-  border-left: 2px solid #3b82f6; /* wealth-500 */
 }
 
 /* Deep-link target — wealth-100 fade so a row/card jumped to from the
@@ -158,44 +157,79 @@ body {
   animation: asset-target-flash 2.5s ease-out;
 }
 
+/* Option lists inside the holdings view-settings drawer. Items are real
+   <button>s (keyboard reachable), full-width so the whole row is the target. */
 .menu-list {
   position: relative;
   list-style: none;
   padding: 0;
   margin: 0;
-  font-family: var(--font-dm-sans), system-ui, sans-serif;
 }
 
 .menu-item {
-  padding: 10px;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
   display: flex;
+  width: 100%;
   justify-content: space-between;
   align-items: center;
-  font-family: inherit;
-  font-size: 14px; /* Adjust this value to match the title text size */
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: 0.375rem; /* rounded-md */
+  font-size: 0.875rem;
+  text-align: left;
+  color: #374151; /* gray-700 */
+  cursor: pointer;
+  transition: background-color 150ms ease-out;
 }
 
 .menu-item:hover {
-  background-color: #f0f0f0;
+  background-color: #f3f4f6; /* gray-100 */
+}
+
+.menu-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
 }
 
 .check-mark {
-  margin-left: 10px;
+  margin-left: 0.5rem;
+  color: var(--color-primary);
 }
 
-.flyout-menu {
-  display: none;
-  position: absolute;
-  left: 100%;
-  top: 0;
-  background-color: white;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  z-index: 1000; /* Set a higher z-index value */
+/* Dropdown/panel entrance — state feedback, not choreography. */
+@keyframes menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-menu-in {
+  animation: menu-in 150ms ease-out;
+}
+
+/* Drawer entrance — slides in from the left edge on mount. */
+@keyframes drawer-in {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+.animate-drawer-in {
+  animation: drawer-in 200ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-menu-in,
+  .animate-drawer-in {
+    animation: none;
+  }
 }
 
 /* Custom scrollbar styling for holdings table */


### PR DESCRIPTION
## Summary
- Mobile nav: floating dropdown → full-height slide-in drawer (backdrop, Escape, brand header, sentence-case section labels; removed the "Press Esc" hint that made no sense on touch).
- Holdings view-settings flyout: replaced the 8px hover-strip trigger with a visible 24×96px pull-tab (click/tap only — no accidental hover-open), added a titled drawer header, and removed the hostile mouse-leave auto-close.
- Option lists (Value In / Display Currency / Group By): rows are now real buttons — keyboard reachable with focus-visible outlines; tokenised hover + blue check marks.
- Desktop nav dropdowns: 150ms entrance motion (reduced-motion safe) and an Action-Blue underline on the active section per DESIGN.md.
- User menu: DRYed link list, focus rings on eye toggle + avatar button, consistent panel shadow/motion.
- globals.css: deleted dead .flyout-menu, removed the 2px border-left hover stripe on holdings rows (banned side-stripe pattern; caused 2px layout shift).

## Testing
- Full jest suite 1943/1943 green; new tests for drawer open/close (backdrop, Escape) and flyout no-close-on-mouse-leave.
- prettier + eslint + markdownlint + tsc clean.
- Verified in browser (localhost dev): flyout tab, drawer, Escape/backdrop dismiss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dsQtTiCYf7ELrQFt8WTLz