### PR TITLE
fix: composite FI progress from backend echo (rental-aware, unclamped)

### DIFF
--- a/src/components/features/independence/composite/__tests__/FiOverviewTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/FiOverviewTab.test.tsx
@@ -1,0 +1,230 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import type {
+  CompositeProjectionResult,
+  CompositePhase,
+} from "types/independence"
+import {
+  CompositeProjectionProvider,
+  type CompositeProjectionValue,
+} from "../CompositeProjectionContext"
+
+// ——— Module mocks ———
+
+jest.mock("recharts", () => ({
+  __esModule: true,
+  ComposedChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="chart">{children}</div>
+  ),
+  Line: () => null,
+  Area: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  ReferenceLine: () => null,
+  ReferenceArea: () => null,
+}))
+
+jest.mock("@components/features/independence/ChartFrame", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="chart-frame">{children}</div>
+  ),
+}))
+
+jest.mock("@lib/independence/ageAxis", () => ({
+  ageAxisDomain: () => [55, 90],
+  ageAxisTicks: () => [55, 60, 65, 70, 75, 80, 85, 90],
+}))
+
+jest.mock("@hooks/useCompositeMonteCarloSimulation", () => ({
+  __esModule: true,
+  default: () => ({
+    result: null,
+    isRunning: false,
+    error: null,
+    runSimulation: jest.fn(),
+  }),
+}))
+
+jest.mock("@hooks/usePrivacyMode", () => ({
+  usePrivacyMode: () => ({ hideValues: false }),
+}))
+
+jest.mock("@hooks/useIndependenceSettings", () => ({
+  useIndependenceSettings: () => ({ settings: undefined }),
+}))
+
+// ——— Fixtures ———
+
+const defaultPhases: CompositePhase[] = [
+  { planId: "p1", fromAge: 65, toAge: 90 },
+]
+
+function makeProjection(
+  overrides: Partial<CompositeProjectionResult> = {},
+): CompositeProjectionResult {
+  return {
+    asOfDate: "2026-01-01",
+    displayCurrency: "SGD",
+    phases: [
+      {
+        planId: "p1",
+        planName: "Plan 1",
+        fromAge: 65,
+        toAge: 90,
+        expensesCurrency: "SGD",
+      },
+    ],
+    totalAssets: 1_500_000,
+    liquidAssets: 1_360_893,
+    runwayYears: 30,
+    isSustainable: true,
+    yearlyProjections: [
+      {
+        age: 65,
+        year: 2036,
+        planId: "p1",
+        planName: "Plan 1",
+        startingBalance: 1_360_893,
+        investmentReturns: 0,
+        income: 0,
+        expenses: 60_000,
+        endingBalance: 1_360_893,
+        nonSpendableValue: 0,
+        totalWealth: 1_360_893,
+        currency: "SGD",
+      },
+      {
+        age: 70,
+        year: 2041,
+        planId: "p1",
+        planName: "Plan 1",
+        startingBalance: 1_360_893,
+        investmentReturns: 0,
+        income: 0,
+        expenses: 60_000,
+        endingBalance: 1_200_000,
+        nonSpendableValue: 0,
+        totalWealth: 1_200_000,
+        currency: "SGD",
+      },
+    ],
+    warnings: [],
+    ...overrides,
+  }
+}
+
+function makeCtx(
+  overrides: Partial<CompositeProjectionValue> = {},
+): CompositeProjectionValue {
+  return {
+    plans: [],
+    phases: defaultPhases,
+    setPhases: jest.fn(),
+    displayCurrency: "SGD",
+    setDisplayCurrency: jest.fn(),
+    excludedPlanIds: new Set<string>(),
+    toggleExclusion: jest.fn(),
+    compositeNarrative: "",
+    setCompositeNarrative: jest.fn(),
+    compositeWorkScenarioId: undefined,
+    setCompositeWorkScenarioId: jest.fn(),
+    projection: undefined,
+    scenarios: undefined,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  }
+}
+
+import FiOverviewTab from "../tabs/FiOverviewTab"
+
+function renderWithCtx(
+  ctxOverrides: Partial<CompositeProjectionValue> = {},
+): ReturnType<typeof render> {
+  const ctx = makeCtx(ctxOverrides)
+  return render(
+    <CompositeProjectionProvider value={ctx}>
+      <FiOverviewTab />
+    </CompositeProjectionProvider>,
+  )
+}
+
+// =====================================================================
+// Test A — backend fiNumber + fiProgress: renders unclamped (>100%)
+// =====================================================================
+
+describe("FiOverviewTab — backend-echo fiNumber/fiProgress", () => {
+  it("renders 104% progress when backend sends fiProgress: 103.6 (unclamped)", () => {
+    const projection = makeProjection({
+      fiNumber: 1_313_100,
+      fiProgress: 103.6,
+      liquidAssets: 1_360_893,
+    })
+    renderWithCtx({ projection })
+    // Math.round(103.6) = 104 — must show 104%, not 100%
+    expect(screen.getByText("104%")).toBeInTheDocument()
+    expect(screen.queryByText("100%")).not.toBeInTheDocument()
+  })
+
+  it("caps the progress bar fill width at 100% even when fiProgress > 100", () => {
+    const projection = makeProjection({
+      fiNumber: 1_313_100,
+      fiProgress: 103.6,
+      liquidAssets: 1_360_893,
+    })
+    renderWithCtx({ projection })
+    // The label shows 104%, but the bar <div> must cap at 100%
+    const progressBars = document.querySelectorAll("[style]")
+    const cappedBar = Array.from(progressBars).find(
+      (el) => (el as HTMLElement).style.width === "100%",
+    )
+    expect(cappedBar).toBeTruthy()
+  })
+
+  it("shows the FI-achieved message when liquidAssets >= fiNumber", () => {
+    const projection = makeProjection({
+      fiNumber: 1_313_100,
+      fiProgress: 103.6,
+      liquidAssets: 1_360_893,
+    })
+    renderWithCtx({ projection })
+    expect(
+      screen.getByText(/Portfolio covers your FI target/i),
+    ).toBeInTheDocument()
+  })
+})
+
+// =====================================================================
+// Test B — missing fiNumber → no crash, progress absent
+// =====================================================================
+
+describe("FiOverviewTab — missing backend fiNumber", () => {
+  it("does not crash when projection has no fiNumber", () => {
+    const projection = makeProjection({
+      // No fiNumber / fiProgress fields
+      liquidAssets: 500_000,
+    })
+    expect(() => renderWithCtx({ projection })).not.toThrow()
+  })
+
+  it("does not render the FI progress bar when fiNumber is absent", () => {
+    const projection = makeProjection({
+      liquidAssets: 500_000,
+    })
+    renderWithCtx({ projection })
+    // fiNumber = 0 → progress section is hidden
+    expect(screen.queryByText(/Progress to FI/i)).not.toBeInTheDocument()
+  })
+
+  it("does not render the progress percentage when fiNumber is absent", () => {
+    const projection = makeProjection({
+      liquidAssets: 500_000,
+    })
+    renderWithCtx({ projection })
+    expect(screen.queryByText(/\d+%/)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/features/independence/composite/tabs/FiOverviewTab.tsx
+++ b/src/components/features/independence/composite/tabs/FiOverviewTab.tsx
@@ -18,7 +18,6 @@ import { usePrivacyMode } from "@hooks/usePrivacyMode"
 import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
 import { useCompositeProjectionContext } from "../CompositeProjectionContext"
 import useCompositeMonteCarloSimulation from "@hooks/useCompositeMonteCarloSimulation"
-import { calculateFiNumberFromMonthly } from "@utils/independence/fiCalculations"
 
 const HIDDEN_VALUE = "****"
 const MC_ITERATION_OPTIONS = [500, 1000, 2000, 5000]
@@ -137,20 +136,20 @@ export default function FiOverviewTab(): React.ReactElement | null {
     return yob ? CURRENT_YEAR - yob : undefined
   }, [settings, primaryPlan])
 
-  // Net monthly retirement expenses (total spend minus guaranteed income sources)
-  const netMonthlyExpenses = useMemo(() => {
-    if (!primaryPlan) return 0
-    const guaranteedIncome =
-      (primaryPlan.pensionMonthly ?? 0) +
-      (primaryPlan.socialSecurityMonthly ?? 0) +
-      (primaryPlan.otherIncomeMonthly ?? 0)
-    return Math.max(0, primaryPlan.monthlyExpenses - guaranteedIncome)
-  }, [primaryPlan])
+  // Net monthly retirement expenses — for the income breakdown display only
+  const netMonthlyExpenses = primaryPlan
+    ? Math.max(
+        0,
+        primaryPlan.monthlyExpenses -
+          (primaryPlan.pensionMonthly ?? 0) -
+          (primaryPlan.socialSecurityMonthly ?? 0) -
+          (primaryPlan.otherIncomeMonthly ?? 0),
+      )
+    : 0
 
-  const fiNumber = useMemo(
-    () => calculateFiNumberFromMonthly(netMonthlyExpenses),
-    [netMonthlyExpenses],
-  )
+  // Backend-authoritative FI number: phase-weighted 25× duration-weighted net spend,
+  // rental-offset included. Falls back to 0 when old backend omits the field.
+  const fiNumber = projection?.fiNumber ?? 0
 
   // Build chart rows — merge MC percentile bands when available
   const chartData = useMemo((): ChartRow[] => {
@@ -206,10 +205,9 @@ export default function FiOverviewTab(): React.ReactElement | null {
 
   const currentLiquid = projection?.liquidAssets ?? 0
   const isAchieved = fiNumber > 0 && currentLiquid >= fiNumber
-  const fiProgress =
-    fiNumber > 0
-      ? Math.min(100, Math.round((currentLiquid / fiNumber) * 100))
-      : 100
+  // Backend-authoritative progress (unclamped — can exceed 100 when FI is surpassed).
+  // Visual bar width is capped at 100% via Math.min in the style below.
+  const fiProgress = Math.round(projection?.fiProgress ?? 0)
   const gap = fiNumber - currentLiquid
 
   const yrsToFi =

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -1261,6 +1261,10 @@ export interface CompositeProjectionResult {
   warnings: string[]
   /** Pre-retirement accumulation rows (currentAge → firstPhaseAge-1). Empty when already retired. */
   accumulationProjections?: CompositeYearlyProjection[]
+  /** Phase-weighted FI number (25× duration-weighted annual net spend), display currency. */
+  fiNumber?: number
+  /** Progress toward fiNumber as %; unclamped (can exceed 100). */
+  fiProgress?: number
 }
 
 export interface CompositeScenarioResult {


### PR DESCRIPTION
Remove client-side fiNumber/fiProgress derivation in FiOverviewTab; use
backend-authoritative fields instead. fiProgress is now unclamped (shows
e.g. 104%) matching phase cards; progress-bar fill width stays visually
capped at 100%. Falls back to 0 when old backend omits the fields.

Backend counterpart: monowai/svc-retire#123 (UI falls back gracefully until deployed)