### PR TITLE
feat(holdings): persist section collapse per groupBy; slim flyout tab

### DIFF
--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -585,45 +585,64 @@ const CardView: React.FC<CardViewProps> = ({
     )
   }, [groupedPositions])
 
-  // Track collapsed groups. Expand groups from the top until cumulative
-  // position count crosses ~20, then collapse the rest. First group is
-  // always expanded so the page is never blank, and the target asset's
-  // group is force-expanded so deep-links can scroll to it.
-  // Parent passes `key={groupBy}` so this component remounts (and the
-  // initial state below re-runs) whenever groupBy changes — no manual
-  // reset effect needed.
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => {
-    const POSITION_THRESHOLD = 20
-    const targetGroupKey = targetAssetId
-      ? groupedPositions.find((g) =>
-          g.positions.some((p) => p.asset.id === targetAssetId),
-        )?.groupKey
-      : undefined
-    const collapsed = new Set<string>()
-    let count = 0
-    groupedPositions.forEach((g, i) => {
-      const keepOpen =
-        i === 0 || g.groupKey === targetGroupKey || count < POSITION_THRESHOLD
-      if (keepOpen) {
-        count += g.positions.length
-      } else {
-        collapsed.add(g.groupKey)
+  // Track which groups the user has expanded. Default: everything collapsed.
+  // The expanded set is persisted to localStorage (keyed by groupBy) so the
+  // choice survives navigation between portfolios and page reloads. Groups the
+  // user has never opened stay collapsed. The deep-link target group is
+  // force-expanded so anchored scrolls land on a visible card.
+  // Parent passes `key={groupBy}` so this component remounts (and the lazy
+  // initializer below re-runs) whenever groupBy changes — the stored set is
+  // keyed by groupBy to match. CardView renders client-side after the holdings
+  // fetch, so reading localStorage in the initializer is hydration-safe.
+  const expandedStorageKey = `bc:holdings:expandedGroups:${groupBy ?? ""}`
+
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => {
+    const next = new Set<string>()
+    if (typeof window !== "undefined") {
+      try {
+        const raw = window.localStorage.getItem(expandedStorageKey)
+        if (raw) {
+          for (const key of JSON.parse(raw) as string[]) next.add(key)
+        }
+      } catch {
+        // Corrupt/blocked storage — fall back to all-collapsed.
       }
-    })
-    return collapsed
+    }
+    // Force-expand the deep-link target group so anchored scrolls land on a
+    // visible card.
+    if (targetAssetId) {
+      const targetGroupKey = groupedPositions.find((g) =>
+        g.positions.some((p) => p.asset.id === targetAssetId),
+      )?.groupKey
+      if (targetGroupKey) next.add(targetGroupKey)
+    }
+    return next
   })
 
-  const toggleGroup = useCallback((groupKey: string) => {
-    setCollapsedGroups((prev) => {
-      const next = new Set(prev)
-      if (next.has(groupKey)) {
-        next.delete(groupKey)
-      } else {
-        next.add(groupKey)
-      }
-      return next
-    })
-  }, [])
+  const toggleGroup = useCallback(
+    (groupKey: string) => {
+      setExpandedGroups((prev) => {
+        const next = new Set(prev)
+        if (next.has(groupKey)) {
+          next.delete(groupKey)
+        } else {
+          next.add(groupKey)
+        }
+        if (typeof window !== "undefined") {
+          try {
+            window.localStorage.setItem(
+              expandedStorageKey,
+              JSON.stringify([...next]),
+            )
+          } catch {
+            // Ignore storage write failures (private mode / quota).
+          }
+        }
+        return next
+      })
+    },
+    [expandedStorageKey],
+  )
 
   // Source currency based on valueIn selection
   // For TRADE with mixed currencies, use BASE for header totals
@@ -733,7 +752,7 @@ const CardView: React.FC<CardViewProps> = ({
 
       {/* Grouped Position Cards */}
       {groupedPositions.map((group) => {
-        const isCollapsed = collapsedGroups.has(group.groupKey)
+        const isCollapsed = !expandedGroups.has(group.groupKey)
         const groupSubTotals = holdings.holdingGroups[group.groupKey]?.subTotals
         const groupMarketValue = groupSubTotals
           ? convert(groupSubTotals[valueIn]?.marketValue || 0)

--- a/src/components/features/holdings/HoldingMenu.tsx
+++ b/src/components/features/holdings/HoldingMenu.tsx
@@ -56,13 +56,13 @@ const HoldingMenu: React.FC<HoldingMenuOptions> = ({
         aria-label="Open menu"
         aria-expanded={menuOpen}
         aria-haspopup="dialog"
-        className="fixed left-0 top-1/2 -translate-y-1/2 z-40 flex h-24 w-6 cursor-pointer items-center justify-center rounded-r-lg bg-gray-800 text-white shadow-md transition-colors hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        className="fixed left-0 top-24 z-40 flex h-24 w-3 cursor-pointer items-center justify-center rounded-r-lg bg-gray-800 text-white shadow-md transition-colors hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         onClick={toggleMenu}
         title="View settings"
       >
         {/* Chevron icon */}
         <svg
-          className="w-3.5 h-3.5"
+          className="w-2 h-2"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/src/components/features/holdings/__tests__/CardView.test.tsx
+++ b/src/components/features/holdings/__tests__/CardView.test.tsx
@@ -30,6 +30,17 @@ const mockedUsePrivacyMode = usePrivacyMode as jest.MockedFunction<
   typeof usePrivacyMode
 >
 
+// Groups now default to collapsed. These suites assert card *content*, so
+// pre-expand the fixture groups via the same localStorage key CardView reads
+// (groupBy is undefined here → empty suffix).
+beforeEach(() => {
+  window.localStorage.setItem(
+    "bc:holdings:expandedGroups:",
+    JSON.stringify(["Equity", "Policy", "Cash"]),
+  )
+})
+afterEach(() => window.localStorage.clear())
+
 const renderWithFooter = (): void => {
   const portfolio = makePortfolio()
   const position = makePosition({


### PR DESCRIPTION
## What
- **Holdings sections**: default to all-collapsed; the set of user-expanded groups now persists to `localStorage` (keyed by `groupBy`) so it survives navigation between portfolios and page reloads. Unseen groups stay collapsed; deep-link target group force-expands.
- **Flyout pull-tab** (`HoldingMenu`): moved up (`top-1/2` → `top-24`) and halved width (`w-6` → `w-3`) to reduce on-screen intrusion.

## Test
- `CardView.test.tsx` pre-seeds the expanded-groups localStorage key for content-assertion suites (groups now start collapsed).
- 197 holdings tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
