### PR TITLE
feat(independence): shade the bridge window + mark where SS/CPF income starts

### DIFF
--- a/src/components/features/independence/FiMetrics.tsx
+++ b/src/components/features/independence/FiMetrics.tsx
@@ -764,7 +764,7 @@ function BridgeStrategySection({
     <div className="pt-4 border-t border-gray-100 space-y-3">
       <StrategyHeader
         title="Self-funded Years"
-        tooltip="For savers whose pension covers retirement but who want to stop working before pensions start. Measures how many years of expenses your liquid pot can self-fund until the pension kicks in."
+        tooltip="When your guaranteed income (Social Security / CPF LIFE) starts after you stop working, your liquid pot must bridge the gap. Measures how many years of expenses it can self-fund until that income kicks in."
         iconClass="fas fa-bridge text-blue-500"
         active={active}
       />
@@ -772,7 +772,7 @@ function BridgeStrategySection({
       {hasData ? (
         <PensionGauge
           label="Self-funded years"
-          tooltip={`Years of full expenses your liquid pot covers, capped at the ${bridgeYearsNeeded}-year gap to your pension payout age. 100% means you could stop working today and self-fund every year until your pension starts.`}
+          tooltip={`Years of expenses your liquid pot covers, capped at the ${bridgeYearsNeeded}-year gap until your guaranteed income (Social Security / CPF LIFE) starts. 100% means you can self-fund every year until it kicks in.`}
           value={bridgeProgress}
           hideValues={hideValues}
           format={() =>
@@ -781,8 +781,9 @@ function BridgeStrategySection({
         />
       ) : (
         <p className="text-sm text-gray-500 italic">
-          No pension payout configured, or no working-years gap. Configure
-          pension income on the plan to enable this view.
+          No gap to bridge — your guaranteed income starts when you stop
+          working, or none is configured. Add Social Security / CPF LIFE income
+          with a later start age to enable this view.
         </p>
       )}
     </div>

--- a/src/components/features/independence/TimelineTabContent.tsx
+++ b/src/components/features/independence/TimelineTabContent.tsx
@@ -18,6 +18,7 @@ import { RetirementProjection } from "types/independence"
 import { HIDDEN_VALUE } from "@lib/independence/planHelpers"
 import { netHousingValue } from "@lib/independence/wealthJourneyChartData"
 import { ageAxisDomain, ageAxisTicks } from "@lib/independence/ageAxis"
+import { deriveBridgeWindow } from "@lib/independence/bridgeWindow"
 import {
   deriveJourneyRibbon,
   fromSinglePlan,
@@ -108,6 +109,18 @@ export default function TimelineTabContent({
   // end-of-year balances, so the transition lands on the start-of-year row
   // (age 54) and the marker would read "CPF LIFE (54)".
   const cpfLockAge = projection?.cpfLifeAge ?? null
+
+  // Age at which deferred guaranteed income (Social Security / CPF LIFE) starts
+  // paying — the end of the self-funded "bridge" window. When it lands after the
+  // independence age, the years between are covered from liquid alone; we shade
+  // that gap and mark where the income kicks in. Null when income already flows
+  // from independence (no gap to show).
+  const bridgeWindow = deriveBridgeWindow({
+    bridgeToAge: projection?.fiMetrics?.bridgeToAge,
+    retirementAge,
+  })
+  const showBridgeWindow = bridgeWindow.show
+  const bridgeToAge = bridgeWindow.toAge
 
   // Active scenario = backend captured a baseline overlay alongside the
   // adjusted projection. Used to gate the "compared to baseline" UI.
@@ -429,6 +442,40 @@ export default function TimelineTabContent({
                     value: `🔒 CPF LIFE (${cpfLockAge})`,
                     position: "insideTopLeft",
                     fill: "#64748b",
+                    fontSize: 11,
+                    fontWeight: 500,
+                  }}
+                />
+              )}
+            {/* Bridge window — the years from independence until deferred
+                  guaranteed income (Social Security / CPF LIFE) starts, funded
+                  from liquid alone. Amber shade for the self-funded gap, solid
+                  line + label where the income kicks in. Traditional view only
+                  (ages are the independence journey, hidden in FIRE view). */}
+            {timelineViewMode === "traditional" &&
+              showBridgeWindow &&
+              bridgeToAge != null && (
+                <ReferenceArea
+                  x1={retirementAge}
+                  x2={bridgeToAge}
+                  fill="#f59e0b"
+                  fillOpacity={0.12}
+                  stroke="#f59e0b"
+                  strokeOpacity={0.25}
+                />
+              )}
+            {timelineViewMode === "traditional" &&
+              showBridgeWindow &&
+              bridgeToAge != null && (
+                <ReferenceLine
+                  x={bridgeToAge}
+                  stroke="#f59e0b"
+                  strokeDasharray="4 4"
+                  strokeWidth={2}
+                  label={{
+                    value: `💰 Income starts (${bridgeToAge})`,
+                    position: "insideTopRight",
+                    fill: "#b45309",
                     fontSize: 11,
                     fontWeight: 500,
                   }}

--- a/src/lib/utils/independence/bridgeWindow.test.ts
+++ b/src/lib/utils/independence/bridgeWindow.test.ts
@@ -1,0 +1,37 @@
+import { deriveBridgeWindow } from "./bridgeWindow"
+
+describe("deriveBridgeWindow", () => {
+  it("shows the window when income starts after the independence age", () => {
+    // NZD Live In: retire 60, Social Security at 67 -> 7-year self-funded gap.
+    const w = deriveBridgeWindow({ bridgeToAge: 67, retirementAge: 60 })
+    expect(w.show).toBe(true)
+    expect(w.fromAge).toBe(60)
+    expect(w.toAge).toBe(67)
+  })
+
+  it("hides the window when income starts at the independence age (no gap)", () => {
+    const w = deriveBridgeWindow({ bridgeToAge: 60, retirementAge: 60 })
+    expect(w.show).toBe(false)
+    expect(w.fromAge).toBeNull()
+    expect(w.toAge).toBeNull()
+  })
+
+  it("hides the window when income starts before the independence age", () => {
+    const w = deriveBridgeWindow({ bridgeToAge: 55, retirementAge: 60 })
+    expect(w.show).toBe(false)
+  })
+
+  it("hides the window when bridgeToAge is missing", () => {
+    expect(deriveBridgeWindow({ retirementAge: 60 }).show).toBe(false)
+    expect(
+      deriveBridgeWindow({ bridgeToAge: null, retirementAge: 60 }).show,
+    ).toBe(false)
+  })
+
+  it("hides the window when the retirement age is unknown", () => {
+    expect(deriveBridgeWindow({ bridgeToAge: 67 }).show).toBe(false)
+    expect(
+      deriveBridgeWindow({ bridgeToAge: 67, retirementAge: null }).show,
+    ).toBe(false)
+  })
+})

--- a/src/lib/utils/independence/bridgeWindow.ts
+++ b/src/lib/utils/independence/bridgeWindow.ts
@@ -1,0 +1,32 @@
+/**
+ * The "bridge window" is the stretch of retirement funded from liquid assets
+ * alone, before deferred guaranteed income (Social Security / CPF LIFE) begins.
+ *
+ * The backend reports `fiMetrics.bridgeToAge` — the age that income starts. When
+ * it lands after the independence age, the years between are self-funded and the
+ * timeline shades them + marks where the income kicks in. When income already
+ * flows from independence (bridgeToAge <= retirementAge, or either is unknown),
+ * there is no gap to show.
+ */
+export interface BridgeWindow {
+  /** Whether to render the shaded gap + income-start marker. */
+  show: boolean
+  /** Start of the self-funded window (independence age). */
+  fromAge: number | null
+  /** End of the window = age guaranteed income begins. */
+  toAge: number | null
+}
+
+export function deriveBridgeWindow(opts: {
+  bridgeToAge?: number | null
+  retirementAge?: number | null
+}): BridgeWindow {
+  const { bridgeToAge, retirementAge } = opts
+  const show =
+    bridgeToAge != null && retirementAge != null && bridgeToAge > retirementAge
+  return {
+    show,
+    fromAge: show ? (retirementAge ?? null) : null,
+    toAge: show ? (bridgeToAge ?? null) : null,
+  }
+}

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -545,12 +545,22 @@ export interface FiMetrics {
   retirementAgeFiProgress?: number
   /** Present value today of the guaranteed income stream used by retirementAgeFiProgress. */
   pvGuaranteedIncomeToday?: number
-  /** Years of full pre-retirement expenses the current liquid pot covers. */
+  /**
+   * Years the liquid pot covers the self-funded window before guaranteed income
+   * begins — the deferred-benefits bridge (retirementAge -> bridgeToAge), with a
+   * pre-retirement runway fallback. Null when there is no gap.
+   */
   bridgeYears?: number
-  /** Years of bridge cover needed (= yearsToRetirement). */
+  /** Years of bridge cover needed (bridgeToAge - drawdown start age). */
   bridgeYearsNeeded?: number
   /** bridgeYears / bridgeYearsNeeded x 100, capped at 100. */
   bridgeProgress?: number
+  /**
+   * Age at which the bridged guaranteed income (Social Security / CPF LIFE)
+   * begins — the end of the self-funded bridge window. Used by the timeline to
+   * shade the bridge and mark where SS/CPF income kicks in.
+   */
+  bridgeToAge?: number
   /** Income coverage at retirement age = totalMonthlyIncome / monthlyExpenses x 100. */
   incomeCoverageAtRetirement?: number
 }


### PR DESCRIPTION
Timeline shades the self-funded gap between the independence age and the age
guaranteed income (Social Security / CPF LIFE) begins, with an amber marker at
the income-start age. Reads the new backend fiMetrics.bridgeToAge; the
Self-funded Years section now shows the deferred-benefits bridge (repurposed
bridge fields) with copy reflecting the retire-early / income-late gap.

deriveBridgeWindow helper (unit-tested) decides when the window renders.