### PR TITLE
feat(independence): stacked FI bar — portfolio + guaranteed income, overflow shown

### DIFF
--- a/src/components/features/independence/FiMetrics.tsx
+++ b/src/components/features/independence/FiMetrics.tsx
@@ -16,7 +16,6 @@ import {
   calculateGapToFi,
   calculateFiNumberFromMonthly,
   isFinanciallyIndependent,
-  clampFiProgress,
   calculateCoastFiNumber,
   calculateCoastFiProgress,
   isCoastFireAchieved,
@@ -35,6 +34,7 @@ import {
   RETIREMENT_PROGRESS_TOOLTIP,
   RETIREMENT_PROGRESS_OFFTRACK_TOOLTIP,
 } from "@utils/independence/gaugeTooltips"
+import { deriveFiStack } from "@utils/independence/fiStack"
 import FiAgeExplorer from "./FiAgeExplorer"
 
 interface FiMetricsProps {
@@ -147,8 +147,15 @@ export default function FiMetrics({
   // Using || fallback to local calculation when backend returns 0
   const localFiProgress = calculateFiProgress(liquidAssets, fiNumber)
   const fiProgress = backendFiProgress || localFiProgress
-  const fiProgressClamped = clampFiProgress(fiProgress)
   const isFi = isFinanciallyIndependent(fiProgress)
+
+  // Stacked FI progress: the portfolio's own progress plus the extra bought by
+  // guaranteed income (SS / CPF LIFE) as its present value. Same denominator, so
+  // the segments are additive. Overflow above 100% is shown honestly.
+  const fiStack = deriveFiStack({
+    fiProgress,
+    retirementAgeFiProgress: backendRetirementAgeFiProgress,
+  })
 
   // Always calculate Gap locally to ensure What-If changes are reflected
   const gapToFi = calculateGapToFi(fiNumber, liquidAssets)
@@ -304,12 +311,52 @@ export default function FiMetrics({
                   className={`font-semibold ${getProgressTextColor(fiProgress)}`}
                 />
               </div>
-              <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
+              <div className="h-2 bg-gray-200 rounded-full overflow-hidden flex">
                 <div
                   className={`h-full ${getProgressBgColor(fiProgress)} transition-all duration-500`}
-                  style={{ width: hideValues ? "0%" : `${fiProgressClamped}%` }}
+                  style={{ width: hideValues ? "0%" : `${fiStack.liquidPct}%` }}
                 />
+                {fiStack.hasIncome && (
+                  <div
+                    className="h-full bg-amber-400 transition-all duration-500"
+                    style={{
+                      width: hideValues ? "0%" : `${fiStack.incomePct}%`,
+                    }}
+                    title="Guaranteed income (Social Security / CPF LIFE), credited as the present value of the future stream"
+                  />
+                )}
               </div>
+              {fiStack.hasIncome && (
+                <div className="mt-1 flex items-center justify-between gap-3 flex-wrap text-xs">
+                  <span className="flex items-center gap-3 text-gray-500">
+                    <span className="flex items-center gap-1">
+                      <span
+                        className={`inline-block w-2 h-2 rounded-sm ${getProgressBgColor(fiProgress)}`}
+                      />
+                      Portfolio
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span className="inline-block w-2 h-2 rounded-sm bg-amber-400" />
+                      + Social Security
+                    </span>
+                  </span>
+                  <InfoTooltip text="Financial Independence including the present value of your guaranteed income (Social Security / CPF LIFE). Above 100% is surplus.">
+                    <span
+                      className={`font-semibold ${fiStack.achieved ? "text-green-600" : "text-gray-700"}`}
+                    >
+                      {fiStack.achieved ? "✓ " : ""}
+                      <PrivatePercentage
+                        value={fiStack.totalProgress}
+                        hideValues={hideValues}
+                        className="inline"
+                      />
+                      <span className="ml-1 font-normal text-gray-500">
+                        incl. income
+                      </span>
+                    </span>
+                  </InfoTooltip>
+                </div>
+              )}
               {/* Gap/Surplus to FI */}
               <div
                 className={`flex justify-between items-center mt-3 p-2 rounded-lg ${gapColors.bg}`}

--- a/src/components/features/independence/__tests__/FiMetrics.test.tsx
+++ b/src/components/features/independence/__tests__/FiMetrics.test.tsx
@@ -719,7 +719,9 @@ describe("FiMetrics", () => {
       render(<FiMetrics {...offTrackProps} />)
       // The value stays clean ("125.0%"); the 4%-rule explanation now lives in
       // the gauge tooltip so a green % can't read as success on its own.
-      expect(screen.getByText("125.0%")).toBeInTheDocument()
+      // Appears twice — the stacked headline "incl. income" label and the
+      // Retirement-Age gauge — both clean.
+      expect(screen.getAllByText("125.0%").length).toBeGreaterThan(0)
       expect(
         screen.queryByText(/125\.0% — based on the 4% rule/),
       ).not.toBeInTheDocument()
@@ -756,6 +758,37 @@ describe("FiMetrics", () => {
       expect(
         screen.getByText("Funded — liquid covers the gap to your pension"),
       ).toBeInTheDocument()
+    })
+  })
+
+  describe("Stacked FI progress (portfolio + guaranteed income)", () => {
+    it("renders the guaranteed-income segment and the combined 'incl. income' total", () => {
+      // NZD Live In: portfolio 82.45%, with Social Security 105.63%.
+      render(
+        <FiMetrics
+          {...defaultProps}
+          backendFiMetrics={mkFi({
+            fiProgress: 82.45,
+            retirementAgeFiProgress: 105.63,
+          })}
+        />,
+      )
+      expect(screen.getByText("+ Social Security")).toBeInTheDocument()
+      expect(screen.getByText("incl. income")).toBeInTheDocument()
+      // Combined total shown with overflow (unclamped) — one decimal. Appears in
+      // both the headline label and the Retirement-Age gauge below.
+      expect(screen.getAllByText("105.6%").length).toBeGreaterThan(0)
+    })
+
+    it("omits the income segment when there is no guaranteed income", () => {
+      render(
+        <FiMetrics
+          {...defaultProps}
+          backendFiMetrics={mkFi({ fiProgress: 60 })}
+        />,
+      )
+      expect(screen.queryByText("+ Social Security")).not.toBeInTheDocument()
+      expect(screen.queryByText("incl. income")).not.toBeInTheDocument()
     })
   })
 })

--- a/src/lib/utils/independence/fiStack.test.ts
+++ b/src/lib/utils/independence/fiStack.test.ts
@@ -1,0 +1,55 @@
+import { deriveFiStack } from "./fiStack"
+
+describe("deriveFiStack", () => {
+  it("splits liquid and guaranteed-income segments over the same denominator", () => {
+    // NZD Live In: portfolio 82.45%, with SS 105.63% -> income segment ~23.18.
+    const s = deriveFiStack({
+      fiProgress: 82.45,
+      retirementAgeFiProgress: 105.63,
+    })
+    expect(s.hasIncome).toBe(true)
+    expect(s.liquidPct).toBeCloseTo(82.45, 2)
+    // segment stacks up to the 100 edge: 100 - 82.45
+    expect(s.incomePct).toBeCloseTo(17.55, 2)
+    // total is unclamped for the label (overflow shown)
+    expect(s.totalProgress).toBeCloseTo(105.63, 2)
+    expect(s.achieved).toBe(true)
+  })
+
+  it("stacks the full income contribution when the total stays under 100", () => {
+    // portfolio 40%, with income 65% -> income segment 25.
+    const s = deriveFiStack({ fiProgress: 40, retirementAgeFiProgress: 65 })
+    expect(s.liquidPct).toBe(40)
+    expect(s.incomePct).toBe(25)
+    expect(s.totalProgress).toBe(65)
+    expect(s.achieved).toBe(false)
+  })
+
+  it("shows no income segment when there is no guaranteed income", () => {
+    const s = deriveFiStack({
+      fiProgress: 82.45,
+      retirementAgeFiProgress: null,
+    })
+    expect(s.hasIncome).toBe(false)
+    expect(s.incomePct).toBe(0)
+    expect(s.totalProgress).toBe(82.45)
+  })
+
+  it("shows no income segment when guaranteed income does not raise progress", () => {
+    // retirementAgeFi <= fiProgress (e.g. no PV credit) -> single-segment bar.
+    const s = deriveFiStack({ fiProgress: 90, retirementAgeFiProgress: 90 })
+    expect(s.hasIncome).toBe(false)
+    expect(s.incomePct).toBe(0)
+  })
+
+  it("clamps the liquid segment at 100 when the portfolio alone is already FI", () => {
+    const s = deriveFiStack({
+      fiProgress: 130,
+      retirementAgeFiProgress: 150,
+    })
+    expect(s.liquidPct).toBe(100)
+    expect(s.incomePct).toBe(0)
+    expect(s.totalProgress).toBe(150)
+    expect(s.achieved).toBe(true)
+  })
+})

--- a/src/lib/utils/independence/fiStack.ts
+++ b/src/lib/utils/independence/fiStack.ts
@@ -1,0 +1,60 @@
+/**
+ * The FI progress bar can be shown as two stacked segments:
+ *   1. the portfolio's own progress (liquid assets / FI Number), and
+ *   2. the extra progress bought by guaranteed income (Social Security / CPF
+ *      LIFE), credited as the present value of that future stream.
+ *
+ * Both share the same denominator (the portfolio-only FI Number), so the
+ * segments are additive: liquid% + income% = "FI including guaranteed income".
+ * The backend supplies `fiProgress` (segment 1) and `retirementAgeFiProgress`
+ * (the combined total); the income segment is the difference.
+ *
+ * Overflow is shown honestly — `totalProgress` is left unclamped so the caller
+ * can render e.g. "106%" while the bar itself fills to the 100% edge.
+ */
+export interface FiStack {
+  /** Blue segment width (%), clamped to [0, 100]. */
+  liquidPct: number
+  /** Guaranteed-income segment width (%), stacked after liquid, clamped so the pair never exceeds 100. */
+  incomePct: number
+  /** Combined progress including guaranteed income — UNCLAMPED, for the label. */
+  totalProgress: number
+  /** Whether a distinct guaranteed-income segment should render. */
+  hasIncome: boolean
+  /** Combined progress reaches financial independence (>= 100%). */
+  achieved: boolean
+}
+
+export function deriveFiStack(opts: {
+  fiProgress: number
+  retirementAgeFiProgress?: number | null
+}): FiStack {
+  const { fiProgress, retirementAgeFiProgress } = opts
+  const liquidPct = clamp(fiProgress, 0, 100)
+
+  const hasIncome =
+    retirementAgeFiProgress != null && retirementAgeFiProgress > fiProgress
+
+  if (!hasIncome) {
+    return {
+      liquidPct,
+      incomePct: 0,
+      totalProgress: fiProgress,
+      hasIncome: false,
+      achieved: fiProgress >= 100,
+    }
+  }
+
+  const totalClamped = clamp(retirementAgeFiProgress, 0, 100)
+  return {
+    liquidPct,
+    incomePct: Math.max(0, totalClamped - liquidPct),
+    totalProgress: retirementAgeFiProgress,
+    hasIncome: true,
+    achieved: retirementAgeFiProgress >= 100,
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}


### PR DESCRIPTION
The FI Progress bar now renders two additive segments over the same
(portfolio-only) FI Number: liquid progress, plus the extra bought by
guaranteed income (Social Security / CPF LIFE) credited as the present value of
the future stream. A combined 'incl. income' total is shown unclamped so
overflow above 100% reads as surplus.

Uses existing fiMetrics.fiProgress + retirementAgeFiProgress (single-plan; the
plan's own SS age already drives the PV). deriveFiStack pure helper, unit-tested.
Composite decomposition (first non-zero-SS phase) follows in a separate change.