### PR TITLE
feat(independence): stacked FI bar in the composite FI overview

### DIFF
--- a/src/components/features/independence/composite/tabs/FiOverviewTab.tsx
+++ b/src/components/features/independence/composite/tabs/FiOverviewTab.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts"
 import ChartFrame from "@components/features/independence/ChartFrame"
 import { ageAxisDomain, ageAxisTicks } from "@lib/independence/ageAxis"
+import { deriveFiStack } from "@lib/independence/fiStack"
 import Spinner from "@components/ui/Spinner"
 import Alert from "@components/ui/Alert"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
@@ -210,6 +211,13 @@ export default function FiOverviewTab(): React.ReactElement | null {
   const fiProgress = Math.round(projection?.fiProgress ?? 0)
   const gap = fiNumber - currentLiquid
 
+  // Stacked FI: portfolio (fiProgress) + guaranteed income (Social Security) as
+  // its present value, over the same portfolio-only fiNumber. Overflow shown.
+  const fiStack = deriveFiStack({
+    fiProgress: projection?.fiProgress ?? 0,
+    retirementAgeFiProgress: projection?.retirementAgeFiProgress ?? null,
+  })
+
   const yrsToFi =
     fiCrossingAge != null && currentAge != null
       ? fiCrossingAge - currentAge
@@ -320,14 +328,48 @@ export default function FiOverviewTab(): React.ReactElement | null {
               {hideValues ? "—" : `${fiProgress}%`}
             </span>
           </div>
-          <div className="h-2.5 bg-gray-100 rounded-full overflow-hidden">
+          <div className="h-2.5 bg-gray-100 rounded-full overflow-hidden flex">
             <div
-              className={`h-full rounded-full transition-all duration-700 ${
+              className={`h-full transition-all duration-700 ${
                 isAchieved ? "bg-green-500" : "bg-independence-500"
               }`}
-              style={{ width: `${Math.min(100, fiProgress)}%` }}
+              style={{
+                width: hideValues ? "0%" : `${Math.min(100, fiProgress)}%`,
+              }}
             />
+            {fiStack.hasIncome && (
+              <div
+                className="h-full bg-amber-400 transition-all duration-700"
+                style={{ width: hideValues ? "0%" : `${fiStack.incomePct}%` }}
+                title="Guaranteed income (Social Security), credited as the present value of the future stream"
+              />
+            )}
           </div>
+          {fiStack.hasIncome && (
+            <div className="mt-1.5 flex items-center justify-between gap-3 flex-wrap text-xs">
+              <span className="flex items-center gap-3 text-gray-500">
+                <span className="flex items-center gap-1">
+                  <span className="inline-block w-2 h-2 rounded-sm bg-independence-500" />
+                  Portfolio
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="inline-block w-2 h-2 rounded-sm bg-amber-400" />
+                  + Social Security
+                </span>
+              </span>
+              <span
+                className={`font-semibold ${
+                  fiStack.achieved ? "text-green-600" : "text-gray-700"
+                }`}
+              >
+                {fiStack.achieved ? "✓ " : ""}
+                {hideValues ? "—" : `${Math.round(fiStack.totalProgress)}%`}
+                <span className="ml-1 font-normal text-gray-500">
+                  incl. income
+                </span>
+              </span>
+            </div>
+          )}
           {isAchieved && (
             <p className="text-xs text-green-600 mt-1.5 font-medium">
               <i className="fas fa-check-circle mr-1" />

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -1271,10 +1271,17 @@ export interface CompositeProjectionResult {
   warnings: string[]
   /** Pre-retirement accumulation rows (currentAge → firstPhaseAge-1). Empty when already retired. */
   accumulationProjections?: CompositeYearlyProjection[]
-  /** Phase-weighted FI number (25× duration-weighted annual net spend), display currency. */
+  /** Phase-weighted FI number (25× duration-weighted annual net spend), display currency. Portfolio-only (SS excluded). */
   fiNumber?: number
   /** Progress toward fiNumber as %; unclamped (can exceed 100). */
   fiProgress?: number
+  /**
+   * Combined FI including guaranteed income: (liquid + pvGuaranteedIncomeToday) / fiNumber × 100,
+   * unclamped. Lets the FI bar stack portfolio + Social Security. Null when no phase carries SS.
+   */
+  retirementAgeFiProgress?: number
+  /** Present value today of the Social Security stream (first non-zero-SS phase). Null when no SS. */
+  pvGuaranteedIncomeToday?: number
 }
 
 export interface CompositeScenarioResult {


### PR DESCRIPTION
The composite Progress-to-FI bar now stacks the portfolio segment and the
guaranteed-income (Social Security) segment over the same portfolio-only
fiNumber, with a combined 'incl. income' total shown unclamped (overflow =
surplus). Reuses the deriveFiStack helper and reads the new composite
retirementAgeFiProgress / pvGuaranteedIncomeToday fields.