### PR TITLE
feat(chat): thread conversation history to svc-agent

### DIFF
--- a/src/hooks/__tests__/useChat.test.ts
+++ b/src/hooks/__tests__/useChat.test.ts
@@ -320,4 +320,91 @@ describe("useChat", () => {
       }),
     )
   })
+
+  it("sends no history on the first message", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "token", data: "ok" }]),
+    )
+    const { result } = renderHook(() => useChat())
+
+    await act(async () => {
+      await result.current.sendMessage("hello")
+    })
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string)
+    expect(body.history).toBeUndefined()
+  })
+
+  it("threads prior turns as history on a follow-up message", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "token", data: "which portfolio?" }]),
+    )
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "token", data: "got it" }]),
+    )
+    const { result } = renderHook(() => useChat())
+
+    await act(async () => {
+      await result.current.sendMessage("what's my NZD exposure?")
+    })
+    await act(async () => {
+      await result.current.sendMessage("Kiwi")
+    })
+
+    const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body as string)
+    expect(secondBody.history).toEqual([
+      { role: "user", content: "what's my NZD exposure?" },
+      { role: "assistant", content: "which portfolio?" },
+    ])
+  })
+
+  it("excludes an errored assistant turn from history — the model never actually said that text", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, body: null })
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "token", data: "ok" }]),
+    )
+    const { result } = renderHook(() => useChat())
+
+    await act(async () => {
+      await result.current.sendMessage("first question")
+    })
+    await act(async () => {
+      await result.current.sendMessage("second question")
+    })
+
+    const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body as string)
+    // The user's real question survives; the fabricated error text the
+    // assistant never actually said does not.
+    expect(secondBody.history).toEqual([
+      { role: "user", content: "first question" },
+    ])
+  })
+
+  it("caps history to the trailing 6 turns", async () => {
+    const { result } = renderHook(() => useChat())
+
+    for (let i = 0; i < 4; i++) {
+      mockFetch.mockResolvedValueOnce(
+        sseResponse([{ event: "token", data: `answer ${i}` }]),
+      )
+      await act(async () => {
+        await result.current.sendMessage(`question ${i}`)
+      })
+    }
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([{ event: "token", data: "final answer" }]),
+    )
+    await act(async () => {
+      await result.current.sendMessage("final question")
+    })
+
+    const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]
+    const body = JSON.parse(lastCall[1].body as string)
+    expect(body.history).toHaveLength(6)
+    expect(body.history[0]).toEqual({ role: "user", content: "question 1" })
+    expect(body.history[5]).toEqual({
+      role: "assistant",
+      content: "answer 3",
+    })
+  })
 })

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,5 +1,8 @@
-import { useState, useCallback, useRef } from "react"
-import { ChatMessage } from "types/agent"
+import { useState, useCallback, useRef, useEffect } from "react"
+import { ChatMessage, ChatTurn } from "types/agent"
+
+/** Trailing turns sent as history — mirrors svc-agent's server-side cap. */
+const MAX_HISTORY_TURNS = 6
 
 /**
  * Human-readable rendering of svc-agent's opaque SSE error codes. Codes are
@@ -57,6 +60,13 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const abortRef = useRef<AbortController | null>(null)
+  // sendMessage is memoized on [context] only, so it can't read `messages`
+  // directly without going stale after the first render — mirror it into a
+  // ref instead so each call sees the latest transcript.
+  const messagesRef = useRef<ChatMessage[]>(messages)
+  useEffect(() => {
+    messagesRef.current = messages
+  }, [messages])
 
   const cancel = useCallback(() => {
     abortRef.current?.abort()
@@ -68,6 +78,17 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
       deepThink: boolean = false,
       think: boolean = false,
     ) => {
+      // Snapshot the transcript so far as history — before appending this
+      // turn's placeholders — so the model sees its own prior question when
+      // the user replies to it instead of retyping the whole context. Error
+      // turns (failed / cancelled requests) are excluded: the model never
+      // actually said that text, so replaying it back as an assistant turn
+      // would be misleading context, not a real prior answer.
+      const history: ChatTurn[] = messagesRef.current
+        .filter((m) => m.content.length > 0 && !m.error)
+        .slice(-MAX_HISTORY_TURNS)
+        .map((m) => ({ role: m.role, content: m.content }))
+
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
         role: "user",
@@ -110,7 +131,13 @@ export function useChat(context?: Record<string, unknown>): UseChatReturn {
             "Content-Type": "application/json",
             Accept: "text/event-stream",
           },
-          body: JSON.stringify({ query, context, deepThink, think }),
+          body: JSON.stringify({
+            query,
+            context,
+            deepThink,
+            think,
+            history: history.length > 0 ? history : undefined,
+          }),
           signal: controller.signal,
         })
         if (!res.ok || !res.body) {

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -1,8 +1,20 @@
+export interface ChatTurn {
+  role: "user" | "assistant"
+  content: string
+}
+
 export interface AgentQuery {
   query: string
   context?: Record<string, unknown>
   /** Caller-driven escalation to svc-agent's DEEP tier. Default false. */
   deepThink?: boolean
+  /**
+   * Prior conversation turns, oldest first, so the model can see its own
+   * previous question when the user replies to it. Caller-supplied and
+   * scoped to this request only — no server-side persistence. svc-agent
+   * truncates to the trailing 6 turns regardless of length.
+   */
+  history?: ChatTurn[]
 }
 
 export interface AgentResponse {


### PR DESCRIPTION
Lets a user answer the agent's own clarifying question instead of
retyping the whole enriched query each round. Sends the trailing 6
non-error turns as history alongside each request; failed/cancelled
turns are excluded since the model never actually said that text.