### PR TITLE
fix(rebalance): seed plan weights on warm SWR cache; prompt copy fields

### DIFF
--- a/__tests__/pages/rebalance/models/[modelId]/plans/planId.test.tsx
+++ b/__tests__/pages/rebalance/models/[modelId]/plans/planId.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 
 // Controllable router mock — mimics Next.js Pages Router behaviour where, on
 // client-side navigation, router.query is empty until router.isReady flips true.
@@ -123,5 +124,100 @@ describe("/rebalance/models/[modelId]/plans/[planId] — Target Allocations", ()
     expect(await screen.findByText("Target Allocations")).toBeInTheDocument()
     expect(screen.getByText("Vanguard S&P 500 ETF")).toBeInTheDocument()
     expect(screen.getByText("Invesco QQQ Trust")).toBeInTheDocument()
+  })
+
+  test("renders allocations on mount when SWR already has warm cache (revisit nav)", async () => {
+    const { default: PlanDetailPage } =
+      await import("../../../../../../src/pages/rebalance/models/[modelId]/plans/[planId]")
+
+    // Router is ready and SWR resolves data on the very first render — mirrors
+    // a client-side revisit where the plan key is already cached, so `plan`
+    // is non-undefined from the first render pass.
+    routerState.isReady = true
+    routerState.query = { modelId: "model-1", planId: "plan-1" }
+    render(<PlanDetailPage />)
+
+    expect(await screen.findByText("Target Allocations")).toBeInTheDocument()
+    expect(screen.getByText("Vanguard S&P 500 ETF")).toBeInTheDocument()
+    expect(screen.getByText("Invesco QQQ Trust")).toBeInTheDocument()
+    expect(screen.queryByText(/No assets added yet/i)).not.toBeInTheDocument()
+  })
+})
+
+describe("/rebalance/models/[modelId]/plans/[planId] — Copy allocations", () => {
+  beforeEach(() => {
+    mockUseSwr.mockReset()
+    mockUseSwr.mockImplementation((key: unknown) => swrByKey(key))
+    routerState.isReady = true
+    routerState.query = { modelId: "model-1", planId: "plan-1" }
+    window.localStorage.clear()
+  })
+
+  const openCopyDialog = async (
+    user: ReturnType<typeof userEvent.setup>,
+  ): Promise<void> => {
+    await user.click(
+      screen.getByRole("button", { name: "Copy target allocations" }),
+    )
+  }
+  const submitCopyDialog = async (
+    user: ReturnType<typeof userEvent.setup>,
+  ): Promise<void> => {
+    await user.click(screen.getByRole("button", { name: "Copy" }))
+  }
+
+  // userEvent.setup() installs its own navigator.clipboard stub, clobbering
+  // any mock assigned beforehand — spy on the stub's writeText afterwards.
+  const setupWithClipboardSpy = (): {
+    user: ReturnType<typeof userEvent.setup>
+    writeText: jest.SpyInstance
+  } => {
+    const user = userEvent.setup()
+    const writeText = jest
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+    return { user, writeText }
+  }
+
+  test("prompts for fields, defaults narrative off, and remembers the choice", async () => {
+    const { user, writeText } = setupWithClipboardSpy()
+    const { default: PlanDetailPage } =
+      await import("../../../../../../src/pages/rebalance/models/[modelId]/plans/[planId]")
+
+    render(<PlanDetailPage />)
+    await screen.findByText("Target Allocations")
+
+    await openCopyDialog(user)
+
+    expect(screen.getByLabelText("Weight %")).toBeChecked()
+    expect(screen.getByLabelText("Price")).toBeChecked()
+    expect(screen.getByLabelText("Currency")).toBeChecked()
+    expect(screen.getByLabelText("Narrative")).not.toBeChecked()
+
+    // Opt in to Narrative for this copy
+    await user.click(screen.getByLabelText("Narrative"))
+    await submitCopyDialog(user)
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    expect(writeText.mock.calls[0][0]).toContain("Description")
+
+    // Re-opening remembers the Narrative opt-in from the previous copy
+    await openCopyDialog(user)
+    expect(screen.getByLabelText("Narrative")).toBeChecked()
+  })
+
+  test("cancelling the dialog does not copy anything", async () => {
+    const { user, writeText } = setupWithClipboardSpy()
+    const { default: PlanDetailPage } =
+      await import("../../../../../../src/pages/rebalance/models/[modelId]/plans/[planId]")
+
+    render(<PlanDetailPage />)
+    await screen.findByText("Target Allocations")
+
+    await openCopyDialog(user)
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(writeText).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText("Narrative")).not.toBeInTheDocument()
   })
 })

--- a/src/components/features/rebalance/models/CopyFieldsDialog.tsx
+++ b/src/components/features/rebalance/models/CopyFieldsDialog.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react"
+import Dialog from "@components/ui/Dialog"
+
+export interface CopyFields {
+  weight: boolean
+  price: boolean
+  currency: boolean
+  narrative: boolean
+}
+
+export const DEFAULT_COPY_FIELDS: CopyFields = {
+  weight: true,
+  price: true,
+  currency: true,
+  narrative: false,
+}
+
+interface CopyFieldsDialogProps {
+  initialFields: CopyFields
+  onConfirm: (fields: CopyFields) => void
+  onCancel: () => void
+}
+
+const FIELD_LABELS: { key: keyof CopyFields; label: string }[] = [
+  { key: "weight", label: "Weight %" },
+  { key: "price", label: "Price" },
+  { key: "currency", label: "Currency" },
+  { key: "narrative", label: "Narrative" },
+]
+
+const CopyFieldsDialog: React.FC<CopyFieldsDialogProps> = ({
+  initialFields,
+  onConfirm,
+  onCancel,
+}) => {
+  const [fields, setFields] = useState<CopyFields>(initialFields)
+
+  const toggle = (key: keyof CopyFields): void => {
+    setFields((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  return (
+    <Dialog
+      title="Copy Target Allocations"
+      onClose={onCancel}
+      maxWidth="sm"
+      footer={
+        <>
+          <Dialog.CancelButton onClick={onCancel} />
+          <Dialog.SubmitButton
+            onClick={() => onConfirm(fields)}
+            label="Copy"
+            variant="blue"
+          />
+        </>
+      }
+    >
+      <p className="text-sm text-gray-600">
+        {"Asset is always included. Choose which other fields to copy:"}
+      </p>
+      <div className="space-y-2">
+        {FIELD_LABELS.map(({ key, label }) => (
+          <label
+            key={key}
+            className="flex items-center gap-2 text-sm text-gray-700"
+          >
+            <input
+              type="checkbox"
+              checked={fields[key]}
+              onChange={() => toggle(key)}
+              className="rounded border-gray-300"
+            />
+            {label}
+          </label>
+        ))}
+      </div>
+    </Dialog>
+  )
+}
+
+export default CopyFieldsDialog

--- a/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
+++ b/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
@@ -10,6 +10,10 @@ import { TableSkeletonLoader } from "@components/ui/SkeletonLoader"
 import ModelWeightsEditor from "@components/features/rebalance/models/ModelWeightsEditor"
 import ImportHoldingsDialog from "@components/features/rebalance/models/ImportHoldingsDialog"
 import AssetInsightPopup from "@components/features/rebalance/models/AssetInsightPopup"
+import CopyFieldsDialog, {
+  CopyFields,
+  DEFAULT_COPY_FIELDS,
+} from "@components/features/rebalance/models/CopyFieldsDialog"
 import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
 import { PlanAssetDto, AssetWeightWithDetails } from "types/rebalance"
 import { Asset, Market } from "types/beancounter"
@@ -17,6 +21,9 @@ import { escapeCSV, downloadCsv } from "@lib/csvExport"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
 import Spinner from "@components/ui/Spinner"
 import { todayIso } from "@lib/formatters"
+import { getLocalValue, setLocalValue } from "@lib/storage/localState"
+
+const COPY_FIELDS_STORAGE_KEY = "rebalance-plan-copy-fields"
 
 function PlanDetailPage(): React.ReactElement {
   const router = useRouter()
@@ -35,6 +42,10 @@ function PlanDetailPage(): React.ReactElement {
   const [deleting, setDeleting] = useState(false)
   const [saving, setSaving] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [showCopyFieldsDialog, setShowCopyFieldsDialog] = useState(false)
+  const [copyFields, setCopyFields] = useState<CopyFields>(() =>
+    getLocalValue(COPY_FIELDS_STORAGE_KEY, DEFAULT_COPY_FIELDS),
+  )
   const [actionError, setActionError] = useState<string | null>(null)
   const [fetchingPrices, setFetchingPrices] = useState(false)
   const [creatingVersion, setCreatingVersion] = useState(false)
@@ -78,7 +89,10 @@ function PlanDetailPage(): React.ReactElement {
   // moment any background revalidation fires — the asset vanishes before Save.
   // Only re-seed from the server when there are no pending local edits (initial
   // load and after a successful save, which resets hasChanges).
-  const [prevPlan, setPrevPlan] = useState(plan)
+  // Init to undefined (not `plan`) so the seed still fires when SWR already
+  // has warm cache on mount (revisit nav) — else plan === prevPlan on the
+  // very first render and weights never get seeded from cached data.
+  const [prevPlan, setPrevPlan] = useState<typeof plan | undefined>(undefined)
   if (plan !== prevPlan) {
     setPrevPlan(plan)
     if (plan?.assets && !hasChanges) {
@@ -388,14 +402,27 @@ function PlanDetailPage(): React.ReactElement {
     return `${(weight * 100).toFixed(2)}%`
   }
 
-  const buildCSV = (): string => {
-    const headers = ["Asset", "Weight %", "Price", "Currency", "Description"]
+  const ALL_FIELDS: CopyFields = {
+    weight: true,
+    price: true,
+    currency: true,
+    narrative: true,
+  }
+
+  const buildCSV = (fields: CopyFields = ALL_FIELDS): string => {
+    const headers = [
+      "Asset",
+      ...(fields.weight ? ["Weight %"] : []),
+      ...(fields.price ? ["Price"] : []),
+      ...(fields.currency ? ["Currency"] : []),
+      ...(fields.narrative ? ["Description"] : []),
+    ]
     const rows = weights.map((w) => [
       escapeCSV(w.assetCode || w.assetId),
-      w.weight.toFixed(2),
-      w.capturedPrice?.toString() || "",
-      w.priceCurrency || "",
-      escapeCSV(w.rationale || ""),
+      ...(fields.weight ? [w.weight.toFixed(2)] : []),
+      ...(fields.price ? [w.capturedPrice?.toString() || ""] : []),
+      ...(fields.currency ? [w.priceCurrency || ""] : []),
+      ...(fields.narrative ? [escapeCSV(w.rationale || "")] : []),
     ])
     return [headers.join(","), ...rows.map((r) => r.join(","))].join("\n")
   }
@@ -408,10 +435,17 @@ function PlanDetailPage(): React.ReactElement {
     downloadCsv(filename, csv)
   }
 
-  // Copy allocations as CSV to clipboard
-  const handleCopyCSV = async (): Promise<void> => {
+  // Copy allocations as CSV to clipboard — ask which fields to include first
+  const handleCopyCSV = (): void => {
     if (!weights.length) return
-    await navigator.clipboard.writeText(buildCSV())
+    setShowCopyFieldsDialog(true)
+  }
+
+  const handleConfirmCopy = async (fields: CopyFields): Promise<void> => {
+    setCopyFields(fields)
+    setLocalValue(COPY_FIELDS_STORAGE_KEY, fields)
+    setShowCopyFieldsDialog(false)
+    await navigator.clipboard.writeText(buildCSV(fields))
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }
@@ -706,6 +740,7 @@ function PlanDetailPage(): React.ReactElement {
               <>
                 <button
                   onClick={handleCopyCSV}
+                  aria-label="Copy target allocations"
                   className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
                 >
                   <i
@@ -918,6 +953,13 @@ function PlanDetailPage(): React.ReactElement {
         onClose={() => setShowImportHoldingsDialog(false)}
         onImport={handleImportHoldings}
       />
+      {showCopyFieldsDialog && (
+        <CopyFieldsDialog
+          initialFields={copyFields}
+          onConfirm={handleConfirmCopy}
+          onCancel={() => setShowCopyFieldsDialog(false)}
+        />
+      )}
       {showApproveConfirm && (
         <ConfirmDialog
           title={"Approve Plan"}


### PR DESCRIPTION
Plan detail page latched empty weights on client-side revisit nav because
prevPlan was seeded from `plan` itself, skipping the reseed when SWR
already had cached data at mount. Hard reload always masked it by
resetting the cache.

Copy button now asks which fields to include (Weight/Price/Currency/
Narrative), defaults Narrative off, and remembers the choice.