### PR TITLE
fix(trades): show split-adjusted qty total on mobile group footer

### DIFF
--- a/src/pages/trns/trades/[...trades].tsx
+++ b/src/pages/trns/trades/[...trades].tsx
@@ -620,6 +620,18 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
               <div className="bg-indigo-50 border border-indigo-200 rounded-b-lg px-4 py-2">
                 <div className="grid grid-cols-2 gap-2 text-sm">
                   <div>
+                    <span className="text-indigo-600">{"Qty"}:</span>
+                    <span className="ml-1 font-semibold text-indigo-900">
+                      <NumericFormat
+                        value={group.totals.quantity}
+                        displayType={"text"}
+                        decimalScale={2}
+                        fixedDecimalScale={true}
+                        thousandSeparator={true}
+                      />
+                    </span>
+                  </div>
+                  <div>
                     <span className="text-indigo-600">{"Amount"}:</span>
                     <span className="ml-1 font-semibold text-indigo-900">
                       <NumericFormat


### PR DESCRIPTION
The trade drill-down's mobile group footer showed Amount/Cash/Fees/Tax but not the per-broker (single) / per-portfolio (aggregated) quantity total — so the split-adjusted quantity added in #1060 was invisible on mobile. Adds a Qty cell to the mobile footer, mirroring the desktop table total (decimalScale 2). Display-only; the quantity value is already unit-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)