### PR TITLE
fix(trades): quick sell available qty reflects selected broker

### DIFF
--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -52,6 +52,7 @@ import {
   buildDefaultCashAsset,
   resolveBrokerSettlementAccount,
   brokerHasSettlementForCurrency,
+  resolveSellableQuantity,
 } from "@lib/trns/tradeFormHelpers"
 import {
   submitEditMode,
@@ -337,13 +338,31 @@ const TradeInputForm: React.FC<{
   const type = watch("type")
   const tradeCurrency = watch("tradeCurrency")
   const asset = watch("asset")
+  const brokerId = watch("brokerId")
 
   // Weight basis: aggregate market value when supplied (aggregated view),
   // otherwise the single portfolio's own market value.
   const weightBasis = weightBasisMarketValue ?? portfolio.marketValue
-  // Calculate current weight from position data
-  const positionQty =
-    initialValues?.currentPositionQuantity ?? initialValues?.quantity ?? 0
+  // Available quantity to trade. When a broker is selected and per-broker
+  // holdings are known, this is what THAT broker holds (split-adjusted), not
+  // the whole-holding total.
+  const positionQty = useMemo(
+    () =>
+      resolveSellableQuantity({
+        held: initialValues?.held,
+        brokerId,
+        brokers,
+        currentPositionQuantity: initialValues?.currentPositionQuantity,
+        quantity: initialValues?.quantity,
+      }),
+    [
+      initialValues?.held,
+      initialValues?.currentPositionQuantity,
+      initialValues?.quantity,
+      brokerId,
+      brokers,
+    ],
+  )
   const currentPositionWeight = useMemo(
     () =>
       currentWeightOverride ??

--- a/src/lib/utils/trns/tradeFormHelpers.test.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.test.ts
@@ -14,6 +14,7 @@ import {
   resolveBrokerSettlementAccount,
   brokerHasSettlementForCurrency,
   resolveBrokerCashAssetId,
+  resolveSellableQuantity,
 } from "./tradeFormHelpers"
 import { Transaction } from "types/beancounter"
 
@@ -793,6 +794,68 @@ describe("tradeFormHelpers", () => {
           brokers: brokers as any,
         }),
       ).toBe(false)
+    })
+  })
+
+  describe("resolveSellableQuantity", () => {
+    const brokers = [
+      { id: "dbs", name: "DBS" },
+      { id: "ib", name: "IB" },
+    ]
+    const held = { DBS: 40, IB: 10 }
+
+    test("returns the selected broker's held quantity", () => {
+      expect(
+        resolveSellableQuantity({
+          held,
+          brokerId: "dbs",
+          brokers: brokers as any,
+          quantity: 50,
+        }),
+      ).toBe(40)
+    })
+
+    test("falls back to the whole-holding total when no broker is selected", () => {
+      expect(
+        resolveSellableQuantity({
+          held,
+          brokerId: undefined,
+          brokers: brokers as any,
+          quantity: 50,
+        }),
+      ).toBe(50)
+    })
+
+    test("returns 0 when the selected broker holds none", () => {
+      expect(
+        resolveSellableQuantity({
+          held: { DBS: 0 },
+          brokerId: "dbs",
+          brokers: brokers as any,
+          quantity: 50,
+        }),
+      ).toBe(0)
+    })
+
+    test("falls back to the total when held has no entry for the broker", () => {
+      expect(
+        resolveSellableQuantity({
+          held: { DBS: 40 },
+          brokerId: "ib",
+          brokers: brokers as any,
+          quantity: 50,
+        }),
+      ).toBe(50)
+    })
+
+    test("prefers currentPositionQuantity over quantity when no held match", () => {
+      expect(
+        resolveSellableQuantity({
+          brokers: brokers as any,
+          currentPositionQuantity: 25,
+          quantity: 50,
+        }),
+      ).toBe(25)
     })
   })
 })

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -452,3 +452,27 @@ export const resolveBrokerCashAssetId = (params: {
   const conv = accountAssets.find((a) => stripOwnerPrefix(a.code) === target)
   return conv?.id ?? null
 }
+
+// --- Sellable quantity resolution ---
+
+/**
+ * Quantity available to trade for the current form state. When a specific
+ * broker is selected and per-broker holdings are known, this is the quantity
+ * held BY THAT BROKER (svc-position `held`, split-adjusted, keyed by broker
+ * name) rather than the whole-holding total. Falls back to the position total
+ * when no broker is selected or the broker holds none of the tracked map.
+ */
+export const resolveSellableQuantity = (params: {
+  held?: Record<string, number>
+  brokerId?: string
+  brokers: BrokerWithAccounts[]
+  currentPositionQuantity?: number
+  quantity?: number
+}): number => {
+  const { held, brokerId, brokers, currentPositionQuantity, quantity } = params
+  const brokerName = brokerId
+    ? brokers.find((b) => b.id === brokerId)?.name
+    : undefined
+  const perBroker = held && brokerName ? held[brokerName] : undefined
+  return perBroker ?? currentPositionQuantity ?? quantity ?? 0
+}


### PR DESCRIPTION
In Quick Sell, the available quantity label showed the whole-holding total (all brokers combined). When a broker is selected it now shows that broker's split-adjusted held quantity, resolved via the position `held` map (broker name → qty) from the selected `brokerId`. Falls back to the position total when no broker is selected. Extracted as pure `resolveSellableQuantity` with unit tests.

Stacked on the mobile-group-footer PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)