### PR TITLE
fix(trades): quick sell qty follows selected broker on mobile and dropdown

### DIFF
--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -296,8 +296,14 @@ const PositionCard: React.FC<PositionCardProps> = ({
 }) => {
   const router = useRouter()
   const { popup, showNews } = useNewsAsset()
-  const { asset, moneyValues, quantityValues, dateValues, portfolioBreakdown } =
-    position
+  const {
+    asset,
+    moneyValues,
+    quantityValues,
+    dateValues,
+    portfolioBreakdown,
+    held,
+  } = position
   const values = moneyValues[valueIn]
 
   const positionCurrency =
@@ -370,6 +376,7 @@ const PositionCard: React.FC<PositionCardProps> = ({
             fromDate={dateValues?.opened}
             closedDate={dateValues?.closed}
             quantity={quantityValues.total}
+            held={held}
             price={values.priceData?.close || 0}
             costBasis={tradeMoney?.costBasis || 0}
             tradeCurrency={tradeCurrency}

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -53,6 +53,7 @@ import {
   resolveBrokerSettlementAccount,
   brokerHasSettlementForCurrency,
   resolveSellableQuantity,
+  heldQuantityForBroker,
 } from "@lib/trns/tradeFormHelpers"
 import {
   submitEditMode,
@@ -643,6 +644,19 @@ const TradeInputForm: React.FC<{
       setValue("brokerId", brokers[0].id)
     }
   }, [isEditMode, type?.value, brokers, setValue, watch])
+
+  // Quick Sell: choosing a broker sets the quantity to that broker's holding
+  // (the intent is to sell out one custodian's split-adjusted position). Only
+  // fires when per-broker holdings are known (`held`); leaves the field alone
+  // for brokers that hold none, and is inert in edit mode (no `held`).
+  useEffect(() => {
+    const brokerQty = heldQuantityForBroker(
+      initialValues?.held,
+      brokerId,
+      brokers,
+    )
+    if (brokerQty !== undefined) setValue("quantity", brokerQty)
+  }, [brokerId, brokers, initialValues?.held, setValue])
 
   const cashAmountField = watch("cashAmount")
   const market = watch("market")

--- a/src/lib/utils/trns/tradeFormHelpers.test.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.test.ts
@@ -15,6 +15,7 @@ import {
   brokerHasSettlementForCurrency,
   resolveBrokerCashAssetId,
   resolveSellableQuantity,
+  heldQuantityForBroker,
 } from "./tradeFormHelpers"
 import { Transaction } from "types/beancounter"
 
@@ -794,6 +795,36 @@ describe("tradeFormHelpers", () => {
           brokers: brokers as any,
         }),
       ).toBe(false)
+    })
+  })
+
+  describe("heldQuantityForBroker", () => {
+    const brokers = [
+      { id: "dbs", name: "DBS" },
+      { id: "ib", name: "IB" },
+    ]
+    const held = { DBS: 367, IB: 47 }
+
+    test("returns the broker's held quantity", () => {
+      expect(heldQuantityForBroker(held, "dbs", brokers as any)).toBe(367)
+    })
+
+    test("returns undefined when no broker is selected", () => {
+      expect(heldQuantityForBroker(held, undefined, brokers as any)).toBe(
+        undefined,
+      )
+    })
+
+    test("returns undefined when held is missing", () => {
+      expect(heldQuantityForBroker(undefined, "dbs", brokers as any)).toBe(
+        undefined,
+      )
+    })
+
+    test("returns undefined when the broker holds none", () => {
+      expect(heldQuantityForBroker({ DBS: 367 }, "ib", brokers as any)).toBe(
+        undefined,
+      )
     })
   })
 

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -456,11 +456,26 @@ export const resolveBrokerCashAssetId = (params: {
 // --- Sellable quantity resolution ---
 
 /**
+ * Split-adjusted quantity a specific broker holds of the position, or undefined
+ * when no broker is selected or that broker holds none of the tracked map.
+ * `held` (svc-position) is keyed by broker NAME, so the selected brokerId is
+ * resolved to its name first.
+ */
+export const heldQuantityForBroker = (
+  held: Record<string, number> | undefined,
+  brokerId: string | undefined,
+  brokers: BrokerWithAccounts[],
+): number | undefined => {
+  if (!held || !brokerId) return undefined
+  const name = brokers.find((b) => b.id === brokerId)?.name
+  return name ? held[name] : undefined
+}
+
+/**
  * Quantity available to trade for the current form state. When a specific
  * broker is selected and per-broker holdings are known, this is the quantity
- * held BY THAT BROKER (svc-position `held`, split-adjusted, keyed by broker
- * name) rather than the whole-holding total. Falls back to the position total
- * when no broker is selected or the broker holds none of the tracked map.
+ * held BY THAT BROKER rather than the whole-holding total. Falls back to the
+ * position total when no broker is selected or the broker holds none.
  */
 export const resolveSellableQuantity = (params: {
   held?: Record<string, number>
@@ -470,9 +485,6 @@ export const resolveSellableQuantity = (params: {
   quantity?: number
 }): number => {
   const { held, brokerId, brokers, currentPositionQuantity, quantity } = params
-  const brokerName = brokerId
-    ? brokers.find((b) => b.id === brokerId)?.name
-    : undefined
-  const perBroker = held && brokerName ? held[brokerName] : undefined
+  const perBroker = heldQuantityForBroker(held, brokerId, brokers)
   return perBroker ?? currentPositionQuantity ?? quantity ?? 0
 }


### PR DESCRIPTION
Quick Sell now sets the sell quantity to the selected broker's split-adjusted holding. Three gaps fixed: (1) CardView (mobile) never passed the position `held` map to the actions menu, so per-broker data never reached the form; (2) the broker dropdown set only brokerId and never updated the quantity field — an effect now sets it to that broker's held qty; (3) the available-qty label reads the same via a shared `heldQuantityForBroker` helper. Depends on the svc-position split-adjusted `held` fix (#1021).

🤖 Generated with [Claude Code](https://claude.com/claude-code)