### PR TITLE
feat(trades): quick sell qty label opens brokerage picker

### DIFF
--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -54,6 +54,7 @@ import {
   brokerHasSettlementForCurrency,
   resolveSellableQuantity,
   heldQuantityForBroker,
+  singleHeldBrokerId,
 } from "@lib/trns/tradeFormHelpers"
 import {
   submitEditMode,
@@ -372,6 +373,10 @@ const TradeInputForm: React.FC<{
   )
 
   const actualPositionQuantity = positionQty
+  // Quick Sell: the Qty label offers a brokerage picker only when the asset is
+  // held at MORE than one brokerage. A single brokerage is auto-defaulted (see
+  // effect below), so a picker there would be redundant.
+  const hasHeldBrokers = Object.keys(initialValues?.held ?? {}).length > 1
 
   // Handle target weight change
   const handleTargetWeightChange = (newTargetWeight: string): void => {
@@ -644,6 +649,19 @@ const TradeInputForm: React.FC<{
       setValue("brokerId", brokers[0].id)
     }
   }, [isEditMode, type?.value, brokers, setValue, watch])
+
+  // Quick Sell: when the asset is held at exactly one brokerage, default to it
+  // (the brokerId effect below then fills the quantity). Fires once; create
+  // mode only. Multi-brokerage holdings surface the picker instead.
+  const heldBrokerDefaultedRef = useRef(false)
+  useEffect(() => {
+    if (heldBrokerDefaultedRef.current || isEditMode) return
+    if (watch("brokerId")) return
+    const only = singleHeldBrokerId(initialValues?.held, brokers)
+    if (!only) return
+    heldBrokerDefaultedRef.current = true
+    setValue("brokerId", only)
+  }, [isEditMode, initialValues?.held, brokers, setValue, watch])
 
   // Quick Sell: choosing a broker sets the quantity to that broker's holding
   // (the intent is to sell out one custodian's split-adjusted position). Only
@@ -1020,9 +1038,28 @@ const TradeInputForm: React.FC<{
                       <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
                         <div>
                           <label className={labelClass}>
-                            {actualPositionQuantity > 0
-                              ? `${"Qty"} (${actualPositionQuantity.toLocaleString()})`
-                              : "Qty"}
+                            {actualPositionQuantity > 0 ? (
+                              hasHeldBrokers ? (
+                                <>
+                                  {"Qty ("}
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      setShowBrokerSelectionDialog(true)
+                                    }
+                                    className="underline decoration-dotted underline-offset-2 text-indigo-600 hover:text-indigo-800 cursor-pointer"
+                                    title="Choose the brokerage to sell from"
+                                  >
+                                    {actualPositionQuantity.toLocaleString()}
+                                  </button>
+                                  {")"}
+                                </>
+                              ) : (
+                                `${"Qty"} (${actualPositionQuantity.toLocaleString()})`
+                              )
+                            ) : (
+                              "Qty"
+                            )}
                           </label>
                           <Controller
                             name="quantity"

--- a/src/lib/utils/trns/tradeFormHelpers.test.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.test.ts
@@ -16,6 +16,7 @@ import {
   resolveBrokerCashAssetId,
   resolveSellableQuantity,
   heldQuantityForBroker,
+  singleHeldBrokerId,
 } from "./tradeFormHelpers"
 import { Transaction } from "types/beancounter"
 
@@ -825,6 +826,32 @@ describe("tradeFormHelpers", () => {
       expect(heldQuantityForBroker({ DBS: 367 }, "ib", brokers as any)).toBe(
         undefined,
       )
+    })
+  })
+
+  describe("singleHeldBrokerId", () => {
+    const brokers = [
+      { id: "dbs", name: "DBS" },
+      { id: "ib", name: "IB" },
+    ]
+
+    test("returns the broker id when held at exactly one brokerage", () => {
+      expect(singleHeldBrokerId({ DBS: 367 }, brokers as any)).toBe("dbs")
+    })
+
+    test("returns undefined when held at multiple brokerages", () => {
+      expect(
+        singleHeldBrokerId({ DBS: 367, IB: 47 }, brokers as any),
+      ).toBeUndefined()
+    })
+
+    test("returns undefined when held is empty or missing", () => {
+      expect(singleHeldBrokerId({}, brokers as any)).toBeUndefined()
+      expect(singleHeldBrokerId(undefined, brokers as any)).toBeUndefined()
+    })
+
+    test("returns undefined when the single broker name is unknown", () => {
+      expect(singleHeldBrokerId({ Unknown: 5 }, brokers as any)).toBeUndefined()
     })
   })
 

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -472,6 +472,19 @@ export const heldQuantityForBroker = (
 }
 
 /**
+ * The broker id when a position is held at exactly one brokerage (so the form
+ * can default to it), otherwise undefined. `held` is keyed by broker name.
+ */
+export const singleHeldBrokerId = (
+  held: Record<string, number> | undefined,
+  brokers: BrokerWithAccounts[],
+): string | undefined => {
+  const names = Object.keys(held ?? {})
+  if (names.length !== 1) return undefined
+  return brokers.find((b) => b.name === names[0])?.id
+}
+
+/**
  * Quantity available to trade for the current form state. When a specific
  * broker is selected and per-broker holdings are known, this is the quantity
  * held BY THAT BROKER rather than the whole-holding total. Falls back to the


### PR DESCRIPTION
The Quick Sell "Qty (###)" label is now a clickable link that opens the brokerage picker (BrokerSelectionDialog) listing each broker holding the asset and its quantity. Selecting one sets both the broker and the sell quantity. When the asset is held at exactly one brokerage, the form defaults to that broker automatically. Decision logic extracted to a pure `singleHeldBrokerId` helper with unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)