### PR TITLE
fix(trades): raise broker picker above the trade modal (z-order)

### DIFF
--- a/src/components/features/transactions/BrokerSelectionDialog.tsx
+++ b/src/components/features/transactions/BrokerSelectionDialog.tsx
@@ -17,7 +17,7 @@ const BrokerSelectionDialog: React.FC<BrokerSelectionDialogProps> = ({
   onSelect,
   onSkip,
 }) => (
-  <Dialog title="Select Broker" onClose={onSkip} maxWidth="md">
+  <Dialog title="Select Broker" onClose={onSkip} maxWidth="md" zClass="z-[60]">
     <p className="text-sm text-gray-600">
       This position is held across multiple brokers. Select which broker to sell
       from:

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -8,6 +8,9 @@ interface DialogProps {
   maxWidth?: "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl"
   scrollable?: boolean
   footer?: React.ReactNode
+  // Stacking layer for the overlay. Default sits at z-50; raise it (e.g.
+  // "z-[60]") when this Dialog opens on top of another z-50 modal.
+  zClass?: string
 }
 
 const maxWidthClasses: Record<string, string> = {
@@ -28,6 +31,7 @@ export default function Dialog({
   maxWidth = "md",
   scrollable = false,
   footer,
+  zClass = "z-50",
 }: DialogProps): React.ReactElement {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
@@ -40,7 +44,7 @@ export default function Dialog({
   }, [onClose])
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className={`fixed inset-0 ${zClass} flex items-center justify-center`}>
       <div
         className="fixed inset-0 bg-black opacity-50"
         onClick={onClose}


### PR DESCRIPTION
The brokerage picker (BrokerSelectionDialog) opened from the Quick Sell "Qty (###)" link rendered behind the trade modal — both used `z-50` and the trade modal is later in the DOM, so it painted on top. Dialog now takes an optional `zClass` (default `z-50`); the broker picker passes `z-[60]` so it stacks above the trade modal regardless of DOM order.

Follow-up to #1064.

🤖 Generated with [Claude Code](https://claude.com/claude-code)