### PR TITLE
fix(trades): skip broker resets quick sell to entire position

### DIFF
--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -722,7 +722,13 @@ const TradeInputForm: React.FC<{
             setValue("quantity", maxQty)
             setShowBrokerSelectionDialog(false)
           }}
-          onSkip={() => setShowBrokerSelectionDialog(false)}
+          onSkip={() => {
+            // Skip = sell the entire position with no specific broker, so
+            // clear any prior broker pick and restore the whole-holding qty.
+            setValue("brokerId", "")
+            setValue("quantity", initialValues.quantity ?? 0)
+            setShowBrokerSelectionDialog(false)
+          }}
         />
       )}
 


### PR DESCRIPTION
In Quick Sell, clicking "Skip - sell without specifying broker" in the brokerage picker previously just closed the dialog, leaving whatever broker/quantity was last set. Skip now clears the broker and restores the whole-holding quantity — i.e. sell the entire position with no specific broker.

Follow-up to #1064 / #1065.

🤖 Generated with [Claude Code](https://claude.com/claude-code)