### PR TITLE
fix(holdings): show buy/sell markers on aggregate price chart

### DIFF
--- a/src/components/features/holdings/PriceChartPopup.tsx
+++ b/src/components/features/holdings/PriceChartPopup.tsx
@@ -29,6 +29,9 @@ interface PriceChartPopupProps {
   asset: Asset
   currencySymbol?: string
   portfolioId?: string
+  // Aggregated holdings drill-down: an asset held across several portfolios.
+  // Takes precedence over portfolioId; trades are fetched for the union.
+  portfolios?: string[]
   onClose: () => void
 }
 
@@ -230,6 +233,7 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
   asset,
   currencySymbol = "",
   portfolioId,
+  portfolios,
   onClose,
 }) => {
   const [months, setMonths] = useState(DEFAULT_MONTHS)
@@ -296,9 +300,14 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
     }
   }, [asset.id, priceUrl])
 
-  const tradesUrl = portfolioId
-    ? `/api/trns/trades/${portfolioId}/${asset.id}`
-    : null
+  const tradesUrl =
+    portfolios && portfolios.length > 0
+      ? `/api/trns/trades/${asset.id}?portfolios=${encodeURIComponent(
+          portfolios.join(","),
+        )}`
+      : portfolioId
+        ? `/api/trns/trades/${portfolioId}/${asset.id}`
+        : null
   const { data: tradesData } = useSwr<{ data: Transaction[] }>(
     tradesUrl,
     tradesUrl ? simpleFetcher(tradesUrl) : null,

--- a/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
@@ -95,16 +95,28 @@ function makeRouter(options: {
 }
 
 function renderPopup(
-  overrides: Partial<{ portfolioId: string }> = {},
+  overrides: Partial<{ portfolioId: string; portfolios: string[] }> = {},
 ): ReturnType<typeof render> {
   return render(
     <PriceChartPopup
       asset={asset}
       currencySymbol="$"
-      portfolioId={overrides.portfolioId ?? "pf-1"}
+      portfolioId={
+        overrides.portfolios ? undefined : (overrides.portfolioId ?? "pf-1")
+      }
+      portfolios={overrides.portfolios}
       onClose={jest.fn()}
     />,
   )
+}
+
+function tradesKeys(): string[] {
+  return mockUseSwr.mock.calls
+    .map((call) => call[0])
+    .filter(
+      (k): k is string =>
+        typeof k === "string" && k.includes("/api/trns/trades/"),
+    )
 }
 
 describe("PriceChartPopup", () => {
@@ -168,6 +180,26 @@ describe("PriceChartPopup", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "SMA 20" }))
     expect(screen.getByTestId("line-sma")).toBeInTheDocument()
+  })
+
+  it("fetches trades from a single portfolio via the path form", () => {
+    mockUseSwr.mockImplementation(makeRouter({}) as typeof useSwr)
+
+    renderPopup({ portfolioId: "pf-1" })
+
+    const keys = tradesKeys()
+    expect(keys[keys.length - 1]).toBe(`/api/trns/trades/pf-1/${asset.id}`)
+  })
+
+  it("fetches trades across portfolios via the aggregated query form", () => {
+    mockUseSwr.mockImplementation(makeRouter({}) as typeof useSwr)
+
+    renderPopup({ portfolios: ["pf-1", "pf-2"] })
+
+    const keys = tradesKeys()
+    expect(keys[keys.length - 1]).toBe(
+      `/api/trns/trades/${asset.id}?portfolios=pf-1%2Cpf-2`,
+    )
   })
 
   it("renders buy and sell scatter series from trades", () => {

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -746,6 +746,9 @@ function AggregatedHoldingsPage(): React.ReactElement {
           <PriceChartPopup
             asset={priceChartData.asset}
             currencySymbol={priceChartData.currencySymbol}
+            portfolios={(
+              breakdownByAssetId.get(priceChartData.asset.id) ?? []
+            ).map((b) => b.portfolioId)}
             onClose={handlePriceChartClose}
           />
         )}


### PR DESCRIPTION
Aggregate holdings view opened the Price History chart without a portfolio context, so no buy/sell markers rendered (the synthetic aggregate portfolio id can't drive the single-portfolio trades endpoint).

Fix (frontend only — backend `/trns/asset/{assetId}/trades?portfolios=` and the bc-view API route already support multi-portfolio):
- PriceChartPopup: new optional `portfolios?: string[]` prop; when set, fetches trades for the union of portfolios via the aggregated query form, else falls back to the single-portfolio path.
- aggregated.tsx: passes the constituent portfolio ids from the per-asset breakdown already in scope.

Tests: 2 new (single-path + aggregated query URL forms); 14 total pass. prettier/typecheck/eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)