### PR TITLE
feat(trns): split aggregate trade drill-down by broker within portfolio

### DIFF
--- a/src/lib/utils/trns/tradeUtils.test.ts
+++ b/src/lib/utils/trns/tradeUtils.test.ts
@@ -18,8 +18,9 @@ import {
   getAssetCurrency,
   deriveDefaultMarket,
   computeTradeGroupTotals,
+  buildTradeGroups,
 } from "./tradeUtils"
-import { TradeFormData, Transaction } from "types/beancounter"
+import { TradeFormData, Transaction, TrnTradeSummary } from "types/beancounter"
 
 describe("TradeUtils", () => {
   test("calculateTradeAmount for BUY type", () => {
@@ -1144,5 +1145,110 @@ describe("computeTradeGroupTotals", () => {
       expect(totals.quantity).toBe(100)
       expect(totals.tradeAmount).toBe(100)
     }
+  })
+})
+
+describe("buildTradeGroups", () => {
+  const dbsPf = { id: "p1", code: "DBS" }
+  const dbs = { id: "b-dbs", name: "DBS" }
+  const scb = { id: "b-scb", name: "SCB" }
+
+  const trn = (over: Partial<Transaction>): Transaction =>
+    ({
+      trnType: "BUY",
+      tradeDate: "2025-01-01",
+      quantity: 0,
+      tradeAmount: 0,
+      cashAmount: 0,
+      fees: 0,
+      tax: 0,
+      portfolio: dbsPf,
+      ...over,
+    }) as Transaction
+
+  // The reported bug: SCHD bought 175 via DBS and 80 via SCB, both in the
+  // "DBS"-coded portfolio. The aggregate drill-down must split the two brokers
+  // out instead of collapsing the 80 under the portfolio named "DBS".
+  test("aggregated view splits one portfolio into its brokers", () => {
+    const summary: TrnTradeSummary = {
+      groupBy: "PORTFOLIO",
+      groups: [
+        {
+          groupId: "p1",
+          quantity: 255,
+          subTotals: [
+            { groupId: "b-dbs", quantity: 175 },
+            { groupId: "b-scb", quantity: 80 },
+          ],
+        },
+      ],
+    }
+    const groups = buildTradeGroups(
+      [
+        trn({ id: "t1", quantity: 175, broker: dbs }),
+        trn({ id: "t2", quantity: 80, broker: scb, tradeDate: "2025-12-03" }),
+      ],
+      true,
+      summary,
+    )
+
+    expect(groups).toHaveLength(2)
+    const dbsGroup = groups.find((g) => g.label === "DBS")!
+    const scbGroup = groups.find((g) => g.label === "SCB")!
+    expect(dbsGroup.portfolioCode).toBe("DBS")
+    expect(scbGroup.portfolioCode).toBe("DBS")
+    // Server-authoritative split-adjusted quantity per broker, not the naive sum.
+    expect(dbsGroup.totals.quantity).toBe(175)
+    expect(scbGroup.totals.quantity).toBe(80)
+    // Both brokers, and the 80 is no longer hidden under the portfolio total.
+    expect(scbGroup.transactions.map((t) => t.id)).toEqual(["t2"])
+  })
+
+  test("single-portfolio view still groups by broker only", () => {
+    const summary: TrnTradeSummary = {
+      groupBy: "BROKER",
+      groups: [
+        { groupId: "b-dbs", quantity: 175 },
+        { groupId: "b-scb", quantity: 80 },
+      ],
+    }
+    const groups = buildTradeGroups(
+      [
+        trn({ id: "t1", quantity: 175, broker: dbs }),
+        trn({ id: "t2", quantity: 80, broker: scb }),
+      ],
+      false,
+      summary,
+    )
+
+    expect(groups.map((g) => g.label).sort()).toEqual(["DBS", "SCB"])
+    expect(groups.every((g) => g.portfolioCode === undefined)).toBe(true)
+    expect(groups.find((g) => g.label === "SCB")!.totals.quantity).toBe(80)
+  })
+
+  test("no-broker trns fall into a 'No Broker' group sorted last", () => {
+    const summary: TrnTradeSummary = {
+      groupBy: "PORTFOLIO",
+      groups: [
+        {
+          groupId: "p1",
+          quantity: 175,
+          subTotals: [
+            { groupId: "b-dbs", quantity: 175 },
+            { groupId: "", quantity: 0 },
+          ],
+        },
+      ],
+    }
+    const groups = buildTradeGroups(
+      [
+        trn({ id: "t1", quantity: 175, broker: dbs }),
+        trn({ id: "d1", trnType: "DIVI", quantity: 175 }),
+      ],
+      true,
+      summary,
+    )
+
+    expect(groups.map((g) => g.label)).toEqual(["DBS", "No Broker"])
   })
 })

--- a/src/lib/utils/trns/tradeUtils.ts
+++ b/src/lib/utils/trns/tradeUtils.ts
@@ -1,4 +1,4 @@
-import { TradeFormData, Transaction } from "types/beancounter"
+import { TradeFormData, Transaction, TrnTradeSummary } from "types/beancounter"
 import { stripOwnerPrefix } from "@lib/assets/assetUtils"
 import { todayIso } from "@lib/formatters"
 import { TRN_STATUS } from "types/constants"
@@ -463,6 +463,111 @@ export interface TradeGroupTotals {
  */
 const sameDateRank = (trnType: string): number =>
   trnType === "BALANCE" ? 1 : isPositionAdjustment(trnType) ? 2 : 0
+
+/**
+ * A rendered group of an asset's trades in the drill-down: a broker (single
+ * portfolio) or a portfolio+broker pair (aggregated multi-portfolio view).
+ */
+export interface TradeGroup {
+  id: string
+  label: string // broker name, or "No Broker"
+  sortName: string
+  summaryId: string // key into the server summary's split-adjusted quantity
+  portfolioCode?: string // set only in the aggregated view
+  transactions: Transaction[]
+  totals: TradeGroupTotals
+}
+
+/**
+ * Build the drill-down groups for an asset's trades.
+ *
+ * Single-portfolio view groups by broker. The aggregated (multi-portfolio)
+ * view groups by portfolio AND broker, so a broker's slice of an asset is
+ * never hidden inside a portfolio that happens to share a broker's name.
+ *
+ * The split-adjusted quantity is authoritative from the server summary (a
+ * SPLIT row carries the ratio, not shares): keyed by broker id for the single
+ * view, or by "portfolioId|brokerId" (the portfolio group's broker sub-total)
+ * for the aggregated view. "" is the server's "No Broker" key.
+ */
+export const buildTradeGroups = (
+  transactions: Transaction[],
+  isMulti: boolean,
+  summary?: TrnTradeSummary,
+): TradeGroup[] => {
+  if (!transactions || transactions.length === 0) return []
+
+  const summaryQty = new Map<string, number>()
+  summary?.groups.forEach((g) => {
+    if (isMulti) {
+      g.subTotals?.forEach((s) =>
+        summaryQty.set(`${g.groupId}|${s.groupId}`, s.quantity),
+      )
+    } else {
+      summaryQty.set(g.groupId, g.quantity)
+    }
+  })
+
+  const acc: Record<string, Omit<TradeGroup, "totals">> = {}
+  transactions.forEach((trn) => {
+    const brokerId = trn.broker?.id || ""
+    const brokerName = trn.broker?.name || "No Broker"
+    if (isMulti) {
+      const pid = trn.portfolio?.id || "__no_portfolio__"
+      const pCode = trn.portfolio?.code || "Unknown Portfolio"
+      const key = `${pid}|${brokerId}`
+      if (!acc[key]) {
+        acc[key] = {
+          id: key,
+          label: brokerName,
+          // Cluster by portfolio, then broker; "No Broker" (~) sorts last
+          // within its portfolio.
+          sortName: `${pCode} ${trn.broker ? brokerName : "~"}`,
+          summaryId: `${pid}|${brokerId}`,
+          portfolioCode: pCode,
+          transactions: [],
+        }
+      }
+      acc[key].transactions.push(trn)
+    } else {
+      const key = trn.broker?.id || "__no_broker__"
+      if (!acc[key]) {
+        acc[key] = {
+          id: key,
+          label: brokerName,
+          sortName: trn.broker ? brokerName : "",
+          summaryId: brokerId,
+          transactions: [],
+        }
+      }
+      acc[key].transactions.push(trn)
+    }
+  })
+
+  return Object.values(acc)
+    .map((group) => {
+      const totals = computeTradeGroupTotals(group.transactions)
+      const authQuantity = summaryQty.get(group.summaryId)
+      return {
+        ...group,
+        totals:
+          authQuantity !== undefined
+            ? { ...totals, quantity: authQuantity }
+            : totals,
+      }
+    })
+    .sort((a, b) => {
+      // Named groups first (alphabetically), unnamed ("No Broker") last.
+      if (!a.sortName && b.sortName) return 1
+      if (a.sortName && !b.sortName) return -1
+      // Code-unit order, not localeCompare: the aggregated view's "~" sentinel
+      // (No Broker last within a portfolio) is punctuation that localeCompare
+      // ignores, which would re-order the groups.
+      if (a.sortName < b.sortName) return -1
+      if (a.sortName > b.sortName) return 1
+      return 0
+    })
+}
 
 export const computeTradeGroupTotals = (
   transactions: Transaction[],

--- a/src/pages/trns/trades/[...trades].tsx
+++ b/src/pages/trns/trades/[...trades].tsx
@@ -21,7 +21,7 @@ import FxEditModal from "@components/features/transactions/FxEditModal"
 import SubAccountTrnEditModal from "@components/features/transactions/SubAccountTrnEditModal"
 import TradeInputForm from "@components/features/transactions/TradeInputForm"
 import { unsettleTrn } from "@utils/trns/apiHelper"
-import { computeTradeGroupTotals } from "@utils/trns/tradeUtils"
+import { buildTradeGroups } from "@utils/trns/tradeUtils"
 import { holdingsHighlightHref } from "@utils/holdings/holdingsHref"
 
 export default withPageAuthRequired(function Trades(): React.ReactElement {
@@ -118,106 +118,69 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
     (): Transaction[] => trades.data?.data || [],
     [trades.data?.data],
   )
-  // Backend-authoritative, split-adjusted quantity per group. A SPLIT row holds
-  // the ratio (not shares), so the server folds it correctly (see
-  // TrnTradeSummaryBuilder) and we key it by broker id (single) / portfolio id
-  // (aggregated). "" is the server's "No Broker" key.
-  const summaryQty = useMemo(() => {
-    const summary = trades.data?.summary as TrnTradeSummary | undefined
-    const map = new Map<string, number>()
-    summary?.groups.forEach((g) => map.set(g.groupId, g.quantity))
-    return map
-  }, [trades.data?.summary])
-  // Single-portfolio view groups by broker; the aggregated drill-down groups by
-  // portfolio (one asset held across several portfolios).
-  const groups = useMemo(() => {
-    if (!trnResults || trnResults.length === 0) return []
+  // Single-portfolio view groups by broker. The aggregated drill-down groups by
+  // portfolio AND broker (one asset held across several portfolios, each split
+  // over several brokers) so a broker's slice is never hidden inside a portfolio
+  // that happens to share a broker's name. Split-adjusted quantities come from
+  // the server summary (see buildTradeGroups / TrnTradeSummaryBuilder).
+  const groups = useMemo(
+    () =>
+      buildTradeGroups(
+        trnResults,
+        isMulti,
+        trades.data?.summary as TrnTradeSummary | undefined,
+      ),
+    [trnResults, isMulti, trades.data?.summary],
+  )
 
-    const acc: Record<
-      string,
-      {
-        id: string
-        label: string
-        sortName: string
-        transactions: Transaction[]
-      }
-    > = {}
-
-    trnResults.forEach((trn: Transaction) => {
-      const key = isMulti
-        ? trn.portfolio?.id || "__no_portfolio__"
-        : trn.broker?.id || "__no_broker__"
-      const named = isMulti ? !!trn.portfolio : !!trn.broker
-      const label = isMulti
-        ? trn.portfolio?.code || "Unknown Portfolio"
-        : trn.broker?.name || "No Broker"
-      if (!acc[key]) {
-        acc[key] = {
-          id: key,
-          label,
-          sortName: named ? label : "",
-          transactions: [],
-        }
-      }
-      acc[key].transactions.push(trn)
-    })
-
-    // A BALANCE transaction states the absolute position as at its trade date,
-    // so the running quantity must reset to it — computeTradeGroupTotals folds
-    // the trades chronologically rather than naively summing every quantity.
-    const withTotals = Object.values(acc).map((group) => {
-      const totals = computeTradeGroupTotals(group.transactions)
-      // Prefer the server's split-adjusted quantity; the client fold sums raw
-      // trn.quantity and would corrupt the total on a SPLIT. Map the local
-      // "no broker/portfolio" sentinel onto the server's "" key.
-      const summaryId =
-        group.id === "__no_broker__" || group.id === "__no_portfolio__"
-          ? ""
-          : group.id
-      const authQuantity = summaryQty.get(summaryId)
-      return {
-        ...group,
-        totals:
-          authQuantity !== undefined
-            ? { ...totals, quantity: authQuantity }
-            : totals,
-      }
-    })
-
-    // Named groups first (alphabetically), unnamed ("No Broker") last
-    return withTotals.sort((a, b) => {
-      if (!a.sortName && b.sortName) return 1
-      if (a.sortName && !b.sortName) return -1
-      return a.sortName.localeCompare(b.sortName)
-    })
-  }, [trnResults, isMulti, summaryQty])
-
-  // Group header label. In the aggregated (multi-portfolio) view the label is a
-  // portfolio code, so make it a link to that portfolio's holdings page with the
-  // drilled-down asset highlighted. sortName is only set for named portfolios,
-  // so the "Unknown Portfolio" fallback stays plain text.
+  // Group header label. The aggregated (multi-portfolio) view shows the
+  // portfolio code — linked to that portfolio's holdings with the drilled-down
+  // asset highlighted — alongside a broker badge, so one asset split across
+  // brokers within a portfolio is visible. The single-portfolio view shows the
+  // broker name only.
   const renderGroupLabel = (group: {
     label: string
-    sortName: string
+    portfolioCode?: string
+    transactions: Transaction[]
   }): React.ReactElement => {
-    const content = (
-      <>
-        <i className="fas fa-building mr-2 text-indigo-400"></i>
-        {group.label}
-      </>
-    )
-    if (isMulti && assetId && group.sortName) {
+    if (isMulti) {
+      const pCode = group.portfolioCode ?? group.label
+      const isNamedPortfolio = !!group.portfolioCode
+      const brokerBadge = (
+        <span className="ml-2 inline-flex items-center rounded bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700">
+          <i className="fas fa-university mr-1"></i>
+          {group.label}
+        </span>
+      )
+      const portfolio = (
+        <>
+          <i className="fas fa-building mr-2 text-indigo-400"></i>
+          {pCode}
+        </>
+      )
       return (
-        <Link
-          href={holdingsHighlightHref(group.label, assetId as string)}
-          className="font-medium text-indigo-900 hover:text-indigo-700 hover:underline"
-          title={`View ${group.label} holdings`}
-        >
-          {content}
-        </Link>
+        <span className="flex items-center font-medium text-indigo-900">
+          {assetId && isNamedPortfolio ? (
+            <Link
+              href={holdingsHighlightHref(pCode, assetId as string)}
+              className="hover:text-indigo-700 hover:underline"
+              title={`View ${pCode} holdings`}
+            >
+              {portfolio}
+            </Link>
+          ) : (
+            <span>{portfolio}</span>
+          )}
+          {brokerBadge}
+        </span>
       )
     }
-    return <span className="font-medium text-indigo-900">{content}</span>
+    return (
+      <span className="font-medium text-indigo-900">
+        <i className="fas fa-building mr-2 text-indigo-400"></i>
+        {group.label}
+      </span>
+    )
   }
 
   // Copy row data to clipboard as tab-separated values

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -429,6 +429,9 @@ export interface TrnPayload {
 export interface TrnGroupTotal {
   groupId: string
   quantity: number
+  // Broker breakdown of a portfolio group (empty for broker grouping). Each
+  // sub-total is split-adjusted; summing them reconstructs `quantity`.
+  subTotals?: TrnGroupTotal[]
 }
 
 /**


### PR DESCRIPTION
The aggregated (multi-portfolio) drill-down grouped an asset's trades by
portfolio only, so multiple brokers inside one portfolio collapsed into a
single group — a slice bought via one broker was hidden under a portfolio
that shares another broker's name. Group by portfolio AND broker, reading
the server's per-broker split-adjusted sub-total. Grouping extracted to a
pure buildTradeGroups helper with unit coverage.