### PR TITLE
fix(classify): de-duplicate sectors and show current value in pickers

### DIFF
--- a/__tests__/components/features/assets/AssetClassifyPanel.test.tsx
+++ b/__tests__/components/features/assets/AssetClassifyPanel.test.tsx
@@ -1,0 +1,89 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { beforeEach, describe, it } from "@jest/globals"
+import AssetClassifyPanel from "@components/features/assets/AssetClassifyPanel"
+
+// The same name exists in two standards — the picker must show it once.
+const sectors = {
+  data: [
+    {
+      code: "INFORMATION_TECHNOLOGY",
+      name: "Information Technology",
+      standard: "USER",
+    },
+    {
+      code: "COMMUNICATION_SERVICES",
+      name: "Communication Services",
+      standard: "ALPHA",
+    },
+    {
+      code: "INFORMATION_TECHNOLOGY",
+      name: "Information Technology",
+      standard: "ALPHA",
+    },
+  ],
+}
+
+// `current` are the asset's classification rows returned by
+// GET /api/classifications/{assetId} (a list, not a summary object).
+function mockFetch(current: unknown[] = []): void {
+  global.fetch = jest.fn((url: string) => {
+    if (url.includes("/api/classifications/sectors")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(sectors) })
+    }
+    if (url.includes("/exposures")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      })
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ data: current }),
+    })
+  }) as unknown as typeof fetch
+}
+
+describe("AssetClassifyPanel sector picker", () => {
+  beforeEach(() => {
+    mockFetch()
+  })
+
+  it("de-duplicates a name shared across standards to one selectable chip", async () => {
+    render(<AssetClassifyPanel assetId="a1" assetLabel="GOOG" />)
+
+    const itChips = await screen.findAllByRole("button", {
+      name: "Information Technology",
+    })
+    expect(itChips).toHaveLength(1)
+
+    fireEvent.click(itChips[0])
+
+    const pressed = screen.getAllByRole("button", { pressed: true })
+    expect(pressed).toHaveLength(1)
+    expect(pressed[0]).toBe(itChips[0])
+  })
+
+  it("shows and pre-selects the asset's current sector on open", async () => {
+    mockFetch([
+      {
+        level: "SECTOR",
+        source: "MANUAL",
+        standard: { key: "USER" },
+        item: { code: "INFORMATION_TECHNOLOGY", name: "Information Technology" },
+      },
+    ])
+
+    render(<AssetClassifyPanel assetId="a1" assetLabel="GOOG" />)
+
+    expect(await screen.findByText(/Current:/)).toBeInTheDocument()
+
+    const itChip = await screen.findByRole("button", {
+      name: "Information Technology",
+    })
+    const pressed = screen.getAllByRole("button", { pressed: true })
+    expect(pressed).toHaveLength(1)
+    expect(pressed[0]).toBe(itChip)
+  })
+})

--- a/src/components/features/admin/AdminAssetEditDialog.tsx
+++ b/src/components/features/admin/AdminAssetEditDialog.tsx
@@ -4,9 +4,11 @@ import Dialog from "@components/ui/Dialog"
 import { simpleFetcher } from "@utils/api/fetchHelper"
 import { Asset, AssetCategory } from "types/beancounter"
 import { useDialogSubmit } from "@hooks/useDialogSubmit"
+import { dedupeSectorsByName } from "@utils/assets/dedupeSectors"
 
 interface SectorInfo {
   name: string
+  standard: string
 }
 
 interface AdminAssetEditDialogProps {
@@ -90,7 +92,7 @@ const AdminAssetEditDialog: React.FC<AdminAssetEditDialogProps> = ({
   }
 
   const categories = categoriesData?.data ?? []
-  const sectors = sectorsData?.data ?? []
+  const sectors = dedupeSectorsByName(sectorsData?.data ?? [])
 
   return (
     <Dialog

--- a/src/components/features/assets/AssetClassifyPanel.tsx
+++ b/src/components/features/assets/AssetClassifyPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react"
 import Dialog from "@components/ui/Dialog"
 import Alert from "@components/ui/Alert"
 import Spinner from "@components/ui/Spinner"
+import { dedupeSectorsByName } from "@utils/assets/dedupeSectors"
 
 interface SectorInfo {
   code: string
@@ -9,10 +10,12 @@ interface SectorInfo {
   standard: string
 }
 
-interface ClassificationResult {
-  assetId: string
-  sector?: string
-  industry?: string
+// GET /classifications/{assetId} returns the asset's classification rows.
+interface AssetClassificationRow {
+  level: string
+  source?: string
+  standard: { key: string }
+  item: { code: string; name: string }
 }
 
 interface ExposureItem {
@@ -39,6 +42,8 @@ const AssetClassifyPanel: React.FC<AssetClassifyPanelProps> = ({
   const [currentAssetSector, setCurrentAssetSector] = useState<string | null>(
     null,
   )
+  // The chosen sector name, "custom", or "". Sectors are de-duplicated by name
+  // (see sectorsByStandard), so a name uniquely identifies one chip.
   const [selectedSector, setSelectedSector] = useState("")
   const [customSector, setCustomSector] = useState("")
   const [isSaving, setIsSaving] = useState(false)
@@ -93,12 +98,13 @@ const AssetClassifyPanel: React.FC<AssetClassifyPanelProps> = ({
 
         let sector: string | undefined
 
-        // Check direct classification first (equities)
+        // Direct classification (equities) — GET returns a list of rows.
         if (classResponse.ok) {
-          const classData: { data: ClassificationResult } =
+          const classData: { data: AssetClassificationRow[] } =
             await classResponse.json()
-          if (classData.data?.sector) {
-            sector = classData.data.sector
+          const sectorRow = classData.data?.find((c) => c.level === "SECTOR")
+          if (sectorRow) {
+            sector = sectorRow.item.name
           }
         }
 
@@ -116,13 +122,11 @@ const AssetClassifyPanel: React.FC<AssetClassifyPanelProps> = ({
 
         if (sector) {
           setCurrentAssetSector(sector)
-          const existingInDb = dbSectors.find((s) => s.name === sector)
-          if (existingInDb) {
-            setSelectedSector(sector)
-          } else {
-            setSelectedSector("custom")
-            setCustomSector(sector)
-          }
+          // Every classification maps to a picker chip of the same name (names
+          // are unique after de-duplication), so pre-select by name. The chip
+          // highlights on render, regardless of whether the sector list has
+          // finished loading yet.
+          setSelectedSector(sector)
         }
       } catch (error) {
         console.error("Failed to fetch classification:", error)
@@ -130,14 +134,12 @@ const AssetClassifyPanel: React.FC<AssetClassifyPanelProps> = ({
     }
 
     fetchCurrentSector()
-    // dbSectors intentionally omitted: we only want to re-fetch when assetId changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assetId])
 
-  // Group sectors by standard
+  // De-duplicate by name, then group by standard for display.
   const sectorsByStandard = React.useMemo(() => {
     const grouped: Record<string, SectorInfo[]> = {}
-    dbSectors.forEach((sector) => {
+    dedupeSectorsByName(dbSectors).forEach((sector) => {
       if (!grouped[sector.standard]) {
         grouped[sector.standard] = []
       }
@@ -264,35 +266,42 @@ const AssetClassifyPanel: React.FC<AssetClassifyPanelProps> = ({
                     {standardLabels[standard] || standard}
                   </h4>
                   <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
-                    {sectors.map((sector) => (
-                      <div key={sector.code} className="relative group">
-                        <button
-                          onClick={() => {
-                            setSelectedSector(sector.name)
-                            setCustomSector("")
-                          }}
-                          className={`w-full px-3 py-2 text-sm rounded-lg border transition-colors text-left ${
-                            selectedSector === sector.name
-                              ? "border-blue-500 bg-blue-50 text-blue-700"
-                              : "border-gray-200 hover:border-gray-300 text-gray-700"
-                          } ${standard === "USER" ? "pr-8" : ""}`}
+                    {sectors.map((sector) => {
+                      const isSelected = selectedSector === sector.name
+                      return (
+                        <div
+                          key={`${standard}:${sector.code}`}
+                          className="relative group"
                         >
-                          {sector.name}
-                        </button>
-                        {standard === "USER" && (
                           <button
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              setSectorToDelete(sector)
+                            aria-pressed={isSelected}
+                            onClick={() => {
+                              setSelectedSector(sector.name)
+                              setCustomSector("")
                             }}
-                            className="absolute right-1 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
-                            title={"Delete sector"}
+                            className={`w-full px-3 py-2 text-sm rounded-lg border transition-colors text-left ${
+                              isSelected
+                                ? "border-blue-500 bg-blue-50 text-blue-700"
+                                : "border-gray-200 hover:border-gray-300 text-gray-700"
+                            } ${standard === "USER" ? "pr-8" : ""}`}
                           >
-                            <i className="fas fa-times text-xs"></i>
+                            {sector.name}
                           </button>
-                        )}
-                      </div>
-                    ))}
+                          {standard === "USER" && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                setSectorToDelete(sector)
+                              }}
+                              className="absolute right-1 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                              title={"Delete sector"}
+                            >
+                              <i className="fas fa-times text-xs"></i>
+                            </button>
+                          )}
+                        </div>
+                      )
+                    })}
                   </div>
                 </div>
               ))}
@@ -311,7 +320,10 @@ const AssetClassifyPanel: React.FC<AssetClassifyPanelProps> = ({
                 </h4>
                 <div className="flex items-center space-x-2">
                   <button
-                    onClick={() => setSelectedSector("custom")}
+                    aria-pressed={selectedSector === "custom"}
+                    onClick={() => {
+                      setSelectedSector("custom")
+                    }}
                     className={`px-3 py-2 text-sm rounded-lg border transition-colors ${
                       selectedSector === "custom"
                         ? "border-blue-500 bg-blue-50 text-blue-700"

--- a/src/lib/utils/assets/__tests__/dedupeSectors.test.ts
+++ b/src/lib/utils/assets/__tests__/dedupeSectors.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "@jest/globals"
+import { dedupeSectorsByName } from "@utils/assets/dedupeSectors"
+
+describe("dedupeSectorsByName", () => {
+  it("collapses a name shared across standards to one entry, preferring ALPHA", () => {
+    const result = dedupeSectorsByName([
+      { code: "INFORMATION_TECHNOLOGY", name: "Information Technology", standard: "USER" },
+      { code: "COMMUNICATION_SERVICES", name: "Communication Services", standard: "ALPHA" },
+      { code: "INFORMATION_TECHNOLOGY", name: "Information Technology", standard: "ALPHA" },
+    ])
+
+    expect(result).toHaveLength(2)
+    const it = result.find((s) => s.name === "Information Technology")
+    expect(it?.standard).toBe("ALPHA")
+  })
+
+  it("keeps a user-only sector that has no provider twin", () => {
+    const result = dedupeSectorsByName([
+      { code: "LARGE_BLEND", name: "Large Blend", standard: "USER" },
+    ])
+
+    expect(result).toEqual([
+      { code: "LARGE_BLEND", name: "Large Blend", standard: "USER" },
+    ])
+  })
+})

--- a/src/lib/utils/assets/dedupeSectors.ts
+++ b/src/lib/utils/assets/dedupeSectors.ts
@@ -1,0 +1,20 @@
+// A sector name can exist in more than one classification standard (e.g. a
+// provider "ALPHA" sector and a user-created "USER" one share the name
+// "Information Technology"). The pickers are single-select and persist by name,
+// so a name must appear only once. Collapse duplicates by name, preferring the
+// provider (ALPHA) entry, which keeps a stable code and group for the survivor.
+export function dedupeSectorsByName<T extends { name: string; standard: string }>(
+  sectors: T[],
+): T[] {
+  const byName = new Map<string, T>()
+  for (const sector of sectors) {
+    const existing = byName.get(sector.name)
+    if (
+      !existing ||
+      (existing.standard !== "ALPHA" && sector.standard === "ALPHA")
+    ) {
+      byName.set(sector.name, sector)
+    }
+  }
+  return Array.from(byName.values())
+}


### PR DESCRIPTION
A sector name can exist in both the ALPHA and USER standards (e.g. a
user-created "Information Technology" alongside the provider one), so the
Asset Admin chip grid and the Edit Asset dropdown listed it twice and could
highlight both. De-duplicate by name (shared dedupeSectorsByName, preferring
the provider entry); selection is single and keyed by name. Also parse the
classification list correctly so the current sector shows and pre-selects on
open.