### PR TITLE
feat: sell action on broker reconciliation screen

### DIFF
--- a/__tests__/components/features/brokers/WeightedSellDialog.test.tsx
+++ b/__tests__/components/features/brokers/WeightedSellDialog.test.tsx
@@ -1,0 +1,209 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import WeightedSellDialog from "@components/features/brokers/WeightedSellDialog"
+import { BrokerHoldingPosition } from "types/beancounter"
+
+const holding: BrokerHoldingPosition = {
+  assetId: "asset-1",
+  assetCode: "VOO",
+  assetName: "Vanguard S&P 500",
+  market: "US",
+  quantity: 175,
+  portfolioGroups: [
+    {
+      portfolioId: "pf-1",
+      portfolioCode: "GROWTH",
+      quantity: 100,
+      transactions: [],
+    },
+    {
+      portfolioId: "pf-2",
+      portfolioCode: "INCOME",
+      quantity: 75,
+      transactions: [],
+    },
+    {
+      // Excluded from preview: non-positive holding at this broker
+      portfolioId: "pf-3",
+      portfolioCode: "ZERO",
+      quantity: 0,
+      transactions: [],
+    },
+  ],
+}
+
+const priceResponse = {
+  ok: true,
+  json: () => Promise.resolve({ data: [{ close: 420.5 }] }),
+}
+
+describe("WeightedSellDialog", () => {
+  beforeEach(() => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(priceResponse) as unknown as typeof fetch
+  })
+
+  it("renders per-portfolio preview rows, excluding zero/negative groups", async () => {
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={holding}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText("GROWTH")).toBeInTheDocument())
+    expect(screen.getByText("INCOME")).toBeInTheDocument()
+    expect(screen.queryByText("ZERO")).not.toBeInTheDocument()
+  })
+
+  it("computes sell quantities for 50% correctly", async () => {
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={holding}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    // Price prefilled asynchronously from /api/prices
+    await waitFor(() =>
+      expect(screen.getByLabelText("Price")).toHaveValue(420.5),
+    )
+
+    // Default percent is 50 -> 100 * 0.5 = 50, 75 * 0.5 = 37.5
+    expect(screen.getByText("50")).toBeInTheDocument()
+    expect(screen.getByText("37.5")).toBeInTheDocument()
+  })
+
+  it("POSTs the propose contract on submit", async () => {
+    const onSubmitted = jest.fn()
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.startsWith("/api/prices")) return Promise.resolve(priceResponse)
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      })
+    })
+
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={holding}
+        onSubmitted={onSubmitted}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Price")).toHaveValue(420.5),
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /propose 2 sells/i }))
+
+    await waitFor(() => expect(onSubmitted).toHaveBeenCalled())
+
+    const proposeCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url]) => url === "/api/trns/broker/broker-1/propose",
+    )
+    expect(proposeCall).toBeDefined()
+    const [, init] = proposeCall as [string, RequestInit]
+    expect(init.method).toBe("POST")
+    expect(JSON.parse(init.body as string)).toEqual({
+      assetId: "asset-1",
+      trnType: "SELL",
+      weight: 0.5,
+      price: 420.5,
+      tradeDate: expect.any(String),
+    })
+  })
+
+  it("disables submit when percent is blank or zero", async () => {
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={holding}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Price")).toHaveValue(420.5),
+    )
+
+    const percentInput = screen.getByLabelText("Percent to sell")
+    fireEvent.change(percentInput, { target: { value: "" } })
+    expect(screen.getByRole("button", { name: /propose/i })).toBeDisabled()
+
+    fireEvent.change(percentInput, { target: { value: "0" } })
+    expect(screen.getByRole("button", { name: /propose/i })).toBeDisabled()
+  })
+
+  it("disables submit when price is zero or negative", async () => {
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={holding}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Price")).toHaveValue(420.5),
+    )
+
+    const priceInput = screen.getByLabelText("Price")
+    fireEvent.change(priceInput, { target: { value: "0" } })
+    expect(screen.getByRole("button", { name: /propose/i })).toBeDisabled()
+  })
+
+  it("shows an error and keeps the dialog open when the POST fails", async () => {
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.startsWith("/api/prices")) return Promise.resolve(priceResponse)
+      return Promise.resolve({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ message: "Rejected for NO_BROKER" }),
+      })
+    })
+
+    const onClose = jest.fn()
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={onClose}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={holding}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Price")).toHaveValue(420.5),
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /propose 2 sells/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Rejected for NO_BROKER")).toBeInTheDocument(),
+    )
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/features/brokers/WeightedSellDialog.tsx
+++ b/src/components/features/brokers/WeightedSellDialog.tsx
@@ -1,0 +1,332 @@
+import React, { useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import Dialog from "@components/ui/Dialog"
+import DateInput from "@components/ui/DateInput"
+import { todayIso } from "@lib/formatters"
+import { useDialogSubmit } from "@hooks/useDialogSubmit"
+import { BrokerHoldingPosition, BrokerProposalRequest } from "types/beancounter"
+
+interface WeightedSellDialogProps {
+  open: boolean
+  onClose: () => void
+  brokerId: string
+  brokerName: string
+  holding: BrokerHoldingPosition
+  onSubmitted: () => void
+}
+
+interface PreviewRow {
+  portfolioId: string
+  portfolioCode: string
+  heldQty: number
+  sellQty: number
+  proceeds: number
+}
+
+// Display up to 6dp, trimming trailing zeros (e.g. 37.500000 -> "37.5").
+const trimQty = (qty: number): string => parseFloat(qty.toFixed(6)).toString()
+
+const formatMoney = (amount: number): string =>
+  amount.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+
+const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
+  open,
+  onClose,
+  brokerId,
+  brokerName,
+  holding,
+  onSubmitted,
+}) => {
+  const [percent, setPercent] = useState<string>("50")
+  const [price, setPrice] = useState<string>("")
+  const [tradeDate, setTradeDate] = useState<string>(todayIso())
+  const [isFetchingPrice, setIsFetchingPrice] = useState(false)
+
+  const { isSubmitting, submitError, submitSuccess, handleSubmit, reset } =
+    useDialogSubmit({
+      autoCloseDelay: 0,
+      fallbackError: "Failed to propose sells",
+    })
+
+  // Reset form fields once per open+asset combination. Adjusting state
+  // during render (rather than in a useEffect) avoids the extra
+  // synchronous-setState-in-effect render this would otherwise trigger.
+  const openKey = open ? holding.assetId : ""
+  const [resetKey, setResetKey] = useState<string>("")
+  if (openKey !== resetKey) {
+    setResetKey(openKey)
+    if (open) {
+      setPercent("50")
+      setPrice("")
+      setTradeDate(todayIso())
+      reset()
+    }
+  }
+
+  // Prefill price from the latest known market price whenever the dialog
+  // opens for a (possibly new) asset.
+  useEffect(() => {
+    if (!open) return undefined
+
+    let cancelled = false
+    const fetchPrice = async (): Promise<void> => {
+      setIsFetchingPrice(true)
+      try {
+        const response = await fetch(
+          `/api/prices/${holding.market}/${holding.assetCode}`,
+        )
+        if (!response.ok) return
+        const data = await response.json()
+        if (!cancelled && data.data && data.data.length > 0) {
+          setPrice(String(data.data[0].close))
+        }
+      } catch {
+        // Ignore - user can enter the price manually.
+      } finally {
+        if (!cancelled) setIsFetchingPrice(false)
+      }
+    }
+
+    fetchPrice()
+    return () => {
+      cancelled = true
+    }
+  }, [open, holding.assetId, holding.market, holding.assetCode])
+
+  const percentNum = parseFloat(percent)
+  const priceNum = parseFloat(price)
+  const weight = (isNaN(percentNum) ? 0 : percentNum) / 100
+
+  const previewRows: PreviewRow[] = useMemo(() => {
+    return (holding.portfolioGroups || [])
+      .filter((pg) => pg.quantity > 0)
+      .map((pg) => {
+        const sellQty = pg.quantity * weight
+        return {
+          portfolioId: pg.portfolioId,
+          portfolioCode: pg.portfolioCode,
+          heldQty: pg.quantity,
+          sellQty,
+          proceeds: sellQty * (isNaN(priceNum) ? 0 : priceNum),
+        }
+      })
+  }, [holding.portfolioGroups, weight, priceNum])
+
+  const canSubmit =
+    !isNaN(percentNum) &&
+    percentNum > 0 &&
+    percentNum <= 100 &&
+    !isNaN(priceNum) &&
+    priceNum > 0 &&
+    previewRows.length > 0
+
+  const handlePropose = async (): Promise<void> => {
+    if (!canSubmit) return
+    await handleSubmit(async () => {
+      const body: BrokerProposalRequest = {
+        assetId: holding.assetId,
+        trnType: "SELL",
+        weight,
+        price: priceNum,
+        tradeDate,
+      }
+      const response = await fetch(`/api/trns/broker/${brokerId}/propose`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(errorData.message || "Failed to propose sells")
+      }
+      onSubmitted()
+    })
+  }
+
+  if (!open) return null
+
+  const assetDisplay = `${holding.market}:${holding.assetCode}`
+  const sellsLabel = `Propose ${previewRows.length} sell${
+    previewRows.length === 1 ? "" : "s"
+  }`
+
+  return (
+    <Dialog
+      title={`Sell ${assetDisplay}`}
+      onClose={onClose}
+      maxWidth="lg"
+      scrollable={true}
+      footer={
+        submitSuccess ? (
+          <Dialog.CancelButton onClick={onClose} label={"Close"} />
+        ) : (
+          <>
+            <Dialog.CancelButton onClick={onClose} label={"Cancel"} />
+            <Dialog.SubmitButton
+              onClick={handlePropose}
+              label={sellsLabel}
+              loadingLabel={"Proposing..."}
+              isSubmitting={isSubmitting}
+              disabled={!canSubmit}
+              variant="red"
+            />
+          </>
+        )
+      }
+    >
+      <Dialog.ErrorAlert message={submitError} />
+
+      {submitSuccess ? (
+        <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
+          <i className="fas fa-check-circle text-green-500 text-2xl mb-2"></i>
+          <p className="text-green-700 font-medium">
+            {`Created ${previewRows.length} proposed sell${
+              previewRows.length === 1 ? "" : "s"
+            }`}
+          </p>
+          <Link
+            href="/trns/proposed"
+            className="text-sm text-blue-600 hover:text-blue-800 underline"
+          >
+            {"Review proposed transactions"}
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <div className="font-semibold text-lg text-gray-900">
+              {assetDisplay}
+            </div>
+            {holding.assetName && (
+              <div className="text-sm text-gray-600">{holding.assetName}</div>
+            )}
+            <div className="text-sm text-gray-600 mt-1">
+              {`Total at ${brokerName}: `}
+              <span className="font-medium text-gray-900">
+                {trimQty(holding.quantity)}
+              </span>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="sell-percent"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {"Percent to sell"}
+              </label>
+              <input
+                id="sell-percent"
+                aria-label="Percent to sell"
+                type="number"
+                min="0"
+                max="100"
+                step="0.01"
+                inputMode="decimal"
+                value={percent}
+                onChange={(e) => setPercent(e.target.value)}
+                disabled={isSubmitting}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-red-500 focus:border-red-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="sell-price"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                {"Price"}
+                {isFetchingPrice && (
+                  <span className="ml-1 text-xs text-gray-400">
+                    {"(fetching...)"}
+                  </span>
+                )}
+              </label>
+              <input
+                id="sell-price"
+                aria-label="Price"
+                type="number"
+                min="0"
+                step="0.01"
+                inputMode="decimal"
+                value={price}
+                onChange={(e) => setPrice(e.target.value)}
+                disabled={isSubmitting}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-red-500 focus:border-red-500"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="sell-trade-date"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              {"Trade Date"}
+            </label>
+            <DateInput
+              value={tradeDate}
+              onChange={setTradeDate}
+              disabled={isSubmitting}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-red-500 focus:border-red-500"
+            />
+          </div>
+
+          <div className="border rounded-lg overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                    {"Portfolio"}
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">
+                    {"Held"}
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">
+                    {"Sell Qty"}
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">
+                    {"Est. Proceeds"}
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {previewRows.map((row) => (
+                  <tr key={row.portfolioId}>
+                    <td className="px-3 py-2 text-sm font-medium text-gray-900">
+                      {row.portfolioCode}
+                    </td>
+                    <td className="px-3 py-2 text-sm text-right font-mono text-gray-600">
+                      {trimQty(row.heldQty)}
+                    </td>
+                    <td className="px-3 py-2 text-sm text-right font-mono text-red-600">
+                      {trimQty(row.sellQty)}
+                    </td>
+                    <td className="px-3 py-2 text-sm text-right font-mono text-gray-600">
+                      {formatMoney(row.proceeds)}
+                    </td>
+                  </tr>
+                ))}
+                {previewRows.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={4}
+                      className="px-3 py-4 text-center text-sm text-gray-500"
+                    >
+                      {"No portfolios hold this position at this broker."}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </Dialog>
+  )
+}
+
+export default WeightedSellDialog

--- a/src/pages/api/trns/broker/[brokerId]/propose.ts
+++ b/src/pages/api/trns/broker/[brokerId]/propose.ts
@@ -1,0 +1,7 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getDataUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: (req) => getDataUrl(`/trns/broker/${req.query.brokerId}/propose`),
+  methods: ["POST"],
+})

--- a/src/pages/brokers/[brokerId]/holdings.tsx
+++ b/src/pages/brokers/[brokerId]/holdings.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from "react"
-import useSwr from "swr"
+import useSwr, { useSWRConfig } from "swr"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import {
   Broker,
@@ -13,6 +13,7 @@ import { errorOut } from "@components/errors/ErrorOut"
 import { useRouter } from "next/router"
 import { rootLoader } from "@components/ui/PageLoader"
 import Link from "next/link"
+import WeightedSellDialog from "@components/features/brokers/WeightedSellDialog"
 
 const brokersKey = "/api/brokers"
 
@@ -25,6 +26,9 @@ export default withPageAuthRequired(
     const [reconciledAssets, setReconciledAssets] = useState<Set<string>>(
       new Set(),
     )
+    const [sellHolding, setSellHolding] =
+      useState<BrokerHoldingPosition | null>(null)
+    const { mutate } = useSWRConfig()
 
     const { data: brokersData, error: brokersError } = useSwr(
       brokersKey,
@@ -124,8 +128,11 @@ export default withPageAuthRequired(
 
     const brokers: Broker[] = brokersData.data || []
     const holdings:
-      | (BrokerHoldingsResponse & { totalHoldings: number })
-      | null = mergedHoldings
+      (BrokerHoldingsResponse & { totalHoldings: number }) | null =
+      mergedHoldings
+    // Sell proposes SELL trns against a real broker; NO_BROKER is a UI
+    // sentinel grouping unassigned transactions, not a real broker id.
+    const canSell = brokerId !== "NO_BROKER"
 
     const handleBrokerChange = (newBrokerId: string): void => {
       setExpandedAsset(null)
@@ -146,6 +153,13 @@ export default withPageAuthRequired(
         }
         return next
       })
+    }
+
+    // Refresh data but leave the dialog open so its success state (with the
+    // link to review proposed transactions) stays visible; onClose dismisses.
+    const handleSellSubmitted = (): void => {
+      if (positionsKey) mutate(positionsKey)
+      if (transactionsKey) mutate(transactionsKey)
     }
 
     const formatQuantity = (qty: number): string => {
@@ -225,12 +239,24 @@ export default withPageAuthRequired(
                 ></i>
               </button>
             </td>
+            {canSell && (
+              <td className="px-4 py-3 text-right">
+                <button
+                  onClick={() => setSellHolding(holding)}
+                  className="text-red-600 hover:text-red-800 px-2 py-1 rounded hover:bg-red-50"
+                  title={"Sell"}
+                >
+                  <i className="fas fa-hand-holding-usd mr-1"></i>
+                  {"Sell"}
+                </button>
+              </td>
+            )}
           </tr>
 
           {/* Expanded detail */}
           {isExpanded && portfolioGroups.length > 0 && (
             <tr>
-              <td colSpan={2} className="px-0 py-0 bg-gray-50">
+              <td colSpan={canSell ? 3 : 2} className="px-0 py-0 bg-gray-50">
                 <div className="border-t border-b border-gray-200">
                   {portfolioGroups.map((pg) => (
                     <div
@@ -390,6 +416,18 @@ export default withPageAuthRequired(
                 ></i>
               </button>
             </div>
+            {canSell && (
+              <div className="mt-2 flex justify-end">
+                <button
+                  onClick={() => setSellHolding(holding)}
+                  className="text-red-600 hover:text-red-800 text-sm px-2 py-1 rounded hover:bg-red-50"
+                  title={"Sell"}
+                >
+                  <i className="fas fa-hand-holding-usd mr-1"></i>
+                  {"Sell"}
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Expanded detail */}
@@ -557,6 +595,11 @@ export default withPageAuthRequired(
                         <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                           {"Qty"}
                         </th>
+                        {canSell && (
+                          <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            {"Actions"}
+                          </th>
+                        )}
                       </tr>
                     </thead>
                     <tbody className="bg-white divide-y divide-gray-200">
@@ -584,6 +627,17 @@ export default withPageAuthRequired(
             </div>
           </div>
         </div>
+
+        {sellHolding && (
+          <WeightedSellDialog
+            open={true}
+            onClose={() => setSellHolding(null)}
+            brokerId={String(brokerId)}
+            brokerName={holdings?.brokerName || String(brokerId)}
+            holding={sellHolding}
+            onSubmitted={handleSellSubmitted}
+          />
+        )}
       </div>
     )
   },

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -1054,6 +1054,26 @@ export interface BrokerHoldingsResponse {
   holdings: BrokerHoldingPosition[]
 }
 
+/**
+ * Request body for POST /trns/broker/{brokerId}/propose — creates one
+ * PROPOSED transaction per portfolio holding the asset at that broker,
+ * sized as `weight` (a fraction of each portfolio's held quantity).
+ */
+export interface BrokerProposalRequest {
+  assetId: string
+  trnType: TrnType
+  weight: number
+  price: number
+  tradeDate?: string
+}
+
+/**
+ * Response envelope from POST /trns/broker/{brokerId}/propose.
+ */
+export interface BrokerProposalResponse {
+  data: Transaction[]
+}
+
 // ============ Monthly Income Report ============
 
 /**


### PR DESCRIPTION
WeightedSellDialog proposes PROPOSED SELLs - one per portfolio holding
the asset at the broker - via POST /api/trns/broker/{id}/propose.
Percent-of-holding weighting with per-portfolio preview; hidden on the
NO_BROKER route.