### PR TITLE
fix: board-lot rounding in weighted sell preview

### DIFF
--- a/__tests__/components/features/brokers/WeightedSellDialog.test.tsx
+++ b/__tests__/components/features/brokers/WeightedSellDialog.test.tsx
@@ -79,9 +79,141 @@ describe("WeightedSellDialog", () => {
       expect(screen.getByLabelText("Price")).toHaveValue(420.5),
     )
 
-    // Default percent is 50 -> 100 * 0.5 = 50, 75 * 0.5 = 37.5
+    // Default percent is 50 -> 100 * 0.5 = 50, 75 * 0.5 = 37.5 which
+    // rounds to 38 under the default board lot of 1 (whole shares).
     expect(screen.getByText("50")).toBeInTheDocument()
-    expect(screen.getByText("37.5")).toBeInTheDocument()
+    expect(screen.getByText("38")).toBeInTheDocument()
+  })
+
+  it("rounds sell quantities to whole shares by default", async () => {
+    const wholeShareHolding: BrokerHoldingPosition = {
+      assetId: "asset-1",
+      assetCode: "VOO",
+      market: "US",
+      quantity: 87,
+      portfolioGroups: [
+        {
+          portfolioId: "pf-1",
+          portfolioCode: "CHAT",
+          quantity: 69,
+          transactions: [],
+        },
+        {
+          portfolioId: "pf-2",
+          portfolioCode: "TYLER",
+          quantity: 18,
+          transactions: [],
+        },
+      ],
+    }
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={wholeShareHolding}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Price")).toHaveValue(420.5),
+    )
+
+    // 69 * 0.5 = 34.5 -> 35 (never 34.5); 18 * 0.5 = 9
+    expect(screen.getByText("35")).toBeInTheDocument()
+    expect(screen.queryByText("34.5")).not.toBeInTheDocument()
+    expect(screen.getByText("9")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /propose 2 sells/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("keeps fractional quantities when boardLot is 0", async () => {
+    const fractionalHolding: BrokerHoldingPosition = {
+      assetId: "asset-1",
+      assetCode: "FUND",
+      market: "US",
+      quantity: 69,
+      boardLot: 0,
+      portfolioGroups: [
+        {
+          portfolioId: "pf-1",
+          portfolioCode: "CHAT",
+          quantity: 69,
+          transactions: [],
+        },
+      ],
+    }
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={fractionalHolding}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Price")).toHaveValue(420.5),
+    )
+
+    expect(screen.getByText("34.5")).toBeInTheDocument()
+  })
+
+  it("rounds to board lot multiples and mutes sub-lot rows", async () => {
+    const lotHolding: BrokerHoldingPosition = {
+      assetId: "asset-1",
+      assetCode: "SGX1",
+      market: "SG",
+      quantity: 170,
+      boardLot: 100,
+      portfolioGroups: [
+        {
+          portfolioId: "pf-1",
+          portfolioCode: "BIG",
+          quantity: 130,
+          transactions: [],
+        },
+        {
+          portfolioId: "pf-2",
+          portfolioCode: "SMALL",
+          quantity: 40,
+          transactions: [],
+        },
+      ],
+    }
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={lotHolding}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Price")).toHaveValue(420.5),
+    )
+
+    // 130 * 0.5 = 65 -> nearest lot = 100 (<= held); 40 * 0.5 = 20 -> 0
+    expect(screen.getByText("100")).toBeInTheDocument()
+    expect(screen.getByTitle("Below board lot")).toBeInTheDocument()
+    // Sub-lot row is excluded from the proposal count
+    expect(
+      screen.getByRole("button", { name: /propose 1 sell/i }),
+    ).toBeInTheDocument()
+
+    // Every row below the lot -> nothing to propose -> disabled
+    fireEvent.change(screen.getByLabelText("Percent to sell"), {
+      target: { value: "10" },
+    })
+    expect(screen.getByRole("button", { name: /propose/i })).toBeDisabled()
   })
 
   it("POSTs the propose contract on submit", async () => {

--- a/src/components/features/brokers/WeightedSellDialog.tsx
+++ b/src/components/features/brokers/WeightedSellDialog.tsx
@@ -100,11 +100,22 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
   const priceNum = parseFloat(price)
   const weight = (isNaN(percentNum) ? 0 : percentNum) / 100
 
+  // Mirrors backend rounding: quantities are whole multiples of the asset's
+  // board lot (default 1 share), never above the held quantity; boardLot 0
+  // means the accounting type permits fractional quantities.
+  const boardLot = holding.boardLot ?? 1
   const previewRows: PreviewRow[] = useMemo(() => {
     return (holding.portfolioGroups || [])
       .filter((pg) => pg.quantity > 0)
       .map((pg) => {
-        const sellQty = pg.quantity * weight
+        const raw = pg.quantity * weight
+        let sellQty = raw
+        if (boardLot >= 1) {
+          sellQty = Math.round(raw / boardLot) * boardLot
+          if (sellQty > pg.quantity) {
+            sellQty = Math.floor(pg.quantity / boardLot) * boardLot
+          }
+        }
         return {
           portfolioId: pg.portfolioId,
           portfolioCode: pg.portfolioCode,
@@ -113,7 +124,9 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
           proceeds: sellQty * (isNaN(priceNum) ? 0 : priceNum),
         }
       })
-  }, [holding.portfolioGroups, weight, priceNum])
+  }, [holding.portfolioGroups, boardLot, weight, priceNum])
+
+  const proposalCount = previewRows.filter((row) => row.sellQty > 0).length
 
   const canSubmit =
     !isNaN(percentNum) &&
@@ -121,7 +134,7 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
     percentNum <= 100 &&
     !isNaN(priceNum) &&
     priceNum > 0 &&
-    previewRows.length > 0
+    proposalCount > 0
 
   const handlePropose = async (): Promise<void> => {
     if (!canSubmit) return
@@ -149,8 +162,8 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
   if (!open) return null
 
   const assetDisplay = `${holding.market}:${holding.assetCode}`
-  const sellsLabel = `Propose ${previewRows.length} sell${
-    previewRows.length === 1 ? "" : "s"
+  const sellsLabel = `Propose ${proposalCount} sell${
+    proposalCount === 1 ? "" : "s"
   }`
 
   return (
@@ -183,8 +196,8 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
         <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
           <i className="fas fa-check-circle text-green-500 text-2xl mb-2"></i>
           <p className="text-green-700 font-medium">
-            {`Created ${previewRows.length} proposed sell${
-              previewRows.length === 1 ? "" : "s"
+            {`Created ${proposalCount} proposed sell${
+              proposalCount === 1 ? "" : "s"
             }`}
           </p>
           <Link
@@ -302,11 +315,20 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
                     <td className="px-3 py-2 text-sm text-right font-mono text-gray-600">
                       {trimQty(row.heldQty)}
                     </td>
-                    <td className="px-3 py-2 text-sm text-right font-mono text-red-600">
-                      {trimQty(row.sellQty)}
-                    </td>
+                    {row.sellQty > 0 ? (
+                      <td className="px-3 py-2 text-sm text-right font-mono text-red-600">
+                        {trimQty(row.sellQty)}
+                      </td>
+                    ) : (
+                      <td
+                        className="px-3 py-2 text-sm text-right font-mono text-gray-400"
+                        title="Below board lot"
+                      >
+                        {"0"}
+                      </td>
+                    )}
                     <td className="px-3 py-2 text-sm text-right font-mono text-gray-600">
-                      {formatMoney(row.proceeds)}
+                      {row.sellQty > 0 ? formatMoney(row.proceeds) : "—"}
                     </td>
                   </tr>
                 ))}

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -1042,6 +1042,11 @@ export interface BrokerHoldingPosition {
   assetName?: string
   market: string
   quantity: number
+  /**
+   * Trading lot size: quantities must be whole multiples of this.
+   * 0 = fractional quantities allowed. Absent (older responses) = 1.
+   */
+  boardLot?: number
   portfolioGroups: BrokerPortfolioGroup[]
 }
 


### PR DESCRIPTION
Mirror backend rounding: nearest boardLot multiple (default 1), capped
at held; boardLot=0 keeps fractional. Sub-lot rows shown muted and
excluded from the proposal count.