### PR TITLE
fix: label cross-broker total in weighted sell dialog

### DIFF
--- a/__tests__/components/features/brokers/WeightedSellDialog.test.tsx
+++ b/__tests__/components/features/brokers/WeightedSellDialog.test.tsx
@@ -60,6 +60,46 @@ describe("WeightedSellDialog", () => {
     await waitFor(() => expect(screen.getByText("GROWTH")).toBeInTheDocument())
     expect(screen.getByText("INCOME")).toBeInTheDocument()
     expect(screen.queryByText("ZERO")).not.toBeInTheDocument()
+    // quantity === sum of groups: total is broker-scoped, no cross-broker note
+    expect(screen.getByText("175")).toBeInTheDocument()
+    expect(screen.queryByText(/Across all brokers/)).not.toBeInTheDocument()
+  })
+
+  it("shows broker-scoped total and labels the cross-broker figure when they differ", async () => {
+    // holding.quantity spans all brokers (96); only 51 + 15 = 66 sit at this one
+    const crossBroker: BrokerHoldingPosition = {
+      ...holding,
+      quantity: 96,
+      portfolioGroups: [
+        {
+          portfolioId: "pf-1",
+          portfolioCode: "TYLER",
+          quantity: 51,
+          transactions: [],
+        },
+        {
+          portfolioId: "pf-2",
+          portfolioCode: "USV",
+          quantity: 15,
+          transactions: [],
+        },
+      ],
+    }
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="IBRK"
+        holding={crossBroker}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText("TYLER")).toBeInTheDocument())
+    expect(screen.getByText(/Total at IBRK/)).toBeInTheDocument()
+    expect(screen.getByText("66")).toBeInTheDocument()
+    expect(screen.getByText("Across all brokers: 96")).toBeInTheDocument()
   })
 
   it("computes sell quantities for 50% correctly", async () => {

--- a/src/components/features/brokers/WeightedSellDialog.tsx
+++ b/src/components/features/brokers/WeightedSellDialog.tsx
@@ -128,6 +128,12 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
 
   const proposalCount = previewRows.filter((row) => row.sellQty > 0).length
 
+  // holding.quantity comes from the positions merge and can span ALL brokers;
+  // only the portfolio groups are scoped to this broker. Sell against the
+  // broker-scoped total and surface the cross-broker figure separately.
+  const brokerTotal = previewRows.reduce((sum, row) => sum + row.heldQty, 0)
+  const crossesBrokers = Math.abs(holding.quantity - brokerTotal) > 1e-9
+
   const canSubmit =
     !isNaN(percentNum) &&
     percentNum > 0 &&
@@ -219,9 +225,14 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
             <div className="text-sm text-gray-600 mt-1">
               {`Total at ${brokerName}: `}
               <span className="font-medium text-gray-900">
-                {trimQty(holding.quantity)}
+                {trimQty(brokerTotal)}
               </span>
             </div>
+            {crossesBrokers && (
+              <div className="text-xs text-gray-500 mt-0.5">
+                {`Across all brokers: ${trimQty(holding.quantity)}`}
+              </div>
+            )}
           </div>
 
           <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
holding.quantity from the positions merge can span all brokers; header
now shows the broker-scoped group total and, when different, a separate
'Across all brokers' line.