### PR TITLE
docs(trns): unsettle reverts cash legs to PROPOSED, not delete

### DIFF
--- a/src/lib/utils/trns/apiHelper.ts
+++ b/src/lib/utils/trns/apiHelper.ts
@@ -8,9 +8,9 @@ export function deleteTrn(trnId: string): Promise<Response> {
 
 /**
  * PATCH /trns/{trnId}/status — Unsettle a SETTLED trn (sets PROPOSED).
- * Response: { updated, siblings: string[] } — the server cascade-deletes the
- * auto-emitted cash legs (WITHDRAWAL + DEPOSIT) on unsettle; `siblings` reports
- * the removed ids for reference (no longer a delete prompt).
+ * Response: { updated, siblings: string[] } — the server reverts the
+ * auto-settled cash legs (WITHDRAWAL + DEPOSIT) to PROPOSED on unsettle; they
+ * are not deleted. `siblings` lists their ids; a list refresh shows them as PROPOSED.
  */
 export function unsettleTrn(trnId: string): Promise<Response> {
   return fetch(`/api/trns/status/${trnId}`, {

--- a/src/pages/api/trns/status/[trnId].ts
+++ b/src/pages/api/trns/status/[trnId].ts
@@ -3,8 +3,8 @@ import { getDataUrl } from "@utils/api/bcConfig"
 
 /**
  * Proxy for PATCH /trns/{trnId}/status (Unsettle action).
- * Returns TrnStatusUpdateResponse — the updated TrnDto plus the auto-emitted
- * sibling ids the UI should prompt the user to delete.
+ * Returns TrnStatusUpdateResponse — the updated TrnDto plus the ids of auto-settled
+ * cash legs reverted to PROPOSED by the server (not deleted); see `siblings`.
  */
 export default createApiHandler({
   url: (req) => {

--- a/src/pages/trns/proposed.tsx
+++ b/src/pages/trns/proposed.tsx
@@ -670,8 +670,8 @@ function ProposedTransactions(): React.JSX.Element {
         byPortfolio.set(trn.portfolio.id, ids)
       })
 
-      // Unsettle each portfolio's transactions. The server cascade-deletes each
-      // trade's auto-emitted cash legs.
+      // Unsettle each portfolio's transactions. The server reverts each trade's
+      // auto-settled cash legs to PROPOSED (not deleted); mutate shows them on refresh.
       for (const [portfolioId, trnIds] of byPortfolio) {
         const response = await fetch(
           `/api/trns/portfolio/${portfolioId}/unsettle`,

--- a/src/pages/trns/trades/[...trades].tsx
+++ b/src/pages/trns/trades/[...trades].tsx
@@ -296,9 +296,9 @@ export default withPageAuthRequired(function Trades(): React.ReactElement {
           )
           return
         }
-        // The server cascade-deletes the auto-emitted cash legs on unsettle, so
-        // there is nothing for the user to confirm. Invalidate holdings so the row
-        // reflects the new PROPOSED status, then close.
+        // On unsettle the server reverts the auto-settled cash legs to PROPOSED
+        // (not deleted). Invalidate holdings so the row reflects the new PROPOSED
+        // status, then close.
         setTimeout(() => {
           mutate(holdingKey(transaction.portfolio.code, "today"))
           mutate("/api/holdings/aggregated?asAt=today")

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -478,7 +478,7 @@ export interface TrnStatusUpdateRequest {
 
 /**
  * Response from PATCH /trns/{trnId}/status. [siblings] is the auto-settled
- * cash leg ids; the UI prompts to delete them after a successful Unsettle.
+ * cash leg ids; they are reverted to PROPOSED server-side (not deleted).
  */
 export interface TrnStatusUpdateResponse {
   updated: TrnDto
@@ -493,14 +493,21 @@ interface Registration {
 }
 
 export type HoldingsView =
-  "SUMMARY" | "TABLE" | "CARDS" | "HEATMAP" | "ALLOCATION"
+  | "SUMMARY"
+  | "TABLE"
+  | "CARDS"
+  | "HEATMAP"
+  | "ALLOCATION"
 
 // Type aliases for UserPreferences - runtime values defined in types/constants.ts
 export type ValueInOption = "PORTFOLIO" | "BASE" | "TRADE"
 
 // Backend GroupBy API values (enum names as persisted in the database)
 export type GroupByApiValue =
-  "ASSET_CLASS" | "SECTOR" | "MARKET_CURRENCY" | "MARKET"
+  | "ASSET_CLASS"
+  | "SECTOR"
+  | "MARKET_CURRENCY"
+  | "MARKET"
 
 // Frontend GroupBy property paths (used for client-side grouping)
 export type GroupByOption =
@@ -1142,7 +1149,10 @@ export interface MonthlyIncomeResponse {
 
 export type ShareAccessLevel = "VIEW" | "FULL"
 export type ShareStatus =
-  "PENDING_CLIENT_INVITE" | "PENDING_ADVISER_REQUEST" | "ACTIVE" | "REVOKED"
+  | "PENDING_CLIENT_INVITE"
+  | "PENDING_ADVISER_REQUEST"
+  | "ACTIVE"
+  | "REVOKED"
 
 export interface PortfolioShare {
   id: string


### PR DESCRIPTION
Five comment/JSDoc locations incorrectly described the unsettle
behaviour as a server cascade-delete of the auto-settled cash legs.
Updated to reflect the current behaviour: the server reverts those legs
to PROPOSED and returns their ids in `siblings`; a list refresh shows
them as PROPOSED.