### PR TITLE
feat(assets): US 401k/IRA + UK ISA wrapper account editor (#1087)

### DIFF
--- a/src/components/features/accounts/EditAccountDialog.tsx
+++ b/src/components/features/accounts/EditAccountDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react"
 import useSWR from "swr"
 import { Asset, CurrencyOption } from "types/beancounter"
-import { PolicyType, SubAccountRequest } from "types/beancounter"
+import { PolicyType, SubAccountRequest, TaxTreatment } from "types/beancounter"
 import { stripOwnerPrefix, getAssetCurrency } from "@lib/assets/assetUtils"
 import MathInput from "@components/ui/MathInput"
 import CompositeAssetEditor from "@components/features/assets/CompositeAssetEditor"
@@ -45,6 +45,12 @@ interface AssetConfigState {
   // CPF LIFE settings
   cpfLifePlan?: "STANDARD" | "BASIC" | "ESCALATING"
   cpfPayoutStartAge?: number
+  // US 401(k)/IRA + UK ISA wrapper settings
+  taxTreatment?: TaxTreatment
+  employeeDeferralPercent?: number
+  employerMatchPercent?: number
+  employerMatchCapPercent?: number
+  withdrawalTaxRate?: number
   // For projection calculation (client-side only)
   currentAge: string
 }
@@ -370,6 +376,14 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
               // CPF LIFE settings
               cpfLifePlan: data.data.cpfLifePlan || undefined,
               cpfPayoutStartAge: data.data.cpfPayoutStartAge || undefined,
+              // US 401(k)/IRA + UK ISA wrapper settings
+              taxTreatment: data.data.taxTreatment || undefined,
+              employeeDeferralPercent:
+                data.data.employeeDeferralPercent ?? undefined,
+              employerMatchPercent: data.data.employerMatchPercent ?? undefined,
+              employerMatchCapPercent:
+                data.data.employerMatchCapPercent ?? undefined,
+              withdrawalTaxRate: data.data.withdrawalTaxRate ?? undefined,
               // Client-side only for projection calculation
               currentAge: "",
             })
@@ -538,6 +552,11 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
               subAccounts: config.subAccounts,
               cpfLifePlan: config.cpfLifePlan || null,
               cpfPayoutStartAge: config.cpfPayoutStartAge || null,
+              taxTreatment: config.taxTreatment || null,
+              employeeDeferralPercent: config.employeeDeferralPercent ?? null,
+              employerMatchPercent: config.employerMatchPercent ?? null,
+              employerMatchCapPercent: config.employerMatchCapPercent ?? null,
+              withdrawalTaxRate: config.withdrawalTaxRate ?? null,
             })
           }
         }
@@ -925,6 +944,11 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                       subAccounts={config.subAccounts}
                       cpfLifePlan={config.cpfLifePlan}
                       cpfPayoutStartAge={config.cpfPayoutStartAge}
+                      taxTreatment={config.taxTreatment}
+                      employeeDeferralPercent={config.employeeDeferralPercent}
+                      employerMatchPercent={config.employerMatchPercent}
+                      employerMatchCapPercent={config.employerMatchCapPercent}
+                      withdrawalTaxRate={config.withdrawalTaxRate}
                       onPolicyTypeChange={(val) =>
                         // Functional updates: selecting CPF fires policy +
                         // template + CPF-LIFE setters in one tick; stale-closure
@@ -947,6 +971,33 @@ const EditAccountDialog: React.FC<EditAccountDialogProps> = ({
                         setConfig((prev) => ({
                           ...prev,
                           cpfPayoutStartAge: val,
+                        }))
+                      }
+                      onTaxTreatmentChange={(val) =>
+                        setConfig((prev) => ({ ...prev, taxTreatment: val }))
+                      }
+                      onEmployeeDeferralPercentChange={(val) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          employeeDeferralPercent: val,
+                        }))
+                      }
+                      onEmployerMatchPercentChange={(val) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          employerMatchPercent: val,
+                        }))
+                      }
+                      onEmployerMatchCapPercentChange={(val) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          employerMatchCapPercent: val,
+                        }))
+                      }
+                      onWithdrawalTaxRateChange={(val) =>
+                        setConfig((prev) => ({
+                          ...prev,
+                          withdrawalTaxRate: val,
                         }))
                       }
                     />

--- a/src/components/features/assets/CompositeAssetEditor.tsx
+++ b/src/components/features/assets/CompositeAssetEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from "react"
-import { PolicyType, SubAccountRequest } from "types/beancounter"
+import { PolicyType, SubAccountRequest, TaxTreatment } from "types/beancounter"
 import TouchDatePicker from "@components/ui/TouchDatePicker"
 import MathInput from "@components/ui/MathInput"
 
@@ -37,10 +37,22 @@ const CPF_TEMPLATE: SubAccountRequest[] = [
   },
 ]
 
+/**
+ * US 401(k)/IRA + UK ISA default to a single sub-account holding the whole
+ * balance — unlike CPF's prescribed OA/SA/MA/RA split, these wrappers don't
+ * have statutory buckets.
+ */
+const SINGLE_ACCOUNT_TEMPLATE: SubAccountRequest[] = [
+  { code: "BAL", displayName: "Balance", balance: 0, liquid: true },
+]
+
 const POLICY_TYPE_OPTIONS: { value: PolicyType; label: string }[] = [
   { value: "CPF", label: "CPF" },
   { value: "ILP", label: "Investment-Linked Policy" },
   { value: "GENERIC", label: "Generic Composite" },
+  { value: "US_401K", label: "US 401(k)" },
+  { value: "US_IRA", label: "US IRA" },
+  { value: "UK_ISA", label: "UK ISA" },
 ]
 
 type CpfLifePlan = "STANDARD" | "BASIC" | "ESCALATING"
@@ -74,11 +86,22 @@ export interface CompositeAssetEditorProps {
   subAccounts: SubAccountRequest[]
   cpfLifePlan?: CpfLifePlan
   cpfPayoutStartAge?: number
+  // US 401(k)/IRA + UK ISA wrapper settings. Decimals (e.g. 0.06 = 6%).
+  taxTreatment?: TaxTreatment
+  employeeDeferralPercent?: number
+  employerMatchPercent?: number
+  employerMatchCapPercent?: number
+  withdrawalTaxRate?: number
   onPolicyTypeChange: (value: PolicyType | undefined) => void
   onLockedUntilDateChange: (value: string) => void
   onSubAccountsChange: (accounts: SubAccountRequest[]) => void
   onCpfLifePlanChange?: (value: CpfLifePlan | undefined) => void
   onCpfPayoutStartAgeChange?: (value: number | undefined) => void
+  onTaxTreatmentChange?: (value: TaxTreatment | undefined) => void
+  onEmployeeDeferralPercentChange?: (value: number | undefined) => void
+  onEmployerMatchPercentChange?: (value: number | undefined) => void
+  onEmployerMatchCapPercentChange?: (value: number | undefined) => void
+  onWithdrawalTaxRateChange?: (value: number | undefined) => void
 }
 
 export default function CompositeAssetEditor({
@@ -87,11 +110,21 @@ export default function CompositeAssetEditor({
   subAccounts,
   cpfLifePlan,
   cpfPayoutStartAge,
+  taxTreatment,
+  employeeDeferralPercent,
+  employerMatchPercent,
+  employerMatchCapPercent,
+  withdrawalTaxRate,
   onPolicyTypeChange,
   onLockedUntilDateChange,
   onSubAccountsChange,
   onCpfLifePlanChange,
   onCpfPayoutStartAgeChange,
+  onTaxTreatmentChange,
+  onEmployeeDeferralPercentChange,
+  onEmployerMatchPercentChange,
+  onEmployerMatchCapPercentChange,
+  onWithdrawalTaxRateChange,
 }: CompositeAssetEditorProps): React.ReactElement {
   const [newCode, setNewCode] = useState("")
 
@@ -134,6 +167,38 @@ export default function CompositeAssetEditor({
 
   const isComposite = policyType !== undefined
   const isCpf = policyType === "CPF"
+  const isUsWrapper = policyType === "US_401K" || policyType === "US_IRA"
+
+  // CPF LIFE settings (cpfLifePlan/cpfPayoutStartAge) are CPF-only — clear
+  // them when switching to any other policy type.
+  const clearCpfOnlyFields = (): void => {
+    if (cpfLifePlan) {
+      onCpfLifePlanChange?.(undefined)
+    }
+    if (cpfPayoutStartAge != null) {
+      onCpfPayoutStartAgeChange?.(undefined)
+    }
+  }
+
+  // US 401(k)/IRA/ISA wrapper settings — clear when switching to CPF/ILP/
+  // Generic/None so they can't leak into an unrelated policy's save.
+  const clearWrapperFields = (): void => {
+    if (taxTreatment) {
+      onTaxTreatmentChange?.(undefined)
+    }
+    if (employeeDeferralPercent != null) {
+      onEmployeeDeferralPercentChange?.(undefined)
+    }
+    if (employerMatchPercent != null) {
+      onEmployerMatchPercentChange?.(undefined)
+    }
+    if (employerMatchCapPercent != null) {
+      onEmployerMatchCapPercentChange?.(undefined)
+    }
+    if (withdrawalTaxRate != null) {
+      onWithdrawalTaxRateChange?.(undefined)
+    }
+  }
 
   return (
     <div className="space-y-4">
@@ -167,18 +232,40 @@ export default function CompositeAssetEditor({
                 if (lockedUntilDate) {
                   onLockedUntilDateChange("")
                 }
+                clearWrapperFields()
+              } else if (val === "US_401K" || val === "US_IRA") {
+                // No statutory buckets — start from a single Balance
+                // sub-account and default to TRADITIONAL (svc-retire projects
+                // net of withdrawalTaxRate for TRADITIONAL, 1:1 for ROTH).
+                // Keep an already-chosen treatment (e.g. re-selecting IRA
+                // after ROTH).
+                onSubAccountsChange(
+                  SINGLE_ACCOUNT_TEMPLATE.map((t) => ({ ...t })),
+                )
+                if (!taxTreatment) {
+                  onTaxTreatmentChange?.("TRADITIONAL")
+                }
+                clearCpfOnlyFields()
+              } else if (val === "UK_ISA") {
+                // ISA is always tax-free — not a user choice — so force
+                // TAX_FREE unconditionally rather than only-if-unset.
+                onSubAccountsChange(
+                  SINGLE_ACCOUNT_TEMPLATE.map((t) => ({ ...t })),
+                )
+                onTaxTreatmentChange?.("TAX_FREE")
+                onEmployeeDeferralPercentChange?.(undefined)
+                onEmployerMatchPercentChange?.(undefined)
+                onEmployerMatchCapPercentChange?.(undefined)
+                onWithdrawalTaxRateChange?.(undefined)
+                clearCpfOnlyFields()
               } else {
                 // ILP / Generic / None have no prescribed buckets — start from
-                // an empty template and drop CPF-only settings.
+                // an empty template and drop CPF-only and wrapper settings.
                 if (subAccounts.length > 0) {
                   onSubAccountsChange([])
                 }
-                if (cpfLifePlan) {
-                  onCpfLifePlanChange?.(undefined)
-                }
-                if (cpfPayoutStartAge != null) {
-                  onCpfPayoutStartAgeChange?.(undefined)
-                }
+                clearCpfOnlyFields()
+                clearWrapperFields()
               }
             }}
             className="flex-1 border-gray-300 rounded-md shadow-sm px-3 py-2 border focus:ring-indigo-500 focus:border-indigo-500"
@@ -281,6 +368,180 @@ export default function CompositeAssetEditor({
                   </p>
                 </div>
               </div>
+            </div>
+          )}
+
+          {/* US 401(k)/IRA Wrapper Settings — UK ISA has no user-facing tax
+              fields (TAX_FREE is implied and forced above). */}
+          {isUsWrapper && (
+            <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-3 space-y-3">
+              <h4 className="text-sm font-medium text-emerald-800">
+                Retirement Wrapper Settings
+              </h4>
+              <div>
+                <span className="block text-xs font-medium text-emerald-700 mb-1">
+                  Tax Treatment
+                </span>
+                <div className="flex items-center space-x-4">
+                  <label className="flex items-center text-sm text-emerald-700">
+                    <input
+                      type="radio"
+                      name="taxTreatment"
+                      value="TRADITIONAL"
+                      checked={
+                        (taxTreatment || "TRADITIONAL") === "TRADITIONAL"
+                      }
+                      onChange={() => onTaxTreatmentChange?.("TRADITIONAL")}
+                      className="mr-1.5"
+                    />
+                    Traditional
+                  </label>
+                  <label className="flex items-center text-sm text-emerald-700">
+                    <input
+                      type="radio"
+                      name="taxTreatment"
+                      value="ROTH"
+                      checked={taxTreatment === "ROTH"}
+                      onChange={() => onTaxTreatmentChange?.("ROTH")}
+                      className="mr-1.5"
+                    />
+                    Roth
+                  </label>
+                </div>
+                <p className="text-xs text-emerald-600 mt-1">
+                  Traditional projects withdrawals net of tax; Roth projects 1:1
+                  (already taxed).
+                </p>
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                <div>
+                  <label
+                    htmlFor="employeeDeferralPercent"
+                    className="block text-xs font-medium text-emerald-700 mb-1"
+                  >
+                    Employee Deferral %
+                  </label>
+                  <input
+                    id="employeeDeferralPercent"
+                    type="number"
+                    step="0.1"
+                    min="0"
+                    max="100"
+                    value={
+                      employeeDeferralPercent != null
+                        ? Math.round(employeeDeferralPercent * 1000) / 10
+                        : ""
+                    }
+                    onChange={(e) =>
+                      onEmployeeDeferralPercentChange?.(
+                        e.target.value
+                          ? parseFloat(e.target.value) / 100
+                          : undefined,
+                      )
+                    }
+                    placeholder="--"
+                    className="w-full border-emerald-300 rounded px-2 py-1.5 border text-sm focus:ring-emerald-500 focus:border-emerald-500"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="employerMatchPercent"
+                    className="block text-xs font-medium text-emerald-700 mb-1"
+                  >
+                    Employer Match %
+                  </label>
+                  <input
+                    id="employerMatchPercent"
+                    type="number"
+                    step="0.1"
+                    min="0"
+                    max="100"
+                    value={
+                      employerMatchPercent != null
+                        ? Math.round(employerMatchPercent * 1000) / 10
+                        : ""
+                    }
+                    onChange={(e) =>
+                      onEmployerMatchPercentChange?.(
+                        e.target.value
+                          ? parseFloat(e.target.value) / 100
+                          : undefined,
+                      )
+                    }
+                    placeholder="--"
+                    className="w-full border-emerald-300 rounded px-2 py-1.5 border text-sm focus:ring-emerald-500 focus:border-emerald-500"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="employerMatchCapPercent"
+                    className="block text-xs font-medium text-emerald-700 mb-1"
+                  >
+                    Match Cap % (of salary)
+                  </label>
+                  <input
+                    id="employerMatchCapPercent"
+                    type="number"
+                    step="0.1"
+                    min="0"
+                    max="100"
+                    value={
+                      employerMatchCapPercent != null
+                        ? Math.round(employerMatchCapPercent * 1000) / 10
+                        : ""
+                    }
+                    onChange={(e) =>
+                      onEmployerMatchCapPercentChange?.(
+                        e.target.value
+                          ? parseFloat(e.target.value) / 100
+                          : undefined,
+                      )
+                    }
+                    placeholder="--"
+                    className="w-full border-emerald-300 rounded px-2 py-1.5 border text-sm focus:ring-emerald-500 focus:border-emerald-500"
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-emerald-600">
+                Match = min(deferral, cap % of salary) × match %.
+              </p>
+              {/* Withdrawal tax rate only applies when withdrawals are
+                  taxable — Roth is already taxed, so hide it. */}
+              {(taxTreatment || "TRADITIONAL") !== "ROTH" && (
+                <div>
+                  <label
+                    htmlFor="withdrawalTaxRate"
+                    className="block text-xs font-medium text-emerald-700 mb-1"
+                  >
+                    Withdrawal Tax Rate %
+                  </label>
+                  <input
+                    id="withdrawalTaxRate"
+                    type="number"
+                    step="0.1"
+                    min="0"
+                    max="100"
+                    value={
+                      withdrawalTaxRate != null
+                        ? Math.round(withdrawalTaxRate * 1000) / 10
+                        : ""
+                    }
+                    onChange={(e) =>
+                      onWithdrawalTaxRateChange?.(
+                        e.target.value
+                          ? parseFloat(e.target.value) / 100
+                          : undefined,
+                      )
+                    }
+                    placeholder="22"
+                    className="w-full border-emerald-300 rounded px-2 py-1.5 border text-sm focus:ring-emerald-500 focus:border-emerald-500"
+                  />
+                  <p className="text-xs text-emerald-600 mt-1">
+                    Applied to projected withdrawals. Defaults to 22% if left
+                    blank.
+                  </p>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
+++ b/src/components/features/assets/__tests__/CompositeAssetEditor.test.tsx
@@ -176,3 +176,169 @@ describe("CompositeAssetEditor — CPF LIFE plan default", () => {
     ).not.toBeInTheDocument()
   })
 })
+
+/**
+ * US 401(k)/IRA + UK ISA wrapper support (#1087). Mirrors the CPF pattern:
+ * selecting the policy type applies a single-account template and, for
+ * US wrappers, defaults tax treatment to TRADITIONAL (svc-retire projects
+ * net-of-tax for TRADITIONAL, 1:1 for ROTH/TAX_FREE).
+ */
+describe("CompositeAssetEditor — US 401(k)/IRA + UK ISA wrappers", () => {
+  const baseProps = {
+    lockedUntilDate: "",
+    subAccounts: [],
+    onPolicyTypeChange: jest.fn(),
+    onLockedUntilDateChange: jest.fn(),
+    onSubAccountsChange: jest.fn(),
+    onCpfLifePlanChange: jest.fn(),
+    onCpfPayoutStartAgeChange: jest.fn(),
+  }
+
+  it("seeds a single Balance sub-account and defaults TRADITIONAL when policy turns US_401K", () => {
+    const onPolicyTypeChange = jest.fn()
+    const onSubAccountsChange = jest.fn()
+    const onTaxTreatmentChange = jest.fn()
+    render(
+      <CompositeAssetEditor
+        {...baseProps}
+        policyType={undefined}
+        taxTreatment={undefined}
+        onPolicyTypeChange={onPolicyTypeChange}
+        onSubAccountsChange={onSubAccountsChange}
+        onTaxTreatmentChange={onTaxTreatmentChange}
+      />,
+    )
+    const policySelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement
+    fireEvent.change(policySelect, { target: { value: "US_401K" } })
+    expect(onPolicyTypeChange).toHaveBeenCalledWith("US_401K")
+    const applied = onSubAccountsChange.mock.calls[0][0] as { code: string }[]
+    expect(applied.map((a) => a.code)).toEqual(["BAL"])
+    expect(onTaxTreatmentChange).toHaveBeenCalledWith("TRADITIONAL")
+  })
+
+  it("shows Traditional/Roth toggle + match fields for US_401K, and hides withdrawal tax rate for Roth", () => {
+    const { rerender } = render(
+      <CompositeAssetEditor
+        {...baseProps}
+        policyType="US_401K"
+        taxTreatment="TRADITIONAL"
+      />,
+    )
+    expect(
+      screen.getByRole("radio", { name: /Traditional/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: /Roth/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/Employee Deferral/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Employer Match %/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Match Cap/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Withdrawal Tax Rate/i)).toBeInTheDocument()
+
+    rerender(
+      <CompositeAssetEditor
+        {...baseProps}
+        policyType="US_401K"
+        taxTreatment="ROTH"
+      />,
+    )
+    expect(
+      screen.queryByLabelText(/Withdrawal Tax Rate/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it("submits deferral/match/cap as decimals from percent input", () => {
+    const onEmployeeDeferralPercentChange = jest.fn()
+    const onEmployerMatchPercentChange = jest.fn()
+    const onEmployerMatchCapPercentChange = jest.fn()
+    render(
+      <CompositeAssetEditor
+        {...baseProps}
+        policyType="US_401K"
+        taxTreatment="TRADITIONAL"
+        onEmployeeDeferralPercentChange={onEmployeeDeferralPercentChange}
+        onEmployerMatchPercentChange={onEmployerMatchPercentChange}
+        onEmployerMatchCapPercentChange={onEmployerMatchCapPercentChange}
+      />,
+    )
+    fireEvent.change(screen.getByLabelText(/Employee Deferral/i), {
+      target: { value: "6" },
+    })
+    expect(onEmployeeDeferralPercentChange).toHaveBeenCalledWith(0.06)
+
+    fireEvent.change(screen.getByLabelText(/Employer Match %/i), {
+      target: { value: "3" },
+    })
+    expect(onEmployerMatchPercentChange).toHaveBeenCalledWith(0.03)
+
+    fireEvent.change(screen.getByLabelText(/Match Cap/i), {
+      target: { value: "6" },
+    })
+    expect(onEmployerMatchCapPercentChange).toHaveBeenCalledWith(0.06)
+  })
+
+  it("seeds a single Balance sub-account and forces TAX_FREE (hidden) for UK_ISA — no tax fields shown", () => {
+    const onSubAccountsChange = jest.fn()
+    const onTaxTreatmentChange = jest.fn()
+    render(
+      <CompositeAssetEditor
+        {...baseProps}
+        policyType={undefined}
+        onSubAccountsChange={onSubAccountsChange}
+        onTaxTreatmentChange={onTaxTreatmentChange}
+      />,
+    )
+    const policySelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement
+    fireEvent.change(policySelect, { target: { value: "UK_ISA" } })
+    const applied = onSubAccountsChange.mock.calls[0][0] as { code: string }[]
+    expect(applied.map((a) => a.code)).toEqual(["BAL"])
+    expect(onTaxTreatmentChange).toHaveBeenCalledWith("TAX_FREE")
+
+    // Re-render as the committed UK_ISA state — no tax-treatment/deferral/
+    // match fields for ISA; TAX_FREE is implied, not user-editable.
+    render(
+      <CompositeAssetEditor
+        {...baseProps}
+        policyType="UK_ISA"
+        taxTreatment="TAX_FREE"
+        subAccounts={[makeSubAccount({ code: "BAL", displayName: "Balance" })]}
+      />,
+    )
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(/Employee Deferral/i),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(/Withdrawal Tax Rate/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it("clears wrapper fields when switching away from a US wrapper policy type", () => {
+    const onTaxTreatmentChange = jest.fn()
+    const onEmployeeDeferralPercentChange = jest.fn()
+    const onEmployerMatchPercentChange = jest.fn()
+    const onEmployerMatchCapPercentChange = jest.fn()
+    const onWithdrawalTaxRateChange = jest.fn()
+    render(
+      <CompositeAssetEditor
+        {...baseProps}
+        policyType="US_401K"
+        taxTreatment="TRADITIONAL"
+        employeeDeferralPercent={0.06}
+        employerMatchPercent={0.03}
+        employerMatchCapPercent={0.06}
+        withdrawalTaxRate={0.22}
+        onTaxTreatmentChange={onTaxTreatmentChange}
+        onEmployeeDeferralPercentChange={onEmployeeDeferralPercentChange}
+        onEmployerMatchPercentChange={onEmployerMatchPercentChange}
+        onEmployerMatchCapPercentChange={onEmployerMatchCapPercentChange}
+        onWithdrawalTaxRateChange={onWithdrawalTaxRateChange}
+      />,
+    )
+    const policySelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement
+    fireEvent.change(policySelect, { target: { value: "ILP" } })
+    expect(onTaxTreatmentChange).toHaveBeenCalledWith(undefined)
+    expect(onEmployeeDeferralPercentChange).toHaveBeenCalledWith(undefined)
+    expect(onEmployerMatchPercentChange).toHaveBeenCalledWith(undefined)
+    expect(onEmployerMatchCapPercentChange).toHaveBeenCalledWith(undefined)
+    expect(onWithdrawalTaxRateChange).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/src/components/features/independence/steps/AssetsStep.tsx
+++ b/src/components/features/independence/steps/AssetsStep.tsx
@@ -8,6 +8,7 @@ import {
   Portfolio,
   PolicyType,
   SubAccountRequest,
+  TaxTreatment,
 } from "types/beancounter"
 import { wizardMessages } from "@lib/independence/messages"
 import CompositeAssetEditor from "@components/features/assets/CompositeAssetEditor"
@@ -119,6 +120,21 @@ export default function AssetsStep({
     "STANDARD" | "BASIC" | "ESCALATING" | undefined
   >(undefined)
   const [cpfPayoutStartAge, setCpfPayoutStartAge] = useState<
+    number | undefined
+  >(undefined)
+  const [taxTreatment, setTaxTreatment] = useState<TaxTreatment | undefined>(
+    undefined,
+  )
+  const [employeeDeferralPercent, setEmployeeDeferralPercent] = useState<
+    number | undefined
+  >(undefined)
+  const [employerMatchPercent, setEmployerMatchPercent] = useState<
+    number | undefined
+  >(undefined)
+  const [employerMatchCapPercent, setEmployerMatchCapPercent] = useState<
+    number | undefined
+  >(undefined)
+  const [withdrawalTaxRate, setWithdrawalTaxRate] = useState<
     number | undefined
   >(undefined)
   // Simple asset balance (when no policyType)
@@ -476,6 +492,11 @@ export default function AssetsStep({
     setPolicyType(undefined)
     setLockedUntilDate("")
     setSubAccounts([])
+    setTaxTreatment(undefined)
+    setEmployeeDeferralPercent(undefined)
+    setEmployerMatchPercent(undefined)
+    setEmployerMatchCapPercent(undefined)
+    setWithdrawalTaxRate(undefined)
     setSimpleBalance(0)
     setExpectedReturnRate("4")
     setPayoutAge("65")
@@ -574,6 +595,11 @@ export default function AssetsStep({
           subAccounts,
           cpfLifePlan: cpfLifePlan || null,
           cpfPayoutStartAge: cpfPayoutStartAge || null,
+          taxTreatment: taxTreatment || null,
+          employeeDeferralPercent: employeeDeferralPercent ?? null,
+          employerMatchPercent: employerMatchPercent ?? null,
+          employerMatchCapPercent: employerMatchCapPercent ?? null,
+          withdrawalTaxRate: withdrawalTaxRate ?? null,
         })
       }
 
@@ -664,6 +690,11 @@ export default function AssetsStep({
     lockedUntilDate,
     cpfLifePlan,
     cpfPayoutStartAge,
+    taxTreatment,
+    employeeDeferralPercent,
+    employerMatchPercent,
+    employerMatchCapPercent,
+    withdrawalTaxRate,
   ])
 
   return (
@@ -1141,11 +1172,21 @@ export default function AssetsStep({
                 subAccounts={subAccounts}
                 cpfLifePlan={cpfLifePlan}
                 cpfPayoutStartAge={cpfPayoutStartAge}
+                taxTreatment={taxTreatment}
+                employeeDeferralPercent={employeeDeferralPercent}
+                employerMatchPercent={employerMatchPercent}
+                employerMatchCapPercent={employerMatchCapPercent}
+                withdrawalTaxRate={withdrawalTaxRate}
                 onPolicyTypeChange={setPolicyType}
                 onLockedUntilDateChange={setLockedUntilDate}
                 onSubAccountsChange={setSubAccounts}
                 onCpfLifePlanChange={setCpfLifePlan}
                 onCpfPayoutStartAgeChange={setCpfPayoutStartAge}
+                onTaxTreatmentChange={setTaxTreatment}
+                onEmployeeDeferralPercentChange={setEmployeeDeferralPercent}
+                onEmployerMatchPercentChange={setEmployerMatchPercent}
+                onEmployerMatchCapPercentChange={setEmployerMatchCapPercent}
+                onWithdrawalTaxRateChange={setWithdrawalTaxRate}
               />
 
               {/* Simple Asset Balance (when no policy type selected) */}

--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -8,6 +8,7 @@ import {
   PolicyType,
   Portfolio,
   SubAccountRequest,
+  TaxTreatment,
 } from "types/beancounter"
 import OnboardingProgress from "./OnboardingProgress"
 import WelcomeStep from "./steps/WelcomeStep"
@@ -53,10 +54,16 @@ export interface Pension {
   monthlyPayoutAmount?: number
   lumpSum?: boolean // If true, pays out in full rather than monthly
   monthlyContribution?: number // Regular contribution amount
-  policyType?: PolicyType // Composite policy type (CPF, ILP, GENERIC)
+  policyType?: PolicyType // Composite policy type (CPF, ILP, GENERIC, US_401K, US_IRA, UK_ISA)
   cpfLifePlan?: "STANDARD" | "BASIC" | "ESCALATING" // CPF LIFE payout plan
   lockedUntilDate?: string // Date when asset can be liquidated
   subAccounts?: SubAccountRequest[] // Sub-accounts for composite policies
+  // US 401(k)/IRA + UK ISA wrapper settings
+  taxTreatment?: TaxTreatment
+  employeeDeferralPercent?: number
+  employerMatchPercent?: number
+  employerMatchCapPercent?: number
+  withdrawalTaxRate?: number
 }
 
 export interface Insurance {
@@ -501,6 +508,11 @@ const OnboardingWizard: React.FC = () => {
             cpfLifePlan: pension.cpfLifePlan,
             lockedUntilDate: pension.lockedUntilDate || null,
             subAccounts: pension.subAccounts,
+            taxTreatment: pension.taxTreatment,
+            employeeDeferralPercent: pension.employeeDeferralPercent,
+            employerMatchPercent: pension.employerMatchPercent,
+            employerMatchCapPercent: pension.employerMatchCapPercent,
+            withdrawalTaxRate: pension.withdrawalTaxRate,
           }),
         })
 

--- a/src/components/features/onboarding/steps/AssetsStep.tsx
+++ b/src/components/features/onboarding/steps/AssetsStep.tsx
@@ -641,6 +641,11 @@ const AssetsStep: React.FC<AssetsStepProps> = ({
               cpfPayoutStartAge={newPension.payoutAge}
               lockedUntilDate={newPension.lockedUntilDate || ""}
               subAccounts={newPension.subAccounts || []}
+              taxTreatment={newPension.taxTreatment}
+              employeeDeferralPercent={newPension.employeeDeferralPercent}
+              employerMatchPercent={newPension.employerMatchPercent}
+              employerMatchCapPercent={newPension.employerMatchCapPercent}
+              withdrawalTaxRate={newPension.withdrawalTaxRate}
               onPolicyTypeChange={(value: PolicyType | undefined) =>
                 // Functional update: the CPF branch also fires
                 // onCpfLifePlanChange in the same tick, and a stale-closure
@@ -666,6 +671,33 @@ const AssetsStep: React.FC<AssetsStepProps> = ({
               }
               onCpfPayoutStartAgeChange={(value) =>
                 setNewPension((prev) => ({ ...prev, payoutAge: value }))
+              }
+              onTaxTreatmentChange={(value) =>
+                setNewPension((prev) => ({ ...prev, taxTreatment: value }))
+              }
+              onEmployeeDeferralPercentChange={(value) =>
+                setNewPension((prev) => ({
+                  ...prev,
+                  employeeDeferralPercent: value,
+                }))
+              }
+              onEmployerMatchPercentChange={(value) =>
+                setNewPension((prev) => ({
+                  ...prev,
+                  employerMatchPercent: value,
+                }))
+              }
+              onEmployerMatchCapPercentChange={(value) =>
+                setNewPension((prev) => ({
+                  ...prev,
+                  employerMatchCapPercent: value,
+                }))
+              }
+              onWithdrawalTaxRateChange={(value) =>
+                setNewPension((prev) => ({
+                  ...prev,
+                  withdrawalTaxRate: value,
+                }))
               }
             />
 

--- a/src/hooks/useStandaloneCompositeAssets.ts
+++ b/src/hooks/useStandaloneCompositeAssets.ts
@@ -49,6 +49,9 @@ const CONFIGS_KEY = "/api/assets/config"
 // a server-side lookup (deferred — empty string forces the caller to handle).
 const POLICY_CURRENCY: Record<string, string> = {
   CPF: "SGD",
+  US_401K: "USD",
+  US_IRA: "USD",
+  UK_ISA: "GBP",
 }
 
 /**

--- a/src/pages/assets/account.tsx
+++ b/src/pages/assets/account.tsx
@@ -7,6 +7,7 @@ import {
   CurrencyOption,
   PolicyType,
   SubAccountRequest,
+  TaxTreatment,
 } from "types/beancounter"
 import { ccyKey, categoriesKey, simpleFetcher } from "@utils/api/fetchHelper"
 import { useRouter } from "next/router"
@@ -81,6 +82,21 @@ export default withPageAuthRequired(
       "STANDARD" | "BASIC" | "ESCALATING" | undefined
     >(undefined)
     const [cpfPayoutStartAge, setCpfPayoutStartAge] = useState<
+      number | undefined
+    >(undefined)
+    const [taxTreatment, setTaxTreatment] = useState<TaxTreatment | undefined>(
+      undefined,
+    )
+    const [employeeDeferralPercent, setEmployeeDeferralPercent] = useState<
+      number | undefined
+    >(undefined)
+    const [employerMatchPercent, setEmployerMatchPercent] = useState<
+      number | undefined
+    >(undefined)
+    const [employerMatchCapPercent, setEmployerMatchCapPercent] = useState<
+      number | undefined
+    >(undefined)
+    const [withdrawalTaxRate, setWithdrawalTaxRate] = useState<
       number | undefined
     >(undefined)
 
@@ -264,6 +280,24 @@ export default withPageAuthRequired(
                       if (cpfPayoutStartAge != null) {
                         configPayload.cpfPayoutStartAge = cpfPayoutStartAge
                       }
+                      if (taxTreatment) {
+                        configPayload.taxTreatment = taxTreatment
+                      }
+                      if (employeeDeferralPercent != null) {
+                        configPayload.employeeDeferralPercent =
+                          employeeDeferralPercent
+                      }
+                      if (employerMatchPercent != null) {
+                        configPayload.employerMatchPercent =
+                          employerMatchPercent
+                      }
+                      if (employerMatchCapPercent != null) {
+                        configPayload.employerMatchCapPercent =
+                          employerMatchCapPercent
+                      }
+                      if (withdrawalTaxRate != null) {
+                        configPayload.withdrawalTaxRate = withdrawalTaxRate
+                      }
                     }
 
                     await fetch(`/api/assets/config/${createdAsset.id}`, {
@@ -413,11 +447,21 @@ export default withPageAuthRequired(
                 subAccounts={subAccounts}
                 cpfLifePlan={cpfLifePlan}
                 cpfPayoutStartAge={cpfPayoutStartAge}
+                taxTreatment={taxTreatment}
+                employeeDeferralPercent={employeeDeferralPercent}
+                employerMatchPercent={employerMatchPercent}
+                employerMatchCapPercent={employerMatchCapPercent}
+                withdrawalTaxRate={withdrawalTaxRate}
                 onPolicyTypeChange={setPolicyType}
                 onLockedUntilDateChange={setLockedUntilDate}
                 onSubAccountsChange={setSubAccounts}
                 onCpfLifePlanChange={setCpfLifePlan}
                 onCpfPayoutStartAgeChange={setCpfPayoutStartAge}
+                onTaxTreatmentChange={setTaxTreatment}
+                onEmployeeDeferralPercentChange={setEmployeeDeferralPercent}
+                onEmployerMatchPercentChange={setEmployerMatchPercent}
+                onEmployerMatchCapPercentChange={setEmployerMatchCapPercent}
+                onWithdrawalTaxRateChange={setWithdrawalTaxRate}
               />
 
               <p className="text-xs text-gray-500 mt-4">

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -493,21 +493,14 @@ interface Registration {
 }
 
 export type HoldingsView =
-  | "SUMMARY"
-  | "TABLE"
-  | "CARDS"
-  | "HEATMAP"
-  | "ALLOCATION"
+  "SUMMARY" | "TABLE" | "CARDS" | "HEATMAP" | "ALLOCATION"
 
 // Type aliases for UserPreferences - runtime values defined in types/constants.ts
 export type ValueInOption = "PORTFOLIO" | "BASE" | "TRADE"
 
 // Backend GroupBy API values (enum names as persisted in the database)
 export type GroupByApiValue =
-  | "ASSET_CLASS"
-  | "SECTOR"
-  | "MARKET_CURRENCY"
-  | "MARKET"
+  "ASSET_CLASS" | "SECTOR" | "MARKET_CURRENCY" | "MARKET"
 
 // Frontend GroupBy property paths (used for client-side grouping)
 export type GroupByOption =
@@ -796,7 +789,16 @@ export interface AssetHoldingsResponse {
 /**
  * Type of composite policy asset.
  */
-export type PolicyType = "CPF" | "ILP" | "GENERIC"
+export type PolicyType =
+  "CPF" | "ILP" | "GENERIC" | "US_401K" | "US_IRA" | "UK_ISA"
+
+/**
+ * Tax treatment for a composite policy asset. Determines whether projected
+ * withdrawals are taxed (TRADITIONAL), tax-free (ROTH / TAX_FREE), or net of
+ * a configured withdrawal tax rate. US_401K/US_IRA default TRADITIONAL when
+ * omitted; UK_ISA is always TAX_FREE.
+ */
+export type TaxTreatment = "TRADITIONAL" | "ROTH" | "TAX_FREE"
 
 /**
  * Sub-account within a composite policy asset (e.g. CPF OA/SA/MA/RA, ILP funds).
@@ -867,6 +869,14 @@ export interface PrivateAssetConfig {
   // CPF LIFE settings
   cpfLifePlan?: "STANDARD" | "BASIC" | "ESCALATING"
   cpfPayoutStartAge?: number
+  // US 401(k)/IRA + UK ISA wrapper settings. Decimals (e.g. 0.06 = 6%).
+  // Omitted taxTreatment defaults to TRADITIONAL for US_401K/US_IRA and
+  // TAX_FREE for UK_ISA.
+  taxTreatment?: TaxTreatment
+  employeeDeferralPercent?: number
+  employerMatchPercent?: number
+  employerMatchCapPercent?: number
+  withdrawalTaxRate?: number
   // Timestamps
   createdDate: string
   updatedDate: string
@@ -903,6 +913,12 @@ export interface PrivateAssetConfigRequest {
   // CPF LIFE settings
   cpfLifePlan?: "STANDARD" | "BASIC" | "ESCALATING"
   cpfPayoutStartAge?: number
+  // US 401(k)/IRA + UK ISA wrapper settings. Decimals (e.g. 0.06 = 6%).
+  taxTreatment?: TaxTreatment
+  employeeDeferralPercent?: number
+  employerMatchPercent?: number
+  employerMatchCapPercent?: number
+  withdrawalTaxRate?: number
 }
 
 export interface PrivateAssetConfigResponse {
@@ -1149,10 +1165,7 @@ export interface MonthlyIncomeResponse {
 
 export type ShareAccessLevel = "VIEW" | "FULL"
 export type ShareStatus =
-  | "PENDING_CLIENT_INVITE"
-  | "PENDING_ADVISER_REQUEST"
-  | "ACTIVE"
-  | "REVOKED"
+  "PENDING_CLIENT_INVITE" | "PENDING_ADVISER_REQUEST" | "ACTIVE" | "REVOKED"
 
 export interface PortfolioShare {
   id: string

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -439,6 +439,10 @@ export interface YearlyAccumulation {
   totalWealth: number
   /** Currency code */
   currency: string
+  /** Portion of endingBalance held in tax-advantaged wrappers (401(k)/IRA/ISA
+   * sub-accounts) whose withdrawal tax treatment differs from the rest of the
+   * balance. Undefined/null when no wrapper configs exist for the plan. */
+  shieldedValue?: number
 }
 
 /** Breakdown of income sources for a projection year */


### PR DESCRIPTION
Closes #1087. Frontend slice of the US 401(k)/IRA + UK ISA feature (monowai/beancounter#1033 schema + monowai/svc-retire#156 engine — merge those first; this PR only sends fields the backend already accepts).

- `PolicyType` += `US_401K | US_IRA | UK_ISA`; `TaxTreatment` type; 5 wrapper fields on `PrivateAssetConfig`/`Request`; `YearlyAccumulation.shieldedValue?`
- `POLICY_CURRENCY`: 401k/IRA → USD, ISA → GBP
- `CompositeAssetEditor`: single Balance sub-account template; Retirement Wrapper Settings panel (US only) — Traditional/Roth radio, deferral/match/cap %, withdrawal-tax % hidden for Roth; UK ISA forces TAX_FREE internally, no tax panel; field-clearing on type switch prevents stale leaks
- Wrapper props threaded through EditAccountDialog, assets/account.tsx, OnboardingWizard + both AssetsSteps
- Percent fields follow the expectedReturnRate convention (decimal-stored, percent-displayed)
- Generic branches verified correct untouched: PensionProjectionPanel, ScenarioContributions, ExistingRetirementAccounts, PayslipModal
- Tests: 5 new editor specs (RED-first), 7 existing CPF specs unchanged; 218 suites / 2097 tests green