### PR TITLE
feat(holdings): earmarked cash display on card and table

### DIFF
--- a/src/components/features/holdings/CardView.tsx
+++ b/src/components/features/holdings/CardView.tsx
@@ -447,6 +447,24 @@ const PositionCard: React.FC<PositionCardProps> = ({
           <FormatValue value={marketValue} />
         </div>
         <div className="text-sm text-gray-500">Current Value</div>
+        {values.earmarked !== 0 && (
+          <div className="mt-1 text-sm text-muted-foreground">
+            <div className="flex justify-between">
+              <span className="text-xs">Earmarked</span>
+              <span>
+                {currencySymbol}
+                <FormatValue value={convert(values.earmarked)} />
+              </span>
+            </div>
+            <div className="flex justify-between font-medium">
+              <span className="text-xs">Nominal</span>
+              <span>
+                {currencySymbol}
+                <FormatValue value={marketValue + convert(values.earmarked)} />
+              </span>
+            </div>
+          </div>
+        )}
       </div>
 
       <PositionPnL

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -422,10 +422,30 @@ export default function Rows({
               </span>
             </td>
             <td className={getCellClasses(5)}>
-              <ResponsiveFormatValue
-                value={convert(moneyValues[valueIn].marketValue)}
-                defaultValue="0"
-              />
+              {moneyValues[valueIn].earmarked !== 0 ? (
+                <span className="relative group cursor-help">
+                  <ResponsiveFormatValue
+                    value={convert(moneyValues[valueIn].marketValue)}
+                    defaultValue="0"
+                  />
+                  <span className="absolute right-0 transform -translate-y-full mb-1 bg-slate-800 text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none whitespace-nowrap z-50 shadow-lg">
+                    Current {effectiveCurrencySymbol}
+                    {convert(moneyValues[valueIn].marketValue).toFixed(2)} +
+                    Earmarked {effectiveCurrencySymbol}
+                    {convert(moneyValues[valueIn].earmarked).toFixed(2)} =
+                    Nominal {effectiveCurrencySymbol}
+                    {(
+                      convert(moneyValues[valueIn].marketValue) +
+                      convert(moneyValues[valueIn].earmarked)
+                    ).toFixed(2)}
+                  </span>
+                </span>
+              ) : (
+                <ResponsiveFormatValue
+                  value={convert(moneyValues[valueIn].marketValue)}
+                  defaultValue="0"
+                />
+              )}
             </td>
             <td className={getCellClasses(6)}>
               {!isCashRelated(asset) && (

--- a/src/lib/utils/holdings/calculateHoldings.ts
+++ b/src/lib/utils/holdings/calculateHoldings.ts
@@ -127,6 +127,7 @@ function zeroMoneyValues(currency: Currency, valueIn: ValueIn): MoneyValues {
     unrealisedGain: 0,
     fees: 0,
     cash: 0,
+    earmarked: 0,
     purchases: 0,
     sales: 0,
     tax: 0,

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -142,6 +142,8 @@ export interface MoneyValues {
   fees: number
   tax: number
   cash: number // separate out cash into its own bucket
+  /** Cash reserved for pending/unsettled settlement; marketValue + earmarked = nominal */
+  earmarked: number
   purchases: number
   sales: number
   costBasis: number


### PR DESCRIPTION
Show earmarked cash (pending settlement) on holdings views:
- Card: Current / Earmarked / Nominal sub-lines when earmarked != 0
- Table: hover tooltip with breakdown when earmarked != 0
- Hidden entirely when earmarked === 0 (non-cash, most holdings)

Backed by MoneyValues.earmarked (signed; marketValue + earmarked = nominal).

Also adds earmarked: 0 to zeroMoneyValues() in calculateHoldings.ts to satisfy the required type field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)