### PR TITLE
feat(nav): merge Brokers and Open Brokerage into one Tools entry

### DIFF
--- a/__tests__/pages/brokers/index.test.tsx
+++ b/__tests__/pages/brokers/index.test.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import Brokers from "@pages/brokers"
+
+// Cast to any since withPageAuthRequired HOC strips prop types in v4
+const BrokersPage = Brokers as React.ComponentType<any>
+
+const mockPush = jest.fn()
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: jest.fn(),
+  }),
+}))
+
+jest.mock("@hooks/useBrokers", () => ({
+  useBrokers: () => ({
+    brokers: [],
+    accountAssets: [],
+    error: undefined,
+    isLoading: false,
+    saveBroker: jest.fn(),
+    deleteBroker: jest.fn(),
+    transferTransactions: jest.fn(),
+  }),
+}))
+
+describe("Brokers Page", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("offers Open Brokerage from the page header", () => {
+    render(<BrokersPage />)
+    const button = screen.getByRole("button", { name: /Open Brokerage/i })
+    fireEvent.click(button)
+    expect(mockPush).toHaveBeenCalledWith("/tools/open-brokerage")
+  })
+})

--- a/src/components/layout/HeaderBrand.tsx
+++ b/src/components/layout/HeaderBrand.tsx
@@ -30,7 +30,8 @@ interface NavSection {
 }
 
 // Main nav: core domain actions only.
-// Settings, Brokers, Admin live in the user menu (HeaderUserControls).
+// Settings and Admin live in the user menu (HeaderUserControls).
+// Brokers (incl. Open Brokerage, reachable from /brokers) lives under Tools.
 const navSections: NavSection[] = [
   {
     title: "Wealth",
@@ -79,11 +80,7 @@ const navSections: NavSection[] = [
         icon: "fa-money-check-dollar",
         action: "payslip",
       },
-      {
-        href: "/tools/open-brokerage",
-        label: "Open Brokerage",
-        icon: "fa-building-columns",
-      },
+      { href: "/brokers", label: "Brokers", icon: "fa-building" },
       {
         href: "/tools/cost-stack",
         label: "Cost Stack",

--- a/src/components/layout/HeaderUserControls.tsx
+++ b/src/components/layout/HeaderUserControls.tsx
@@ -27,7 +27,6 @@ function Avatar({
 const userMenuLinks: { href: string; label: string; icon: string }[] = [
   { href: "/settings", label: "Settings", icon: "fa-cog" },
   { href: "/milestones", label: "Milestones", icon: "fa-trophy" },
-  { href: "/brokers", label: "Brokers", icon: "fa-building" },
   { href: "/shares", label: "Shares", icon: "fa-share-alt" },
 ]
 

--- a/src/components/layout/__tests__/HeaderBrand.test.tsx
+++ b/src/components/layout/__tests__/HeaderBrand.test.tsx
@@ -61,6 +61,16 @@ describe("HeaderBrand", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("Tools dropdown has a single Brokers entry (Open Brokerage lives on /brokers)", () => {
+    render(<HeaderBrand />)
+    fireEvent.click(screen.getByRole("button", { name: /^Tools/i }))
+    const brokers = screen.getByRole("link", { name: /Brokers/i })
+    expect(brokers).toHaveAttribute("href", "/brokers")
+    expect(
+      screen.queryByRole("link", { name: /Open Brokerage/i }),
+    ).not.toBeInTheDocument()
+  })
+
   it("Tools dropdown includes Cost Stack link", () => {
     render(<HeaderBrand />)
     fireEvent.click(screen.getByRole("button", { name: /^Tools/i }))

--- a/src/pages/brokers/index.tsx
+++ b/src/pages/brokers/index.tsx
@@ -200,6 +200,14 @@ export default withPageAuthRequired(function Brokers(): React.ReactElement {
             </div>
             <div className="flex space-x-2">
               <button
+                className="bg-purple-500 text-white py-2 px-4 rounded-lg hover:bg-purple-600 transition-colors flex items-center shadow-sm"
+                onClick={() => router.push("/tools/open-brokerage")}
+                title={"Open Brokerage"}
+              >
+                <i className="fas fa-building-columns mr-2"></i>
+                <span className="hidden sm:inline">{"Open Brokerage"}</span>
+              </button>
+              <button
                 className="bg-green-500 text-white py-2 px-4 rounded-lg hover:bg-green-600 transition-colors flex items-center shadow-sm"
                 onClick={() => router.push("/brokers/NO_BROKER/holdings")}
                 title={"Reconcile Holdings"}


### PR DESCRIPTION
## Why

PR #1086 (group Brokers under Tools) was merged against `graphite-base/1086` instead of `main`, so it never landed — and it kept Brokers and Open Brokerage as two separate menu items anyway. The intent was a single entry.

## What

- **Nav**: one `Brokers` item under Tools (`/brokers`). `Open Brokerage` removed from the Tools menu; `Brokers` removed from the user menu.
- **/brokers page**: new `Open Brokerage` header button that routes to `/tools/open-brokerage`, alongside Reconcile Holdings / Add Broker.

## Tests

- `HeaderBrand.test.tsx`: Tools dropdown has a single Brokers entry and no Open Brokerage link.
- `__tests__/pages/brokers/index.test.tsx` (new): page header offers Open Brokerage and routes to the wizard.
- Full suite: 219 suites / 2099 tests green; prettier, eslint, typecheck clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018S9bnhfJ6CUiCExUhLKJnV
