### PR TITLE
feat(nav): merge Brokers and Open Brokerage into one Tools entry

### DIFF
--- a/__tests__/components/features/brokers/WeightedSellDialog.test.tsx
+++ b/__tests__/components/features/brokers/WeightedSellDialog.test.tsx
@@ -102,6 +102,23 @@ describe("WeightedSellDialog", () => {
     expect(screen.getByText("Across all brokers: 96")).toBeInTheDocument()
   })
 
+  it("defaults 'Percent to sell' to 100", async () => {
+    render(
+      <WeightedSellDialog
+        open={true}
+        onClose={jest.fn()}
+        brokerId="broker-1"
+        brokerName="Interactive Brokers"
+        holding={holding}
+        onSubmitted={jest.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Percent to sell")).toHaveValue(100),
+    )
+  })
+
   it("computes sell quantities for 50% correctly", async () => {
     render(
       <WeightedSellDialog
@@ -119,8 +136,11 @@ describe("WeightedSellDialog", () => {
       expect(screen.getByLabelText("Price")).toHaveValue(420.5),
     )
 
-    // Default percent is 50 -> 100 * 0.5 = 50, 75 * 0.5 = 37.5 which
-    // rounds to 38 under the default board lot of 1 (whole shares).
+    // 50% -> 100 * 0.5 = 50, 75 * 0.5 = 37.5 which rounds to 38 under the
+    // default board lot of 1 (whole shares).
+    fireEvent.change(screen.getByLabelText("Percent to sell"), {
+      target: { value: "50" },
+    })
     expect(screen.getByText("50")).toBeInTheDocument()
     expect(screen.getByText("38")).toBeInTheDocument()
   })
@@ -161,6 +181,9 @@ describe("WeightedSellDialog", () => {
       expect(screen.getByLabelText("Price")).toHaveValue(420.5),
     )
 
+    fireEvent.change(screen.getByLabelText("Percent to sell"), {
+      target: { value: "50" },
+    })
     // 69 * 0.5 = 34.5 -> 35 (never 34.5); 18 * 0.5 = 9
     expect(screen.getByText("35")).toBeInTheDocument()
     expect(screen.queryByText("34.5")).not.toBeInTheDocument()
@@ -201,6 +224,9 @@ describe("WeightedSellDialog", () => {
       expect(screen.getByLabelText("Price")).toHaveValue(420.5),
     )
 
+    fireEvent.change(screen.getByLabelText("Percent to sell"), {
+      target: { value: "50" },
+    })
     expect(screen.getByText("34.5")).toBeInTheDocument()
   })
 
@@ -281,6 +307,9 @@ describe("WeightedSellDialog", () => {
       expect(screen.getByLabelText("Price")).toHaveValue(420.5),
     )
 
+    fireEvent.change(screen.getByLabelText("Percent to sell"), {
+      target: { value: "50" },
+    })
     fireEvent.click(screen.getByRole("button", { name: /propose 2 sells/i }))
 
     await waitFor(() => expect(onSubmitted).toHaveBeenCalled())

--- a/src/components/features/brokers/WeightedSellDialog.tsx
+++ b/src/components/features/brokers/WeightedSellDialog.tsx
@@ -40,7 +40,7 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
   holding,
   onSubmitted,
 }) => {
-  const [percent, setPercent] = useState<string>("50")
+  const [percent, setPercent] = useState<string>("100")
   const [price, setPrice] = useState<string>("")
   const [tradeDate, setTradeDate] = useState<string>(todayIso())
   const [isFetchingPrice, setIsFetchingPrice] = useState(false)
@@ -59,7 +59,7 @@ const WeightedSellDialog: React.FC<WeightedSellDialogProps> = ({
   if (openKey !== resetKey) {
     setResetKey(openKey)
     if (open) {
-      setPercent("50")
+      setPercent("100")
       setPrice("")
       setTradeDate(todayIso())
       reset()


### PR DESCRIPTION
## Problem

In the Brokerage per-broker holdings view, the **Weighted Sell** dialog defaulted "Percent to sell" to **50%**. Selling out a whole broker position (the common case) always required a manual edit to 100.

## Fix

Default the percent to **100** (sell the full holding). Partial sells simply dial it back.

`WeightedSellDialog.tsx` — initial and per-open reset value `"50"` → `"100"`.

## Tests

- New: `defaults 'Percent to sell' to 100`.
- The three rounding tests and the propose-contract test now set the percent explicitly (they exercise rounding math, not the default), so they stay valid independent of the default.
- Full `jest` suite green; `typecheck` clean; changed files `eslint`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QxrM8N6CNm221DVaC55TN
