### PR TITLE
fix(holdings): weigh trade-currency price against base portfolio value

### DIFF
--- a/src/components/features/holdings/ActionsMenus.tsx
+++ b/src/components/features/holdings/ActionsMenus.tsx
@@ -145,6 +145,9 @@ export interface ActionsMenuProps {
   tradeCurrency: { code: string; symbol: string; name: string }
   valueIn: string
   held?: Record<string, number>
+  /** Trade-currency -> portfolio base-currency rate for the trade dialog's
+   * weight/target-sizing maths. Omitted for same-currency holdings. */
+  fxRate?: number
   onTrade?: (data: QuickSellData) => void
   onQuickSell?: (data: QuickSellData) => void
   onCorporateActions?: (data: CorporateActionsData) => void
@@ -171,6 +174,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
   costBasis,
   tradeCurrency,
   held,
+  fxRate,
   onTrade,
   onQuickSell,
   onCorporateActions,
@@ -195,6 +199,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
     quantity,
     price,
     held,
+    fxRate,
   })
 
   const handle =

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -43,6 +43,7 @@ import {
   CorporateActionsData,
   SectorWeightingsData,
 } from "./ActionsMenus"
+import { deriveTradeToBaseFxRate } from "@lib/trns/tradeFormHelpers"
 import { COPYABLE_HOLDING_COLUMNS } from "./constants"
 
 export type { CorporateActionsData, SectorWeightingsData }
@@ -217,6 +218,7 @@ export default function Rows({
                       }
                       valueIn={valueIn}
                       held={held}
+                      fxRate={deriveTradeToBaseFxRate(moneyValues)}
                       onTrade={isCashRelated(asset) ? undefined : onTrade}
                       onQuickSell={
                         isCashRelated(asset) ? undefined : onQuickSell

--- a/src/components/features/holdings/__tests__/QuickSell.test.tsx
+++ b/src/components/features/holdings/__tests__/QuickSell.test.tsx
@@ -109,6 +109,7 @@ describe("Quick Sell Feature via Actions Menu", () => {
         quantity: 100,
         price: 150,
         held: undefined,
+        fxRate: 1,
       })
     })
 
@@ -194,6 +195,8 @@ describe("Quick Sell Feature via Actions Menu", () => {
         market: "NASDAQ",
         quantity: 100,
         price: 150,
+        held: undefined,
+        fxRate: 1,
       })
     })
 

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -345,6 +345,10 @@ const TradeInputForm: React.FC<{
   // Weight basis: aggregate market value when supplied (aggregated view),
   // otherwise the single portfolio's own market value.
   const weightBasis = weightBasisMarketValue ?? portfolio.marketValue
+  // `price` is the asset's trade currency but `weightBasis` is base currency.
+  // fxRate (trade->base) reconciles them so weights/target-sizing are correct
+  // for foreign-currency holdings. Defaults to 1 for same-currency positions.
+  const fxRate = initialValues?.fxRate ?? 1
   // Available quantity to trade. When a broker is selected and per-broker
   // holdings are known, this is what THAT broker holds (split-adjusted), not
   // the whole-holding total.
@@ -368,8 +372,8 @@ const TradeInputForm: React.FC<{
   const currentPositionWeight = useMemo(
     () =>
       currentWeightOverride ??
-      computeCurrentPositionWeight(positionQty, price, weightBasis),
-    [currentWeightOverride, positionQty, price, weightBasis],
+      computeCurrentPositionWeight(positionQty, price, weightBasis, fxRate),
+    [currentWeightOverride, positionQty, price, weightBasis, fxRate],
   )
 
   const actualPositionQuantity = positionQty
@@ -387,6 +391,7 @@ const TradeInputForm: React.FC<{
       currentPositionWeight,
       price,
       weightBasis,
+      fxRate,
     )
     if (!result) return
     setValue("quantity", result.quantity)
@@ -403,9 +408,10 @@ const TradeInputForm: React.FC<{
             parseFloat(targetWeight),
             price,
             weightBasis,
+            fxRate,
           )
         : null,
-    [currentPositionWeight, targetWeight, price, weightBasis],
+    [currentPositionWeight, targetWeight, price, weightBasis, fxRate],
   )
   const canTargetNewPositionWeight =
     currentPositionWeight === null && price > 0 && weightBasis > 0
@@ -419,6 +425,7 @@ const TradeInputForm: React.FC<{
       parseFloat(newTargetWeight),
       price,
       weightBasis,
+      fxRate,
     )
     if (!result) return
     setValue("quantity", result.quantity)
@@ -514,6 +521,7 @@ const TradeInputForm: React.FC<{
         tradeType: type.value,
         portfolioMarketValue: weightBasis,
         actualPositionQuantity,
+        fxRate,
       }),
     [
       quantity,
@@ -523,6 +531,7 @@ const TradeInputForm: React.FC<{
       weightBasis,
       type.value,
       actualPositionQuantity,
+      fxRate,
     ],
   )
 

--- a/src/lib/utils/trns/tradeFormHelpers.test.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.test.ts
@@ -17,6 +17,7 @@ import {
   resolveSellableQuantity,
   heldQuantityForBroker,
   singleHeldBrokerId,
+  deriveTradeToBaseFxRate,
 } from "./tradeFormHelpers"
 import { Transaction } from "types/beancounter"
 
@@ -159,6 +160,52 @@ describe("tradeFormHelpers", () => {
       // tradeAmount = 10 * 100 + 10 = 1010
       expect(result!.value).toBeCloseTo(10.1, 1)
     })
+
+    test("weights a foreign-currency BUY against a base-converted price", () => {
+      // BUY, no existing position: trade weight = qty*priceBase / base PV.
+      // priceBase = 100 * 2 = 200; tradeAmount = 10*200 = 2000; 2000/10000 = 20%.
+      const result = computeWeightInfo({
+        quantity: 10,
+        price: 100,
+        tax: 0,
+        fees: 0,
+        tradeType: "BUY",
+        portfolioMarketValue: 10000,
+        actualPositionQuantity: 0,
+        fxRate: 2,
+      })
+      expect(result).toEqual({ label: "Trade Weight", value: 20 })
+    })
+  })
+
+  describe("deriveTradeToBaseFxRate", () => {
+    test("returns base/trade market value ratio", () => {
+      expect(
+        deriveTradeToBaseFxRate({
+          TRADE: { marketValue: 8860.25 },
+          BASE: { marketValue: 11451.98 },
+        }),
+      ).toBeCloseTo(1.2925, 4)
+    })
+
+    test("returns 1 when trade market value is zero or missing", () => {
+      expect(
+        deriveTradeToBaseFxRate({
+          TRADE: { marketValue: 0 },
+          BASE: { marketValue: 100 },
+        }),
+      ).toBe(1)
+      expect(deriveTradeToBaseFxRate({ BASE: { marketValue: 100 } })).toBe(1)
+    })
+
+    test("returns 1 for same-currency holdings (equal values)", () => {
+      expect(
+        deriveTradeToBaseFxRate({
+          TRADE: { marketValue: 5000 },
+          BASE: { marketValue: 5000 },
+        }),
+      ).toBe(1)
+    })
   })
 
   describe("computeCurrentPositionWeight", () => {
@@ -176,6 +223,20 @@ describe("tradeFormHelpers", () => {
 
     test("returns null when portfolioMarketValue is 0", () => {
       expect(computeCurrentPositionWeight(100, 10, 0)).toBeNull()
+    })
+
+    test("converts trade-currency price to base via fxRate before weighting", () => {
+      // Numerator (qty*price) is in the asset's trade currency; the
+      // portfolioMarketValue denominator is in the portfolio's base currency.
+      // fxRate (trade->base) must be applied so both sides share a currency.
+      // 100 * 10 * 2 = 2000 base / 10000 base = 20%.
+      expect(computeCurrentPositionWeight(100, 10, 10000, 2)).toBe(20)
+    })
+
+    test("fxRate defaults to 1 (same-currency, unchanged behaviour)", () => {
+      expect(computeCurrentPositionWeight(100, 10, 10000)).toBe(
+        computeCurrentPositionWeight(100, 10, 10000, 1),
+      )
     })
   })
 
@@ -203,6 +264,15 @@ describe("tradeFormHelpers", () => {
 
     test("returns null for NaN target weight", () => {
       expect(calculateQuantityFromTargetWeight(NaN, 5, 10, 10000)).toBeNull()
+    })
+
+    test("divides the base-currency value diff by the base-converted price", () => {
+      // target 15% and current 10% are base-currency weights of a base PV.
+      // The required-share count must divide the base value diff by the price
+      // expressed in base currency (price * fxRate), not the raw trade price.
+      // diff = 500 base; priceBase = 10 * 2 = 20; shares = round(500/20) = 25.
+      const result = calculateQuantityFromTargetWeight(15, 10, 10, 10000, 2)
+      expect(result).toEqual({ quantity: 25, tradeType: "BUY" })
     })
   })
 
@@ -256,6 +326,25 @@ describe("tradeFormHelpers", () => {
       expect(
         calculateNewPositionQuantityFromTargetWeight(NaN, 10, 10000),
       ).toBeNull()
+    })
+
+    test("sizes a foreign-currency new position using the base-converted price", () => {
+      // PV (base) = 30000, want 70%. Target base value V = 0.7*30000/0.3 = 70000.
+      // priceBase = 10 * 2 = 20; qty = round(70000/20) = 3500;
+      // nominal = 30000 + 3500*20 = 100000. Realised weight lands on 70%.
+      const result = calculateNewPositionQuantityFromTargetWeight(
+        70,
+        10,
+        30000,
+        2,
+      )
+      expect(result).toEqual({
+        quantity: 3500,
+        tradeType: "BUY",
+        nominalPortfolioValue: 100000,
+      })
+      const { quantity, nominalPortfolioValue } = result!
+      expect(((quantity * 20) / nominalPortfolioValue) * 100).toBeCloseTo(70, 5)
     })
   })
 

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -29,6 +29,10 @@ export interface ComputeWeightInfoParams {
   tradeType: string
   portfolioMarketValue: number
   actualPositionQuantity: number
+  // Trade-currency -> portfolio base-currency rate. `price` is in the asset's
+  // trade currency but `portfolioMarketValue` is base currency, so the price
+  // is converted before weighing the two together. Defaults to 1 (same ccy).
+  fxRate?: number
 }
 
 /**
@@ -46,13 +50,16 @@ export const computeWeightInfo = (
     tradeType,
     portfolioMarketValue,
     actualPositionQuantity,
+    fxRate = 1,
   } = params
 
   if (!quantity || !price || !portfolioMarketValue) return null
 
+  // Weight is a base-currency ratio, so express the trade price in base ccy.
+  const priceInBase = price * fxRate
   const tradeAmount = calculateTradeAmount(
     quantity,
-    price,
+    priceInBase,
     tax,
     fees,
     tradeType,
@@ -62,7 +69,7 @@ export const computeWeightInfo = (
     const newWeight = calculateNewPositionWeight(
       actualPositionQuantity,
       quantity,
-      price,
+      priceInBase,
       portfolioMarketValue,
     )
     const tradeWeight = calculateTradeWeight(tradeAmount, portfolioMarketValue)
@@ -70,7 +77,7 @@ export const computeWeightInfo = (
   }
 
   if (tradeType === "BUY" && actualPositionQuantity > 0) {
-    const currentPositionValue = actualPositionQuantity * price
+    const currentPositionValue = actualPositionQuantity * priceInBase
     const newPositionValue = currentPositionValue + tradeAmount
     const newWeight = (newPositionValue / portfolioMarketValue) * 100
     const tradeWeight = calculateTradeWeight(tradeAmount, portfolioMarketValue)
@@ -91,6 +98,23 @@ export const computeWeightInfo = (
 }
 
 /**
+ * Derive the trade-currency -> portfolio base-currency FX rate for a position
+ * from its already-valued money buckets: base marketValue / trade marketValue.
+ * Both buckets value the same holding, so their ratio is the FX rate. Falls
+ * back to 1 (same currency / insufficient data) when either bucket is missing
+ * or the trade value is zero.
+ */
+export const deriveTradeToBaseFxRate = (moneyValues: {
+  TRADE?: { marketValue?: number }
+  BASE?: { marketValue?: number }
+}): number => {
+  const tradeValue = moneyValues.TRADE?.marketValue
+  const baseValue = moneyValues.BASE?.marketValue
+  if (!tradeValue || baseValue === undefined || baseValue === null) return 1
+  return baseValue / tradeValue
+}
+
+/**
  * Compute the current position weight as a percentage of portfolio value.
  * Returns null if any required value is missing or zero.
  */
@@ -98,9 +122,12 @@ export const computeCurrentPositionWeight = (
   positionQuantity: number,
   price: number,
   portfolioMarketValue: number,
+  fxRate = 1,
 ): number | null => {
   if (!positionQuantity || !price || !portfolioMarketValue) return null
-  const positionValue = positionQuantity * price
+  // `price` is trade currency; `portfolioMarketValue` is base currency.
+  // Convert so numerator and denominator share a currency.
+  const positionValue = positionQuantity * price * fxRate
   return (positionValue / portfolioMarketValue) * 100
 }
 
@@ -113,13 +140,15 @@ export const calculateQuantityFromTargetWeight = (
   currentPositionWeight: number,
   price: number,
   portfolioMarketValue: number,
+  fxRate = 1,
 ): { quantity: number; tradeType: "BUY" | "SELL" } | null => {
   if (isNaN(targetWeightPercent) || !price || !portfolioMarketValue) return null
 
   const targetValue = (targetWeightPercent / 100) * portfolioMarketValue
   const currentValue = (currentPositionWeight / 100) * portfolioMarketValue
   const valueDiff = targetValue - currentValue
-  const requiredShares = Math.round(Math.abs(valueDiff) / price)
+  // valueDiff is base currency; divide by the base-converted price for shares.
+  const requiredShares = Math.round(Math.abs(valueDiff) / (price * fxRate))
 
   return {
     quantity: requiredShares,
@@ -140,6 +169,7 @@ export const calculateNewPositionQuantityFromTargetWeight = (
   targetWeightPercent: number,
   price: number,
   portfolioMarketValue: number,
+  fxRate = 1,
 ): {
   quantity: number
   tradeType: "BUY"
@@ -157,13 +187,16 @@ export const calculateNewPositionQuantityFromTargetWeight = (
 
   const w = targetWeightPercent / 100
   const targetValue = (w * portfolioMarketValue) / (1 - w)
+  // targetValue and portfolioMarketValue are base currency; convert the trade
+  // price to base so the share count and nominal total stay currency-consistent.
+  const priceInBase = price * fxRate
   // Round (not floor) so we land on the nearest share to the target weight,
   // matching calculateQuantityFromTargetWeight and avoiding float undershoot.
-  const quantity = Math.round(targetValue / price)
+  const quantity = Math.round(targetValue / priceInBase)
   return {
     quantity,
     tradeType: "BUY",
-    nominalPortfolioValue: portfolioMarketValue + quantity * price,
+    nominalPortfolioValue: portfolioMarketValue + quantity * priceInBase,
   }
 }
 

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -29,6 +29,10 @@ export interface QuickSellData {
   type?: "BUY" | "SELL" | "INCOME" | "EXPENSE"
   currentPositionQuantity?: number // For rebalance: the current position size
   held?: Record<string, number> // Broker name -> quantity for broker selection
+  // Trade-currency -> portfolio base-currency rate, so the trade dialog can
+  // weigh a trade-currency price against the base-currency portfolio value.
+  // Omitted for same-currency holdings (treated as 1).
+  fxRate?: number
 }
 
 export interface RebalanceData {


### PR DESCRIPTION
## Problem
The invest/trade dialog showed a position's **Current Weight** that disagreed with the holdings page — e.g. 5.61% in the dialog vs 7.25% on the card for the same holding. The gap was exactly the position's FX rate.

Root cause: the dialog computed `qty × price / portfolio.marketValue`, but `price` is in the asset's **trade currency** while `portfolio.marketValue` is in the portfolio's **base currency**. The same mismatch skewed target-weight → share-count sizing.

## Fix
Thread a trade→base FX rate through the weight and target-sizing helpers so both sides share a currency. The rate is derived per position from its already-valued buckets: `moneyValues.BASE.marketValue / moneyValues.TRADE.marketValue`. It defaults to 1, so same-currency holdings are unchanged.

## Tests
- New unit tests for `fxRate` on `computeCurrentPositionWeight`, `calculateQuantityFromTargetWeight`, `calculateNewPositionQuantityFromTargetWeight`, `computeWeightInfo`, and `deriveTradeToBaseFxRate`.
- Full suite green (2105 tests); typecheck, eslint, prettier clean.

## Not covered
Not yet exercised in a running browser against a foreign-currency holding — math is unit-verified only.
