### PR TITLE
feat: export proposed trades as IBKR BasketTrader CSV

### DIFF
--- a/__tests__/lib/utils/ibkrBasket.test.ts
+++ b/__tests__/lib/utils/ibkrBasket.test.ts
@@ -1,0 +1,151 @@
+import { buildIbkrBasketCsv, ibkrBasketFilename } from "@lib/ibkrBasket"
+import { Transaction } from "types/beancounter"
+
+const HEADER =
+  "Action,Quantity,Symbol,SecType,Exchange,Currency,TimeInForce,OrderType,LmtPrice,BasketTag"
+
+const makeTrn = (overrides: Record<string, unknown> = {}): Transaction =>
+  ({
+    id: "trn-1",
+    callerRef: { provider: "BC", batch: "b1", callerId: "caller-1" },
+    trnType: "BUY",
+    status: "PROPOSED",
+    quantity: 10,
+    price: 5.25,
+    tradeCurrency: { code: "USD" },
+    asset: {
+      id: "asset-1",
+      code: "AAPL",
+      name: "Apple Inc",
+      market: { code: "NASDAQ" },
+    },
+    ...overrides,
+  }) as unknown as Transaction
+
+describe("buildIbkrBasketCsv", () => {
+  it("returns header only for empty input", () => {
+    expect(buildIbkrBasketCsv([])).toBe(HEADER)
+  })
+
+  it("emits the exact TWS header with no spaces after commas", () => {
+    const csv = buildIbkrBasketCsv([makeTrn()])
+    const lines = csv.split("\n")
+    expect(lines[0]).toBe(HEADER)
+    lines.forEach((line) => {
+      expect(line).not.toContain(", ")
+    })
+  })
+
+  it("maps BUY and SELL rows with LMT order when price is positive", () => {
+    const csv = buildIbkrBasketCsv([
+      makeTrn({ id: "t-buy", trnType: "BUY", quantity: 10, price: 5.25 }),
+      makeTrn({
+        id: "t-sell",
+        trnType: "SELL",
+        quantity: -4,
+        price: 100,
+        asset: {
+          id: "a2",
+          code: "VOD",
+          name: "Vodafone",
+          market: { code: "LON" },
+        },
+        tradeCurrency: { code: "GBP" },
+      }),
+    ])
+    const lines = csv.split("\n")
+    expect(lines).toHaveLength(3)
+    expect(lines[1]).toBe("BUY,10,AAPL,STK,SMART,USD,DAY,LMT,5.25,BC-t-buy")
+    expect(lines[2]).toBe("SELL,4,VOD,STK,LSE,GBP,DAY,LMT,100,BC-t-sell")
+  })
+
+  it("skips non-trade transaction types", () => {
+    const csv = buildIbkrBasketCsv([
+      makeTrn({ id: "t1", trnType: "DIVI" }),
+      makeTrn({ id: "t2", trnType: "FX_BUY" }),
+      makeTrn({ id: "t3", trnType: "DEPOSIT" }),
+      makeTrn({ id: "t4", trnType: "WITHDRAWAL" }),
+      makeTrn({ id: "t5", trnType: "SPLIT" }),
+      makeTrn({ id: "t6", trnType: "BALANCE" }),
+      makeTrn({ id: "t7", trnType: "BUY" }),
+    ])
+    const lines = csv.split("\n")
+    expect(lines).toHaveLength(2)
+    expect(lines[1]).toContain("BC-t7")
+  })
+
+  it("falls back to MKT with blank LmtPrice when price is missing or non-positive", () => {
+    const csv = buildIbkrBasketCsv([
+      makeTrn({ id: "t-null", price: null }),
+      makeTrn({ id: "t-zero", price: 0 }),
+      makeTrn({ id: "t-neg", price: -1 }),
+    ])
+    const lines = csv.split("\n")
+    expect(lines[1]).toBe("BUY,10,AAPL,STK,SMART,USD,DAY,MKT,,BC-t-null")
+    expect(lines[2]).toBe("BUY,10,AAPL,STK,SMART,USD,DAY,MKT,,BC-t-zero")
+    expect(lines[3]).toBe("BUY,10,AAPL,STK,SMART,USD,DAY,MKT,,BC-t-neg")
+  })
+
+  it.each([
+    ["NYSE", "SMART"],
+    ["NASDAQ", "SMART"],
+    ["US", "SMART"],
+    ["AMEX", "SMART"],
+    ["LON", "LSE"],
+    ["LSE", "LSE"],
+    ["ASX", "ASX"],
+    ["SGX", "SGX"],
+    ["NZX", "NZSE"],
+    ["TSX", "TSE"],
+    ["XETRA", "SMART"], // unmapped market falls back to SMART
+  ])("maps market %s to exchange %s", (market, exchange) => {
+    const csv = buildIbkrBasketCsv([
+      makeTrn({
+        asset: { id: "a", code: "X", name: "X", market: { code: market } },
+      }),
+    ])
+    expect(csv.split("\n")[1].split(",")[4]).toBe(exchange)
+  })
+
+  it("formats quantity as absolute plain decimal with trailing zeros stripped", () => {
+    const csv = buildIbkrBasketCsv([
+      makeTrn({ id: "t1", quantity: -12.5 }),
+      makeTrn({ id: "t2", quantity: 100.0 }),
+      makeTrn({ id: "t3", quantity: 0.123456 }),
+    ])
+    const lines = csv.split("\n")
+    expect(lines[1].split(",")[1]).toBe("12.5")
+    expect(lines[2].split(",")[1]).toBe("100")
+    expect(lines[3].split(",")[1]).toBe("0.123456")
+  })
+
+  it("uses callerRef.callerId in the BasketTag when id is absent", () => {
+    const csv = buildIbkrBasketCsv([
+      makeTrn({
+        id: undefined,
+        callerRef: { provider: "BC", batch: "b", callerId: "cr-9" },
+      }),
+    ])
+    expect(csv.split("\n")[1].split(",")[9]).toBe("BC-cr-9")
+  })
+
+  it("escapes symbol fields containing commas", () => {
+    const csv = buildIbkrBasketCsv([
+      makeTrn({
+        asset: {
+          id: "a",
+          code: "WEIRD,CODE",
+          name: "X",
+          market: { code: "NYSE" },
+        },
+      }),
+    ])
+    expect(csv.split("\n")[1]).toContain('"WEIRD,CODE"')
+  })
+})
+
+describe("ibkrBasketFilename", () => {
+  it("builds a dated filename", () => {
+    expect(ibkrBasketFilename("2026-07-10")).toBe("ibkr-basket-2026-07-10.csv")
+  })
+})

--- a/__tests__/pages/trns/proposedIbkrExport.test.tsx
+++ b/__tests__/pages/trns/proposedIbkrExport.test.tsx
@@ -1,0 +1,173 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    query: {},
+    isReady: true,
+  }),
+}))
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+  mutate: jest.fn(),
+}))
+
+jest.mock("@auth0/nextjs-auth0/client", () => ({
+  useUser: () => ({
+    user: { email: "test@example.com", sub: "auth0|test" },
+    error: null,
+    isLoading: false,
+  }),
+  withPageAuthRequired: (Component: React.ComponentType) => Component,
+}))
+
+jest.mock("@lib/csvExport", () => ({
+  ...jest.requireActual("@lib/csvExport"),
+  downloadCsv: jest.fn(),
+}))
+
+import useSWR from "swr"
+import { downloadCsv } from "@lib/csvExport"
+import ProposedTransactions from "@pages/trns/proposed"
+
+const brokers = [
+  { id: "b1", name: "Saxo" },
+  { id: "b2", name: "SCB" },
+]
+
+const makeTrn = (
+  id: string,
+  assetCode: string,
+  broker: { id: string; name: string },
+  trnType = "BUY",
+  price = 5,
+): Record<string, unknown> => ({
+  id,
+  trnType,
+  status: "PROPOSED",
+  quantity: 10,
+  price,
+  fees: 0,
+  tradeDate: "2026-07-08",
+  tradeCurrency: { code: "USD" },
+  portfolio: { id: "p1", code: "PF1", name: "Portfolio 1" },
+  asset: {
+    id: `asset-${assetCode}`,
+    code: assetCode,
+    name: `${assetCode} Inc`,
+    market: { code: "NYSE" },
+  },
+  broker,
+})
+
+const mockSwr = (trns: Record<string, unknown>[]): void => {
+  // Stable response objects: the page compares data identity between renders,
+  // so returning a fresh object per call would loop it forever.
+  const proposed = { data: { data: trns }, error: undefined, mutate: jest.fn() }
+  const brokerData = {
+    data: { data: brokers },
+    error: undefined,
+    mutate: jest.fn(),
+  }
+  const empty = { data: undefined, error: undefined, mutate: jest.fn() }
+  ;(useSWR as jest.Mock).mockImplementation((key: string | null) => {
+    if (typeof key === "string" && key.startsWith("/api/trns/proposed")) {
+      return proposed
+    }
+    if (key === "/api/brokers") {
+      return brokerData
+    }
+    return empty
+  })
+}
+
+describe("Proposed Transactions IBKR basket export", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockReturnValue({ matches: true }),
+    })
+  })
+
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("downloads the filtered BUY/SELL trns as an IBKR basket CSV", async () => {
+    mockSwr([
+      makeTrn("t1", "AAA", brokers[0], "BUY", 5),
+      makeTrn("t2", "BBB", brokers[1], "SELL", 7),
+      makeTrn("t3", "CCC", brokers[0], "DIVI", 1),
+    ])
+    render(<ProposedTransactions />)
+
+    await waitFor(() => {
+      expect(screen.getByText("AAA")).toBeInTheDocument()
+    })
+
+    const exportButton = screen.getByRole("button", {
+      name: /export ibkr basket/i,
+    })
+    expect(exportButton).toBeEnabled()
+    fireEvent.click(exportButton)
+
+    expect(downloadCsv).toHaveBeenCalledTimes(1)
+    const [filename, csv] = (downloadCsv as jest.Mock).mock.calls[0]
+    expect(filename).toMatch(/^ibkr-basket-\d{4}-\d{2}-\d{2}\.csv$/)
+    const lines = (csv as string).split("\n")
+    expect(lines[0]).toBe(
+      "Action,Quantity,Symbol,SecType,Exchange,Currency,TimeInForce,OrderType,LmtPrice,BasketTag",
+    )
+    // Only the BUY and SELL rows — DIVI is skipped
+    expect(lines).toHaveLength(3)
+    expect(csv).toContain("BUY,10,AAA,STK,SMART,USD,DAY,LMT,5,BC-t1")
+    expect(csv).toContain("SELL,10,BBB,STK,SMART,USD,DAY,LMT,7,BC-t2")
+    expect(csv).not.toContain("CCC")
+  })
+
+  it("respects the broker filter when exporting", async () => {
+    mockSwr([
+      makeTrn("t1", "AAA", brokers[0], "BUY"),
+      makeTrn("t2", "BBB", brokers[1], "SELL"),
+    ])
+    render(<ProposedTransactions />)
+
+    await waitFor(() => {
+      expect(screen.getByText("AAA")).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText("Broker filter"), {
+      target: { value: "b1" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /export ibkr basket/i }))
+
+    const [, csv] = (downloadCsv as jest.Mock).mock.calls[0]
+    expect(csv).toContain("AAA")
+    expect(csv).not.toContain("BBB")
+  })
+
+  it("is disabled when there are no exportable BUY/SELL trns", async () => {
+    mockSwr([makeTrn("t1", "DDD", brokers[0], "DIVI")])
+    render(<ProposedTransactions />)
+
+    await waitFor(() => {
+      expect(screen.getByText("DDD")).toBeInTheDocument()
+    })
+
+    const exportButton = screen.getByRole("button", {
+      name: /export ibkr basket/i,
+    })
+    expect(exportButton).toBeDisabled()
+    fireEvent.click(exportButton)
+    expect(downloadCsv).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/utils/ibkrBasket.ts
+++ b/src/lib/utils/ibkrBasket.ts
@@ -1,0 +1,56 @@
+import { Transaction } from "types/beancounter"
+import { escapeCSV } from "@lib/csvExport"
+
+// TWS BasketTrader import format. Column order and header text are exact;
+// TWS also requires no space after the comma separator.
+const HEADER =
+  "Action,Quantity,Symbol,SecType,Exchange,Currency,TimeInForce,OrderType,LmtPrice,BasketTag"
+
+// BC market code → IBKR exchange. US listings route via SMART; anything
+// unmapped also falls back to SMART and TWS resolves the listing itself.
+const EXCHANGE_ALIASES: Record<string, string> = {
+  NYSE: "SMART",
+  NASDAQ: "SMART",
+  US: "SMART",
+  AMEX: "SMART",
+  LON: "LSE",
+  LSE: "LSE",
+  ASX: "ASX",
+  SGX: "SGX",
+  NZX: "NZSE",
+  TSX: "TSE",
+}
+
+// Plain decimal (no exponent) with trailing zeros stripped, e.g. 100.0 → "100".
+const plainDecimal = (value: number): string =>
+  value.toFixed(8).replace(/0+$/, "").replace(/\.$/, "")
+
+/**
+ * Build a TWS BasketTrader CSV from proposed transactions. Only BUY and SELL
+ * rows are exportable orders; all other trn types are skipped.
+ */
+export function buildIbkrBasketCsv(trns: Transaction[]): string {
+  const rows = trns
+    .filter((trn) => trn.trnType === "BUY" || trn.trnType === "SELL")
+    .map((trn) => {
+      const isLimit = typeof trn.price === "number" && trn.price > 0
+      const tag = `BC-${trn.id ?? trn.callerRef?.callerId ?? ""}`
+      return [
+        trn.trnType,
+        plainDecimal(Math.abs(trn.quantity)),
+        escapeCSV(trn.asset.code),
+        "STK",
+        EXCHANGE_ALIASES[trn.asset.market.code] ?? "SMART",
+        trn.tradeCurrency.code,
+        "DAY",
+        isLimit ? "LMT" : "MKT",
+        isLimit ? plainDecimal(trn.price) : "",
+        escapeCSV(tag),
+      ].join(",")
+    })
+  return [HEADER, ...rows].join("\n")
+}
+
+export function ibkrBasketFilename(asAt: string): string {
+  return `ibkr-basket-${asAt}.csv`
+}

--- a/src/pages/trns/proposed.tsx
+++ b/src/pages/trns/proposed.tsx
@@ -8,6 +8,8 @@ import { ProposedTransaction, AggregatedTransaction } from "types/proposed"
 import Head from "next/head"
 import { useUser, withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import { calculateTradeAmount } from "@utils/trns/tradeUtils"
+import { downloadCsv } from "@lib/csvExport"
+import { buildIbkrBasketCsv, ibkrBasketFilename } from "@lib/ibkrBasket"
 import { stripOwnerPrefix } from "@lib/assets/assetUtils"
 import { solePortfolio as soleActivePortfolio } from "@lib/user/zenMode"
 import DateInput from "@components/ui/DateInput"
@@ -703,6 +705,20 @@ function ProposedTransactions(): React.JSX.Element {
     }
   }
 
+  // IBKR basket export covers the rows currently shown (post broker filter);
+  // only BUY/SELL become TWS orders, so the button is inert without any.
+  const exportableTrnCount = visibleTransactions.filter(
+    (trn) => trn.trnType === "BUY" || trn.trnType === "SELL",
+  ).length
+
+  const handleExportIbkrBasket = (): void => {
+    if (exportableTrnCount === 0) return
+    downloadCsv(
+      ibkrBasketFilename(toDate),
+      buildIbkrBasketCsv(visibleTransactions),
+    )
+  }
+
   const hasChanges = (trn: ProposedTransaction): boolean =>
     trn.editedPrice !== trn.price ||
     trn.editedFees !== trn.fees ||
@@ -1055,6 +1071,14 @@ function ProposedTransactions(): React.JSX.Element {
                 className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
               >
                 {isSaving ? "Saving..." : "Save"}
+              </button>
+              <button
+                onClick={handleExportIbkrBasket}
+                disabled={exportableTrnCount === 0}
+                title="Download the visible BUY/SELL rows as a TWS BasketTrader CSV"
+                className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+              >
+                {`Export IBKR Basket (${exportableTrnCount})`}
               </button>
               {anyChanges && (
                 <span className="text-sm text-gray-500">


### PR DESCRIPTION
Adds an "Export IBKR Basket" button to the proposed transactions page.
Visible BUY/SELL rows (post broker filter) download as a TWS
BasketTrader CSV (LMT when price set, else MKT; exchange alias map with
SMART fallback; BC-<trnId> BasketTag for reconciliation). User imports
the file into TWS, reviews staged orders, and transmits manually.