### PR TITLE
fix(holdings): Open Only also hides zero-balance account assets

### DIFF
--- a/src/lib/utils/holdings/calculate.test.tsx
+++ b/src/lib/utils/holdings/calculate.test.tsx
@@ -302,3 +302,47 @@ describe("Cash grouping behavior", () => {
     expect(holdings.holdingGroups["PRIVATE"]).toBeUndefined()
   })
 })
+
+describe("hideEmpty filtering for ACCOUNT assets", () => {
+  const valueIn = ValueIn.PORTFOLIO
+  const groupBy = GroupBy.ASSET_CLASS
+
+  function buildContractWithZeroBalanceAccount(): HoldingContract {
+    const contract: HoldingContract = JSON.parse(data).data
+    const cashTemplate = contract.positions["USD:CASH"]
+    contract.positions["BANK:PRIVATE"] = {
+      ...cashTemplate,
+      asset: {
+        ...cashTemplate.asset,
+        code: "user.BANK",
+        id: "bank-account-id",
+        name: "Bank Account",
+        market: { ...cashTemplate.asset.market, code: "PRIVATE" },
+        assetCategory: { id: "ACCOUNT", name: "Bank Account" },
+      },
+      quantityValues: {
+        ...cashTemplate.quantityValues,
+        total: 0,
+      },
+    } as unknown as Position
+    return contract
+  }
+
+  function accountPositionsIn(result: Holdings): Position[] {
+    return Object.values(result.holdingGroups)
+      .flatMap((group) => group.positions)
+      .filter((p) => p.asset.assetCategory.id === "ACCOUNT")
+  }
+
+  it("excludes a zero-balance ACCOUNT position when hideEmpty is true", () => {
+    const contract = buildContractWithZeroBalanceAccount()
+    const result = calculateHoldings(contract, true, valueIn, groupBy)
+    expect(accountPositionsIn(result).length).toEqual(0)
+  })
+
+  it("includes a zero-balance ACCOUNT position when hideEmpty is false", () => {
+    const contract = buildContractWithZeroBalanceAccount()
+    const result = calculateHoldings(contract, false, valueIn, groupBy)
+    expect(accountPositionsIn(result).length).toEqual(1)
+  })
+})

--- a/src/lib/utils/holdings/calculateHoldings.ts
+++ b/src/lib/utils/holdings/calculateHoldings.ts
@@ -7,12 +7,7 @@ import {
   Position,
   Total,
 } from "types/beancounter"
-import {
-  isNonTradeable,
-  isCash,
-  isAccount,
-  isCashRelated,
-} from "@lib/assets/assetUtils"
+import { isNonTradeable, isCash, isCashRelated } from "@lib/assets/assetUtils"
 import { GroupBy, ValueIn } from "@components/features/holdings/GroupByOptions"
 import { getReportCategory } from "../categoryMapping"
 
@@ -238,11 +233,6 @@ export function calculateHoldings(
 ): Holdings {
   const filteredPositions = Object.keys(contract.positions).filter((key) => {
     const position = contract.positions[key]
-    // Always show ACCOUNT assets (bank accounts) regardless of balance
-    if (isAccount(position.asset)) {
-      return true
-    }
-    // Apply hideEmpty filtering to other positions
     return !(hideEmpty && position.quantityValues.total === 0)
   })
 


### PR DESCRIPTION
Removes the unconditional ACCOUNT-category bypass in calculateHoldings so the Open Only (hideEmpty) filter applies uniformly; zero-balance bank/settlement accounts are now hidden when Open Only is on. Toggle off still shows them.