### PR TITLE
feat(holdings): google-finance style treemap heatmap

### DIFF
--- a/src/components/ui/PerformanceHeatmap.tsx
+++ b/src/components/ui/PerformanceHeatmap.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import { HoldingGroup } from "types/beancounter"
 import { FormatValue } from "@components/ui/MoneyUtils"
 import {
@@ -9,6 +9,7 @@ import {
 import { getGroupComparator } from "@lib/categoryMapping"
 import { ProgressBar } from "@components/ui/ProgressBar"
 import Dialog from "@components/ui/Dialog"
+import { squarify, TreemapRect } from "@lib/holdings/treemapLayout"
 
 interface PerformanceHeatmapProps {
   holdingGroups: Record<string, HoldingGroup>
@@ -20,6 +21,7 @@ interface PerformanceHeatmapProps {
 }
 
 type MetricType = "totalReturn" | "irr" | "dailyGain"
+type ViewMode = "groups" | "assets"
 
 interface HeatmapCell {
   code: string
@@ -34,42 +36,184 @@ interface HeatmapCell {
   gainOnDay: number
 }
 
-const getPerformanceColor = (value: number, metric: MetricType): string => {
-  let thresholds: {
-    strong: number
-    positive: number
-    flat: number
-    negative: number
-  }
-
-  switch (metric) {
-    case "irr":
-      thresholds = { strong: 0.15, positive: 0.05, flat: 0, negative: -0.1 }
-      break
-    case "dailyGain":
-    default:
-      thresholds = { strong: 0.03, positive: 0, flat: -0.01, negative: -0.03 }
-      break
-  }
-
-  if (value > thresholds.strong) return "bg-green-500 text-white"
-  if (value > thresholds.positive) return "bg-green-200 text-green-900"
-  if (value > thresholds.flat) return "bg-yellow-100 text-yellow-900"
-  if (value > thresholds.negative) return "bg-red-200 text-red-900"
-  return "bg-red-500 text-white"
-}
-
-const getOpacity = (weight: number): string => {
-  if (weight >= 0.1) return "opacity-100"
-  if (weight >= 0.05) return "opacity-90"
-  if (weight >= 0.02) return "opacity-80"
-  return "opacity-70"
-}
-
 interface GroupedCells {
   groupKey: string
   cells: HeatmapCell[]
   groupMarketValue: number
+}
+
+const FALLBACK_WIDTH = 800
+const FALLBACK_HEIGHT = 480
+// Canvas height adapts to the viewport so the full treemap (and the legend
+// below it) stays on screen — reserved space covers app nav + card chrome.
+const CANVAS_VIEWPORT_RESERVED = 290
+const MIN_CANVAS_HEIGHT = 300
+const MAX_CANVAS_HEIGHT = 840
+
+// Color scale — darker/more saturated = bigger move (Google Finance style).
+// dailyGain thresholds are fractions (0.02 = 2%); irr reuses the same table
+// scaled x5 since annualized returns run much larger than daily moves.
+const GRAY_NO_DATA = "#8a8f98"
+const STRONG_GREEN = "#1f4d21"
+const MID_GREEN = "#37652f"
+const LIGHT_GREEN = "#5f8f57"
+const FLAT = "#66716b"
+const LIGHT_RED = "#c96b60"
+const MID_RED = "#a03d36"
+const STRONG_RED = "#7f1d1d"
+
+const DAILY_GAIN_STRONG = 0.02
+const DAILY_GAIN_MID = 0.0075
+const DAILY_GAIN_LIGHT = 0.001
+const IRR_SCALE = 5
+
+export function getHeatColor(
+  value: number | null | undefined,
+  metric: MetricType,
+): string {
+  if (value === null || value === undefined) return GRAY_NO_DATA
+
+  const scale = metric === "irr" ? IRR_SCALE : 1
+  const strong = DAILY_GAIN_STRONG * scale
+  const mid = DAILY_GAIN_MID * scale
+  const light = DAILY_GAIN_LIGHT * scale
+
+  if (value >= strong) return STRONG_GREEN
+  if (value >= mid) return MID_GREEN
+  if (value > light) return LIGHT_GREEN
+  if (value >= -light) return FLAT
+  if (value > -mid) return LIGHT_RED
+  if (value > -strong) return MID_RED
+  return STRONG_RED
+}
+
+function getMetricValue(
+  cell: HeatmapCell,
+  metric: MetricType,
+  mode: ViewMode,
+): number | null {
+  switch (metric) {
+    case "irr":
+      return cell.irr
+    case "totalReturn":
+      return cell.totalGainPercent
+    case "dailyGain":
+    default:
+      if (mode === "assets") {
+        return cell.changePercent === undefined || cell.changePercent === null
+          ? null
+          : cell.changePercent
+      }
+      return cell.marketValue > 0 ? cell.gainOnDay / cell.marketValue : 0
+  }
+}
+
+function formatMetricValue(value: number | null): string {
+  if (value === null) return "--"
+  return `${value >= 0 ? "+" : ""}${(value * 100).toFixed(2)}%`
+}
+
+function getMetricLabel(metric: MetricType): string {
+  switch (metric) {
+    case "totalReturn":
+      return "Total Return"
+    case "irr":
+      return "IRR"
+    case "dailyGain":
+    default:
+      return "Daily Gain"
+  }
+}
+
+function getMetricTooltip(metric: MetricType): string {
+  switch (metric) {
+    case "dailyGain":
+      return "Today's change in value"
+    case "totalReturn":
+      return "Simple return: (Current Value - Cost) / Cost. Does not account for timing of purchases."
+    case "irr":
+      return "Internal Rate of Return: Annualized return accounting for when you bought and sold. Better for comparing investments held for different periods."
+    default:
+      return ""
+  }
+}
+
+interface HeatTileProps {
+  cell: HeatmapCell
+  rect: TreemapRect
+  metric: MetricType
+  mode: ViewMode
+  onClick?: () => void
+}
+
+// Module-scoped tile renderer — kept out of PerformanceHeatmap's render body
+// per the React Compiler rule against defining components inline.
+function HeatTile({
+  cell,
+  rect,
+  metric,
+  mode,
+  onClick,
+}: HeatTileProps): React.ReactElement {
+  const value = getMetricValue(cell, metric, mode)
+  const color = getHeatColor(value, metric)
+
+  const w = rect.width
+  const h = rect.height
+  const showTicker = w >= 60 && h >= 36
+  const showChip = w >= 90 && h >= 64 && value !== null
+  const showName = w >= 140 && h >= 90
+  const showBadge = w >= 180 && h >= 110
+
+  const padding = w >= 140 ? "p-3" : w >= 90 ? "p-2" : "p-1"
+
+  const title =
+    mode === "assets"
+      ? `${cell.name}\n${getMetricLabel(metric)}: ${formatMetricValue(value)}\nMarket Value: ${cell.marketValue.toLocaleString()}\nWeight: ${(cell.weight * 100).toFixed(2)}%`
+      : `Click to see assets in ${cell.name}`
+
+  return (
+    <div
+      data-testid={`heatmap-tile-${mode}-${cell.code}`}
+      title={title}
+      onClick={onClick}
+      className={`absolute rounded-xl overflow-hidden text-white ${padding} ${
+        mode === "groups" ? "cursor-pointer" : ""
+      }`}
+      style={{
+        left: rect.x + 1.5,
+        top: rect.y + 1.5,
+        width: Math.max(rect.width - 3, 0),
+        height: Math.max(rect.height - 3, 0),
+        backgroundColor: color,
+      }}
+    >
+      {showBadge && (
+        <div className="absolute top-1.5 right-1.5 w-5 h-5 rounded bg-black/25 flex items-center justify-center text-[10px] font-bold">
+          {(cell.name || cell.code).charAt(0).toUpperCase()}
+        </div>
+      )}
+      {showTicker && (
+        <div className="text-xs sm:text-sm font-bold truncate pr-6">
+          {cell.code}
+        </div>
+      )}
+      {showName && (
+        <div className="text-[10px] opacity-80 truncate">{cell.name}</div>
+      )}
+      {showChip && (
+        <div
+          data-testid={`heatmap-chip-${mode}-${cell.code}`}
+          className="mt-1 inline-flex items-center gap-1 text-[11px] font-semibold"
+        >
+          <span>{formatMetricValue(value)}</span>
+          <span className="w-3.5 h-3.5 rounded-full bg-white/30 inline-flex items-center justify-center text-[9px] leading-none">
+            {(value as number) >= 0 ? "↑" : "↓"}
+          </span>
+        </div>
+      )}
+    </div>
+  )
 }
 
 export const PerformanceHeatmap: React.FC<PerformanceHeatmapProps> = ({
@@ -83,6 +227,43 @@ export const PerformanceHeatmap: React.FC<PerformanceHeatmapProps> = ({
   const [selectedMetric, setSelectedMetric] =
     React.useState<MetricType>("dailyGain")
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null)
+  const [viewMode, setViewMode] = useState<ViewMode>(
+    viewByGroup ? "groups" : "assets",
+  )
+
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [canvasSize, setCanvasSize] = useState({
+    width: FALLBACK_WIDTH,
+    height: FALLBACK_HEIGHT,
+  })
+
+  useEffect(() => {
+    const node = containerRef.current
+    if (!node) return undefined
+
+    const measure = (): void => {
+      setCanvasSize({
+        width: node.offsetWidth || FALLBACK_WIDTH,
+        height: Math.min(
+          MAX_CANVAS_HEIGHT,
+          Math.max(
+            MIN_CANVAS_HEIGHT,
+            window.innerHeight - CANVAS_VIEWPORT_RESERVED,
+          ),
+        ),
+      })
+    }
+    measure()
+
+    window.addEventListener("resize", measure)
+    const observer =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(measure) : null
+    observer?.observe(node)
+    return () => {
+      window.removeEventListener("resize", measure)
+      observer?.disconnect()
+    }
+  }, [])
 
   // Build grouped cells
   const sorter = getGroupComparator(groupBy ?? "")
@@ -133,13 +314,11 @@ export const PerformanceHeatmap: React.FC<PerformanceHeatmapProps> = ({
     0,
   )
 
-  // Build group-level cells for viewByGroup mode
+  // Build group-level cells for Groups mode.
   // Use portfolioTotalValue (includes cash) for weight calculation if provided
   const weightDenominator = portfolioTotalValue ?? totalMarketValue
 
   const groupCells: HeatmapCell[] = React.useMemo(() => {
-    if (!viewByGroup) return []
-
     return groupedCells.map((g) => {
       const subTotals = holdingGroups[g.groupKey]?.subTotals?.[valueIn]
       const totalGain = subTotals?.totalGain || 0
@@ -161,261 +340,161 @@ export const PerformanceHeatmap: React.FC<PerformanceHeatmapProps> = ({
         gainOnDay,
       }
     })
-  }, [viewByGroup, groupedCells, holdingGroups, valueIn, weightDenominator])
+  }, [groupedCells, holdingGroups, valueIn, weightDenominator])
 
-  const getMetricValue = (cell: HeatmapCell, metric: MetricType): number => {
-    switch (metric) {
-      case "totalReturn":
-        return cell.totalGainPercent
-      case "irr":
-        return cell.irr
-      case "dailyGain":
-        return cell.gainOnDay / cell.marketValue // Convert to percentage
-      default:
-        return 0
-    }
-  }
+  const assetCells: HeatmapCell[] = useMemo(
+    () => groupedCells.flatMap((g) => g.cells),
+    [groupedCells],
+  )
 
-  const formatMetricValue = (cell: HeatmapCell, metric: MetricType): string => {
-    const value = getMetricValue(cell, metric)
-    return `${value >= 0 ? "+" : ""}${(value * 100).toFixed(1)}%`
-  }
+  const activeCells = viewMode === "groups" ? groupCells : assetCells
 
-  const getMetricLabel = (metric: MetricType): string => {
-    switch (metric) {
-      case "totalReturn":
-        return "Total Return"
-      case "irr":
-        return "IRR"
-      case "dailyGain":
-        return "Daily Gain"
-      default:
-        return metric
-    }
-  }
+  const sortedCells = useMemo(
+    () => [...activeCells].sort((a, b) => b.marketValue - a.marketValue),
+    [activeCells],
+  )
 
-  const getMetricTooltip = (metric: MetricType): string => {
-    switch (metric) {
-      case "dailyGain":
-        return "Today's change in value"
-      case "totalReturn":
-        return "Simple return: (Current Value - Cost) / Cost. Does not account for timing of purchases."
-      case "irr":
-        return "Internal Rate of Return: Annualized return accounting for when you bought and sold. Better for comparing investments held for different periods."
-      default:
-        return ""
-    }
-  }
+  const rects = useMemo(
+    () =>
+      squarify(
+        sortedCells.map((cell) => ({ value: cell.marketValue, data: cell })),
+        canvasSize.width,
+        canvasSize.height,
+      ),
+    [sortedCells, canvasSize],
+  )
+
+  const isIrrMetric = selectedMetric === "irr"
+  const legendLabels = isIrrMetric
+    ? { neg: "-10%", mid: "0", pos: "+10%" }
+    : { neg: "-2%", mid: "0", pos: "+2%" }
 
   return (
     <div
-      className={`bg-white rounded-lg border border-gray-200 overflow-hidden ${className}`}
+      className={`bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800 overflow-hidden ${className}`}
     >
-      <div className="p-4 border-b border-gray-200">
-        <div className="flex justify-between items-center">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-800">
+        <div className="flex flex-wrap justify-between items-center gap-3">
           <div>
-            <h3 className="text-lg font-semibold text-gray-900">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
               Performance Heatmap
             </h3>
-            <p className="text-sm text-gray-600">
-              Color intensity shows performance, cell size shows allocation
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Color intensity shows performance, tile size shows allocation
             </p>
           </div>
-          <div className="flex items-center space-x-1 bg-gray-100 rounded-lg p-1">
-            {(["dailyGain", "irr"] as MetricType[]).map((metric) => (
-              <button
-                key={metric}
-                onClick={() => setSelectedMetric(metric)}
-                className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
-                  selectedMetric === metric
-                    ? "bg-white text-gray-900 shadow-sm"
-                    : "text-gray-600 hover:text-gray-900"
-                }`}
-                title={getMetricTooltip(metric)}
-              >
-                {getMetricLabel(metric)}
-              </button>
-            ))}
+          <div className="flex items-center gap-2">
+            <div className="flex items-center space-x-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
+              {(["groups", "assets"] as ViewMode[]).map((mode) => (
+                <button
+                  key={mode}
+                  onClick={() => setViewMode(mode)}
+                  className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                    viewMode === mode
+                      ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm"
+                      : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+                  }`}
+                >
+                  {mode === "groups" ? "Groups" : "Assets"}
+                </button>
+              ))}
+            </div>
+            <div className="flex items-center space-x-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
+              {(["dailyGain", "irr"] as MetricType[]).map((metric) => (
+                <button
+                  key={metric}
+                  onClick={() => setSelectedMetric(metric)}
+                  className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                    selectedMetric === metric
+                      ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm"
+                      : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+                  }`}
+                  title={getMetricTooltip(metric)}
+                >
+                  {getMetricLabel(metric)}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
       </div>
 
       <div className="p-4 space-y-4">
-        {viewByGroup ? (
-          /* Group-level heatmap - each cell is a group */
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-            {groupCells.map((cell) => {
-              const metricValue = getMetricValue(cell, selectedMetric)
-              const performanceColor = getPerformanceColor(
-                metricValue,
-                selectedMetric,
-              )
-              // Larger cells for group view
-              const sizeClass =
-                cell.weight >= 0.3
-                  ? "h-32"
-                  : cell.weight >= 0.15
-                    ? "h-28"
-                    : "h-24"
+        <div
+          ref={containerRef}
+          className="relative bg-gray-100 dark:bg-gray-950 rounded-lg p-[1.5px]"
+          style={{ height: canvasSize.height }}
+        >
+          {rects.map((rect) => (
+            <HeatTile
+              key={`${viewMode}-${rect.data.code}`}
+              cell={rect.data}
+              rect={rect}
+              metric={selectedMetric}
+              mode={viewMode}
+              onClick={
+                viewMode === "groups"
+                  ? () => setSelectedGroup(rect.data.code)
+                  : undefined
+              }
+            />
+          ))}
+        </div>
 
-              return (
-                <div
-                  key={cell.code}
-                  onClick={() => setSelectedGroup(cell.code)}
-                  className={`
-                    ${sizeClass} ${performanceColor}
-                    rounded-xl p-4 flex flex-col justify-between
-                    hover:scale-102 transition-all duration-200 cursor-pointer
-                    shadow-md hover:shadow-lg
-                  `}
-                  title={`Click to see assets in ${cell.name}`}
-                >
-                  <div>
-                    <div className="text-base font-bold">{cell.code}</div>
-                    <div className="text-xs opacity-80 mt-1">
-                      {(cell.weight * 100).toFixed(1)}% of portfolio
-                    </div>
-                  </div>
-                  <div className="flex justify-between items-end">
-                    <div className="text-lg font-bold">
-                      {formatMetricValue(cell, selectedMetric)}
-                    </div>
-                    <div className="text-xs opacity-80">
-                      <FormatValue value={cell.marketValue} />
-                    </div>
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        ) : (
-          /* Position-level heatmap grouped by category */
-          groupedCells.map((group) => (
-            <div key={group.groupKey}>
-              {/* Group Header */}
-              <div className="flex items-center gap-2 mb-2">
-                <h4 className="text-sm font-semibold text-gray-700">
-                  {group.groupKey}
-                </h4>
-                <span className="text-xs text-gray-400">
-                  ({group.cells.length})
-                </span>
-                <span className="ml-auto text-sm font-medium text-gray-600">
-                  <FormatValue value={group.groupMarketValue} />
-                </span>
-              </div>
-
-              {/* Cells Grid */}
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2">
-                {group.cells.map((cell) => {
-                  const sizeClass =
-                    cell.weight >= 0.1
-                      ? "h-20"
-                      : cell.weight >= 0.05
-                        ? "h-16"
-                        : "h-12"
-                  const metricValue = getMetricValue(cell, selectedMetric)
-                  const performanceColor = getPerformanceColor(
-                    metricValue,
-                    selectedMetric,
-                  )
-                  const opacity = getOpacity(cell.weight)
-
-                  return (
-                    <div
-                      key={cell.code}
-                      className={`
-                        ${sizeClass} ${performanceColor} ${opacity}
-                        rounded-lg p-2 flex flex-col justify-between
-                        hover:scale-105 transition-all duration-200 cursor-pointer
-                        shadow-sm hover:shadow-md
-                      `}
-                      title={`${cell.name}\n${getMetricLabel(selectedMetric)}: ${formatMetricValue(cell, selectedMetric)}\nMarket Value: ${cell.marketValue.toLocaleString()}\nWeight: ${(cell.weight * 100).toFixed(2)}%`}
-                    >
-                      <div className="flex-1 min-w-0">
-                        <div className="text-xs font-semibold truncate">
-                          {cell.code}
-                        </div>
-                        {cell.weight >= 0.05 && (
-                          <div className="text-[10px] opacity-90 truncate mt-1">
-                            {cell.name.length > 24
-                              ? cell.name.substring(0, 24) + "..."
-                              : cell.name}
-                          </div>
-                        )}
-                      </div>
-
-                      <div className="text-xs font-bold">
-                        {formatMetricValue(cell, selectedMetric)}
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
+        <div className="flex flex-wrap justify-between items-center gap-3 text-sm">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-1.5">
+              <span
+                className="w-4 h-4 rounded"
+                style={{ backgroundColor: STRONG_RED }}
+              />
+              <span className="text-gray-600 dark:text-gray-400">
+                {legendLabels.neg}
+              </span>
             </div>
-          ))
-        )}
-
-        <div className="mt-6 flex justify-between items-center text-sm">
-          <div className="flex items-center space-x-4">
-            {(() => {
-              const thresholds =
-                selectedMetric === "irr"
-                  ? { strong: 15, positive: 5, flat: 0, negative: -10 }
-                  : { strong: 3, positive: 0, flat: -1, negative: -3 } // dailyGain
-
-              return (
-                <>
-                  <div className="flex items-center space-x-2">
-                    <div className="w-4 h-4 bg-green-500 rounded"></div>
-                    <span className="text-gray-600">
-                      Strong ({">"}+{thresholds.strong}%)
-                    </span>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <div className="w-4 h-4 bg-green-200 rounded"></div>
-                    <span className="text-gray-600">
-                      Positive ({thresholds.positive}-{thresholds.strong}%)
-                    </span>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <div className="w-4 h-4 bg-yellow-100 rounded border"></div>
-                    <span className="text-gray-600">
-                      Flat ({thresholds.flat}-{thresholds.positive}%)
-                    </span>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <div className="w-4 h-4 bg-red-200 rounded"></div>
-                    <span className="text-gray-600">
-                      Negative ({thresholds.negative}-{thresholds.flat}%)
-                    </span>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <div className="w-4 h-4 bg-red-500 rounded"></div>
-                    <span className="text-gray-600">
-                      Poor ({"<"}
-                      {thresholds.negative}%)
-                    </span>
-                  </div>
-                </>
-              )
-            })()}
+            <div className="flex items-center gap-1.5">
+              <span
+                className="w-4 h-4 rounded"
+                style={{ backgroundColor: FLAT }}
+              />
+              <span className="text-gray-600 dark:text-gray-400">
+                {legendLabels.mid}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span
+                className="w-4 h-4 rounded"
+                style={{ backgroundColor: STRONG_GREEN }}
+              />
+              <span className="text-gray-600 dark:text-gray-400">
+                {legendLabels.pos}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span
+                className="w-4 h-4 rounded"
+                style={{ backgroundColor: GRAY_NO_DATA }}
+              />
+              <span className="text-gray-600 dark:text-gray-400">
+                No price data
+              </span>
+            </div>
           </div>
 
-          <div className="text-gray-600">
+          <div className="text-gray-600 dark:text-gray-400">
             Total: <FormatValue value={totalMarketValue} />
           </div>
         </div>
 
-        <div className="mt-2 text-xs text-gray-500">
-          {viewByGroup
+        <div className="text-xs text-gray-500 dark:text-gray-500">
+          {viewMode === "groups"
             ? "Click a group to see individual assets"
-            : "Cell size indicates position weight • Hover for details"}
+            : "Tile size indicates market value • Hover for details"}
         </div>
       </div>
 
       {/* Group Detail Modal */}
-      {selectedGroup && viewByGroup && (
+      {selectedGroup && (
         <Dialog
           title={
             <div>
@@ -454,7 +533,7 @@ export const PerformanceHeatmap: React.FC<PerformanceHeatmapProps> = ({
                 <th className="pb-2 font-medium text-gray-600 text-right">
                   IRR
                 </th>
-                <th className="pb-2 font-medium text-gray-600 w-32 hidden sm:table-cell">
+                <th className="pb-2 pl-4 font-medium text-gray-600 w-32 hidden sm:table-cell">
                   Alpha
                 </th>
                 <th className="pb-2 font-medium text-gray-600 text-right">

--- a/src/components/ui/__tests__/PerformanceHeatmap.test.tsx
+++ b/src/components/ui/__tests__/PerformanceHeatmap.test.tsx
@@ -1,0 +1,242 @@
+import React from "react"
+import { render, screen, fireEvent, within } from "@testing-library/react"
+import { PerformanceHeatmap, getHeatColor } from "../PerformanceHeatmap"
+import {
+  makeAsset,
+  makeCashAsset,
+  makeHoldingGroup,
+  makePosition,
+} from "@test-fixtures/beancounter"
+import { HoldingGroup } from "types/beancounter"
+
+const VALUE_IN = "PORTFOLIO"
+
+function buildHoldingGroups(): Record<string, HoldingGroup> {
+  const aapl = makePosition({
+    asset: makeAsset({ id: "asset-aapl", code: "AAPL", name: "Apple Inc." }),
+    moneyValues: {
+      marketValue: 50000,
+      weight: 0.5,
+      irr: 0.12,
+      gainOnDay: 500,
+      priceData: {
+        close: 150,
+        previousClose: 149,
+        change: 1,
+        changePercent: 0.05,
+        priceDate: "2024-01-15",
+      },
+    } as any,
+  })
+
+  // MSFT has no priceData.changePercent — the "no data" gray path.
+  const msft = makePosition({
+    asset: makeAsset({
+      id: "asset-msft",
+      code: "MSFT",
+      name: "Microsoft Corp",
+    }),
+    moneyValues: {
+      marketValue: 30000,
+      weight: 0.3,
+      irr: 0.08,
+      gainOnDay: -100,
+      priceData: {
+        close: 300,
+        previousClose: 300,
+        change: 0,
+        changePercent: undefined,
+        priceDate: "2024-01-15",
+      },
+    } as any,
+  })
+
+  const cashPosition = makePosition({
+    asset: makeCashAsset(),
+    moneyValues: { marketValue: 5000, weight: 0.05 } as any,
+  })
+
+  const bond = makePosition({
+    asset: makeAsset({
+      id: "asset-bnd",
+      code: "BND",
+      name: "Vanguard Bond ETF",
+    }),
+    moneyValues: {
+      marketValue: 20000,
+      weight: 0.2,
+      irr: 0.03,
+      gainOnDay: 20,
+      priceData: {
+        close: 80,
+        previousClose: 79.9,
+        change: 0.1,
+        changePercent: 0.0012,
+        priceDate: "2024-01-15",
+      },
+    } as any,
+  })
+
+  return {
+    Equity: makeHoldingGroup({
+      positions: [aapl, msft, cashPosition],
+      subTotals: {
+        marketValue: 80000,
+        totalGain: 8000,
+        costValue: 60000,
+        gainOnDay: 400,
+        weightedIrr: 0.1,
+      },
+    }),
+    Bonds: makeHoldingGroup({
+      positions: [bond],
+      subTotals: {
+        marketValue: 20000,
+        totalGain: 500,
+        costValue: 19000,
+        gainOnDay: 20,
+        weightedIrr: 0.03,
+      },
+    }),
+  }
+}
+
+describe("PerformanceHeatmap", () => {
+  it("renders ticker codes of positions in Assets mode", () => {
+    render(
+      <PerformanceHeatmap
+        holdingGroups={buildHoldingGroups()}
+        valueIn={VALUE_IN}
+        viewByGroup={false}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Assets" }))
+
+    expect(screen.getByText("AAPL")).toBeInTheDocument()
+    expect(screen.getByText("MSFT")).toBeInTheDocument()
+    expect(screen.getByText("BND")).toBeInTheDocument()
+    // Cash position is excluded from the heatmap entirely.
+    expect(screen.queryByText(makeCashAsset().code)).not.toBeInTheDocument()
+  })
+
+  it("renders a position without priceData.changePercent gray, with no % chip", () => {
+    render(
+      <PerformanceHeatmap
+        holdingGroups={buildHoldingGroups()}
+        valueIn={VALUE_IN}
+        viewByGroup={false}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Assets" }))
+
+    const tile = screen.getByTestId("heatmap-tile-assets-MSFT")
+    expect(tile).toHaveStyle({ backgroundColor: "#8a8f98" })
+    expect(
+      within(tile).queryByTestId("heatmap-chip-assets-MSFT"),
+    ).not.toBeInTheDocument()
+
+    // A tile that does have changePercent shows its chip.
+    const aaplTile = screen.getByTestId("heatmap-tile-assets-AAPL")
+    expect(
+      within(aaplTile).getByTestId("heatmap-chip-assets-AAPL"),
+    ).toBeInTheDocument()
+  })
+
+  it("Groups mode renders group names and opens a dialog listing its assets on click", () => {
+    render(
+      <PerformanceHeatmap
+        holdingGroups={buildHoldingGroups()}
+        valueIn={VALUE_IN}
+        viewByGroup={true}
+      />,
+    )
+
+    expect(screen.getAllByText("Equity").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Bonds").length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByTestId("heatmap-tile-groups-Equity"))
+
+    // Dialog title + table rows for the group's (non-cash) assets.
+    const dialogs = screen.getAllByText("Equity")
+    expect(dialogs.length).toBeGreaterThan(1)
+    expect(screen.getByText("Apple Inc.")).toBeInTheDocument()
+    expect(screen.getByText("Microsoft Corp")).toBeInTheDocument()
+  })
+
+  it("switches metric label/values when toggled between Daily Gain and IRR", () => {
+    render(
+      <PerformanceHeatmap
+        holdingGroups={buildHoldingGroups()}
+        valueIn={VALUE_IN}
+        viewByGroup={false}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Assets" }))
+
+    // Default metric is Daily Gain — AAPL's changePercent is +5.00%.
+    expect(screen.getByText("+5.00%")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "IRR" }))
+    // AAPL's irr is 0.12 -> +12.00%
+    expect(screen.getByText("+12.00%")).toBeInTheDocument()
+  })
+
+  it("defaults the internal view toggle from viewByGroup", () => {
+    render(
+      <PerformanceHeatmap
+        holdingGroups={buildHoldingGroups()}
+        valueIn={VALUE_IN}
+        viewByGroup={true}
+      />,
+    )
+    expect(screen.getByRole("button", { name: "Groups" })).toHaveClass(
+      "bg-white",
+    )
+  })
+})
+
+describe("getHeatColor", () => {
+  it("returns gray for null (no data)", () => {
+    expect(getHeatColor(null, "dailyGain")).toBe("#8a8f98")
+  })
+
+  it("dailyGain: strong positive", () => {
+    expect(getHeatColor(0.03, "dailyGain")).toBe("#1f4d21")
+  })
+
+  it("dailyGain: medium positive", () => {
+    expect(getHeatColor(0.01, "dailyGain")).toBe("#37652f")
+  })
+
+  it("dailyGain: light positive", () => {
+    expect(getHeatColor(0.005, "dailyGain")).toBe("#5f8f57")
+  })
+
+  it("dailyGain: flat band", () => {
+    expect(getHeatColor(0, "dailyGain")).toBe("#66716b")
+    expect(getHeatColor(0.0005, "dailyGain")).toBe("#66716b")
+    expect(getHeatColor(-0.0005, "dailyGain")).toBe("#66716b")
+  })
+
+  it("dailyGain: light negative", () => {
+    expect(getHeatColor(-0.005, "dailyGain")).toBe("#c96b60")
+  })
+
+  it("dailyGain: medium negative", () => {
+    expect(getHeatColor(-0.01, "dailyGain")).toBe("#a03d36")
+  })
+
+  it("dailyGain: strong negative", () => {
+    expect(getHeatColor(-0.03, "dailyGain")).toBe("#7f1d1d")
+  })
+
+  it("irr thresholds are scaled 5x vs dailyGain", () => {
+    // 0.01 is only "light positive" for dailyGain but well within the
+    // flat band for irr (flat band is +/-0.005 for dailyGain*5... wait
+    // irr flat band is +/-0.005; 0.01 exceeds it -> light green).
+    expect(getHeatColor(0.01, "irr")).toBe("#5f8f57")
+    expect(getHeatColor(0.1, "irr")).toBe("#1f4d21")
+    expect(getHeatColor(-0.1, "irr")).toBe("#7f1d1d")
+    expect(getHeatColor(0.002, "irr")).toBe("#66716b")
+  })
+})

--- a/src/lib/utils/holdings/__tests__/holdingState.test.ts
+++ b/src/lib/utils/holdings/__tests__/holdingState.test.ts
@@ -1,0 +1,30 @@
+import { renderHook, act } from "@testing-library/react"
+import { useHoldingState } from "@lib/holdings/holdingState"
+import { GROUP_BY_OPTIONS } from "types/constants"
+
+describe("useHoldingState", () => {
+  it("defaults grouping to Sector when entering heatmap view without an explicit choice", () => {
+    const { result } = renderHook(() => useHoldingState())
+
+    act(() => {
+      result.current.setViewMode("heatmap")
+    })
+
+    expect(result.current.viewMode).toBe("heatmap")
+    expect(result.current.groupBy.value).toBe(GROUP_BY_OPTIONS.SECTOR)
+  })
+
+  it("keeps an explicit grouping choice when entering heatmap view", () => {
+    const { result } = renderHook(() => useHoldingState())
+
+    act(() => {
+      result.current.setGroupBy({
+        value: GROUP_BY_OPTIONS.MARKET,
+        label: "Market",
+      })
+      result.current.setViewMode("heatmap")
+    })
+
+    expect(result.current.groupBy.value).toBe(GROUP_BY_OPTIONS.MARKET)
+  })
+})

--- a/src/lib/utils/holdings/__tests__/treemapLayout.test.ts
+++ b/src/lib/utils/holdings/__tests__/treemapLayout.test.ts
@@ -1,0 +1,157 @@
+import { squarify, TreemapRect } from "../treemapLayout"
+
+function totalArea(rects: TreemapRect[]): number {
+  return rects.reduce((sum, r) => sum + r.width * r.height, 0)
+}
+
+function overlaps(a: TreemapRect, b: TreemapRect): boolean {
+  // Allow a tiny epsilon for floating point edges touching.
+  const EPS = 1e-6
+  return (
+    a.x + a.width > b.x + EPS &&
+    b.x + b.width > a.x + EPS &&
+    a.y + a.height > b.y + EPS &&
+    b.y + b.height > a.y + EPS
+  )
+}
+
+function worstAspectRatio(rects: TreemapRect[]): number {
+  return rects.reduce((worst, r) => {
+    if (r.width === 0 || r.height === 0) return worst
+    const ratio = Math.max(r.width / r.height, r.height / r.width)
+    return Math.max(worst, ratio)
+  }, 0)
+}
+
+describe("squarify", () => {
+  it("returns an empty array for empty input", () => {
+    expect(squarify([], 400, 300)).toEqual([])
+  })
+
+  it("fills the entire container for a single item", () => {
+    const result = squarify([{ value: 100, data: "A" }], 400, 300)
+    expect(result).toHaveLength(1)
+    const rect = result[0]
+    expect(rect.x).toBeCloseTo(0)
+    expect(rect.y).toBeCloseTo(0)
+    expect(rect.width).toBeCloseTo(400)
+    expect(rect.height).toBeCloseTo(300)
+    expect(rect.data).toBe("A")
+  })
+
+  it("produces rects whose total area matches the container (proportional to value)", () => {
+    const items = [
+      { value: 500, data: "A" },
+      { value: 300, data: "B" },
+      { value: 150, data: "C" },
+      { value: 50, data: "D" },
+    ]
+    const width = 600
+    const height = 400
+    const result = squarify(items, width, height)
+    const containerArea = width * height
+    const area = totalArea(result)
+    expect(area).toBeGreaterThan(containerArea * 0.995)
+    expect(area).toBeLessThan(containerArea * 1.005)
+  })
+
+  it("gives each rect area proportional to its value", () => {
+    const items = [
+      { value: 500, data: "A" },
+      { value: 300, data: "B" },
+      { value: 150, data: "C" },
+      { value: 50, data: "D" },
+    ]
+    const width = 600
+    const height = 400
+    const containerArea = width * height
+    const totalValue = 1000
+    const result = squarify(items, width, height)
+    const byData = new Map(result.map((r) => [r.data, r]))
+
+    for (const item of items) {
+      const rect = byData.get(item.data)!
+      const expectedArea = (item.value / totalValue) * containerArea
+      const actualArea = rect.width * rect.height
+      expect(actualArea).toBeGreaterThan(expectedArea * 0.995)
+      expect(actualArea).toBeLessThan(expectedArea * 1.005)
+    }
+  })
+
+  it("keeps all rects within container bounds", () => {
+    const items = [
+      { value: 40, data: "A" },
+      { value: 35, data: "B" },
+      { value: 25, data: "C" },
+      { value: 20, data: "D" },
+      { value: 15, data: "E" },
+      { value: 10, data: "F" },
+    ]
+    const width = 500
+    const height = 350
+    const result = squarify(items, width, height)
+    for (const r of result) {
+      expect(r.x).toBeGreaterThanOrEqual(-1e-6)
+      expect(r.y).toBeGreaterThanOrEqual(-1e-6)
+      expect(r.x + r.width).toBeLessThanOrEqual(width + 1e-6)
+      expect(r.y + r.height).toBeLessThanOrEqual(height + 1e-6)
+    }
+  })
+
+  it("does not overlap rects (pairwise check)", () => {
+    const items = [
+      { value: 40, data: "A" },
+      { value: 35, data: "B" },
+      { value: 25, data: "C" },
+      { value: 20, data: "D" },
+      { value: 15, data: "E" },
+      { value: 10, data: "F" },
+      { value: 5, data: "G" },
+    ]
+    const result = squarify(items, 500, 350)
+    for (let i = 0; i < result.length; i++) {
+      for (let j = i + 1; j < result.length; j++) {
+        expect(overlaps(result[i], result[j])).toBe(false)
+      }
+    }
+  })
+
+  it("skips zero/negative value items", () => {
+    const items = [
+      { value: 100, data: "A" },
+      { value: 0, data: "B" },
+      { value: -5, data: "C" },
+    ]
+    const result = squarify(items, 400, 300)
+    expect(result.some((r) => r.data === "B")).toBe(false)
+    expect(result.some((r) => r.data === "C")).toBe(false)
+    expect(result.some((r) => r.data === "A")).toBe(true)
+  })
+
+  it("keeps worst aspect ratio reasonable for equal values in a square container", () => {
+    const items = Array.from({ length: 9 }, (_, i) => ({
+      value: 10,
+      data: `item-${i}`,
+    }))
+    const result = squarify(items, 300, 300)
+    expect(result).toHaveLength(9)
+    expect(worstAspectRatio(result)).toBeLessThan(3)
+  })
+
+  it("handles all-zero values by returning no rects", () => {
+    const items = [
+      { value: 0, data: "A" },
+      { value: 0, data: "B" },
+    ]
+    expect(squarify(items, 400, 300)).toEqual([])
+  })
+
+  it("handles zero-size container by returning empty rects with zero area", () => {
+    const items = [
+      { value: 10, data: "A" },
+      { value: 20, data: "B" },
+    ]
+    const result = squarify(items, 0, 300)
+    expect(totalArea(result)).toBeCloseTo(0)
+  })
+})

--- a/src/lib/utils/holdings/holdingState.ts
+++ b/src/lib/utils/holdings/holdingState.ts
@@ -11,6 +11,7 @@ import { useGroupOptions } from "@components/features/holdings/GroupByOptions"
 import { ViewMode } from "@components/features/holdings/ViewToggle"
 import { useEffect } from "react"
 import { BC_STORAGE_PREFIX } from "../storage/sessionState"
+import { GROUP_BY_OPTIONS } from "types/constants"
 
 const defaultDisplayCurrency: DisplayCurrencyOption = { mode: "PORTFOLIO" }
 
@@ -187,6 +188,11 @@ export function useHoldingState(): HoldingDefaults {
       return state.viewMode.get() || "summary"
     },
     setViewMode(value: ViewMode): void {
+      // Heatmap reads best grouped by sector; only applies until the user
+      // picks a grouping themselves (raw state stays null until they do).
+      if (value === "heatmap" && state.groupBy.get() == null) {
+        state.groupBy.set({ value: GROUP_BY_OPTIONS.SECTOR, label: "Sector" })
+      }
       state.viewMode.set(value)
       saveState()
     },

--- a/src/lib/utils/holdings/treemapLayout.ts
+++ b/src/lib/utils/holdings/treemapLayout.ts
@@ -1,0 +1,154 @@
+/**
+ * Squarified treemap layout (Bruls, Huizing, van Wijk).
+ *
+ * Given items with a `value` (e.g. market value) and arbitrary `data`
+ * payload, lays them out inside a `width` x `height` container so each
+ * rect's AREA is proportional to its value, while keeping aspect ratios
+ * as close to square as possible.
+ *
+ * Callers are expected to sort items descending by value before calling —
+ * the squarify algorithm assumes a pre-sorted input (this keeps the
+ * "worst ratio" comparisons cheap and matches the reference algorithm).
+ */
+export interface TreemapRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+interface AreaItem<T> {
+  area: number
+  data: T
+}
+
+/**
+ * Worst aspect ratio achievable for a row of `areas` laid out along a strip
+ * of length `side` (the shorter side of the remaining rect). Lower is
+ * squarer/better. See Bruls et al. for the derivation.
+ */
+function rowWorst(areas: number[], side: number): number {
+  if (side <= 0 || areas.length === 0) return Infinity
+  const sum = areas.reduce((a, b) => a + b, 0)
+  if (sum <= 0) return Infinity
+  const maxArea = Math.max(...areas)
+  const minArea = Math.min(...areas)
+  return Math.max(
+    (side * side * maxArea) / (sum * sum),
+    (sum * sum) / (side * side * minArea),
+  )
+}
+
+/**
+ * Lays out one row of items as a strip against the given rect, pushing the
+ * resulting rects into `out`, and returns the shrunken remaining rect.
+ */
+function layoutRow<T>(
+  row: AreaItem<T>[],
+  rect: TreemapRect,
+  horizontal: boolean,
+  out: (TreemapRect & { data: T })[],
+): TreemapRect {
+  const rowSum = row.reduce((sum, item) => sum + item.area, 0)
+
+  if (horizontal) {
+    // Strip spans the full width, stacked at the top; thickness = area/width.
+    const thickness = rect.width > 0 ? rowSum / rect.width : 0
+    let cursorX = rect.x
+    for (const item of row) {
+      const itemWidth = rowSum > 0 ? (item.area / rowSum) * rect.width : 0
+      out.push({
+        x: cursorX,
+        y: rect.y,
+        width: itemWidth,
+        height: thickness,
+        data: item.data,
+      })
+      cursorX += itemWidth
+    }
+    return {
+      x: rect.x,
+      y: rect.y + thickness,
+      width: rect.width,
+      height: Math.max(rect.height - thickness, 0),
+    }
+  }
+
+  // Strip spans the full height, stacked on the left; thickness = area/height.
+  const thickness = rect.height > 0 ? rowSum / rect.height : 0
+  let cursorY = rect.y
+  for (const item of row) {
+    const itemHeight = rowSum > 0 ? (item.area / rowSum) * rect.height : 0
+    out.push({
+      x: rect.x,
+      y: cursorY,
+      width: thickness,
+      height: itemHeight,
+      data: item.data,
+    })
+    cursorY += itemHeight
+  }
+  return {
+    x: rect.x + thickness,
+    y: rect.y,
+    width: Math.max(rect.width - thickness, 0),
+    height: rect.height,
+  }
+}
+
+export function squarify<T>(
+  items: { value: number; data: T }[],
+  width: number,
+  height: number,
+): (TreemapRect & { data: T })[] {
+  const positive = items.filter((item) => item.value > 0)
+  if (positive.length === 0) return []
+
+  if (width <= 0 || height <= 0) {
+    return positive.map((item) => ({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      data: item.data,
+    }))
+  }
+
+  const totalValue = positive.reduce((sum, item) => sum + item.value, 0)
+  const scale = (width * height) / totalValue
+
+  let remaining: AreaItem<T>[] = positive.map((item) => ({
+    area: item.value * scale,
+    data: item.data,
+  }))
+
+  const result: (TreemapRect & { data: T })[] = []
+  let rect: TreemapRect = { x: 0, y: 0, width, height }
+
+  while (remaining.length > 0) {
+    const horizontal = rect.width <= rect.height
+    const shorterSide = horizontal ? rect.width : rect.height
+
+    const row: AreaItem<T>[] = [remaining[0]]
+    let rowAreas = [remaining[0].area]
+    let consumed = 1
+
+    while (consumed < remaining.length) {
+      const candidateAreas = [...rowAreas, remaining[consumed].area]
+      if (
+        rowWorst(candidateAreas, shorterSide) <= rowWorst(rowAreas, shorterSide)
+      ) {
+        row.push(remaining[consumed])
+        rowAreas = candidateAreas
+        consumed++
+      } else {
+        break
+      }
+    }
+
+    rect = layoutRow(row, rect, horizontal, result)
+    remaining = remaining.slice(consumed)
+  }
+
+  return result
+}

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -800,7 +800,7 @@ function HoldingsPage(): React.ReactElement {
             holdingGroups={holdings.holdingGroups}
             valueIn={holdingState.valueIn.value}
             groupBy={holdingState.groupBy.value}
-            viewByGroup={true}
+            viewByGroup={false}
             portfolioTotalValue={holdings.viewTotals.marketValue}
           />
         </div>

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -693,7 +693,7 @@ function AggregatedHoldingsPage(): React.ReactElement {
               holdingGroups={holdings.holdingGroups}
               valueIn={holdingState.valueIn.value}
               groupBy={holdingState.groupBy.value}
-              viewByGroup={true}
+              viewByGroup={false}
               portfolioTotalValue={holdings.viewTotals.marketValue}
             />
           </div>


### PR DESCRIPTION
## Summary
- Rebuilds the Performance Heatmap as a Google-Finance-style squarified treemap (`squarify` layout util, tile area = market value).
- Tiles show ticker, name, daily % change chip with arrow, monogram badge; gray tiles when no price data; dark-mode aware card and legend.
- Canvas height adapts to viewport (300–840px) so the full treemap and legend stay visible on short windows — fixes tiles falling off the bottom of the screen.
- Heatmap now defaults to Assets view; entering heatmap view defaults grouping to Sector unless the user has explicitly chosen a grouping.
- Groups mode retained (segmented toggle) including the group-detail dialog; Daily Gain / IRR metric toggle retained.

## Testing
- 10 unit tests for the squarified layout (proportional areas, bounds, overlap, edge cases).
- 14 component tests (modes, gray no-data path, dialog, color buckets) + 2 holdingState tests (sector default, explicit choice preserved).
- Verified in browser against kauri backends: 55-asset aggregated view, adaptive canvas at 1280x700, Assets+Sector defaults, group dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
