### PR TITLE
fix(holdings): heatmap Groups mode groups by industry sector, not asset class

### DIFF
--- a/src/components/ui/PerformanceHeatmap.tsx
+++ b/src/components/ui/PerformanceHeatmap.tsx
@@ -48,7 +48,7 @@ interface GroupedCells {
   groupMarketValue: number
 }
 
-const UNKNOWN_CLASSIFICATION = "Unknown"
+const UNCLASSIFIED_SECTOR = "Unclassified"
 
 // Mirrors CardView's per-view sourceCurrency derivation (see CardView.tsx),
 // specialised for a single position since the heatmap dialog shows one
@@ -347,14 +347,13 @@ export const PerformanceHeatmap: React.FC<PerformanceHeatmapProps> = ({
   // Use portfolioTotalValue (includes cash) for weight calculation if provided
   const weightDenominator = portfolioTotalValue ?? totalMarketValue
 
-  // Groups mode: regroup the flat asset cells by classification
-  // (asset.assetCategory.name), ignoring the page's groupBy entirely.
+  // Groups mode: regroup the flat asset cells by sector/industry
+  // classification (asset.sector), ignoring the page's groupBy entirely.
   const classificationGroups: GroupedCells[] = useMemo(() => {
     const byClassification = new Map<string, HeatmapCell[]>()
 
     assetCells.forEach((cell) => {
-      const key =
-        cell.position?.asset.assetCategory?.name || UNKNOWN_CLASSIFICATION
+      const key = cell.position?.asset.sector || UNCLASSIFIED_SECTOR
       const existing = byClassification.get(key)
       if (existing) {
         existing.push(cell)
@@ -363,7 +362,7 @@ export const PerformanceHeatmap: React.FC<PerformanceHeatmapProps> = ({
       }
     })
 
-    const sorter = getGroupComparator(GROUP_BY_OPTIONS.ASSET_CLASS)
+    const sorter = getGroupComparator(GROUP_BY_OPTIONS.SECTOR)
 
     return Array.from(byClassification.entries())
       .sort(([a], [b]) => sorter(a, b))

--- a/src/components/ui/__tests__/PerformanceHeatmap.test.tsx
+++ b/src/components/ui/__tests__/PerformanceHeatmap.test.tsx
@@ -17,12 +17,25 @@ import { HoldingGroup } from "types/beancounter"
 const VALUE_IN = "PORTFOLIO"
 const PORTFOLIO = makePortfolio()
 
-// Page-groupBy keys are deliberately unrelated to asset classification names
-// ("Sector A"/"Sector B" vs. "Equity"/"Fixed Income") to prove Groups mode
-// regroups by classification and ignores the holdingGroups key entirely.
+// Page-groupBy keys are deliberately unrelated to sector names ("Group
+// Alpha"/"Group Beta" vs. "Technology"/"Healthcare") to prove Groups mode
+// regroups by sector and ignores the holdingGroups key entirely.
+//
+// AAPL and BND share a sector ("Technology") but have *different*
+// assetCategory values (Equity vs. Fixed Income) — proving the grouping key
+// is asset.sector, not asset.assetCategory.name. MSFT sits in a different
+// sector ("Healthcare") despite sharing AAPL's assetCategory (Equity) —
+// proving two same-category assets are NOT merged just because they share a
+// category. CSCO carries no sector at all, exercising the "Unclassified"
+// fallback.
 function buildHoldingGroups(): Record<string, HoldingGroup> {
   const aapl = makePosition({
-    asset: makeAsset({ id: "asset-aapl", code: "AAPL", name: "Apple Inc." }),
+    asset: makeAsset({
+      id: "asset-aapl",
+      code: "AAPL",
+      name: "Apple Inc.",
+      sector: "Technology",
+    }),
     moneyValues: {
       marketValue: 50000,
       weight: 0.5,
@@ -44,6 +57,7 @@ function buildHoldingGroups(): Record<string, HoldingGroup> {
       id: "asset-msft",
       code: "MSFT",
       name: "Microsoft Corp",
+      sector: "Healthcare",
     }),
     moneyValues: {
       marketValue: 30000,
@@ -71,6 +85,7 @@ function buildHoldingGroups(): Record<string, HoldingGroup> {
       code: "BND",
       name: "Vanguard Bond ETF",
       assetCategory: { id: "BOND", name: "Fixed Income" },
+      sector: "Technology",
     }),
     moneyValues: {
       marketValue: 20000,
@@ -89,18 +104,40 @@ function buildHoldingGroups(): Record<string, HoldingGroup> {
     } as any,
   })
 
+  // No sector at all — must fall back to the "Unclassified" group.
+  const csco = makePosition({
+    asset: makeAsset({
+      id: "asset-csco",
+      code: "CSCO",
+      name: "Cisco Systems Inc.",
+    }),
+    moneyValues: {
+      marketValue: 2000,
+      weight: 0.02,
+      irr: 0.05,
+      gainOnDay: 5,
+      priceData: {
+        close: 50,
+        previousClose: 49.9,
+        change: 0.1,
+        changePercent: 0.002,
+        priceDate: "2024-01-15",
+      },
+    } as any,
+  })
+
   return {
-    "Sector A": makeHoldingGroup({
-      positions: [aapl, msft, cashPosition],
+    "Group Alpha": makeHoldingGroup({
+      positions: [aapl, msft, cashPosition, csco],
       subTotals: {
-        marketValue: 80000,
+        marketValue: 82000,
         totalGain: 8000,
         costValue: 60000,
-        gainOnDay: 400,
+        gainOnDay: 405,
         weightedIrr: 0.1,
       },
     }),
-    "Sector B": makeHoldingGroup({
+    "Group Beta": makeHoldingGroup({
       positions: [bond],
       subTotals: {
         marketValue: 20000,
@@ -156,7 +193,7 @@ describe("PerformanceHeatmap", () => {
     ).toBeInTheDocument()
   })
 
-  it("Groups mode regroups by asset classification, not the page's holdingGroups key", () => {
+  it("Groups mode regroups by sector, not asset category or the page's holdingGroups key", () => {
     render(
       <PerformanceHeatmap
         holdingGroups={buildHoldingGroups()}
@@ -166,15 +203,20 @@ describe("PerformanceHeatmap", () => {
       />,
     )
 
-    // Classification names show up as tiles...
-    expect(screen.getAllByText("Equity").length).toBeGreaterThan(0)
-    expect(screen.getAllByText("Fixed Income").length).toBeGreaterThan(0)
-    // ...but the page's own grouping keys never appear as tiles.
-    expect(screen.queryByText("Sector A")).not.toBeInTheDocument()
-    expect(screen.queryByText("Sector B")).not.toBeInTheDocument()
+    // Sector names show up as tiles...
+    expect(screen.getAllByText("Technology").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Healthcare").length).toBeGreaterThan(0)
+    // ...including the fallback for assets with no sector at all.
+    expect(screen.getAllByText("Unclassified").length).toBeGreaterThan(0)
+    // ...but asset-category names never appear as tiles in Groups mode.
+    expect(screen.queryByText("Equity")).not.toBeInTheDocument()
+    expect(screen.queryByText("Fixed Income")).not.toBeInTheDocument()
+    // ...and the page's own grouping keys never appear as tiles.
+    expect(screen.queryByText("Group Alpha")).not.toBeInTheDocument()
+    expect(screen.queryByText("Group Beta")).not.toBeInTheDocument()
   })
 
-  it("Groups mode opens a dialog listing a classification group's assets on click", () => {
+  it("Groups mode opens a dialog listing a sector group's assets on click, merging assets across differing asset categories", () => {
     render(
       <PerformanceHeatmap
         holdingGroups={buildHoldingGroups()}
@@ -184,13 +226,17 @@ describe("PerformanceHeatmap", () => {
       />,
     )
 
-    fireEvent.click(screen.getByTestId("heatmap-tile-groups-Equity"))
+    fireEvent.click(screen.getByTestId("heatmap-tile-groups-Technology"))
 
-    // Dialog title + table rows for the classification group's assets.
-    const dialogs = screen.getAllByText("Equity")
+    // Dialog title + table rows for the sector group's assets. AAPL (Equity)
+    // and BND (Fixed Income) both land in "Technology" — proving the group
+    // is keyed by sector even though their asset categories differ.
+    const dialogs = screen.getAllByText("Technology")
     expect(dialogs.length).toBeGreaterThan(1)
     expect(screen.getByText("Apple Inc.")).toBeInTheDocument()
-    expect(screen.getByText("Microsoft Corp")).toBeInTheDocument()
+    expect(screen.getByText("Vanguard Bond ETF")).toBeInTheDocument()
+    // MSFT is in a different sector ("Healthcare") and must not appear here.
+    expect(screen.queryByText("Microsoft Corp")).not.toBeInTheDocument()
   })
 
   it("switches metric label/values when toggled between Daily Gain and IRR", () => {


### PR DESCRIPTION
## What
The treemap heatmap's Groups mode (Assets/Groups toggle, introduced in #1097/#1098) grouped tiles by asset class (`asset.assetCategory.name` — Equity / Fixed Income / ETF). It now groups by industry classification: `asset.sector`, with an "Unclassified" fallback. Still fully independent of the page's Group-by control.

## How
- `PerformanceHeatmap.tsx`: classification key `assetCategory.name` → `sector || "Unclassified"`; group sort comparator `ASSET_CLASS` → `SECTOR` (alphabetical, Unclassified pinned last). Assets mode, drill-down dialog, weights untouched.
- `PerformanceHeatmap.test.tsx`: fixtures give positions sectors that cross asset-class lines (proves key source); asserts sector tiles appear, asset-class tiles don't, and Groups mode ignores the page's holdingGroups keys.

## Testing
- yarn test (2161 tests), prettier, lint, typecheck — all pass.
- Browser-verified on kauri data: Groups mode shows 21 sector tiles incl. Unclassified on /holdings/aggregated; switching page Group-by to Market leaves heatmap unchanged while the table regroups (LSE/NZX). Assets mode + tile click detail intact.

Noted during verification (pre-existing, NOT addressed here): React duplicate-key warning `assets-NATO` in Assets mode — two assets share ticker NATO; tile key should use asset id. Follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018S9bnhfJ6CUiCExUhLKJnV
