### PR TITLE
feat(trns): price chart popup on proposed review — compare limit vs market

### DIFF
--- a/src/components/features/holdings/PriceChartPopup.tsx
+++ b/src/components/features/holdings/PriceChartPopup.tsx
@@ -32,6 +32,12 @@ interface PriceChartPopupProps {
   // Aggregated holdings drill-down: an asset held across several portfolios.
   // Takes precedence over portfolioId; trades are fetched for the union.
   portfolios?: string[]
+  // Optional limit/target price to compare against the latest market close.
+  // When set, a horizontal reference line is drawn and the header reports the
+  // gap between market and limit — used by the proposed-trade review to sanity
+  // check a limit price against current market.
+  limitPrice?: number
+  limitLabel?: string
   onClose: () => void
 }
 
@@ -234,6 +240,8 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
   currencySymbol = "",
   portfolioId,
   portfolios,
+  limitPrice,
+  limitLabel = "Limit",
   onClose,
 }) => {
   const [months, setMonths] = useState(DEFAULT_MONTHS)
@@ -391,8 +399,10 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
       if (typeof p.buyPrice === "number") vals.push(p.buyPrice)
       if (typeof p.sellPrice === "number") vals.push(p.sellPrice)
     }
+    // Keep the limit line inside the plotted range so it never clips off-axis.
+    if (typeof limitPrice === "number") vals.push(limitPrice)
     return { min: Math.min(...vals), max: Math.max(...vals) }
-  }, [series])
+  }, [series, limitPrice])
 
   const yDomain = useMemo<[number, number]>(() => {
     if (series.length === 0) return [0, 1]
@@ -407,6 +417,14 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
       ? ((last.close - first.close) / first.close) * 100
       : 0
   const positive = changePct >= 0
+
+  // Gap of the latest market close over the supplied limit. Positive means the
+  // market trades above the limit (a buy limit would not fill; a sell limit
+  // would). null until we have both a close and a non-zero limit.
+  const limitGapPct =
+    typeof limitPrice === "number" && limitPrice !== 0 && last
+      ? ((last.close - limitPrice) / limitPrice) * 100
+      : null
 
   const splitEvents = useMemo(
     () => series.filter((p) => typeof p.split === "number"),
@@ -508,6 +526,25 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
               {positive ? "+" : ""}
               {changePct.toFixed(2)}%
             </div>
+            {typeof limitPrice === "number" && (
+              <div className="mt-1 text-xs tabular-nums">
+                <span className="text-gray-500">{limitLabel} </span>
+                <span className="font-medium text-gray-700">
+                  {currencySymbol}
+                  {limitPrice.toFixed(2)}
+                </span>
+                {limitGapPct !== null && (
+                  <span
+                    className={`ml-1 ${
+                      limitGapPct >= 0 ? "text-emerald-600" : "text-red-600"
+                    }`}
+                  >
+                    {limitGapPct >= 0 ? "+" : ""}
+                    {limitGapPct.toFixed(2)}% vs limit
+                  </span>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -595,6 +632,20 @@ const PriceChartPopup: React.FC<PriceChartPopupProps> = ({
                 fill="url(#priceFill)"
                 isAnimationActive={false}
               />
+              {typeof limitPrice === "number" && (
+                <ReferenceLine
+                  y={limitPrice}
+                  stroke="#7C3AED"
+                  strokeDasharray="5 4"
+                  strokeWidth={1.5}
+                  label={{
+                    value: `${limitLabel} ${currencySymbol}${limitPrice.toFixed(2)}`,
+                    position: "insideTopLeft",
+                    fontSize: 10,
+                    fill: "#6D28D9",
+                  }}
+                />
+              )}
               {splitEvents.map((p) => (
                 <ReferenceLine
                   key={`split-${p.priceDate}`}

--- a/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
+++ b/src/components/features/holdings/__tests__/PriceChartPopup.test.tsx
@@ -44,7 +44,12 @@ jest.mock("recharts", () => ({
   Scatter: ({ dataKey }: { dataKey: string }) => (
     <g data-testid={`scatter-${dataKey}`} />
   ),
-  ReferenceLine: ({ x }: { x: string }) => <g data-testid={`refline-${x}`} />,
+  ReferenceLine: ({ x, y }: { x?: string; y?: number }) =>
+    x != null ? (
+      <g data-testid={`refline-${x}`} />
+    ) : (
+      <g data-testid={`refline-y-${y}`} />
+    ),
   XAxis: () => <g />,
   YAxis: () => <g />,
   Tooltip: () => <g />,
@@ -95,7 +100,12 @@ function makeRouter(options: {
 }
 
 function renderPopup(
-  overrides: Partial<{ portfolioId: string; portfolios: string[] }> = {},
+  overrides: Partial<{
+    portfolioId: string
+    portfolios: string[]
+    limitPrice: number
+    limitLabel: string
+  }> = {},
 ): ReturnType<typeof render> {
   return render(
     <PriceChartPopup
@@ -105,6 +115,8 @@ function renderPopup(
         overrides.portfolios ? undefined : (overrides.portfolioId ?? "pf-1")
       }
       portfolios={overrides.portfolios}
+      limitPrice={overrides.limitPrice}
+      limitLabel={overrides.limitLabel}
       onClose={jest.fn()}
     />,
   )
@@ -138,6 +150,27 @@ describe("PriceChartPopup", () => {
     expect(screen.getByText("Microsoft")).toBeInTheDocument()
     expect(screen.getByTestId("area-close")).toBeInTheDocument()
     expect(screen.getByText(/5\.00%/)).toBeInTheDocument()
+  })
+
+  it("draws a limit reference line and the gap vs close when a limit is given", () => {
+    mockUseSwr.mockImplementation(makeRouter({}) as typeof useSwr)
+
+    // Latest close is 420; a 415 limit sits 1.20% below market.
+    renderPopup({ limitPrice: 415 })
+
+    expect(screen.getByTestId("refline-y-415")).toBeInTheDocument()
+    expect(screen.getByText("Limit")).toBeInTheDocument()
+    expect(screen.getByText(/\$415\.00/)).toBeInTheDocument()
+    // Market (close) is above the limit → positive gap.
+    expect(screen.getByText(/\+1\.20% vs limit/)).toBeInTheDocument()
+  })
+
+  it("omits the limit reference line when no limit is supplied", () => {
+    mockUseSwr.mockImplementation(makeRouter({}) as typeof useSwr)
+
+    renderPopup()
+
+    expect(screen.queryByText("Limit")).not.toBeInTheDocument()
   })
 
   it("defaults to the 6m range with SMA 20 on", () => {

--- a/src/components/features/transactions/AggregatedTransactionsTable.tsx
+++ b/src/components/features/transactions/AggregatedTransactionsTable.tsx
@@ -11,6 +11,7 @@ interface AggregatedTransactionsTableProps {
   onPriceChange: (aggregateKey: string, value: number) => void
   onStatusChange: (aggregateKey: string, value: TrnStatus) => void
   onTradeDateChange: (aggregateKey: string, value: string) => void
+  onShowChart?: (agg: AggregatedTransaction) => void
 }
 
 function isAggregatedSelected(
@@ -47,6 +48,7 @@ export default function AggregatedTransactionsTable({
   onPriceChange,
   onStatusChange,
   onTradeDateChange,
+  onShowChart,
 }: AggregatedTransactionsTableProps): React.ReactElement {
   return (
     <div className="overflow-x-auto bg-white rounded-lg shadow">
@@ -186,8 +188,21 @@ export default function AggregatedTransactionsTable({
                     </span>
                   </td>
                   <td className="px-2 py-1.5 whitespace-nowrap">
-                    <div className="font-medium text-gray-900">
-                      {agg.assetCode}
+                    <div className="flex items-center gap-1.5">
+                      <span className="font-medium text-gray-900">
+                        {agg.assetCode}
+                      </span>
+                      {onShowChart && (
+                        <button
+                          type="button"
+                          onClick={() => onShowChart(agg)}
+                          className="text-gray-400 hover:text-blue-600"
+                          title="Price chart vs avg price"
+                          aria-label={`Price chart for ${agg.assetCode}`}
+                        >
+                          <i className="fas fa-chart-line text-xs"></i>
+                        </button>
+                      )}
                     </div>
                     <div className="text-xs text-gray-500 truncate max-w-32">
                       {agg.assetName}

--- a/src/components/features/transactions/DetailedTransactionsTable.tsx
+++ b/src/components/features/transactions/DetailedTransactionsTable.tsx
@@ -21,6 +21,7 @@ interface DetailedTransactionsTableProps {
   onBrokerChange: (id: string, value: string) => void
   onEdit: (portfolioId: string, trnId: string) => void
   onDelete: (id: string) => void
+  onShowChart?: (trn: ProposedTransaction) => void
 }
 
 export default function DetailedTransactionsTable({
@@ -38,6 +39,7 @@ export default function DetailedTransactionsTable({
   onBrokerChange,
   onEdit,
   onDelete,
+  onShowChart,
 }: DetailedTransactionsTableProps): React.ReactElement {
   return (
     <div className="overflow-x-auto bg-white rounded-lg shadow">
@@ -150,8 +152,23 @@ export default function DetailedTransactionsTable({
                 </span>
               </td>
               <td className="px-2 py-1.5 whitespace-nowrap">
-                <div className="font-medium text-gray-900">
-                  {stripOwnerPrefix(trn.asset.code)}
+                <div className="flex items-center gap-1.5">
+                  <span className="font-medium text-gray-900">
+                    {stripOwnerPrefix(trn.asset.code)}
+                  </span>
+                  {onShowChart && (
+                    <button
+                      type="button"
+                      onClick={() => onShowChart(trn)}
+                      className="text-gray-400 hover:text-blue-600"
+                      title="Price chart vs limit"
+                      aria-label={`Price chart for ${stripOwnerPrefix(
+                        trn.asset.code,
+                      )}`}
+                    >
+                      <i className="fas fa-chart-line text-xs"></i>
+                    </button>
+                  )}
                 </div>
               </td>
               <td className="px-2 py-1.5 whitespace-nowrap text-gray-600">

--- a/src/components/features/transactions/__tests__/DetailedTransactionsTable.test.tsx
+++ b/src/components/features/transactions/__tests__/DetailedTransactionsTable.test.tsx
@@ -1,0 +1,82 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import DetailedTransactionsTable from "../DetailedTransactionsTable"
+import { ProposedTransaction } from "types/proposed"
+import {
+  makeAsset,
+  makeCurrency,
+  makePortfolio,
+} from "@test-fixtures/beancounter"
+
+function makeProposedTrn(
+  overrides: Partial<ProposedTransaction> = {},
+): ProposedTransaction {
+  const asset = makeAsset({ id: "msft-id", code: "MSFT", name: "Microsoft" })
+  return {
+    id: "trn-1",
+    trnType: "BUY",
+    status: "PROPOSED",
+    portfolio: makePortfolio({ id: "pf-1", code: "TEST" }),
+    asset,
+    tradeDate: "2026-07-16",
+    quantity: 10,
+    price: 400,
+    tradeCurrency: makeCurrency(),
+    fees: 0,
+    editedPrice: 415,
+    editedFees: 0,
+    editedStatus: "PROPOSED",
+    editedTradeDate: "2026-07-16",
+    ...overrides,
+  } as ProposedTransaction
+}
+
+const noopProps = {
+  brokers: [],
+  selectedIds: new Set<string>(),
+  allProposedSelected: false,
+  someProposedSelected: false,
+  onSelectAll: jest.fn(),
+  onSelectOne: jest.fn(),
+  onPriceChange: jest.fn(),
+  onFeesChange: jest.fn(),
+  onStatusChange: jest.fn(),
+  onTradeDateChange: jest.fn(),
+  onBrokerChange: jest.fn(),
+  onEdit: jest.fn(),
+  onDelete: jest.fn(),
+}
+
+describe("DetailedTransactionsTable price chart button", () => {
+  it("invokes onShowChart with the row when the chart icon is clicked", () => {
+    const trn = makeProposedTrn()
+    const onShowChart = jest.fn()
+
+    render(
+      <DetailedTransactionsTable
+        {...noopProps}
+        transactions={[trn]}
+        onShowChart={onShowChart}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /price chart for MSFT/i }),
+    )
+    expect(onShowChart).toHaveBeenCalledWith(trn)
+  })
+
+  it("omits the chart icon when no handler is supplied", () => {
+    render(
+      <DetailedTransactionsTable
+        {...noopProps}
+        transactions={[makeProposedTrn()]}
+      />,
+    )
+
+    expect(
+      screen.queryByRole("button", { name: /price chart/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/trns/proposed.tsx
+++ b/src/pages/trns/proposed.tsx
@@ -3,7 +3,13 @@ import { useRouter } from "next/router"
 import useSwr, { mutate } from "swr"
 import { fetcher, simpleFetcher, portfoliosKey } from "@utils/api/fetchHelper"
 import { rootLoader } from "@components/ui/PageLoader"
-import { Broker, Portfolio, Transaction, TrnStatus } from "types/beancounter"
+import {
+  Asset,
+  Broker,
+  Portfolio,
+  Transaction,
+  TrnStatus,
+} from "types/beancounter"
 import { ProposedTransaction, AggregatedTransaction } from "types/proposed"
 import Head from "next/head"
 import { useUser, withPageAuthRequired } from "@auth0/nextjs-auth0/client"
@@ -17,6 +23,7 @@ import Alert from "@components/ui/Alert"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
 import DetailedTransactionsTable from "@components/features/transactions/DetailedTransactionsTable"
 import AggregatedTransactionsTable from "@components/features/transactions/AggregatedTransactionsTable"
+import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
 import {
   getToday,
   getDateOffset,
@@ -86,6 +93,16 @@ function ProposedTransactions(): React.JSX.Element {
   const [editTarget, setEditTarget] = useState<{
     portfolioId: string
     trnId: string
+  } | null>(null)
+  // Price-chart popup target. limitPrice is the row's (edited) price so the
+  // reviewer can eyeball the limit against the latest market close.
+  const [chartTarget, setChartTarget] = useState<{
+    asset: Asset
+    portfolioId?: string
+    portfolios?: string[]
+    limitPrice: number
+    limitLabel: string
+    currencySymbol: string
   } | null>(null)
   const [sessionInitialized, setSessionInitialized] = useState(false)
 
@@ -538,6 +555,33 @@ function ProposedTransactions(): React.JSX.Element {
         proposedIds.forEach((id) => next.delete(id))
       }
       return next
+    })
+  }
+
+  const handleShowChart = (trn: ProposedTransaction): void => {
+    setChartTarget({
+      asset: trn.asset,
+      portfolioId: trn.portfolio.id,
+      limitPrice: trn.editedPrice ?? trn.price,
+      limitLabel: "Limit",
+      currencySymbol: trn.tradeCurrency?.symbol ?? "",
+    })
+  }
+
+  const handleShowAggregatedChart = (agg: AggregatedTransaction): void => {
+    const first = agg.transactions[0]
+    if (!first) return
+    // The aggregate spans one asset across portfolios — overlay trades from all
+    // of them and compare the weighted-average price against market.
+    const portfolios = Array.from(
+      new Set(agg.transactions.map((t) => t.portfolio.id)),
+    )
+    setChartTarget({
+      asset: first.asset,
+      portfolios,
+      limitPrice: agg.editedPrice ?? agg.avgPrice,
+      limitLabel: "Avg",
+      currencySymbol: first.tradeCurrency?.symbol ?? "",
     })
   }
 
@@ -1133,6 +1177,7 @@ function ProposedTransactions(): React.JSX.Element {
                   onBrokerChange={handleBrokerChange}
                   onEdit={handleEdit}
                   onDelete={setDeleteTargetId}
+                  onShowChart={handleShowChart}
                 />
               </div>
             )}
@@ -1147,6 +1192,7 @@ function ProposedTransactions(): React.JSX.Element {
                   onPriceChange={handleAggregatedPriceChange}
                   onStatusChange={handleAggregatedStatusChange}
                   onTradeDateChange={handleAggregatedTradeDateChange}
+                  onShowChart={handleShowAggregatedChart}
                 />
               </div>
             )}
@@ -1246,6 +1292,17 @@ function ProposedTransactions(): React.JSX.Element {
           variant="red"
           onConfirm={handleDeleteConfirm}
           onCancel={() => setDeleteTargetId(null)}
+        />
+      )}
+      {chartTarget && (
+        <PriceChartPopup
+          asset={chartTarget.asset}
+          currencySymbol={chartTarget.currencySymbol}
+          portfolioId={chartTarget.portfolioId}
+          portfolios={chartTarget.portfolios}
+          limitPrice={chartTarget.limitPrice}
+          limitLabel={chartTarget.limitLabel}
+          onClose={() => setChartTarget(null)}
         />
       )}
       {editTarget && (


### PR DESCRIPTION
## What

Adds a price-chart popup to the **Review Proposed Transactions** page so a reviewer can sanity-check a limit price against the current market before settling.

A chart icon sits in the Asset cell of every row (Detailed and Aggregated views). Clicking it opens the existing `PriceChartPopup`, now extended to overlay the row's limit price.

## Why

Reviewing proposed trades, there was no way to see whether a limit price was above or below where the asset is actually trading. You had to leave the page to check a chart elsewhere.

## How

- `PriceChartPopup` gains two optional props — `limitPrice` and `limitLabel`:
  - Draws a horizontal reference line at the limit.
  - Header reports the gap of the latest market **close** over the limit (`+Y% vs limit`). Positive means the market trades above the limit.
  - Extends the Y-domain so the limit line never clips off-axis.
  - Backward-compatible — existing holdings/rebalance/lookup callers pass no limit and are unchanged.
- `DetailedTransactionsTable` / `AggregatedTransactionsTable` gain an optional `onShowChart` callback + the chart icon.
- `proposed.tsx` owns the popup state and builds the chart target:
  - Detailed row → limit = the row's edited price; overlays that portfolio's trades.
  - Aggregated row → limit = weighted-average price; overlays trades across all underlying portfolios.

"Market price" is the latest daily close — BC price data is OHLC with no bid/ask, so there is no true mid.

## Tests

- `PriceChartPopup.test.tsx` — limit reference line drawn + gap shown when a limit is supplied; omitted when it isn't.
- `DetailedTransactionsTable.test.tsx` (new) — chart icon invokes `onShowChart` with the row; absent when no handler.
- Full suite green (2165 tests), typecheck clean.

## Not yet done

- Browser walkthrough on local dev with the demo user (pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
