### PR TITLE
fix(brokers): broker drill-down edit opens the trade editor

### DIFF
--- a/src/pages/brokers/[brokerId]/holdings.tsx
+++ b/src/pages/brokers/[brokerId]/holdings.tsx
@@ -128,8 +128,8 @@ export default withPageAuthRequired(
 
     const brokers: Broker[] = brokersData.data || []
     const holdings:
-      (BrokerHoldingsResponse & { totalHoldings: number }) | null =
-      mergedHoldings
+      | (BrokerHoldingsResponse & { totalHoldings: number })
+      | null = mergedHoldings
     // Sell proposes SELL trns against a real broker; NO_BROKER is a UI
     // sentinel grouping unassigned transactions, not a real broker id.
     const canSell = brokerId !== "NO_BROKER"
@@ -334,7 +334,7 @@ export default withPageAuthRequired(
                               </td>
                               <td className="px-4 py-1 text-right">
                                 <Link
-                                  href={`/trns/trades/${pg.portfolioCode}?trnId=${trn.id}`}
+                                  href={`/trns/trades/edit/${pg.portfolioId}/${trn.id}`}
                                   className="text-gray-400 hover:text-blue-600"
                                   title={"Edit"}
                                 >
@@ -471,7 +471,7 @@ export default withPageAuthRequired(
                           </span>
                         </div>
                         <Link
-                          href={`/trns/trades/${pg.portfolioCode}?trnId=${trn.id}`}
+                          href={`/trns/trades/edit/${pg.portfolioId}/${trn.id}`}
                           className="text-gray-400 hover:text-blue-600 p-1"
                         >
                           <i className="far fa-edit"></i>


### PR DESCRIPTION
## What

Fixes the edit (pencil) action on the broker holdings drill-down — it never opened the transaction editor.

## Root cause

The broker drill-down linked to `/trns/trades/{portfolioCode}?trnId={id}`. The trades page (`[...trades].tsx`) only enters edit mode when the path's first segment is `edit`; otherwise it treats segment 0 as an **assetId** (aggregated view) and ignores the `trnId` query param. So clicking edit from the broker drill-down landed on an aggregated view with no editor.

## Fix

Point both edit links (desktop + mobile) at the canonical edit route used everywhere else in the app:

`/trns/trades/edit/${pg.portfolioId}/${trn.id}`

`portfolioId` is already in scope on the `BrokerPortfolioGroup` (used as the React key). This matches the form used in `portfolios/trades`, `trns/proposed`, `trns/events`, `cash-ladder`, and the trades page itself.

## Notes

- Prettier also reformatted a pre-existing union-type annotation in the same file (2 lines) — incidental, formatting-only.

## Tests

- Full suite green (2161 tests), typecheck + eslint clean.
- Manual browser walkthrough on the broker drill-down still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
