### PR TITLE
fix(wealth): Net Worth headline reads live holdings total

### DIFF
--- a/src/components/features/wealth/__tests__/useWealthSummary.test.ts
+++ b/src/components/features/wealth/__tests__/useWealthSummary.test.ts
@@ -183,6 +183,63 @@ describe("useWealthSummary", () => {
     expect(result.current.totalValue).toBeCloseTo(100000, 2)
   })
 
+  it("headline totalValue uses the live holdings totals.BASE, not the stale persisted portfolio.marketValue", () => {
+    // portfolio.marketValue is a persisted snapshot that can lag current FX.
+    // When the live aggregated holdings response is present, the headline must
+    // read its authoritative totals.BASE so it reconciles with the drill-down.
+    const holdingsData = {
+      positions: {},
+      totals: {
+        BASE: { marketValue: 1914364, currency: { code: "USD" } },
+      },
+    } as unknown as HoldingContract
+    const portfolios = [
+      portfolio({
+        code: "P-USD",
+        marketValue: 1912969,
+        base: USD,
+        currency: USD,
+      }),
+    ]
+    const fxRates = { USD: 1 }
+
+    const { result } = renderHook(() =>
+      useWealthSummary(portfolios, fxRates, NO_SORT, holdingsData),
+    )
+    // Live total wins over the stale 1,912,969.
+    expect(result.current.totalValue).toBeCloseTo(1914364, 2)
+  })
+
+  it("converts the live totals.BASE to display currency and still adds standalone custom assets", () => {
+    const holdingsData = {
+      positions: {},
+      totals: {
+        BASE: { marketValue: 40000, currency: { code: "USD" } },
+      },
+    } as unknown as HoldingContract
+    const portfolios = [
+      portfolio({
+        code: "P-USD",
+        marketValue: 39999,
+        base: USD,
+        currency: USD,
+      }),
+    ]
+    const fxRates = { USD: 1.28, SGD: 1 }
+    const customAssetTotals = { SGD: 5000 }
+
+    const { result } = renderHook(() =>
+      useWealthSummary(
+        portfolios,
+        fxRates,
+        NO_SORT,
+        holdingsData,
+        customAssetTotals,
+      ),
+    )
+    expect(result.current.totalValue).toBeCloseTo(40000 * 1.28 + 5000, 2)
+  })
+
   it("converts classificationBreakdown (liquidity) values via fxRates, not raw BASE marketValue", () => {
     // Selected display currency is SGD. One position priced in SGD (Equity,
     // rate 1) and one in USD (Cash, rate 1.28) — the USD position's

--- a/src/components/features/wealth/useWealthSummary.ts
+++ b/src/components/features/wealth/useWealthSummary.ts
@@ -42,7 +42,6 @@ export function useWealthSummary(
       }
     }
 
-    let totalValue = 0
     const portfolioValues: {
       code: string
       name: string
@@ -50,13 +49,15 @@ export function useWealthSummary(
       irr: number
     }[] = []
 
+    // Per-portfolio persisted marketValue — drives the breakdown table rows.
+    let portfolioMarketValueTotal = 0
     portfolios.forEach((portfolio) => {
       // marketValue is stored in the portfolio's BASE currency
       const marketValue = portfolio.marketValue || 0
       const rate = fxRates[portfolio.base.code] || 1
       const convertedValue = marketValue * rate
 
-      totalValue += convertedValue
+      portfolioMarketValueTotal += convertedValue
 
       portfolioValues.push({
         code: portfolio.code,
@@ -65,6 +66,17 @@ export function useWealthSummary(
         irr: portfolio.irr || 0,
       })
     })
+
+    // Headline: prefer the live aggregated holdings total (Σ live positions in
+    // BASE) over the persisted per-portfolio marketValue, which lags current FX
+    // until svc-position revalues. Reading totals.BASE keeps the headline
+    // reconciled with the holdings drill-down. Fall back to the persisted sum
+    // when holdings (or their totals) are unavailable.
+    const liveBase = holdingsData?.totals?.BASE
+    let totalValue =
+      liveBase && typeof liveBase.marketValue === "number"
+        ? liveBase.marketValue * (fxRates[liveBase.currency?.code] || 1)
+        : portfolioMarketValueTotal
 
     Object.entries(customAssetTotals).forEach(([currency, balance]) => {
       const rate = fxRates[currency] || 1


### PR DESCRIPTION
The Net Worth headline summed persisted portfolio.marketValue, which lags
current FX, while the holdings drill-down sums live positions — so the two
disagreed by the intraday FX drift (~0.1%).

useWealthSummary now reads the live aggregated totals.BASE (converted to the
display currency) for the headline, falling back to the persisted per-portfolio
sum only when holdings are unavailable. Custom-asset balances are still added.
Headline reconciles with the drill-down by construction.
