### PR TITLE
feat(rebalance): ad-hoc weight editor entry from holdings

### DIFF
--- a/__tests__/pages/rebalance/execute-adhoc.test.tsx
+++ b/__tests__/pages/rebalance/execute-adhoc.test.tsx
@@ -1,0 +1,179 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { ExecutionDto } from "types/rebalance"
+
+const routerState: {
+  isReady: boolean
+  query: Record<string, string>
+  push: jest.Mock
+  replace: jest.Mock
+  back: jest.Mock
+} = {
+  isReady: true,
+  query: { adhoc: "1", portfolios: "p1", currency: "USD" },
+  push: jest.fn(),
+  replace: jest.fn(),
+  back: jest.fn(),
+}
+jest.mock("next/router", () => ({
+  useRouter: () => ({ ...routerState }),
+}))
+
+const makeAdhocExecution = (): ExecutionDto => ({
+  id: "adhoc-exec-1",
+  planId: null,
+  planVersion: null,
+  modelId: null,
+  modelName: null,
+  portfolioIds: ["p1"],
+  snapshotTotalValue: 10000,
+  snapshotCashValue: 1000,
+  totalPortfolioValue: 10000,
+  currency: "USD",
+  status: "DRAFT",
+  mode: "AD_HOC",
+  items: [
+    {
+      id: "item-1",
+      assetId: "asset-1",
+      assetCode: "AAPL",
+      assetName: "Apple Inc",
+      snapshotWeight: 0.5,
+      snapshotValue: 5000,
+      snapshotQuantity: 50,
+      snapshotPrice: 100,
+      priceCurrency: "USD",
+      planTargetWeight: 0.5,
+      effectiveTarget: 0.5,
+      hasOverride: false,
+      deltaValue: 0,
+      deltaQuantity: 0,
+      action: "HOLD",
+      excluded: false,
+      locked: false,
+      sortOrder: 0,
+      isCash: false,
+    },
+    {
+      id: "cash-item",
+      assetId: "cash-usd",
+      assetCode: "USD",
+      assetName: "US Dollar",
+      snapshotWeight: 0.5,
+      snapshotValue: 5000,
+      snapshotQuantity: 5000,
+      snapshotPrice: 1,
+      priceCurrency: "USD",
+      planTargetWeight: 0.5,
+      effectiveTarget: 0.5,
+      hasOverride: false,
+      deltaValue: 0,
+      deltaQuantity: 0,
+      action: "HOLD",
+      excluded: false,
+      locked: false,
+      sortOrder: 1,
+      isCash: true,
+    },
+  ],
+  cashSummary: {
+    currentCash: 5000,
+    cashFromSales: 0,
+    cashForPurchases: 0,
+    netImpact: 0,
+    projectedCash: 5000,
+    projectedMarketValue: 10000,
+  },
+  createdAt: "2025-01-01",
+  updatedAt: "2025-01-01",
+})
+
+const executionState: {
+  execution: ExecutionDto | null
+  displayItems: unknown[]
+  activeItems: unknown[]
+  cashSummary: {
+    currentMarketValue: number
+    currentCash: number
+    targetCash: number
+    cashFromSales: number
+    cashForPurchases: number
+  }
+  brokers: unknown[]
+  selectedBrokerId: string | undefined
+  setSelectedBrokerId: jest.Mock
+  states: {
+    loading: boolean
+    saving: boolean
+    refreshing: boolean
+    committing: boolean
+    hasChanges: boolean
+    error: string | null
+  }
+  handlers: Record<string, jest.Mock>
+  createdExecutionId: string | null
+} = {
+  execution: null,
+  displayItems: [],
+  activeItems: [],
+  cashSummary: {
+    currentMarketValue: 0,
+    currentCash: 0,
+    targetCash: 0,
+    cashFromSales: 0,
+    cashForPurchases: 0,
+  },
+  brokers: [],
+  selectedBrokerId: undefined,
+  setSelectedBrokerId: jest.fn(),
+  states: {
+    loading: false,
+    saving: false,
+    refreshing: false,
+    committing: false,
+    hasChanges: false,
+    error: null,
+  },
+  handlers: {
+    initialize: jest.fn(),
+    save: jest.fn(),
+    refresh: jest.fn(),
+    commit: jest.fn(),
+    targetChange: jest.fn(),
+    excludeToggle: jest.fn(),
+    setAllToCurrent: jest.fn(),
+    setAllToTarget: jest.fn(),
+    setAllToZero: jest.fn(),
+    setAllToAdjusted: jest.fn(),
+    setToCurrent: jest.fn(),
+    setToTarget: jest.fn(),
+    setError: jest.fn(),
+  },
+  createdExecutionId: null,
+}
+jest.mock("@hooks/useRebalanceExecution", () => ({
+  useRebalanceExecution: () => executionState,
+}))
+
+import ExecuteRebalancePage from "@pages/rebalance/execute"
+
+describe("ExecuteRebalancePage — ad-hoc (no plan/model)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    routerState.query = { adhoc: "1", portfolios: "p1", currency: "USD" }
+    executionState.execution = makeAdhocExecution()
+  })
+
+  it("shows 'Ad-hoc Rebalance' header and no plan/model line when modelName is null", () => {
+    render(<ExecuteRebalancePage />)
+
+    expect(
+      screen.getByRole("heading", { name: "Ad-hoc Rebalance" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Using plan/)).not.toBeInTheDocument()
+  })
+
+  it("does not throw when planVersion/modelId are null", () => {
+    expect(() => render(<ExecuteRebalancePage />)).not.toThrow()
+  })
+})

--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -440,6 +440,18 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
         icon: "fa-chart-pie",
         onClick: () => onInvestCash?.(),
       },
+      {
+        // Ad-hoc rebalance: opens the multi-position rebalance editor seeded
+        // from live holdings (all deltas zero, no model/plan). Available to
+        // all users — unlike "Rebalance Model" below, it doesn't rely on the
+        // (still in-development) model/plan feature.
+        label: "Rebalance Weights",
+        icon: "fa-sliders-h",
+        onClick: () =>
+          router.push(
+            `/rebalance/execute?adhoc=1&portfolios=${holdingResults.portfolio.id}&currency=${holdingResults.portfolio.currency.code}`,
+          ),
+      },
     ]
     // Add "Rebalance Model" for admins only (feature in development)
     if (isAdmin) {
@@ -450,7 +462,14 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
       })
     }
     return items
-  }, [isAdmin, onInvestCash, onSelectPlan])
+  }, [
+    isAdmin,
+    onInvestCash,
+    onSelectPlan,
+    router,
+    holdingResults.portfolio.id,
+    holdingResults.portfolio.currency.code,
+  ])
 
   return (
     <>

--- a/src/components/features/holdings/__tests__/HoldingActions.test.tsx
+++ b/src/components/features/holdings/__tests__/HoldingActions.test.tsx
@@ -4,6 +4,22 @@ import "@testing-library/jest-dom"
 import HoldingActions from "../HoldingActions"
 import { HoldingContract } from "types/beancounter"
 
+// Local router mock (overrides jest.setup.js's default) so we can assert on
+// the exact push() call the "Rebalance Weights" menu item makes.
+const mockPush = jest.fn()
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    route: "/",
+    pathname: "",
+    query: {},
+    asPath: "",
+    push: mockPush,
+    events: { on: jest.fn(), off: jest.fn() },
+    beforePopState: jest.fn(() => null),
+    prefetch: jest.fn(() => null),
+  }),
+}))
+
 // Helper to set up matchMedia mock
 function setupMatchMedia(width: number, height: number): void {
   const isPortrait = height > width
@@ -310,6 +326,46 @@ describe("HoldingActions Mobile Portrait Tests (TDD)", () => {
       fireEvent.click(screen.getByText("Invest Cash"))
 
       expect(onInvestCash).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Ad-hoc rebalance entry point: unlike "Rebalance Model" (admin-gated,
+  // model/plan feature in development), "Rebalance Weights" opens the
+  // multi-position rebalance editor seeded straight from live holdings and
+  // must be reachable by all users.
+  describe("Rebalance Weights entry (ad-hoc)", () => {
+    beforeEach(() => {
+      mockPush.mockClear()
+    })
+
+    it("is reachable for non-admin users", () => {
+      render(
+        <HoldingActions
+          holdingResults={mockHoldingResults}
+          columns={mockColumns}
+          valueIn={mockValueIn}
+        />,
+      )
+
+      fireEvent.click(screen.getByLabelText("Invest"))
+      expect(screen.getByText("Rebalance Weights")).toBeInTheDocument()
+    })
+
+    it("routes to the ad-hoc rebalance execute page with portfolio id and currency", () => {
+      render(
+        <HoldingActions
+          holdingResults={mockHoldingResults}
+          columns={mockColumns}
+          valueIn={mockValueIn}
+        />,
+      )
+
+      fireEvent.click(screen.getByLabelText("Invest"))
+      fireEvent.click(screen.getByText("Rebalance Weights"))
+
+      expect(mockPush).toHaveBeenCalledWith(
+        "/rebalance/execute?adhoc=1&portfolios=test-portfolio&currency=USD",
+      )
     })
   })
 })

--- a/src/components/features/rebalance/execution/ExecutionList.tsx
+++ b/src/components/features/rebalance/execution/ExecutionList.tsx
@@ -98,11 +98,14 @@ const ExecutionList: React.FC = () => {
             >
               <td className="px-4 py-3">
                 <span className="font-medium text-blue-600">
-                  {execution.name || `Plan v${execution.planVersion}`}
+                  {execution.name ||
+                    (execution.modelName
+                      ? `Plan v${execution.planVersion}`
+                      : "Ad-hoc Rebalance")}
                 </span>
               </td>
               <td className={`px-4 py-3 text-gray-600 ${hiddenSm}`}>
-                {execution.modelName}
+                {execution.modelName ?? "Ad-hoc"}
               </td>
               <td className="px-4 py-3 text-center">
                 <span className="bg-gray-100 px-2 py-1 rounded text-sm">

--- a/src/components/features/rebalance/execution/__tests__/ExecutionList.test.tsx
+++ b/src/components/features/rebalance/execution/__tests__/ExecutionList.test.tsx
@@ -1,0 +1,79 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { ExecutionSummaryDto } from "types/rebalance"
+
+const mockPush = jest.fn()
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+const mockUseExecutions: {
+  executions: ExecutionSummaryDto[]
+  isLoading: boolean
+  error: Error | undefined
+} = {
+  executions: [],
+  isLoading: false,
+  error: undefined,
+}
+jest.mock("../../hooks/useExecutions", () => ({
+  useExecutions: () => mockUseExecutions,
+}))
+
+import ExecutionList from "../ExecutionList"
+
+// Spread `overrides` last so an explicit `null` (nullable AD_HOC fields) wins
+// over the default — `??`-per-field would collapse an explicit null back to
+// the default since `??` treats null as "use the fallback".
+const makeSummary = (
+  overrides: Partial<ExecutionSummaryDto> = {},
+): ExecutionSummaryDto => ({
+  id: "exec-1",
+  planId: "plan-1",
+  planVersion: 2,
+  modelId: "model-1",
+  modelName: "Growth Model",
+  name: undefined,
+  portfolioCount: 1,
+  status: "DRAFT",
+  mode: "REBALANCE",
+  snapshotTotalValue: 10000,
+  currency: "USD",
+  createdAt: "2025-01-01",
+  updatedAt: "2025-01-01",
+  ...overrides,
+})
+
+describe("ExecutionList — ad-hoc (null plan/model) rendering", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders 'Ad-hoc' model column and 'Ad-hoc Rebalance' title when modelName is null", () => {
+    mockUseExecutions.executions = [
+      makeSummary({
+        id: "adhoc-1",
+        planId: null,
+        planVersion: null,
+        modelId: null,
+        modelName: null,
+        name: undefined,
+      }),
+    ]
+
+    render(<ExecutionList />)
+
+    expect(screen.getByText("Ad-hoc Rebalance")).toBeInTheDocument()
+    expect(screen.getByText("Ad-hoc")).toBeInTheDocument()
+  })
+
+  it("still renders model-based executions with plan version and model name", () => {
+    mockUseExecutions.executions = [makeSummary()]
+
+    render(<ExecutionList />)
+
+    expect(screen.getByText("Plan v2")).toBeInTheDocument()
+    expect(screen.getByText("Growth Model")).toBeInTheDocument()
+  })
+})

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -296,6 +296,49 @@ describe("useRebalanceExecution", () => {
     expect(result.current.createdExecutionId).toBe("adhoc-exec-1")
   })
 
+  it("guards against a duplicate create POST when the mount effect fires twice before the first create resolves (React 18 dev double-invoke)", async () => {
+    const exec = makeExecution({ id: "new-exec-1" })
+    // Never resolves within this test — we only care how many creates were
+    // dispatched before the (guarded) second attempt bails out.
+    let resolveFetch: (value: unknown) => void = () => {}
+    ;(global.fetch as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        }),
+    )
+
+    const { result } = renderHook(() =>
+      useRebalanceExecution({
+        planId: "plan-1",
+        portfolioIds: ["portfolio-1"],
+        filterByModel: true,
+      }),
+    )
+
+    // The mount effect has already fired initializeExecution() once (fetch
+    // #1 is in flight, paused before its `await` resolves). Simulate a
+    // second invocation of the same effect body — exactly what React 18
+    // StrictMode's dev double-invoke (or a re-render racing the in-flight
+    // create) does — before any state from the first call has committed.
+    act(() => {
+      result.current.handlers.initialize()
+    })
+
+    const createCalls = (global.fetch as jest.Mock).mock.calls.filter(
+      ([url, opts]) =>
+        url === "/api/rebalance/executions" && opts?.method === "POST",
+    )
+    expect(createCalls.length).toBe(1)
+
+    // Let the in-flight create resolve so the test doesn't leak a pending
+    // promise/timer into the next test.
+    await act(async () => {
+      resolveFetch({ ok: true, json: () => Promise.resolve({ data: exec }) })
+      await Promise.resolve()
+    })
+  })
+
   it("does not create an execution when adhoc is true but currency is missing", async () => {
     const { result } = renderHook(() =>
       useRebalanceExecution({

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -60,10 +60,13 @@ const makeExecution = (
   overrides: Partial<ExecutionDto> = {},
 ): ExecutionDto => ({
   id: overrides.id ?? "exec-1",
-  planId: overrides.planId ?? "plan-1",
-  planVersion: overrides.planVersion ?? 1,
-  modelId: overrides.modelId ?? "model-1",
-  modelName: overrides.modelName ?? "Test Model",
+  // Nullable AD_HOC fields: use `in` rather than `??` so an explicit `null`
+  // override (ad-hoc fixtures) isn't collapsed back to the default — `??`
+  // treats null and undefined alike.
+  planId: "planId" in overrides ? overrides.planId! : "plan-1",
+  planVersion: "planVersion" in overrides ? overrides.planVersion! : 1,
+  modelId: "modelId" in overrides ? overrides.modelId! : "model-1",
+  modelName: "modelName" in overrides ? overrides.modelName! : "Test Model",
   portfolioIds: overrides.portfolioIds ?? ["portfolio-1"],
   snapshotTotalValue: overrides.snapshotTotalValue ?? 10000,
   snapshotCashValue: overrides.snapshotCashValue ?? 1000,
@@ -255,6 +258,59 @@ describe("useRebalanceExecution", () => {
     })
     expect(result.current.execution).toEqual(exec)
     expect(result.current.createdExecutionId).toBe("new-exec-1")
+  })
+
+  it("creates ad-hoc execution when adhoc+currency provided without planId", async () => {
+    const exec = makeExecution({
+      id: "adhoc-exec-1",
+      planId: null,
+      planVersion: null,
+      modelId: null,
+      modelName: null,
+    })
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: exec }),
+    })
+
+    const { result } = renderHook(() =>
+      useRebalanceExecution({
+        portfolioIds: ["portfolio-1"],
+        adhoc: true,
+        currency: "USD",
+      }),
+    )
+
+    await act(async () => {})
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/rebalance/executions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mode: "AD_HOC",
+        portfolioIds: ["portfolio-1"],
+        currency: "USD",
+      }),
+    })
+    expect(result.current.execution).toEqual(exec)
+    expect(result.current.createdExecutionId).toBe("adhoc-exec-1")
+  })
+
+  it("does not create an execution when adhoc is true but currency is missing", async () => {
+    const { result } = renderHook(() =>
+      useRebalanceExecution({
+        portfolioIds: ["portfolio-1"],
+        adhoc: true,
+      }),
+    )
+
+    await act(async () => {})
+
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "/api/rebalance/executions",
+      expect.anything(),
+    )
+    expect(result.current.execution).toBeNull()
   })
 
   // --- Display items computation ---

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -606,6 +606,71 @@ describe("useRebalanceExecution", () => {
     expect(result.current.states.hasChanges).toBe(false)
   })
 
+  it("handleSave preserves server-seeded excluded items the user never toggled", async () => {
+    // Regression (E2E-confirmed, critical): on execution CREATE (ad-hoc or
+    // model-based), the hook seeds localOverrides from the response but
+    // never seeds localExclusions (unlike the load-existing-execution path,
+    // which does). So a2 arrives excluded=true from the server (e.g. the
+    // backend auto-excludes a PRIVATE/CPF asset) but localExclusions has no
+    // entry for it. If handleSave falls back to `?? false` instead of `??
+    // item.excluded`, it clobbers the server-seeded exclusion, and the
+    // backend then recalculates and proposes a sell-to-zero for it.
+    const exec = makeExecution({
+      id: "adhoc-exec-1",
+      planId: null,
+      planVersion: null,
+      modelId: null,
+      modelName: null,
+      items: [
+        makeItem({ assetId: "a1", excluded: false }),
+        makeItem({ assetId: "a2", excluded: true }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: exec }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: exec }),
+      })
+
+    const { result } = renderHook(() =>
+      useRebalanceExecution({
+        portfolioIds: ["portfolio-1"],
+        adhoc: true,
+        currency: "USD",
+      }),
+    )
+
+    await act(async () => {})
+    expect(result.current.execution).toEqual(exec)
+
+    // The user never touches a2's checkbox — only an unrelated target
+    // change on a1.
+    act(() => {
+      result.current.handlers.targetChange("a1", 0.7)
+    })
+
+    await act(async () => {
+      await result.current.handlers.save()
+    })
+
+    const putCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url, opts]) =>
+        url === "/api/rebalance/executions/adhoc-exec-1" &&
+        opts?.method === "PUT",
+    )
+    expect(putCall).toBeDefined()
+    const body = JSON.parse(putCall![1].body)
+    const a2Update = body.itemUpdates.find(
+      (u: { assetId: string }) => u.assetId === "a2",
+    )
+    expect(a2Update.excluded).toBe(true)
+  })
+
   // --- Refresh ---
 
   it("handleRefresh sends POST to refresh endpoint", async () => {

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -33,6 +33,10 @@ export interface UseRebalanceExecutionParams {
   planId?: string
   portfolioIds: string[]
   filterByModel?: boolean
+  /** Create an AD_HOC execution (seeded from live holdings, no plan) — requires `currency` */
+  adhoc?: boolean
+  /** Portfolio report currency — required when `adhoc` is true */
+  currency?: string
 }
 
 export interface UseRebalanceExecutionResult {
@@ -81,7 +85,8 @@ export interface UseRebalanceExecutionResult {
 export function useRebalanceExecution(
   params: UseRebalanceExecutionParams,
 ): UseRebalanceExecutionResult {
-  const { executionId, planId, portfolioIds, filterByModel } = params
+  const { executionId, planId, portfolioIds, filterByModel, adhoc, currency } =
+    params
 
   // Core state
   const [execution, setExecution] = useState<ExecutionDto | null>(null)
@@ -169,19 +174,25 @@ export function useRebalanceExecution(
       } finally {
         setLoading(false)
       }
-    } else if (planId && portfolioIds.length > 0) {
-      // Create new execution
+    } else {
+      // Create new execution: model-based (planId) or ad-hoc (adhoc + currency).
+      // Ad-hoc omits planId entirely — the server rejects AD_HOC requests that
+      // supply one.
+      const createBody = planId
+        ? { planId, portfolioIds, filterByModel: filterByModel === true }
+        : adhoc && currency
+          ? { mode: "AD_HOC" as const, portfolioIds, currency }
+          : null
+
+      if (!createBody || portfolioIds.length === 0) return
+
       setLoading(true)
       setError(null)
       try {
         const response = await fetch("/api/rebalance/executions", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            planId,
-            portfolioIds,
-            filterByModel: filterByModel === true,
-          }),
+          body: JSON.stringify(createBody),
         })
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}))
@@ -193,7 +204,9 @@ export function useRebalanceExecution(
         }
         const data = await response.json()
         setExecution(data.data)
-        // Default to return-adjusted targets for new executions
+        // Default to return-adjusted targets for new executions (ad-hoc
+        // executions have no returnAdjustedTarget, so this is a no-op there —
+        // items are already seeded with zero deltas).
         const adjustedOverrides: Record<string, number> = {}
         data.data.items.forEach((item: ExecutionItemDto) => {
           if (!item.isCash && item.returnAdjustedTarget != null) {
@@ -210,7 +223,7 @@ export function useRebalanceExecution(
         setLoading(false)
       }
     }
-  }, [executionId, planId, portfolioIds, filterByModel])
+  }, [executionId, planId, portfolioIds, filterByModel, adhoc, currency])
 
   // Initialize on mount (skip if already loaded, loading, or errored)
   useEffect(() => {
@@ -218,7 +231,9 @@ export function useRebalanceExecution(
       !execution &&
       !loading &&
       !error &&
-      (executionId || (planId && portfolioIds.length > 0))
+      (executionId ||
+        (planId && portfolioIds.length > 0) ||
+        (adhoc && currency && portfolioIds.length > 0))
     ) {
       // Genuine async data-load orchestration: fetches/creates an execution
       // and sets state from the awaited result. Guarded against re-entry by
@@ -233,6 +248,8 @@ export function useRebalanceExecution(
     executionId,
     planId,
     portfolioIds.length,
+    adhoc,
+    currency,
     initializeExecution,
   ])
 

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from "react"
+import { useState, useCallback, useMemo, useEffect, useRef } from "react"
 import useSwr from "swr"
 import { simpleFetcher } from "@utils/api/fetchHelper"
 import { toErrorMessage } from "@lib/formatters"
@@ -115,6 +115,16 @@ export function useRebalanceExecution(
     null,
   )
 
+  // Guards the create-execution POST against firing twice for the same
+  // mount/param-set. The mount effect's re-entry guard reads `execution` /
+  // `loading` from render-time state, but two effect invocations that both
+  // fire before either state update commits (React 18 dev double-invoke, or
+  // any re-render racing the in-flight fetch) both see the pre-create
+  // snapshot and both pass the guard — each issuing its own POST and
+  // orphaning a duplicate DRAFT execution. A ref is synchronous and shared
+  // across those invocations, so the second one bails out immediately.
+  const createInFlightRef = useRef(false)
+
   // --- SWR data ---
 
   const { data: brokersData } = useSwr(
@@ -186,6 +196,11 @@ export function useRebalanceExecution(
 
       if (!createBody || portfolioIds.length === 0) return
 
+      // Bail if a create is already in flight (or already succeeded) for
+      // this hook instance — see createInFlightRef above.
+      if (createInFlightRef.current) return
+      createInFlightRef.current = true
+
       setLoading(true)
       setError(null)
       try {
@@ -200,6 +215,9 @@ export function useRebalanceExecution(
             errorData.message ||
               `Failed to create execution: ${response.status}`,
           )
+          // Allow a retry (e.g. via the error banner's Retry button) to
+          // issue a fresh create.
+          createInFlightRef.current = false
           return
         }
         const data = await response.json()
@@ -219,6 +237,7 @@ export function useRebalanceExecution(
       } catch (err) {
         console.error("Failed to create execution:", err)
         setError(toErrorMessage(err, "Failed to create execution"))
+        createInFlightRef.current = false
       } finally {
         setLoading(false)
       }

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -282,7 +282,7 @@ export function useRebalanceExecution(
         (item) => ({
           assetId: item.assetId,
           effectiveTargetOverride: localOverrides[item.assetId],
-          excluded: localExclusions[item.assetId] ?? false,
+          excluded: localExclusions[item.assetId] ?? item.excluded,
         }),
       )
 

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -16,6 +16,8 @@ function ExecuteRebalancePage(): React.ReactElement {
     executionId,
     source,
     filterByModel: filterByModelParam,
+    adhoc,
+    currency,
   } = router.query
 
   const portfolioIds = useMemo(
@@ -47,6 +49,8 @@ function ExecuteRebalancePage(): React.ReactElement {
     planId: planId as string | undefined,
     portfolioIds,
     filterByModel: filterByModelParam === "true",
+    adhoc: adhoc === "1",
+    currency: currency as string | undefined,
   })
 
   // Handle URL update after new execution creation. The executionId guard is
@@ -119,15 +123,21 @@ function ExecuteRebalancePage(): React.ReactElement {
         <div className="flex items-start justify-between mb-4">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">
-              {"Rebalance Portfolio"}
+              {execution.modelName ? "Rebalance Portfolio" : "Ad-hoc Rebalance"}
             </h1>
             <p className="text-sm text-gray-600 mt-1">
-              {"Using plan"}: {execution.modelName} v{execution.planVersion}
-              {execution.filterByModel && (
-                <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
-                  <i className="fas fa-filter mr-1"></i>
-                  {"Model positions only"}
-                </span>
+              {execution.modelName ? (
+                <>
+                  {"Using plan"}: {execution.modelName} v{execution.planVersion}
+                  {execution.filterByModel && (
+                    <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
+                      <i className="fas fa-filter mr-1"></i>
+                      {"Model positions only"}
+                    </span>
+                  )}
+                </>
+              ) : (
+                "Target weights seeded from current holdings — edit to rebalance"
               )}
             </p>
           </div>

--- a/types/rebalance.d.ts
+++ b/types/rebalance.d.ts
@@ -321,14 +321,15 @@ export interface RebalanceCalculationResponse {
 export type ExecutionPlanStatus =
   "DRAFT" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED"
 
-export type ExecutionMode = "REBALANCE" | "INVEST_CASH"
+export type ExecutionMode = "REBALANCE" | "INVEST_CASH" | "AD_HOC"
 
 export interface ExecutionDto {
   id: string
-  planId: string
-  planVersion: number
-  modelId: string
-  modelName: string
+  /** Null for AD_HOC mode (no model/plan behind the execution) */
+  planId: string | null
+  planVersion: number | null
+  modelId: string | null
+  modelName: string | null
   portfolioIds: string[]
   name?: string
   snapshotTotalValue: number
@@ -349,10 +350,11 @@ export interface ExecutionDto {
 
 export interface ExecutionSummaryDto {
   id: string
-  planId: string
-  planVersion: number
-  modelId: string
-  modelName: string
+  /** Null for AD_HOC mode (no model/plan behind the execution) */
+  planId: string | null
+  planVersion: number | null
+  modelId: string | null
+  modelName: string | null
   name?: string
   portfolioCount: number
   status: ExecutionPlanStatus
@@ -401,15 +403,18 @@ export interface CashSummaryDto {
 }
 
 export interface CreateExecutionRequest {
-  planId: string
+  /** Required for REBALANCE/INVEST_CASH; omitted (and rejected if supplied) for AD_HOC */
+  planId?: string
   portfolioIds: string[]
   name?: string
-  /** Execution mode: REBALANCE (default) or INVEST_CASH */
+  /** Execution mode: REBALANCE (default), INVEST_CASH, or AD_HOC */
   mode?: ExecutionMode
   /** Amount of cash to invest (only used in INVEST_CASH mode) */
   investmentAmount?: number
   /** When true, only consider positions from transactions tagged with this model's ID */
   filterByModel?: boolean
+  /** Required for AD_HOC mode — the portfolio's report currency */
+  currency?: string
 }
 
 export interface CommitExecutionRequest {


### PR DESCRIPTION
## Ad-hoc rebalance weight editor entry

Holdings → Invest → "Rebalance Weights" opens `/rebalance/execute?adhoc=1&portfolios={id}&currency={ccy}` — the existing multi-position editor, now usable without a Model/Plan. Seeded from live holdings (deltas zero); edit weights up/down, CashSummaryPanel shows cash to invest/receive, commit creates PROPOSED trns.

- `types/rebalance.d.ts`: `AD_HOC` mode; nullable planId/modelName fallout
- `useRebalanceExecution`: ad-hoc create body `{mode: "AD_HOC", portfolioIds, currency}`
- Execute page + ExecutionList: null-safe "Ad-hoc Rebalance" display
- `HoldingActions`: new menu item (all users)

Backend counterpart: svc-rebalance `feature/adhoc-rebalance` (must deploy first).

Tests: 2175 green incl. new hook/render/menu tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
