### PR TITLE
feat(rebalance): slider weight editing with step toggle

### DIFF
--- a/__tests__/pages/rebalance/execute-slider.test.tsx
+++ b/__tests__/pages/rebalance/execute-slider.test.tsx
@@ -1,0 +1,274 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { ExecutionDto } from "types/rebalance"
+
+const routerState: {
+  isReady: boolean
+  query: Record<string, string>
+  push: jest.Mock
+  replace: jest.Mock
+  back: jest.Mock
+} = {
+  isReady: true,
+  query: { adhoc: "1", portfolios: "p1", currency: "USD" },
+  push: jest.fn(),
+  replace: jest.fn(),
+  back: jest.fn(),
+}
+jest.mock("next/router", () => ({
+  useRouter: () => ({ ...routerState }),
+}))
+
+const makeExecution = (): ExecutionDto => ({
+  id: "adhoc-exec-1",
+  planId: null,
+  planVersion: null,
+  modelId: null,
+  modelName: null,
+  portfolioIds: ["p1"],
+  snapshotTotalValue: 10000,
+  snapshotCashValue: 1000,
+  totalPortfolioValue: 10000,
+  currency: "USD",
+  status: "DRAFT",
+  mode: "AD_HOC",
+  items: [
+    {
+      id: "item-1",
+      assetId: "asset-qual",
+      assetCode: "QUAL",
+      assetName: "Quality ETF",
+      snapshotWeight: 0.5,
+      snapshotValue: 5000,
+      snapshotQuantity: 50,
+      snapshotPrice: 100,
+      priceCurrency: "USD",
+      planTargetWeight: 0.5,
+      effectiveTarget: 0.5,
+      hasOverride: false,
+      deltaValue: 0,
+      deltaQuantity: 0,
+      action: "HOLD",
+      excluded: false,
+      locked: false,
+      sortOrder: 0,
+      isCash: false,
+    },
+    {
+      id: "item-2",
+      assetId: "asset-excluded",
+      assetCode: "EXCL",
+      assetName: "Excluded Co",
+      snapshotWeight: 0.2,
+      snapshotValue: 2000,
+      snapshotQuantity: 20,
+      snapshotPrice: 100,
+      priceCurrency: "USD",
+      planTargetWeight: 0.2,
+      effectiveTarget: 0.2,
+      hasOverride: false,
+      deltaValue: 0,
+      deltaQuantity: 0,
+      action: "HOLD",
+      excluded: true,
+      locked: false,
+      sortOrder: 1,
+      isCash: false,
+    },
+  ],
+  cashSummary: {
+    currentCash: 3000,
+    cashFromSales: 0,
+    cashForPurchases: 0,
+    netImpact: 0,
+    projectedCash: 3000,
+    projectedMarketValue: 10000,
+  },
+  createdAt: "2025-01-01",
+  updatedAt: "2025-01-01",
+})
+
+const executionState: {
+  execution: ExecutionDto | null
+  displayItems: unknown[]
+  activeItems: unknown[]
+  cashSummary: {
+    currentMarketValue: number
+    currentCash: number
+    targetCash: number
+    cashFromSales: number
+    cashForPurchases: number
+  }
+  brokers: unknown[]
+  selectedBrokerId: string | undefined
+  setSelectedBrokerId: jest.Mock
+  states: {
+    loading: boolean
+    saving: boolean
+    refreshing: boolean
+    committing: boolean
+    hasChanges: boolean
+    error: string | null
+  }
+  handlers: Record<string, jest.Mock>
+  createdExecutionId: string | null
+} = {
+  execution: null,
+  displayItems: [],
+  activeItems: [],
+  cashSummary: {
+    currentMarketValue: 0,
+    currentCash: 0,
+    targetCash: 0,
+    cashFromSales: 0,
+    cashForPurchases: 0,
+  },
+  brokers: [],
+  selectedBrokerId: undefined,
+  setSelectedBrokerId: jest.fn(),
+  states: {
+    loading: false,
+    saving: false,
+    refreshing: false,
+    committing: false,
+    hasChanges: false,
+    error: null,
+  },
+  handlers: {
+    initialize: jest.fn(),
+    save: jest.fn(),
+    refresh: jest.fn(),
+    commit: jest.fn(),
+    targetChange: jest.fn(),
+    excludeToggle: jest.fn(),
+    setAllToCurrent: jest.fn(),
+    setAllToTarget: jest.fn(),
+    setAllToZero: jest.fn(),
+    setAllToAdjusted: jest.fn(),
+    setToCurrent: jest.fn(),
+    setToTarget: jest.fn(),
+    setError: jest.fn(),
+  },
+  createdExecutionId: null,
+}
+jest.mock("@hooks/useRebalanceExecution", () => ({
+  useRebalanceExecution: () => executionState,
+}))
+
+import ExecuteRebalancePage from "@pages/rebalance/execute"
+
+// Build displayItems the way useRebalanceExecution would (adds isExcluded/isCash).
+function displayItemsFor(execution: ExecutionDto): unknown[] {
+  return execution.items.map((item) => ({
+    ...item,
+    effectiveTarget: item.effectiveTarget,
+    deltaValue: item.deltaValue,
+    deltaQuantity: item.deltaQuantity,
+    isExcluded: item.excluded,
+    isCash: item.isCash ?? false,
+  }))
+}
+
+describe("ExecuteRebalancePage — slider weight editing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    routerState.query = { adhoc: "1", portfolios: "p1", currency: "USD" }
+    const execution = makeExecution()
+    executionState.execution = execution
+    executionState.displayItems = displayItemsFor(execution)
+    executionState.activeItems = executionState.displayItems
+  })
+
+  it("renders the step toggle defaulting to 5% and sliders at 5% step", () => {
+    render(<ExecuteRebalancePage />)
+
+    const fiveButton = screen.getByRole("button", { name: "5%" })
+    expect(fiveButton).toHaveAttribute("aria-pressed", "true")
+    expect(screen.getByRole("button", { name: "1%" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    )
+    expect(screen.getByRole("button", { name: "0.01%" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    )
+
+    const slider = screen.getByRole("slider", { name: "QUAL target weight" })
+    expect(slider).toHaveAttribute("step", "5")
+  })
+
+  it("switching the step toggle updates the slider step attr and numeric input step attr", () => {
+    render(<ExecuteRebalancePage />)
+
+    fireEvent.click(screen.getByRole("button", { name: "0.01%" }))
+
+    expect(screen.getByRole("button", { name: "0.01%" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    expect(screen.getByRole("button", { name: "5%" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    )
+
+    const slider = screen.getByRole("slider", { name: "QUAL target weight" })
+    expect(slider).toHaveAttribute("step", "0.01")
+
+    const numeric = screen.getByRole("spinbutton", {
+      name: "QUAL target weight percent",
+    })
+    expect(numeric).toHaveAttribute("step", "0.01")
+  })
+
+  it("dragging a row's slider to 15 with 5% step calls targetChange with 0.15", () => {
+    render(<ExecuteRebalancePage />)
+
+    const slider = screen.getByRole("slider", { name: "QUAL target weight" })
+    fireEvent.change(slider, { target: { value: "15" } })
+
+    expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
+      "asset-qual",
+      0.15,
+    )
+  })
+
+  it("snaps an off-step slider value to the nearest step before calling targetChange", () => {
+    render(<ExecuteRebalancePage />)
+
+    const slider = screen.getByRole("slider", { name: "QUAL target weight" })
+    fireEvent.change(slider, { target: { value: "17" } })
+
+    // 17 snapped to nearest multiple of 5 => 15 => 0.15
+    expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
+      "asset-qual",
+      0.15,
+    )
+  })
+
+  it("disables the slider on an excluded row, mirroring the numeric input", () => {
+    render(<ExecuteRebalancePage />)
+
+    const slider = screen.getByRole("slider", { name: "EXCL target weight" })
+    const numeric = screen.getByRole("spinbutton", {
+      name: "EXCL target weight percent",
+    })
+    expect(slider).toBeDisabled()
+    expect(numeric).toBeDisabled()
+  })
+
+  it("keeps the numeric input free to accept arbitrary 0.01 precision regardless of step toggle", () => {
+    render(<ExecuteRebalancePage />)
+
+    fireEvent.click(screen.getByRole("button", { name: "5%" }))
+
+    const numeric = screen.getByRole("spinbutton", {
+      name: "QUAL target weight percent",
+    })
+    fireEvent.change(numeric, { target: { value: "12.34" } })
+
+    expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
+      "asset-qual",
+      0.1234,
+    )
+  })
+})

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -8,6 +8,21 @@ import { TableSkeletonLoader } from "@components/ui/SkeletonLoader"
 import CashSummaryPanel from "@components/features/rebalance/execution/CashSummaryPanel"
 import { useRebalanceExecution } from "@hooks/useRebalanceExecution"
 
+type SliderStep = 5 | 1 | 0.01
+
+const SLIDER_STEP_OPTIONS: { value: SliderStep; label: string }[] = [
+  { value: 5, label: "5%" },
+  { value: 1, label: "1%" },
+  { value: 0.01, label: "0.01%" },
+]
+
+/** Round a raw percent value to the nearest multiple of `step`, guarding
+ * against floating-point drift (e.g. 0.01 steps producing 14.999999998). */
+function snapToStep(value: number, step: number): number {
+  const snapped = Math.round(value / step) * step
+  return Math.round(snapped * 100) / 100
+}
+
 function ExecuteRebalancePage(): React.ReactElement {
   const router = useRouter()
   const {
@@ -31,6 +46,12 @@ function ExecuteRebalancePage(): React.ReactElement {
 
   // Page-only UI state
   const [step, setStep] = useState<"configure" | "preview">("configure")
+
+  // Slider precision toggle for target-weight editing — pure UI state, not
+  // persisted. Drives both the range input's `step` and the numeric input's
+  // spinner increment; typed numeric entries still accept arbitrary 0.01
+  // precision regardless of this setting.
+  const [sliderStep, setSliderStep] = useState<SliderStep>(5)
 
   // Hook handles all data fetching, state, and operations
   const {
@@ -266,6 +287,37 @@ function ExecuteRebalancePage(): React.ReactElement {
                   </button>
                 </div>
               </div>
+              {/* Slider precision toggle */}
+              <div className="flex items-center gap-3 mt-3">
+                <span className="text-xs text-gray-500">{"Slider step:"}</span>
+                <div
+                  className="inline-flex rounded-md shadow-sm"
+                  role="group"
+                  aria-label="Slider step precision"
+                >
+                  {SLIDER_STEP_OPTIONS.map((opt, idx) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setSliderStep(opt.value)}
+                      aria-pressed={sliderStep === opt.value}
+                      className={`px-3 py-1 text-xs font-medium border ${
+                        idx === 0
+                          ? "rounded-l-md"
+                          : idx === SLIDER_STEP_OPTIONS.length - 1
+                            ? "rounded-r-md border-l-0"
+                            : "border-l-0"
+                      } ${
+                        sliderStep === opt.value
+                          ? "bg-invest-100 text-invest-700 border-invest-200"
+                          : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
             </div>
             <div className="overflow-x-auto">
               <table className="min-w-full divide-y divide-gray-200">
@@ -443,25 +495,47 @@ function ExecuteRebalancePage(): React.ReactElement {
                           )}
                         </td>
                         <td className="px-4 py-3 text-right">
-                          <input
-                            type="number"
-                            min="0"
-                            max="100"
-                            step="0.01"
-                            value={(item.effectiveTarget * 100).toFixed(2)}
-                            onChange={(e) => {
-                              const val = parseFloat(e.target.value) || 0
-                              handlers.targetChange(item.assetId, val / 100)
-                            }}
-                            disabled={item.isExcluded}
-                            className={`w-20 px-2 py-1 text-right border rounded focus:ring-invest-500 focus:border-invest-500 ${
-                              isCash
-                                ? "border-blue-300 bg-blue-50"
-                                : item.isExcluded
-                                  ? "border-gray-300 bg-gray-100"
-                                  : "border-gray-300"
-                            }`}
-                          />
+                          <div className="flex items-center justify-end gap-2">
+                            <input
+                              type="range"
+                              min={0}
+                              max={100}
+                              step={sliderStep}
+                              value={item.effectiveTarget * 100}
+                              onChange={(e) => {
+                                const raw = parseFloat(e.target.value)
+                                if (Number.isNaN(raw)) return
+                                const snapped = snapToStep(raw, sliderStep)
+                                handlers.targetChange(
+                                  item.assetId,
+                                  snapped / 100,
+                                )
+                              }}
+                              disabled={item.isExcluded}
+                              aria-label={`${item.assetCode || item.assetId} target weight`}
+                              className="w-16 sm:w-24 min-w-[60px] h-2 accent-invest-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                            />
+                            <input
+                              type="number"
+                              min="0"
+                              max="100"
+                              step={sliderStep}
+                              value={(item.effectiveTarget * 100).toFixed(2)}
+                              onChange={(e) => {
+                                const val = parseFloat(e.target.value) || 0
+                                handlers.targetChange(item.assetId, val / 100)
+                              }}
+                              disabled={item.isExcluded}
+                              aria-label={`${item.assetCode || item.assetId} target weight percent`}
+                              className={`w-20 px-2 py-1 text-right border rounded focus:ring-invest-500 focus:border-invest-500 ${
+                                isCash
+                                  ? "border-blue-300 bg-blue-50"
+                                  : item.isExcluded
+                                    ? "border-gray-300 bg-gray-100"
+                                    : "border-gray-300"
+                              }`}
+                            />
+                          </div>
                         </td>
                         <td className={`px-4 py-3 text-right ${quantityClass}`}>
                           {isCash ? (


### PR DESCRIPTION
## Summary
- Adds a native range-input slider per row on `/rebalance/execute` alongside the existing numeric target-% input
- Three-option step toggle (5% | 1% | 0.01%, default 5%) controls slider snapping and numeric spinner increment
- Typed numeric entries still accept arbitrary 0.01 precision regardless of step toggle
- Slider mirrors the numeric input's disabled state (excluded rows)
- A11y: slider aria-label includes asset code; step toggle is a keyboard-operable button group with aria-pressed

Note: PR #1103 (the ad-hoc rebalance editor this builds on) already merged to main before this branch was pushed — this is a fresh PR carrying just the slider addition on top of current main.

## Test plan
- [x] `yarn test` — 227 suites / 2183 tests pass, including new `__tests__/pages/rebalance/execute-slider.test.tsx` (step toggle default/switch, slider→targetChange snapping, excluded-row disabled slider, numeric input free precision)
- [x] `yarn prettier`
- [x] `yarn lint` (pre-existing unrelated warning in SetAccountBalancesDialog.tsx only)
- [x] `yarn typecheck`