### PR TITLE
feat(rebalance): projected After % weight column

### DIFF
--- a/__tests__/pages/rebalance/execute-slider.test.tsx
+++ b/__tests__/pages/rebalance/execute-slider.test.tsx
@@ -98,6 +98,8 @@ const executionState: {
     targetCash: number
     cashFromSales: number
     cashForPurchases: number
+    netImpact: number
+    projectedCash: number
   }
   brokers: unknown[]
   selectedBrokerId: string | undefined
@@ -122,6 +124,8 @@ const executionState: {
     targetCash: 0,
     cashFromSales: 0,
     cashForPurchases: 0,
+    netImpact: 0,
+    projectedCash: 0,
   },
   brokers: [],
   selectedBrokerId: undefined,
@@ -157,16 +161,27 @@ jest.mock("@hooks/useRebalanceExecution", () => ({
 
 import ExecuteRebalancePage from "@pages/rebalance/execute"
 
-// Build displayItems the way useRebalanceExecution would (adds isExcluded/isCash).
+// Build displayItems the way useRebalanceExecution would (adds isExcluded/isCash
+// and the projected After-% fields). Non-cash rows here have zero delta, so
+// projectedValue == snapshotValue and the total is just the portfolio value.
 function displayItemsFor(execution: ExecutionDto): unknown[] {
-  return execution.items.map((item) => ({
-    ...item,
-    effectiveTarget: item.effectiveTarget,
-    deltaValue: item.deltaValue,
-    deltaQuantity: item.deltaQuantity,
-    isExcluded: item.excluded,
-    isCash: item.isCash ?? false,
-  }))
+  const total = execution.totalPortfolioValue
+  return execution.items.map((item) => {
+    const isCash = item.isCash ?? false
+    const projectedValue = isCash
+      ? execution.snapshotCashValue
+      : item.snapshotValue + item.deltaValue
+    return {
+      ...item,
+      effectiveTarget: item.effectiveTarget,
+      deltaValue: item.deltaValue,
+      deltaQuantity: item.deltaQuantity,
+      isExcluded: item.excluded,
+      isCash,
+      projectedValue,
+      projectedWeight: item.excluded ? null : projectedValue / total,
+    }
+  })
 }
 
 describe("ExecuteRebalancePage — slider weight editing", () => {
@@ -177,6 +192,15 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     executionState.execution = execution
     executionState.displayItems = displayItemsFor(execution)
     executionState.activeItems = executionState.displayItems
+    executionState.cashSummary = {
+      currentMarketValue: 0,
+      currentCash: 0,
+      targetCash: 0,
+      cashFromSales: 0,
+      cashForPurchases: 0,
+      netImpact: 0,
+      projectedCash: 0,
+    }
   })
 
   it("renders the step toggle defaulting to 5% and sliders at 5% step", () => {
@@ -270,5 +294,121 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
       "asset-qual",
       0.1234,
     )
+  })
+
+  // --- After % column ---
+
+  it("renders the After % column with projected weights, dash for excluded rows, and a 100% total", () => {
+    const execution: ExecutionDto = {
+      ...makeExecution(),
+      totalPortfolioValue: 10000,
+      snapshotCashValue: 3000,
+      items: [
+        {
+          id: "item-1",
+          assetId: "asset-qual",
+          assetCode: "QUAL",
+          assetName: "Quality ETF",
+          snapshotWeight: 0.5,
+          snapshotValue: 5000,
+          snapshotQuantity: 50,
+          snapshotPrice: 100,
+          priceCurrency: "USD",
+          planTargetWeight: 0.5,
+          effectiveTarget: 0.52,
+          hasOverride: true,
+          deltaValue: 200,
+          deltaQuantity: 2,
+          action: "BUY",
+          excluded: false,
+          locked: false,
+          sortOrder: 0,
+          isCash: false,
+        },
+        {
+          id: "item-2",
+          assetId: "asset-excluded",
+          assetCode: "EXCL",
+          assetName: "Excluded Co",
+          snapshotWeight: 0.2,
+          snapshotValue: 2000,
+          snapshotQuantity: 20,
+          snapshotPrice: 100,
+          priceCurrency: "USD",
+          planTargetWeight: 0.2,
+          effectiveTarget: 0.2,
+          hasOverride: false,
+          deltaValue: 0,
+          deltaQuantity: 0,
+          action: "HOLD",
+          excluded: true,
+          locked: false,
+          sortOrder: 1,
+          isCash: false,
+        },
+        {
+          id: "item-cash",
+          assetId: "cash-usd",
+          assetCode: "USD",
+          assetName: "US Dollar",
+          snapshotWeight: 0.3,
+          snapshotValue: 3000,
+          snapshotQuantity: 3000,
+          snapshotPrice: 1,
+          priceCurrency: "USD",
+          planTargetWeight: 0.3,
+          effectiveTarget: 0.3,
+          hasOverride: false,
+          deltaValue: 0,
+          deltaQuantity: 0,
+          action: "HOLD",
+          excluded: false,
+          locked: false,
+          sortOrder: 2,
+          isCash: true,
+        },
+      ],
+    }
+    executionState.execution = execution
+    executionState.displayItems = displayItemsFor(execution)
+    executionState.activeItems = executionState.displayItems
+
+    const { container } = render(<ExecuteRebalancePage />)
+
+    const headerCells = Array.from(container.querySelectorAll("thead th"))
+    const afterIdx = headerCells.findIndex(
+      (th) => th.textContent?.trim() === "After %",
+    )
+    expect(afterIdx).toBeGreaterThan(-1)
+
+    const bodyRows = Array.from(container.querySelectorAll("tbody tr"))
+    const afterValues = bodyRows.map((row) =>
+      row.children[afterIdx]?.textContent?.trim(),
+    )
+    // QUAL: 5200/10000, EXCL: excluded -> dash, cash: 3000/10000
+    expect(afterValues).toEqual(["52.00%", "—", "30.00%"])
+
+    const footerRow = container.querySelector("tfoot tr")!
+    expect(footerRow.children[afterIdx]?.textContent?.trim()).toBe("82.00%")
+  })
+
+  it("shows the funded-by-deposit footnote when projected cash is negative", () => {
+    executionState.cashSummary.projectedCash = -500
+
+    render(<ExecuteRebalancePage />)
+
+    expect(
+      screen.getByText(/Assumes required cash is funded/i),
+    ).toBeInTheDocument()
+  })
+
+  it("hides the funded-by-deposit footnote when projected cash is non-negative", () => {
+    executionState.cashSummary.projectedCash = 100
+
+    render(<ExecuteRebalancePage />)
+
+    expect(
+      screen.queryByText(/Assumes required cash is funded/i),
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -788,6 +788,197 @@ describe("useRebalanceExecution", () => {
     expect(result.current.cashSummary.currentCash).toBe(1000)
   })
 
+  // --- Projected weight (After %) ---
+
+  it("raising a small position's target funds it via deposit and dilutes the other rows' projected weight", async () => {
+    // Portfolio: big position 1000 (25% of 4000), small position 200 (5% of
+    // 4000), a third untouched holding making up the remaining 2800 (70%),
+    // cash 0. Plan target weights mirror snapshot weights so untouched rows
+    // have zero delta unless overridden.
+    const exec = makeExecution({
+      totalPortfolioValue: 4000,
+      snapshotCashValue: 0,
+      items: [
+        makeItem({
+          id: "big",
+          assetId: "big-asset",
+          assetCode: "GOOG",
+          snapshotWeight: 0.25,
+          snapshotValue: 1000,
+          planTargetWeight: 0.25,
+          snapshotPrice: 100,
+        }),
+        makeItem({
+          id: "small",
+          assetId: "small-asset",
+          assetCode: "MSFT",
+          snapshotWeight: 0.05,
+          snapshotValue: 200,
+          planTargetWeight: 0.05,
+          snapshotPrice: 100,
+        }),
+        makeItem({
+          id: "rest",
+          assetId: "rest-asset",
+          assetCode: "OTHER",
+          snapshotWeight: 0.7,
+          snapshotValue: 2800,
+          planTargetWeight: 0.7,
+          snapshotPrice: 100,
+        }),
+        makeCashItem({
+          assetId: "cash",
+          snapshotWeight: 0,
+          snapshotValue: 0,
+          planTargetWeight: 0,
+        }),
+      ],
+    })
+
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      // 5% -> 10%
+      result.current.handlers.targetChange("small-asset", 0.1)
+    })
+
+    const small = result.current.displayItems.find(
+      (i) => i.assetId === "small-asset",
+    )
+    const big = result.current.displayItems.find(
+      (i) => i.assetId === "big-asset",
+    )
+
+    // Funded by a deposit (no sales elsewhere): delta ~= +200
+    expect(small?.deltaValue).toBeCloseTo(200, 5)
+
+    // Big position's own value is untouched, but the portfolio total grows
+    // by the deposit (4000 -> 4200), so its projected weight drops.
+    expect(big?.deltaValue).toBeCloseTo(0, 5)
+    expect(big?.projectedWeight).toBeCloseTo(1000 / 4200, 4)
+
+    // All (non-excluded) rows' projected weights sum to ~100%.
+    const total = result.current.displayItems.reduce(
+      (sum, item) => sum + (item.projectedWeight ?? 0),
+      0,
+    )
+    expect(total).toBeCloseTo(1, 5)
+  })
+
+  it("internal shuffle funded by an offsetting sale leaves projected total and untouched rows' weight unchanged", async () => {
+    // Sell 300 from X, buy 300 into Y — self-funded, cash stays positive and
+    // unchanged, so the projected total should equal the snapshot total and
+    // the untouched row Z's projected weight should equal its current weight.
+    const exec = makeExecution({
+      totalPortfolioValue: 5000,
+      snapshotCashValue: 1000,
+      items: [
+        makeItem({
+          id: "x",
+          assetId: "x-asset",
+          assetCode: "X",
+          snapshotWeight: 0.2,
+          snapshotValue: 1000,
+          planTargetWeight: 0.2,
+          snapshotPrice: 100,
+        }),
+        makeItem({
+          id: "y",
+          assetId: "y-asset",
+          assetCode: "Y",
+          snapshotWeight: 0.2,
+          snapshotValue: 1000,
+          planTargetWeight: 0.2,
+          snapshotPrice: 100,
+        }),
+        makeItem({
+          id: "z",
+          assetId: "z-asset",
+          assetCode: "Z",
+          snapshotWeight: 0.4,
+          snapshotValue: 2000,
+          planTargetWeight: 0.4,
+          snapshotPrice: 100,
+        }),
+        makeCashItem({
+          assetId: "cash",
+          snapshotWeight: 0.2,
+          snapshotValue: 1000,
+          planTargetWeight: 0.2,
+        }),
+      ],
+    })
+
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      result.current.handlers.targetChange("x-asset", 0.14) // sell 300
+      result.current.handlers.targetChange("y-asset", 0.26) // buy 300
+    })
+
+    const z = result.current.displayItems.find((i) => i.assetId === "z-asset")
+    const cash = result.current.displayItems.find((i) => i.isCash)
+
+    expect(result.current.cashSummary.projectedCash).toBeCloseTo(1000, 5)
+    expect(cash?.projectedWeight).toBeCloseTo(1000 / 5000, 5)
+
+    // Untouched row's projected weight is unchanged from its snapshot weight.
+    expect(z?.projectedWeight).toBeCloseTo(z!.snapshotWeight, 5)
+
+    const total = result.current.displayItems.reduce(
+      (sum, item) => sum + (item.projectedWeight ?? 0),
+      0,
+    )
+    expect(total).toBeCloseTo(1, 5)
+  })
+
+  it("excludes an excluded/PRIVATE row from the projected-total denominator and its own projected weight", async () => {
+    const exec = makeExecution({
+      totalPortfolioValue: 5000,
+      snapshotCashValue: 1000,
+      items: [
+        makeItem({
+          id: "priv",
+          assetId: "private-asset",
+          assetCode: "PRIV",
+          snapshotWeight: 0,
+          snapshotValue: 500,
+          planTargetWeight: 0,
+          snapshotPrice: 100,
+          excluded: true,
+        }),
+        makeItem({
+          id: "a1",
+          assetId: "a1",
+          assetCode: "A1",
+          snapshotWeight: 0.6,
+          snapshotValue: 3000,
+          planTargetWeight: 0.6,
+          snapshotPrice: 100,
+        }),
+        makeCashItem({
+          assetId: "cash",
+          snapshotWeight: 0.2,
+          snapshotValue: 1000,
+          planTargetWeight: 0.2,
+        }),
+      ],
+    })
+
+    const { result } = await renderWithExecution(exec)
+
+    const priv = result.current.displayItems.find(
+      (i) => i.assetId === "private-asset",
+    )
+    expect(priv?.projectedWeight).toBeNull()
+
+    const total = result.current.displayItems.reduce(
+      (sum, item) => sum + (item.projectedWeight ?? 0),
+      0,
+    )
+    expect(total).toBeCloseTo(1, 5)
+  })
+
   // --- Brokers ---
 
   it("derives brokers from SWR data", () => {

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -18,6 +18,16 @@ export interface DisplayItem extends ExecutionItemDto {
   deltaQuantity: number
   isExcluded: boolean
   isCash: boolean
+  /** snapshotValue + deltaValue (cash row: currentCash + netImpact, clamped to >= 0) */
+  projectedValue: number
+  /**
+   * projectedValue / projectedTotal, as a decimal (e.g. 0.2381). `null` for
+   * excluded rows (incl. server-auto-excluded PRIVATE/CPF assets) — they sit
+   * outside the projected-total denominator, same as PRIVATE sits outside
+   * the server's snapshotWeight denominator, so a weight against it isn't
+   * meaningful.
+   */
+  projectedWeight: number | null
 }
 
 export interface CashSummary {
@@ -26,6 +36,10 @@ export interface CashSummary {
   targetCash: number
   cashFromSales: number
   cashForPurchases: number
+  /** cashFromSales - cashForPurchases + (currentCash - targetCash); negative means the rebalance needs new deposited cash */
+  netImpact: number
+  /** currentCash + netImpact, unclamped — negative means a deposit is required to fund the changes */
+  projectedCash: number
 }
 
 export interface UseRebalanceExecutionParams {
@@ -489,8 +503,21 @@ export function useRebalanceExecution(
 
   // --- Computed values ---
 
-  const displayItems: DisplayItem[] = useMemo(() => {
-    if (!execution) return []
+  // Single source of truth for target-weight rescaling, projected (post-trade)
+  // values/weights, and cash-impact figures. One pass over `execution.items`
+  // feeds both `displayItems` (incl. the After-% column) and `cashSummary` so
+  // the two never drift out of sync with independent calculations.
+  const computed = useMemo(() => {
+    if (!execution) {
+      return {
+        items: [] as DisplayItem[],
+        targetCash: 0,
+        cashFromSales: 0,
+        cashForPurchases: 0,
+        netImpact: 0,
+        projectedCash: 0,
+      }
+    }
 
     const totalPortfolioValue = execution.totalPortfolioValue
 
@@ -508,7 +535,7 @@ export function useRebalanceExecution(
       .filter((item) => !item.isCash)
       .reduce((sum, item) => sum + item.planTargetWeight, 0)
 
-    return execution.items.map((item) => {
+    const base = execution.items.map((item) => {
       const isCash = item.isCash ?? false
       const isExcluded = localExclusions[item.assetId] ?? item.excluded
 
@@ -543,7 +570,70 @@ export function useRebalanceExecution(
         isCash,
       }
     })
+
+    // Cash impact of the trades: sales generate cash, purchases consume it,
+    // and any explicit cash-target change releases/absorbs the difference.
+    // Excluded rows (incl. server-auto-excluded PRIVATE/CPF assets) never
+    // reach the market, so they're skipped here.
+    const currentCash = execution.snapshotCashValue
+    const cashDisplay = base.find((item) => item.isCash)
+    const targetCash = totalPortfolioValue * (cashDisplay?.effectiveTarget ?? 0)
+
+    let cashFromSales = 0
+    let cashForPurchases = 0
+    for (const item of base) {
+      if (item.isCash || item.isExcluded) continue
+      if (item.deltaValue < 0) {
+        cashFromSales += Math.abs(item.deltaValue)
+      } else if (item.deltaValue > 0) {
+        cashForPurchases += item.deltaValue
+      }
+    }
+    const cashPositionChange = currentCash - targetCash
+    const netImpact = cashFromSales - cashForPurchases + cashPositionChange
+    const projectedCash = currentCash + netImpact
+    // Negative projected cash means the rebalance needs a deposit — it's not
+    // a negative asset, so the After-% denominator clamps it to zero (the
+    // deposit itself is exactly what dilutes the other rows' weights).
+    const projectedCashClamped = Math.max(projectedCash, 0)
+
+    const projectedNonCashTotal = base
+      .filter((item) => !item.isCash && !item.isExcluded)
+      .reduce((sum, item) => sum + (item.snapshotValue + item.deltaValue), 0)
+    const projectedTotal = projectedNonCashTotal + projectedCashClamped
+
+    const items: DisplayItem[] = base.map((item) => {
+      if (item.isCash) {
+        return {
+          ...item,
+          projectedValue: projectedCashClamped,
+          projectedWeight:
+            projectedTotal > 0 ? projectedCashClamped / projectedTotal : 0,
+        }
+      }
+      const projectedValue = item.snapshotValue + item.deltaValue
+      return {
+        ...item,
+        projectedValue,
+        projectedWeight: item.isExcluded
+          ? null
+          : projectedTotal > 0
+            ? projectedValue / projectedTotal
+            : 0,
+      }
+    })
+
+    return {
+      items,
+      targetCash,
+      cashFromSales,
+      cashForPurchases,
+      netImpact,
+      projectedCash,
+    }
   }, [execution, localOverrides, localExclusions])
+
+  const displayItems = computed.items
 
   const activeItems = useMemo(
     () =>
@@ -554,41 +644,18 @@ export function useRebalanceExecution(
     [displayItems],
   )
 
-  const cashSummary: CashSummary = useMemo(() => {
-    if (!execution) {
-      return {
-        currentMarketValue: 0,
-        currentCash: 0,
-        targetCash: 0,
-        cashFromSales: 0,
-        cashForPurchases: 0,
-      }
-    }
-
-    const cashItem = displayItems.find((item) => item.isCash)
-    const targetCash =
-      execution.totalPortfolioValue * (cashItem?.effectiveTarget ?? 0)
-
-    let cashFromSales = 0
-    let cashForPurchases = 0
-
-    for (const item of displayItems) {
-      if (item.isCash || item.isExcluded) continue
-      if (item.deltaValue < 0) {
-        cashFromSales += Math.abs(item.deltaValue)
-      } else if (item.deltaValue > 0) {
-        cashForPurchases += item.deltaValue
-      }
-    }
-
-    return {
-      currentMarketValue: execution.totalPortfolioValue,
-      currentCash: execution.snapshotCashValue,
-      targetCash,
-      cashFromSales,
-      cashForPurchases,
-    }
-  }, [execution, displayItems])
+  const cashSummary: CashSummary = useMemo(
+    () => ({
+      currentMarketValue: execution?.totalPortfolioValue ?? 0,
+      currentCash: execution?.snapshotCashValue ?? 0,
+      targetCash: computed.targetCash,
+      cashFromSales: computed.cashFromSales,
+      cashForPurchases: computed.cashForPurchases,
+      netImpact: computed.netImpact,
+      projectedCash: computed.projectedCash,
+    }),
+    [execution, computed],
+  )
 
   return {
     execution,

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -346,6 +346,16 @@ function ExecuteRebalancePage(): React.ReactElement {
                     <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
                       %
                     </th>
+                    <th
+                      className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"
+                      title={
+                        cashSummary.projectedCash < 0
+                          ? "Assumes required cash is funded"
+                          : "Resulting weight once all target changes are applied"
+                      }
+                    >
+                      {"After %"}
+                    </th>
                     <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
                       {"Quantity"}
                     </th>
@@ -537,6 +547,13 @@ function ExecuteRebalancePage(): React.ReactElement {
                             />
                           </div>
                         </td>
+                        <td
+                          className={`px-4 py-3 text-right ${isCash ? "text-blue-900" : "text-gray-700"}`}
+                        >
+                          {item.projectedWeight == null
+                            ? "—"
+                            : formatPercent(item.projectedWeight)}
+                        </td>
                         <td className={`px-4 py-3 text-right ${quantityClass}`}>
                           {isCash ? (
                             <span>
@@ -591,11 +608,26 @@ function ExecuteRebalancePage(): React.ReactElement {
                         ),
                       )}
                     </td>
+                    <td className="px-4 py-3 text-right font-semibold text-gray-900">
+                      {formatPercent(
+                        displayItems.reduce(
+                          (sum, item) => sum + (item.projectedWeight ?? 0),
+                          0,
+                        ),
+                      )}
+                    </td>
                     <td className="px-4 py-3"></td>
                   </tr>
                 </tfoot>
               </table>
             </div>
+            {cashSummary.projectedCash < 0 && (
+              <p className="px-4 py-2 text-xs text-amber-700 bg-amber-50 border-t border-amber-200">
+                {
+                  "After % assumes required cash is funded — the projected cash shortfall shown above is treated as a deposit."
+                }
+              </p>
+            )}
           </div>
 
           {/* Navigation */}


### PR DESCRIPTION
## Summary
- Adds an **After %** column to the rebalance execution editor (`/rebalance/execute`) showing each row's resulting weight once all target changes are applied — so raising one position's target makes the dilution of every other row's weight visible live, without waiting for commit.
- `useRebalanceExecution`'s `displayItems` memo now also computes `projectedValue`/`projectedWeight` per item and exposes `netImpact`/`projectedCash` on `cashSummary`, all from one combined calculation (no duplicate math in the page).
- Negative projected cash is clamped to zero for the denominator (a deficit means the change needs a deposit, not a negative asset) and surfaces a footnote: "Assumes required cash is funded".
- Excluded rows (incl. server-auto-excluded PRIVATE/CPF assets) are dropped from the projected-total denominator and show "—", mirroring how the server already excludes PRIVATE from `snapshotWeight`'s denominator.
- Total row footer sums to 100.00% as a sanity anchor.

Follows on from #1104 (slider weight editing), which merged before this branch was created — this is a fresh branch off `main`, not a stack.

## Test plan
- [x] `yarn test` — 227 suites / 2189 tests pass, incl. 3 new hook tests (deposit-funded dilution, self-funded internal shuffle, PRIVATE/excluded exclusion) and 3 new page tests (After % column values, footnote shown/hidden)
- [x] `yarn prettier`
- [x] `yarn lint`
- [x] `yarn typecheck`