### PR TITLE
feat(rebalance): price column, chart, AI query, buy/sell row tint; drop adjusted column

### DIFF
--- a/src/__tests__/pages/rebalance/execute/index.test.tsx
+++ b/src/__tests__/pages/rebalance/execute/index.test.tsx
@@ -1,0 +1,277 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import ExecuteRebalancePage from "@pages/rebalance/execute/index"
+import { useRebalanceExecution } from "@hooks/useRebalanceExecution"
+import type {
+  DisplayItem,
+  UseRebalanceExecutionResult,
+} from "@hooks/useRebalanceExecution"
+import type { ExecutionDto } from "types/rebalance"
+
+// --- Mocks ---
+
+jest.mock("@hooks/useRebalanceExecution")
+const mockUseRebalanceExecution = useRebalanceExecution as jest.Mock
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    query: { executionId: "exec-1" },
+    replace: jest.fn(),
+    back: jest.fn(),
+    push: jest.fn(),
+  }),
+}))
+
+// PriceChartPopup and AssetInsightPopup are heavy (recharts / SSE streaming)
+// and already covered by their own test suites — stand in with prop-capturing
+// stubs so this page test only asserts wiring (correct asset/prompt passed).
+jest.mock("@components/features/holdings/PriceChartPopup", () => {
+  return function MockPriceChartPopup(props: {
+    asset: { id: string; code: string }
+    portfolioId?: string
+    onClose: () => void
+  }) {
+    return (
+      <div data-testid="price-chart-popup">
+        <span data-testid="chart-asset-id">{props.asset.id}</span>
+        <span data-testid="chart-asset-code">{props.asset.code}</span>
+        <button onClick={props.onClose}>{"close-chart"}</button>
+      </div>
+    )
+  }
+})
+
+jest.mock("@components/features/rebalance/models/AssetInsightPopup", () => {
+  return function MockAssetInsightPopup(props: {
+    asset: { assetCode?: string; assetId: string }
+    promptOverride?: { query: string; context: Record<string, unknown> }
+    onClose: () => void
+  }) {
+    return (
+      <div data-testid="asset-insight-popup">
+        <span data-testid="insight-asset-code">
+          {props.asset.assetCode || props.asset.assetId}
+        </span>
+        <pre data-testid="insight-query">{props.promptOverride?.query}</pre>
+        <button onClick={props.onClose}>{"close-insight"}</button>
+      </div>
+    )
+  }
+})
+
+// --- Fixtures ---
+
+function makeItem(overrides: Partial<DisplayItem> = {}): DisplayItem {
+  const excluded = overrides.excluded ?? false
+  return {
+    id: overrides.id ?? "item-1",
+    assetId: overrides.assetId ?? "asset-1",
+    assetCode: overrides.assetCode ?? "AAPL",
+    assetName: overrides.assetName ?? "Apple Inc",
+    snapshotWeight: overrides.snapshotWeight ?? 0.5,
+    snapshotValue: overrides.snapshotValue ?? 5000,
+    snapshotQuantity: overrides.snapshotQuantity ?? 50,
+    snapshotPrice: overrides.snapshotPrice ?? 281.31,
+    priceCurrency: overrides.priceCurrency ?? "USD",
+    planTargetWeight: overrides.planTargetWeight ?? 0.6,
+    returnAdjustedTarget: overrides.returnAdjustedTarget ?? 0.58,
+    effectiveTarget: overrides.effectiveTarget ?? 0.6,
+    hasOverride: overrides.hasOverride ?? false,
+    deltaValue: overrides.deltaValue ?? 1000,
+    deltaQuantity: overrides.deltaQuantity ?? 10,
+    action: overrides.action ?? "BUY",
+    excluded,
+    locked: overrides.locked ?? false,
+    sortOrder: overrides.sortOrder ?? 0,
+    isCash: overrides.isCash ?? false,
+    rationale: overrides.rationale ?? undefined,
+    isExcluded: overrides.isExcluded ?? excluded,
+    projectedValue: overrides.projectedValue ?? 6000,
+    projectedWeight:
+      overrides.projectedWeight === undefined
+        ? 0.65
+        : overrides.projectedWeight,
+    ...overrides,
+  } as DisplayItem
+}
+
+function makeExecution(overrides: Partial<ExecutionDto> = {}): ExecutionDto {
+  return {
+    id: "exec-1",
+    planId: "plan-1",
+    planVersion: 1,
+    modelId: "model-1",
+    modelName: "Test Model",
+    portfolioIds: ["portfolio-1"],
+    snapshotTotalValue: 10000,
+    snapshotCashValue: 1000,
+    totalPortfolioValue: 10000,
+    currency: "USD",
+    status: "DRAFT",
+    mode: "REBALANCE",
+    items: [],
+    cashSummary: {
+      currentCash: 1000,
+      cashFromSales: 0,
+      cashForPurchases: 0,
+      netImpact: 0,
+      projectedCash: 1000,
+    },
+    createdAt: "2026-01-01",
+    updatedAt: "2026-01-01",
+    ...overrides,
+  } as ExecutionDto
+}
+
+function mockHookResult(
+  displayItems: DisplayItem[],
+  overrides: Partial<UseRebalanceExecutionResult> = {},
+): void {
+  const execution = makeExecution()
+  mockUseRebalanceExecution.mockReturnValue({
+    execution,
+    displayItems,
+    activeItems: displayItems.filter(
+      (i) => !i.isExcluded && !i.isCash && Math.abs(i.deltaValue) > 100,
+    ),
+    cashSummary: {
+      currentMarketValue: 10000,
+      currentCash: 1000,
+      targetCash: 1000,
+      cashFromSales: 0,
+      cashForPurchases: 0,
+      netImpact: 0,
+      projectedCash: 1000,
+    },
+    brokers: [],
+    selectedBrokerId: undefined,
+    setSelectedBrokerId: jest.fn(),
+    states: {
+      loading: false,
+      saving: false,
+      refreshing: false,
+      committing: false,
+      hasChanges: false,
+      error: null,
+    },
+    handlers: {
+      initialize: jest.fn(),
+      save: jest.fn().mockResolvedValue(true),
+      refresh: jest.fn(),
+      commit: jest.fn(),
+      targetChange: jest.fn(),
+      excludeToggle: jest.fn(),
+      setAllToCurrent: jest.fn(),
+      setAllToTarget: jest.fn(),
+      setAllToZero: jest.fn(),
+      setAllToAdjusted: jest.fn(),
+      setToCurrent: jest.fn(),
+      setToTarget: jest.fn(),
+      setError: jest.fn(),
+    },
+    createdExecutionId: null,
+    ...overrides,
+  } as UseRebalanceExecutionResult)
+}
+
+describe("ExecuteRebalancePage", () => {
+  beforeEach(() => {
+    mockUseRebalanceExecution.mockReset()
+  })
+
+  it("does not render an Adjusted column or an 'All -> Adjusted' bulk button", () => {
+    mockHookResult([makeItem()])
+    render(<ExecuteRebalancePage />)
+
+    expect(screen.queryByText("Adjusted")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /All.*Adjusted/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTitle(/return-adjusted/i)).not.toBeInTheDocument()
+  })
+
+  it("renders the price column as value + currency, and — when price is null", () => {
+    mockHookResult([
+      makeItem({ assetId: "a1", snapshotPrice: 281.31, priceCurrency: "USD" }),
+      makeItem({
+        assetId: "a2",
+        assetCode: "MSFT",
+        snapshotPrice: undefined,
+        priceCurrency: undefined,
+      }),
+    ])
+    render(<ExecuteRebalancePage />)
+
+    expect(screen.getByText("281.31 USD")).toBeInTheDocument()
+    expect(screen.getByText("—")).toBeInTheDocument()
+  })
+
+  it("tints a positive-delta-quantity row green and a negative one red; leaves excluded/zero rows neutral", () => {
+    mockHookResult([
+      makeItem({ assetId: "buy-asset", assetCode: "BUY1", deltaQuantity: 5 }),
+      makeItem({
+        assetId: "sell-asset",
+        assetCode: "SELL1",
+        deltaQuantity: -5,
+      }),
+      makeItem({
+        assetId: "excluded-asset",
+        assetCode: "EXCL1",
+        deltaQuantity: 5,
+        excluded: true,
+        isExcluded: true,
+      }),
+      makeItem({
+        assetId: "flat-asset",
+        assetCode: "FLAT1",
+        deltaQuantity: 0,
+      }),
+    ])
+    render(<ExecuteRebalancePage />)
+
+    const buyRow = screen.getByText("BUY1").closest("tr")
+    const sellRow = screen.getByText("SELL1").closest("tr")
+    const excludedRow = screen.getByText("EXCL1").closest("tr")
+    const flatRow = screen.getByText("FLAT1").closest("tr")
+
+    expect(buyRow?.className).toContain("bg-green-50")
+    expect(sellRow?.className).toContain("bg-red-50")
+    // Excluded takes precedence over a nonzero delta.
+    expect(excludedRow?.className).not.toContain("bg-green-50")
+    expect(excludedRow?.className).not.toContain("bg-red-50")
+    expect(flatRow?.className).not.toContain("bg-green-50")
+    expect(flatRow?.className).not.toContain("bg-red-50")
+  })
+
+  it("opens the price chart with the row's asset identifier when the chart affordance is clicked", () => {
+    mockHookResult([makeItem({ assetId: "asset-xyz", assetCode: "XYZ" })])
+    render(<ExecuteRebalancePage />)
+
+    expect(screen.queryByTestId("price-chart-popup")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTitle("Price history chart"))
+
+    expect(screen.getByTestId("price-chart-popup")).toBeInTheDocument()
+    expect(screen.getByTestId("chart-asset-id")).toHaveTextContent("asset-xyz")
+    expect(screen.getByTestId("chart-asset-code")).toHaveTextContent("XYZ")
+  })
+
+  it("opens the AI insight popup seeded with a prompt containing the asset code and target %", () => {
+    mockHookResult([
+      makeItem({
+        assetId: "asset-xyz",
+        assetCode: "XYZ",
+        effectiveTarget: 0.42,
+      }),
+    ])
+    render(<ExecuteRebalancePage />)
+
+    expect(screen.queryByTestId("asset-insight-popup")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTitle("Ask AI about this asset"))
+
+    expect(screen.getByTestId("asset-insight-popup")).toBeInTheDocument()
+    const query = screen.getByTestId("insight-query").textContent || ""
+    expect(query).toContain("XYZ")
+    expect(query).toContain("42.00%")
+    expect(query).toMatch(/DRAFT/)
+  })
+})

--- a/src/components/features/rebalance/models/AssetInsightPopup.tsx
+++ b/src/components/features/rebalance/models/AssetInsightPopup.tsx
@@ -4,11 +4,19 @@ import remarkGfm from "remark-gfm"
 import Dialog from "@components/ui/Dialog"
 import Spinner from "@components/ui/Spinner"
 import { AssetWeightWithDetails } from "types/rebalance"
+import { AssetInsightPromptOverride } from "types/beancounter"
 
 interface AssetInsightPopupProps {
   asset: AssetWeightWithDetails
-  modelName: string
+  modelName?: string
   onClose: () => void
+  /**
+   * Replaces the default "why does this asset belong in the model" prompt
+   * and context entirely. Used by callers outside the model editor (e.g.
+   * the rebalance execute page) that want a different question answered
+   * about the same streaming endpoint/Dialog wrapper.
+   */
+  promptOverride?: AssetInsightPromptOverride
 }
 
 const ASSET_INSIGHT_PROMPT = `Role: You are a concise financial analyst reviewing individual assets for inclusion in a model portfolio.
@@ -47,13 +55,14 @@ export default function AssetInsightPopup({
   asset,
   modelName,
   onClose,
+  promptOverride,
 }: AssetInsightPopupProps): React.ReactElement {
   const [response, setResponse] = useState<string>("")
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const abortRef = useRef<AbortController | null>(null)
 
-  const cacheKey = `${asset.assetCode || asset.assetId}|${modelName}`
+  const cacheKey = `${asset.assetCode || asset.assetId}|${modelName ?? ""}|${promptOverride?.query ?? ""}`
 
   const cancel = (): void => {
     abortRef.current?.abort()
@@ -86,8 +95,8 @@ export default function AssetInsightPopup({
             Accept: "text/event-stream",
           },
           body: JSON.stringify({
-            query: ASSET_INSIGHT_PROMPT,
-            context: {
+            query: promptOverride?.query ?? ASSET_INSIGHT_PROMPT,
+            context: promptOverride?.context ?? {
               page: "Model Asset Insight",
               description:
                 "AI analysis of a single asset for a rebalance model portfolio",
@@ -177,7 +186,7 @@ export default function AssetInsightPopup({
     return () => {
       controller.abort()
     }
-  }, [cacheKey, asset, modelName])
+  }, [cacheKey, asset, modelName, promptOverride])
 
   const showSpinner = isLoading && response.length === 0
 

--- a/src/components/features/rebalance/models/__tests__/AssetInsightPopup.test.tsx
+++ b/src/components/features/rebalance/models/__tests__/AssetInsightPopup.test.tsx
@@ -167,4 +167,28 @@ describe("AssetInsightPopup", () => {
     )
     await waitFor(() => screen.getByText(/run out of credit/i))
   })
+
+  it("uses promptOverride's query/context instead of the default model-insight prompt", async () => {
+    mockFetch.mockResolvedValueOnce(
+      sseResponse([
+        { event: "token", data: "Draft rebalance take" },
+        { event: "done", data: "{}" },
+      ]),
+    )
+    render(
+      <AssetInsightPopup
+        asset={sampleAsset()}
+        onClose={jest.fn()}
+        promptOverride={{
+          query: "Custom draft-rebalance question about LSE:VUAA",
+          context: { draft: true, portfolioId: "portfolio-1" },
+        }}
+      />,
+    )
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+    const [, init] = mockFetch.mock.calls[0]
+    const body = JSON.parse(init.body)
+    expect(body.query).toBe("Custom draft-rebalance question about LSE:VUAA")
+    expect(body.context).toEqual({ draft: true, portfolioId: "portfolio-1" })
+  })
 })

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -1,12 +1,23 @@
 import React, { useState, useMemo, useEffect } from "react"
-import { formatCurrency, formatPercent } from "@lib/formatters"
+import {
+  formatCurrency,
+  formatPercent,
+  formatSignedNumber,
+} from "@lib/formatters"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
 import Alert from "@components/ui/Alert"
 import { useRouter } from "next/router"
 import Link from "next/link"
 import { TableSkeletonLoader } from "@components/ui/SkeletonLoader"
 import CashSummaryPanel from "@components/features/rebalance/execution/CashSummaryPanel"
-import { useRebalanceExecution } from "@hooks/useRebalanceExecution"
+import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
+import AssetInsightPopup from "@components/features/rebalance/models/AssetInsightPopup"
+import {
+  useRebalanceExecution,
+  DisplayItem,
+} from "@hooks/useRebalanceExecution"
+import { Asset } from "types/beancounter"
+import { ExecutionDto } from "types/rebalance"
 
 type SliderStep = 5 | 1 | 0.01
 
@@ -21,6 +32,83 @@ const SLIDER_STEP_OPTIONS: { value: SliderStep; label: string }[] = [
 function snapToStep(value: number, step: number): number {
   const snapped = Math.round(value / step) * step
   return Math.round(snapped * 100) / 100
+}
+
+/** Builds a minimal Asset for PriceChartPopup from a rebalance display row.
+ * The execution DTO only carries id/code/name/price — market and category
+ * are never resolved server-side for this flow, so a placeholder satisfies
+ * the Asset contract without inventing data; PriceChartPopup replaces the
+ * display name/market once its own price-history fetch resolves. */
+function toChartAsset(item: DisplayItem): Asset {
+  return {
+    id: item.assetId,
+    code: item.assetCode || item.assetId,
+    name: item.assetName || item.assetCode || item.assetId,
+    assetCategory: { id: "", name: "" },
+    market: {
+      code: "",
+      name: "",
+      currency: { code: item.priceCurrency || "", name: "", symbol: "" },
+    },
+  }
+}
+
+/** Seeds the "ask AI about this asset" popup with the row's full draft-
+ * rebalance context so the model can comment on THIS proposed change rather
+ * than the asset in the abstract — includes an explicit note that nothing
+ * has been executed yet. */
+function buildDraftRebalanceInsight(
+  item: DisplayItem,
+  execution: ExecutionDto,
+): { query: string; context: Record<string, unknown> } {
+  const assetLabel = item.assetCode || item.assetId
+  const currentPriceText =
+    item.snapshotPrice != null
+      ? `${formatCurrency(item.snapshotPrice)} ${item.priceCurrency || ""}`.trim()
+      : "unavailable"
+  const afterWeightText =
+    item.projectedWeight != null ? formatPercent(item.projectedWeight) : "n/a"
+  const portfolioLabel =
+    execution.name || execution.modelName || "Ad-hoc rebalance"
+
+  const query = `Role: You are a concise financial analyst helping a user review a DRAFT portfolio rebalance. This rebalance is under consideration only — no transactions have been executed yet.
+
+Analyse this single asset within the draft rebalance (150-250 words):
+1. Does the proposed change (buy/sell/hold) make sense given current vs target weight?
+2. Key risks or considerations specific to this trade
+3. Anything notable about the size of the change relative to the position or portfolio
+
+Portfolio: ${portfolioLabel} (portfolio id: ${execution.portfolioIds.join(", ") || "unknown"})
+Asset: ${assetLabel}${item.assetName ? ` — ${item.assetName}` : ""}
+Current weight: ${formatPercent(item.snapshotWeight)}
+Target weight: ${formatPercent(item.effectiveTarget)}
+After % (projected weight once this draft is applied): ${afterWeightText}
+Delta quantity: ${item.deltaQuantity}
+Delta value: ${formatSignedNumber(item.deltaValue)} ${execution.currency}
+Current price: ${currentPriceText}
+
+Note: this is a DRAFT rebalance under consideration — it has not been executed.
+
+Style: Clear, direct, evidence-based. No filler.`
+
+  return {
+    query,
+    context: {
+      page: "Rebalance Execute — Asset Insight",
+      description:
+        "AI analysis of a single asset within a draft (unexecuted) portfolio rebalance",
+      portfolioIds: execution.portfolioIds,
+      assetCode: assetLabel,
+      assetName: item.assetName,
+      currentWeight: formatPercent(item.snapshotWeight),
+      targetWeight: formatPercent(item.effectiveTarget),
+      afterWeight: afterWeightText,
+      deltaQuantity: item.deltaQuantity,
+      deltaValue: item.deltaValue,
+      currentPrice: currentPriceText,
+      draft: true,
+    },
+  }
 }
 
 function ExecuteRebalancePage(): React.ReactElement {
@@ -52,6 +140,11 @@ function ExecuteRebalancePage(): React.ReactElement {
   // spinner increment; typed numeric entries still accept arbitrary 0.01
   // precision regardless of this setting.
   const [sliderStep, setSliderStep] = useState<SliderStep>(5)
+
+  // Price-chart / AI-insight popup targets — the row the user clicked the
+  // chart-line or wand-sparkles affordance on. Null closes the popup.
+  const [chartTarget, setChartTarget] = useState<DisplayItem | null>(null)
+  const [insightTarget, setInsightTarget] = useState<DisplayItem | null>(null)
 
   // Hook handles all data fetching, state, and operations
   const {
@@ -216,45 +309,6 @@ function ExecuteRebalancePage(): React.ReactElement {
                       "Edit target % to adjust allocations. Exclude positions to maintain their current weight."
                     }
                   </p>
-                  {/* Allocation Method Toggle */}
-                  <div className="flex items-center gap-3 mt-2">
-                    <span className="text-xs text-gray-500">
-                      {"Allocation:"}
-                    </span>
-                    <div
-                      className="inline-flex rounded-md shadow-sm"
-                      role="group"
-                    >
-                      <button
-                        type="button"
-                        onClick={handlers.setAllToTarget}
-                        className={`px-3 py-1 text-xs font-medium rounded-l-md border ${
-                          displayItems.every(
-                            (i) =>
-                              i.isCash ||
-                              i.effectiveTarget === i.planTargetWeight,
-                          )
-                            ? "bg-invest-100 text-invest-700 border-invest-200"
-                            : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-                        }`}
-                        title="Use original model target weights - helps rebalance toward targets"
-                      >
-                        Model
-                      </button>
-                      <button
-                        type="button"
-                        onClick={handlers.setAllToAdjusted}
-                        className={`px-3 py-1 text-xs font-medium rounded-r-md border-t border-b border-r ${
-                          states.hasChanges
-                            ? "bg-amber-100 text-amber-700 border-amber-300"
-                            : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-                        }`}
-                        title="Use return-adjusted weights - maintains current portfolio proportions"
-                      >
-                        Adjusted
-                      </button>
-                    </div>
-                  </div>
                 </div>
                 <div className="flex gap-2">
                   <button
@@ -270,13 +324,6 @@ function ExecuteRebalancePage(): React.ReactElement {
                     title="Reset all to target weights from model"
                   >
                     All &rarr; Target
-                  </button>
-                  <button
-                    onClick={handlers.setAllToAdjusted}
-                    className="px-3 py-1 text-xs text-amber-600 bg-white border border-amber-300 rounded hover:bg-amber-50"
-                    title="Set all to return-adjusted targets (accounts for price movements)"
-                  >
-                    All &rarr; Adjusted
                   </button>
                   <button
                     onClick={handlers.setAllToZero}
@@ -332,16 +379,13 @@ function ExecuteRebalancePage(): React.ReactElement {
                       {"Asset"}
                     </th>
                     <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
+                      {"Price"}
+                    </th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
                       {"Current"}
                     </th>
                     <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
                       {"Target"}
-                    </th>
-                    <th
-                      className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"
-                      title="Return-adjusted target accounting for price movements since model creation"
-                    >
-                      {"Adjusted"}
                     </th>
                     <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
                       %
@@ -364,10 +408,13 @@ function ExecuteRebalancePage(): React.ReactElement {
                 <tbody className="bg-white divide-y divide-gray-200">
                   {displayItems.map((item) => {
                     const isCash = item.isCash
+                    // Row tinge follows deltaQuantity (not deltaValue) so a
+                    // trade of any nonzero size is coloured — excluded/PRIVATE
+                    // rows stay neutral regardless of a stale nonzero delta.
                     const isBuy =
-                      !item.isExcluded && !isCash && item.deltaValue > 100
+                      !item.isExcluded && !isCash && item.deltaQuantity > 0
                     const isSell =
-                      !item.isExcluded && !isCash && item.deltaValue < -100
+                      !item.isExcluded && !isCash && item.deltaQuantity < 0
                     const rowClass = isCash
                       ? "bg-blue-50 border-b-2 border-blue-200"
                       : item.isExcluded
@@ -408,18 +455,38 @@ function ExecuteRebalancePage(): React.ReactElement {
                         </td>
                         <td className="px-4 py-3">
                           <div
-                            className={`font-medium ${isCash ? "text-blue-900" : "text-gray-900"}`}
+                            className={`font-medium flex items-center gap-1 ${isCash ? "text-blue-900" : "text-gray-900"}`}
                             title={item.rationale || undefined}
                           >
                             {isCash && (
                               <i className="fas fa-coins mr-2 text-blue-500"></i>
                             )}
-                            {item.assetCode || item.assetId}
+                            <span>{item.assetCode || item.assetId}</span>
                             {item.rationale && !isCash && (
                               <i
-                                className="fas fa-info-circle ml-1 text-gray-400 text-xs cursor-help"
+                                className="fas fa-info-circle text-gray-400 text-xs cursor-help"
                                 title={item.rationale}
                               ></i>
+                            )}
+                            {!isCash && (
+                              <>
+                                <button
+                                  type="button"
+                                  onClick={() => setChartTarget(item)}
+                                  className="text-gray-400 hover:text-invest-600 p-0.5"
+                                  title="Price history chart"
+                                >
+                                  <i className="fas fa-chart-line text-xs"></i>
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => setInsightTarget(item)}
+                                  className="text-gray-400 hover:text-invest-600 p-0.5"
+                                  title="Ask AI about this asset"
+                                >
+                                  <i className="fas fa-wand-magic-sparkles text-xs"></i>
+                                </button>
+                              </>
                             )}
                           </div>
                           {item.assetName && !isCash && (
@@ -427,6 +494,11 @@ function ExecuteRebalancePage(): React.ReactElement {
                               {item.assetName}
                             </div>
                           )}
+                        </td>
+                        <td className="px-4 py-3 text-right text-gray-700">
+                          {item.snapshotPrice != null
+                            ? `${formatCurrency(item.snapshotPrice)} ${item.priceCurrency || ""}`.trim()
+                            : "—"}
                         </td>
                         <td className="px-4 py-3 text-right">
                           <div className="flex items-center justify-end gap-1">
@@ -475,34 +547,6 @@ function ExecuteRebalancePage(): React.ReactElement {
                               {formatPercent(item.planTargetWeight)}
                             </span>
                           </div>
-                        </td>
-                        <td className="px-4 py-3 text-right">
-                          {item.returnAdjustedTarget != null ? (
-                            <div className="flex items-center justify-end gap-1">
-                              <button
-                                onClick={() =>
-                                  handlers.targetChange(
-                                    item.assetId,
-                                    item.returnAdjustedTarget!,
-                                  )
-                                }
-                                className="text-gray-400 hover:text-invest-600 p-0.5"
-                                title="Copy return-adjusted target to %"
-                              >
-                                <i className="fas fa-arrow-right text-xs"></i>
-                              </button>
-                              <span
-                                className={
-                                  isCash ? "text-blue-600" : "text-amber-600"
-                                }
-                                title="Target adjusted for price movements since model creation"
-                              >
-                                {formatPercent(item.returnAdjustedTarget)}
-                              </span>
-                            </div>
-                          ) : (
-                            <span className="text-gray-400">-</span>
-                          )}
                         </td>
                         <td className="px-4 py-3 text-right">
                           <div className="flex items-center justify-end gap-2">
@@ -580,6 +624,7 @@ function ExecuteRebalancePage(): React.ReactElement {
                       {"Total"}
                     </td>
                     <td className="px-4 py-3"></td>
+                    <td className="px-4 py-3"></td>
                     <td className="px-4 py-3 text-right font-semibold text-gray-700">
                       {formatPercent(
                         displayItems.reduce(
@@ -587,18 +632,6 @@ function ExecuteRebalancePage(): React.ReactElement {
                           0,
                         ),
                       )}
-                    </td>
-                    <td className="px-4 py-3 text-right font-semibold text-amber-700">
-                      {(() => {
-                        const total = displayItems.reduce(
-                          (sum, item) => sum + (item.returnAdjustedTarget ?? 0),
-                          0,
-                        )
-                        const hasAdjusted = displayItems.some(
-                          (item) => item.returnAdjustedTarget != null,
-                        )
-                        return hasAdjusted ? formatPercent(total) : "-"
-                      })()}
                     </td>
                     <td className="px-4 py-3 text-right font-semibold text-gray-900">
                       {formatPercent(
@@ -866,6 +899,25 @@ function ExecuteRebalancePage(): React.ReactElement {
             </button>
           </div>
         </>
+      )}
+      {chartTarget && (
+        <PriceChartPopup
+          asset={toChartAsset(chartTarget)}
+          portfolioId={execution.portfolioIds[0]}
+          onClose={() => setChartTarget(null)}
+        />
+      )}
+      {insightTarget && (
+        <AssetInsightPopup
+          asset={{
+            assetId: insightTarget.assetId,
+            assetCode: insightTarget.assetCode,
+            assetName: insightTarget.assetName,
+            weight: insightTarget.effectiveTarget * 100,
+          }}
+          promptOverride={buildDraftRebalanceInsight(insightTarget, execution)}
+          onClose={() => setInsightTarget(null)}
+        />
       )}
     </div>
   )

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -44,6 +44,15 @@ export interface RebalanceData {
   currentPositionQuantity: number
 }
 
+// Overrides the default query/context sent to /api/agent/query/stream by
+// AssetInsightPopup — lets callers outside the rebalance-model editor (e.g.
+// the rebalance execute page) seed the popup with their own question while
+// reusing the same streaming Dialog wrapper.
+export interface AssetInsightPromptOverride {
+  query: string
+  context: Record<string, unknown>
+}
+
 export interface WeightClickData {
   asset: Asset
   currentWeight: number


### PR DESCRIPTION
## Summary

- **Dropped the "Adjusted" column.** Removed it from the execute-page configuration table (the `returnAdjustedTarget` computation in `useRebalanceExecution` is untouched — only the render was removed). Also removed the **"All → Adjusted"** toolbar button and the **"Adjusted"** half of the "Allocation: Model/Adjusted" toggle group, since both bulk actions did nothing but copy the now-hidden `returnAdjustedTarget` field into targets — with the column gone, that value has no visible meaning. The surviving "Model" toggle button was fully redundant with the existing "All → Target" button (same handler), so the whole "Allocation:" mini toggle group was removed rather than left as an orphaned single button.
- **Current price column.** New "Price" column shows `snapshotPrice` + `priceCurrency` (e.g. `281.31 USD`), reusing the existing `formatCurrency` formatter; renders `—` when price is null/undefined.
- **Price chart affordance.** Added a chart-line icon next to each asset code that opens the existing `PriceChartPopup` (from #1100), wired to that row's asset id — same Dialog wrapper already used on `/trns/proposed` and the rebalance model editor.
- **AI asset query affordance.** Added a wand-sparkles icon that opens the existing `AssetInsightPopup` (used in the rebalance model editor), extended with an optional `promptOverride` prop so the execute page can seed its own question instead of the default "why does this asset belong in the model" prompt. The seeded prompt includes portfolio id, asset code/name, current weight, target weight, After % (projected weight), delta quantity, delta value, current price, and an explicit note that this is a DRAFT rebalance — no transactions have been executed.
- **Buy/sell row tint.** Rows with `deltaQuantity > 0` get the existing `bg-green-50` buy tint, `deltaQuantity < 0` gets `bg-red-50` (same classes already used elsewhere in this table and in `AggregatedTransactionsTable`); excluded/PRIVATE rows stay neutral regardless of delta. Previously the tint was keyed off a `deltaValue` ±100 threshold — changed to `deltaQuantity` per this task's spec.

Frontend-only change — no backend/API modifications.

## Test plan

- [x] `yarn test` — 228 suites / 2195 tests pass, including a new page-level suite (`src/__tests__/pages/rebalance/execute/index.test.tsx`) covering: Adjusted column/button absence, price formatting (value+currency and `—` fallback), buy/sell/neutral row tint, chart affordance wiring, and AI-prompt content (asset code + target % present in the seeded query)
- [x] `yarn prettier` — clean
- [x] `yarn lint` — clean (one pre-existing unrelated warning elsewhere in the repo)
- [x] `yarn typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
