### PR TITLE
feat(rebalance): cash row mirrors net impact; compact stat strip + sticky table layout

### DIFF
--- a/src/__tests__/pages/rebalance/execute/index.test.tsx
+++ b/src/__tests__/pages/rebalance/execute/index.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent, within } from "@testing-library/react"
 import ExecuteRebalancePage from "@pages/rebalance/execute/index"
 import { useRebalanceExecution } from "@hooks/useRebalanceExecution"
 import type {
@@ -273,5 +273,119 @@ describe("ExecuteRebalancePage", () => {
     expect(query).toContain("XYZ")
     expect(query).toContain("42.00%")
     expect(query).toMatch(/DRAFT/)
+  })
+
+  it("renders the configuration table columns in Asset, Price, Current, Target, After %, Delta order", () => {
+    mockHookResult([makeItem()])
+    render(<ExecuteRebalancePage />)
+
+    // Only the configuration table is rendered while step === "configure".
+    const table = screen.getByRole("table")
+    const headers = within(table)
+      .getAllByRole("columnheader")
+      .map((th) => th.textContent?.trim())
+
+    expect(headers).toEqual([
+      "",
+      "Asset",
+      "Price",
+      "Current",
+      "Target",
+      "After %",
+      "Delta",
+    ])
+  })
+
+  it("CASH row's delta cell mirrors cashSummary.netImpact exactly — not the row's own (stale) deltaValue", () => {
+    mockHookResult(
+      [
+        makeItem({
+          assetId: "cash",
+          assetCode: "CASH",
+          isCash: true,
+          deltaValue: 1, // deliberately stale/irrelevant — must NOT be displayed
+        }),
+      ],
+      {
+        cashSummary: {
+          currentMarketValue: 10000,
+          currentCash: 1000,
+          targetCash: 1000,
+          cashFromSales: 2000,
+          cashForPurchases: 1500,
+          netImpact: 500,
+          projectedCash: 1500,
+        },
+      },
+    )
+    render(<ExecuteRebalancePage />)
+
+    const cashRow = screen.getByText("CASH").closest("tr")
+    expect(cashRow).not.toBeNull()
+    expect(within(cashRow!).getByText("+500.00")).toBeInTheDocument()
+    expect(within(cashRow!).getByText("+500.00")).toHaveClass("text-green-700")
+    expect(within(cashRow!).queryByText("+1.00")).not.toBeInTheDocument()
+  })
+
+  it("CASH row's delta cell shows netImpact in red when negative, and a Deposit sub-line when projected cash is negative", () => {
+    mockHookResult(
+      [
+        makeItem({
+          assetId: "cash",
+          assetCode: "CASH",
+          isCash: true,
+          deltaValue: 1,
+          projectedWeight: 0,
+        }),
+      ],
+      {
+        cashSummary: {
+          currentMarketValue: 10000,
+          currentCash: 1000,
+          targetCash: 1000,
+          cashFromSales: 0,
+          cashForPurchases: 11472.49,
+          netImpact: -10472.49,
+          projectedCash: -9472.49,
+        },
+      },
+    )
+    render(<ExecuteRebalancePage />)
+
+    const cashRow = screen.getByText("CASH").closest("tr")
+    expect(cashRow).not.toBeNull()
+    expect(within(cashRow!).getByText("-10,472.49")).toBeInTheDocument()
+    expect(within(cashRow!).getByText("-10,472.49")).toHaveClass("text-red-700")
+    expect(within(cashRow!).getByText(/Deposit/)).toBeInTheDocument()
+    expect(within(cashRow!).getByText(/9,472\.49/)).toBeInTheDocument()
+  })
+
+  it("ad-hoc mode hides the 'All -> Target' bulk button and shows a single 'Reset' button", () => {
+    mockHookResult([makeItem()], {
+      execution: makeExecution({ mode: "AD_HOC", modelName: null }),
+    })
+    render(<ExecuteRebalancePage />)
+
+    expect(
+      screen.queryByRole("button", { name: /All.*Target/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Reset" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /All.*0/i })).toBeInTheDocument()
+  })
+
+  it("plan/model mode keeps the full bulk-button set (All -> Current, All -> Target, All -> 0)", () => {
+    mockHookResult([makeItem()])
+    render(<ExecuteRebalancePage />)
+
+    expect(
+      screen.getByRole("button", { name: /All.*Current/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /All.*Target/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /All.*0/i })).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Reset" }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/components/features/rebalance/execution/CashSummaryPanel.tsx
+++ b/src/components/features/rebalance/execution/CashSummaryPanel.tsx
@@ -1,107 +1,139 @@
-import React from "react"
-import { formatCurrency, gainLossClass } from "@lib/formatters"
+import React, { useState } from "react"
+import {
+  formatCurrency,
+  formatSignedNumber,
+  gainLossClass,
+} from "@lib/formatters"
+
 interface CashSummaryPanelProps {
   currentMarketValue: number
   currentCash: number
-  targetCash: number
   cashFromSales: number
   cashForPurchases: number
+  /** cashFromSales - cashForPurchases + (currentCash - targetCash) — computed once in useRebalanceExecution; passed through, never recomputed here. */
+  netImpact: number
+  /** currentCash + netImpact, unclamped — computed once in useRebalanceExecution; passed through, never recomputed here. */
+  projectedCash: number
   currency: string
+  /** Default disclosure state. Defaults to expanded (desktop-friendly). */
+  defaultExpanded?: boolean
+}
+
+interface StatCard {
+  key: string
+  label: string
+  display: string
+  valueClass: string
 }
 
 const CashSummaryPanel: React.FC<CashSummaryPanelProps> = ({
   currentMarketValue,
   currentCash,
-  targetCash,
   cashFromSales,
   cashForPurchases,
+  netImpact,
+  projectedCash,
   currency,
+  defaultExpanded = true,
 }) => {
-  // Net impact: sales generate cash, purchases consume cash, cash position change provides/absorbs cash
-  // When reducing cash target, freed cash funds purchases (cash neutral)
-  // When increasing cash target, sales fund the cash increase (cash neutral)
-  const cashPositionChange = currentCash - targetCash // positive = cash being released
-  const netImpact = cashFromSales - cashForPurchases + cashPositionChange
-  // Projected cash = target cash (after rebalancing, cash will be at target)
-  const projectedCash = targetCash
-
+  const [expanded, setExpanded] = useState(defaultExpanded)
   const netImpactColor = gainLossClass(netImpact)
 
+  const stats: StatCard[] = [
+    {
+      key: "currentCash",
+      label: "Current Cash",
+      display: `${formatCurrency(currentCash)} ${currency}`,
+      valueClass: "text-gray-900",
+    },
+    {
+      key: "fromSales",
+      label: "From Sales",
+      display: `+${formatCurrency(cashFromSales)} ${currency}`,
+      valueClass: "text-green-600",
+    },
+    {
+      key: "forPurchases",
+      label: "For Purchases",
+      display: `-${formatCurrency(cashForPurchases)} ${currency}`,
+      valueClass: "text-red-600",
+    },
+    {
+      key: "netImpact",
+      label: "Net Impact",
+      display: `${formatSignedNumber(netImpact)} ${currency}`,
+      valueClass: netImpactColor,
+    },
+    {
+      key: "projectedCash",
+      label: "Projected Cash",
+      display: `${formatCurrency(projectedCash)} ${currency}`,
+      valueClass: "text-blue-600",
+    },
+    {
+      key: "projectedValue",
+      label: "Projected Value",
+      display: `${formatCurrency(currentMarketValue)} ${currency}`,
+      valueClass: "text-gray-900",
+    },
+  ]
+
   return (
-    <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-      <h3 className="text-sm font-medium text-gray-700 mb-3">{"Summary"}</h3>
-      <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-        {/* Left column - Market Value */}
-        <div className="flex justify-between">
-          <span className="text-gray-700 font-medium">
-            {"Current Market Value"}:
-          </span>
-          <span className="font-bold text-gray-900">
-            {formatCurrency(currentMarketValue)} {currency}
-          </span>
-        </div>
-
-        {/* Right column - Current Cash */}
-        <div className="flex justify-between">
-          <span className="text-gray-500">{"Current Cash"}:</span>
-          <span className="text-gray-900 font-medium">
-            {formatCurrency(currentCash)} {currency}
-          </span>
-        </div>
-
-        {/* From Sales */}
-        <div className="flex justify-between">
-          <span className="text-gray-500">{"From Sales"}:</span>
-          <span className="text-green-600 font-medium">
-            +{formatCurrency(cashFromSales)} {currency}
-          </span>
-        </div>
-
-        {/* Target Cash */}
-        <div className="flex justify-between">
-          <span className="text-gray-500">{"Target Cash"}:</span>
-          <span className="text-blue-600 font-medium">
-            {formatCurrency(targetCash)} {currency}
-          </span>
-        </div>
-
-        {/* For Purchases */}
-        <div className="flex justify-between">
-          <span className="text-gray-500">{"For Purchases"}:</span>
-          <span className="text-red-600 font-medium">
-            -{formatCurrency(cashForPurchases)} {currency}
-          </span>
-        </div>
-
-        {/* Net Impact */}
-        <div className="flex justify-between">
-          <span className="text-gray-700 font-medium">{"Net Impact"}:</span>
-          <span className={`font-bold ${netImpactColor}`}>
-            {netImpact >= 0 ? "+" : ""}
-            {formatCurrency(netImpact)} {currency}
-          </span>
-        </div>
-
-        {/* Projected values - full width */}
-        <div className="col-span-2 border-t border-gray-200 pt-2 mt-1 space-y-2">
-          <div className="flex justify-between">
-            <span className="text-gray-700 font-medium">
-              {"Projected Market Value"}:
+    <div className="bg-gray-50 border border-gray-200 rounded-lg">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-controls="cash-summary-stats"
+        className="w-full flex flex-wrap items-center justify-between gap-x-4 gap-y-1 px-4 py-2.5 text-left hover:bg-gray-100 rounded-lg transition-colors"
+      >
+        <span className="flex items-center gap-2 text-sm font-medium text-gray-700">
+          <i
+            className={`fas fa-chevron-${expanded ? "down" : "right"} text-xs text-gray-400 w-3`}
+          ></i>
+          {"Cash Summary"}
+        </span>
+        <span className="flex items-center gap-4 text-sm">
+          <span className="text-gray-500">
+            {"Net Impact"}:{" "}
+            <span
+              data-testid="cash-summary-headline-net-impact"
+              className={`font-bold ${netImpactColor}`}
+            >
+              {formatSignedNumber(netImpact)} {currency}
             </span>
-            <span className="font-bold text-gray-900">
-              {formatCurrency(currentMarketValue)} {currency}
-            </span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-gray-700 font-medium">
-              {"Projected Cash"}:
-            </span>
-            <span className="font-bold text-blue-600">
+          </span>
+          <span className="text-gray-500">
+            {"Projected Cash"}:{" "}
+            <span
+              data-testid="cash-summary-headline-projected-cash"
+              className="font-bold text-blue-600"
+            >
               {formatCurrency(projectedCash)} {currency}
             </span>
-          </div>
+          </span>
+        </span>
+      </button>
+      {expanded && (
+        <div
+          id="cash-summary-stats"
+          className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 px-4 pb-4"
+        >
+          {stats.map((stat) => (
+            <div
+              key={stat.key}
+              className="bg-white border border-gray-200 rounded-md px-3 py-2"
+            >
+              <div className="text-xs text-gray-500 truncate">{stat.label}</div>
+              <div
+                className={`text-sm font-bold tabular-nums ${stat.valueClass}`}
+              >
+                {stat.display}
+              </div>
+            </div>
+          ))}
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/src/components/features/rebalance/execution/__tests__/CashSummaryPanel.test.tsx
+++ b/src/components/features/rebalance/execution/__tests__/CashSummaryPanel.test.tsx
@@ -1,0 +1,100 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import CashSummaryPanel from "@components/features/rebalance/execution/CashSummaryPanel"
+
+const baseProps = {
+  currentMarketValue: 10000,
+  currentCash: 1000,
+  cashFromSales: 500,
+  cashForPurchases: 200,
+  netImpact: 300,
+  projectedCash: 1300,
+  currency: "USD",
+}
+
+describe("CashSummaryPanel", () => {
+  it("shows the headline (Net Impact + Projected Cash) when collapsed and hides the stat cards", () => {
+    render(<CashSummaryPanel {...baseProps} defaultExpanded={false} />)
+
+    const toggle = screen.getByRole("button", { name: /cash summary/i })
+    expect(toggle).toHaveAttribute("aria-expanded", "false")
+
+    // Headline always visible, even collapsed.
+    expect(screen.getByText(/Net Impact/i)).toBeInTheDocument()
+    expect(screen.getByText("+300.00 USD")).toBeInTheDocument()
+    expect(screen.getByText(/Projected Cash/i)).toBeInTheDocument()
+    expect(screen.getByText("1,300.00 USD")).toBeInTheDocument()
+
+    // Stat cards not rendered while collapsed.
+    expect(screen.queryByText("Current Cash")).not.toBeInTheDocument()
+    expect(screen.queryByText("From Sales")).not.toBeInTheDocument()
+    expect(screen.queryByText("For Purchases")).not.toBeInTheDocument()
+    expect(screen.queryByText("Projected Value")).not.toBeInTheDocument()
+  })
+
+  it("expands to show the full stat strip on click, and collapses again on a second click", () => {
+    render(<CashSummaryPanel {...baseProps} defaultExpanded={false} />)
+
+    const toggle = screen.getByRole("button", { name: /cash summary/i })
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText("Current Cash")).toBeInTheDocument()
+    expect(screen.getByText("From Sales")).toBeInTheDocument()
+    expect(screen.getByText("For Purchases")).toBeInTheDocument()
+    expect(screen.getByText("Projected Value")).toBeInTheDocument()
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByText("Current Cash")).not.toBeInTheDocument()
+  })
+
+  it("defaults to expanded when defaultExpanded is not specified", () => {
+    render(<CashSummaryPanel {...baseProps} />)
+
+    expect(
+      screen.getByRole("button", { name: /cash summary/i }),
+    ).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText("Current Cash")).toBeInTheDocument()
+  })
+
+  it("colors Net Impact green when positive and red when negative", () => {
+    const { rerender } = render(
+      <CashSummaryPanel {...baseProps} netImpact={300} />,
+    )
+    expect(screen.getByTestId("cash-summary-headline-net-impact")).toHaveClass(
+      "text-green-600",
+    )
+
+    rerender(<CashSummaryPanel {...baseProps} netImpact={-450.5} />)
+    expect(screen.getByTestId("cash-summary-headline-net-impact")).toHaveClass(
+      "text-red-600",
+    )
+  })
+
+  it("renders netImpact and projectedCash exactly as passed, without recomputing them", () => {
+    // netImpact/projectedCash here are deliberately inconsistent with
+    // currentCash/cashFromSales/cashForPurchases to prove the component is a
+    // pure display of the props it's given — not an independent calculator.
+    render(
+      <CashSummaryPanel
+        {...baseProps}
+        currentCash={1000}
+        cashFromSales={0}
+        cashForPurchases={0}
+        netImpact={-9999}
+        projectedCash={-8999}
+      />,
+    )
+
+    // Both appear twice: once in the collapsed headline, once in the stat card.
+    expect(
+      screen.getByTestId("cash-summary-headline-net-impact"),
+    ).toHaveTextContent("-9,999.00 USD")
+    expect(
+      screen.getByTestId("cash-summary-headline-projected-cash"),
+    ).toHaveTextContent("-8,999.00 USD")
+    expect(screen.getAllByText("-9,999.00 USD").length).toBe(2)
+    expect(screen.getAllByText("-8,999.00 USD").length).toBe(2)
+  })
+})

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -221,6 +221,20 @@ function ExecuteRebalancePage(): React.ReactElement {
     )
   }
 
+  // Ad-hoc executions have no model/plan behind them — target weights are
+  // seeded from current holdings, so model-derived controls (All -> Target,
+  // which would be a no-op duplicate of All -> Current) are noise.
+  const isAdHoc = execution.mode === "AD_HOC"
+
+  // CASH row's delta/value cell mirrors this exactly (Change 1) — never
+  // recomputed from the row's own deltaValue, which only reflects cash's own
+  // target-vs-snapshot and drifts from the true net cash impact once other
+  // rows are edited.
+  const cashDeltaClass =
+    cashSummary.netImpact >= 0
+      ? "text-green-700 font-medium"
+      : "text-red-700 font-medium"
+
   return (
     <div className="w-full py-4">
       {/* Breadcrumb */}
@@ -286,9 +300,10 @@ function ExecuteRebalancePage(): React.ReactElement {
           <CashSummaryPanel
             currentMarketValue={cashSummary.currentMarketValue}
             currentCash={cashSummary.currentCash}
-            targetCash={cashSummary.targetCash}
             cashFromSales={cashSummary.cashFromSales}
             cashForPurchases={cashSummary.cashForPurchases}
+            netImpact={cashSummary.netImpact}
+            projectedCash={cashSummary.projectedCash}
             currency={execution.currency}
           />
         </div>
@@ -305,26 +320,38 @@ function ExecuteRebalancePage(): React.ReactElement {
                     {"Execution Plan"}
                   </h2>
                   <p className="text-sm text-gray-500">
-                    {
-                      "Edit target % to adjust allocations. Exclude positions to maintain their current weight."
-                    }
+                    {isAdHoc
+                      ? "Adjust target weights; excluded rows keep their current weight."
+                      : "Edit target % to adjust allocations. Exclude positions to maintain their current weight."}
                   </p>
                 </div>
                 <div className="flex gap-2">
-                  <button
-                    onClick={handlers.setAllToCurrent}
-                    className="px-3 py-1 text-xs text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
-                    title="Set all % to current weights (no changes)"
-                  >
-                    All &rarr; Current
-                  </button>
-                  <button
-                    onClick={handlers.setAllToTarget}
-                    className="px-3 py-1 text-xs text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
-                    title="Reset all to target weights from model"
-                  >
-                    All &rarr; Target
-                  </button>
+                  {isAdHoc ? (
+                    <button
+                      onClick={handlers.setAllToCurrent}
+                      className="px-3 py-1 text-xs text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
+                      title="Reset all target weights to current holdings"
+                    >
+                      {"Reset"}
+                    </button>
+                  ) : (
+                    <>
+                      <button
+                        onClick={handlers.setAllToCurrent}
+                        className="px-3 py-1 text-xs text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
+                        title="Set all % to current weights (no changes)"
+                      >
+                        All &rarr; Current
+                      </button>
+                      <button
+                        onClick={handlers.setAllToTarget}
+                        className="px-3 py-1 text-xs text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
+                        title="Reset all to target weights from model"
+                      >
+                        All &rarr; Target
+                      </button>
+                    </>
+                  )}
                   <button
                     onClick={handlers.setAllToZero}
                     className="px-3 py-1 text-xs text-red-600 bg-white border border-red-300 rounded hover:bg-red-50"
@@ -366,32 +393,38 @@ function ExecuteRebalancePage(): React.ReactElement {
                 </div>
               </div>
             </div>
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
+            <div className="overflow-auto max-h-[65vh]">
+              <table className="min-w-full table-fixed divide-y divide-gray-200">
+                <colgroup>
+                  <col className="w-10" />
+                  <col className="w-44" />
+                  <col className="w-24" />
+                  <col className="w-28" />
+                  <col className="w-56" />
+                  <col className="w-20" />
+                  <col className="w-32" />
+                </colgroup>
                 <thead className="bg-gray-50">
                   <tr>
-                    <th className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase w-12">
+                    <th className="sticky top-0 z-20 bg-gray-50 px-2 py-2 text-center text-xs font-medium text-gray-500 uppercase">
                       <span title="Exclude from execution">
                         <i className="fas fa-ban"></i>
                       </span>
                     </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                    <th className="sticky top-0 left-0 z-30 bg-gray-50 px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">
                       {"Asset"}
                     </th>
-                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
+                    <th className="sticky top-0 z-20 bg-gray-50 px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">
                       {"Price"}
                     </th>
-                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
+                    <th className="sticky top-0 z-20 bg-gray-50 px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">
                       {"Current"}
                     </th>
-                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
+                    <th className="sticky top-0 z-20 bg-gray-50 px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">
                       {"Target"}
                     </th>
-                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
-                      %
-                    </th>
                     <th
-                      className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"
+                      className="sticky top-0 z-20 bg-gray-50 px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase"
                       title={
                         cashSummary.projectedCash < 0
                           ? "Assumes required cash is funded"
@@ -400,8 +433,8 @@ function ExecuteRebalancePage(): React.ReactElement {
                     >
                       {"After %"}
                     </th>
-                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">
-                      {"Quantity"}
+                    <th className="sticky top-0 z-20 bg-gray-50 px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">
+                      {"Delta"}
                     </th>
                   </tr>
                 </thead>
@@ -433,10 +466,23 @@ function ExecuteRebalancePage(): React.ReactElement {
                           : isSell
                             ? "text-red-700 font-medium"
                             : "text-gray-500"
+                    // The sticky Asset cell paints above the rest of the row
+                    // once horizontally scrolled — it needs its own opaque
+                    // background matching the row tint, or content scrolled
+                    // underneath shows through.
+                    const stickyAssetBg = isCash
+                      ? "bg-blue-50"
+                      : item.isExcluded
+                        ? "bg-gray-100"
+                        : isBuy
+                          ? "bg-green-50"
+                          : isSell
+                            ? "bg-red-50"
+                            : "bg-white"
 
                     return (
                       <tr key={item.assetId} className={rowClass}>
-                        <td className="px-2 py-3 text-center">
+                        <td className="px-2 py-2 text-center">
                           {!isCash && (
                             <input
                               type="checkbox"
@@ -453,7 +499,9 @@ function ExecuteRebalancePage(): React.ReactElement {
                             />
                           )}
                         </td>
-                        <td className="px-4 py-3">
+                        <td
+                          className={`sticky left-0 z-10 px-3 py-2 ${stickyAssetBg}`}
+                        >
                           <div
                             className={`font-medium flex items-center gap-1 ${isCash ? "text-blue-900" : "text-gray-900"}`}
                             title={item.rationale || undefined}
@@ -490,65 +538,39 @@ function ExecuteRebalancePage(): React.ReactElement {
                             )}
                           </div>
                           {item.assetName && !isCash && (
-                            <div className="text-xs text-gray-500">
+                            <div className="text-xs text-gray-500 truncate">
                               {item.assetName}
                             </div>
                           )}
                         </td>
-                        <td className="px-4 py-3 text-right text-gray-700">
+                        <td className="px-3 py-2 text-right text-gray-700 tabular-nums">
                           {item.snapshotPrice != null
                             ? `${formatCurrency(item.snapshotPrice)} ${item.priceCurrency || ""}`.trim()
                             : "—"}
                         </td>
-                        <td className="px-4 py-3 text-right">
-                          <div className="flex items-center justify-end gap-1">
-                            <button
-                              onClick={() =>
-                                handlers.setToCurrent(
-                                  item.assetId,
-                                  item.snapshotWeight,
-                                )
-                              }
-                              className="text-gray-400 hover:text-invest-600 p-0.5"
-                              title="Copy to %"
-                            >
-                              <i className="fas fa-arrow-right text-xs"></i>
-                            </button>
-                            <div>
-                              <div
-                                className={
-                                  isCash ? "text-blue-900" : "text-gray-900"
-                                }
-                              >
-                                {formatPercent(item.snapshotWeight)}
-                              </div>
-                              <div
-                                className={`text-xs ${isCash ? "text-blue-600" : "text-gray-500"}`}
-                              >
-                                {formatCurrency(item.snapshotValue)}
-                              </div>
-                            </div>
+                        <td className="px-3 py-2 text-right tabular-nums">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              handlers.setToCurrent(
+                                item.assetId,
+                                item.snapshotWeight,
+                              )
+                            }
+                            title="Set target to current weight"
+                            className={`block w-full text-right hover:underline ${
+                              isCash ? "text-blue-900" : "text-gray-900"
+                            }`}
+                          >
+                            {formatPercent(item.snapshotWeight)}
+                          </button>
+                          <div
+                            className={`text-xs ${isCash ? "text-blue-600" : "text-gray-500"}`}
+                          >
+                            {formatCurrency(item.snapshotValue)}
                           </div>
                         </td>
-                        <td className="px-4 py-3 text-right">
-                          <div className="flex items-center justify-end gap-1">
-                            <button
-                              onClick={() => handlers.setToTarget(item.assetId)}
-                              className="text-gray-400 hover:text-invest-600 p-0.5"
-                              title="Copy to %"
-                            >
-                              <i className="fas fa-arrow-right text-xs"></i>
-                            </button>
-                            <span
-                              className={
-                                isCash ? "text-blue-600" : "text-gray-500"
-                              }
-                            >
-                              {formatPercent(item.planTargetWeight)}
-                            </span>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-right">
+                        <td className="px-3 py-2">
                           <div className="flex items-center justify-end gap-2">
                             <input
                               type="range"
@@ -567,7 +589,7 @@ function ExecuteRebalancePage(): React.ReactElement {
                               }}
                               disabled={item.isExcluded}
                               aria-label={`${item.assetCode || item.assetId} target weight`}
-                              className="w-16 sm:w-24 min-w-[60px] h-2 accent-invest-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                              className="w-14 sm:w-20 min-w-[56px] h-2 accent-invest-500 disabled:opacity-40 disabled:cursor-not-allowed"
                             />
                             <input
                               type="number"
@@ -581,7 +603,7 @@ function ExecuteRebalancePage(): React.ReactElement {
                               }}
                               disabled={item.isExcluded}
                               aria-label={`${item.assetCode || item.assetId} target weight percent`}
-                              className={`w-20 px-2 py-1 text-right border rounded focus:ring-invest-500 focus:border-invest-500 ${
+                              className={`w-16 px-1.5 py-1 text-right text-sm border rounded focus:ring-invest-500 focus:border-invest-500 tabular-nums ${
                                 isCash
                                   ? "border-blue-300 bg-blue-50"
                                   : item.isExcluded
@@ -590,26 +612,46 @@ function ExecuteRebalancePage(): React.ReactElement {
                               }`}
                             />
                           </div>
+                          <button
+                            type="button"
+                            onClick={() => handlers.setToTarget(item.assetId)}
+                            title="Reset target to plan weight"
+                            className="block w-full text-right text-[11px] text-gray-400 hover:text-invest-600 hover:underline mt-0.5"
+                          >
+                            {"Plan"}: {formatPercent(item.planTargetWeight)}
+                          </button>
                         </td>
                         <td
-                          className={`px-4 py-3 text-right ${isCash ? "text-blue-900" : "text-gray-700"}`}
+                          className={`px-3 py-2 text-right tabular-nums ${isCash ? "text-blue-900" : "text-gray-700"}`}
                         >
                           {item.projectedWeight == null
                             ? "—"
                             : formatPercent(item.projectedWeight)}
+                          {isCash && cashSummary.projectedCash < 0 && (
+                            <div className="text-[11px] text-red-600 font-medium">
+                              {"Deposit"}{" "}
+                              {formatCurrency(
+                                Math.abs(cashSummary.projectedCash),
+                              )}
+                            </div>
+                          )}
                         </td>
-                        <td className={`px-4 py-3 text-right ${quantityClass}`}>
+                        <td className="px-3 py-2 text-right tabular-nums">
                           {isCash ? (
-                            <span>
-                              {item.deltaValue > 0 ? "+" : ""}
-                              {formatCurrency(item.deltaValue)}
+                            <span className={cashDeltaClass}>
+                              {formatSignedNumber(cashSummary.netImpact)}
                             </span>
                           ) : item.isExcluded ? (
                             <span className="text-gray-400">-</span>
                           ) : (
                             <>
-                              {item.deltaQuantity > 0 ? "+" : ""}
-                              {item.deltaQuantity}
+                              <div className={quantityClass}>
+                                {item.deltaQuantity > 0 ? "+" : ""}
+                                {item.deltaQuantity}
+                              </div>
+                              <div className="text-xs text-gray-500">
+                                {formatSignedNumber(item.deltaValue)}
+                              </div>
                             </>
                           )}
                         </td>
@@ -619,21 +661,13 @@ function ExecuteRebalancePage(): React.ReactElement {
                 </tbody>
                 <tfoot className="bg-gray-100 border-t-2 border-gray-300">
                   <tr>
-                    <td className="px-2 py-3"></td>
-                    <td className="px-4 py-3 font-semibold text-gray-900">
+                    <td className="px-2 py-2"></td>
+                    <td className="sticky left-0 z-10 bg-gray-100 px-3 py-2 font-semibold text-gray-900">
                       {"Total"}
                     </td>
-                    <td className="px-4 py-3"></td>
-                    <td className="px-4 py-3"></td>
-                    <td className="px-4 py-3 text-right font-semibold text-gray-700">
-                      {formatPercent(
-                        displayItems.reduce(
-                          (sum, item) => sum + item.planTargetWeight,
-                          0,
-                        ),
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-right font-semibold text-gray-900">
+                    <td className="px-3 py-2"></td>
+                    <td className="px-3 py-2"></td>
+                    <td className="px-3 py-2 text-right font-semibold text-gray-900 tabular-nums">
                       {formatPercent(
                         displayItems.reduce(
                           (sum, item) => sum + item.effectiveTarget,
@@ -641,7 +675,7 @@ function ExecuteRebalancePage(): React.ReactElement {
                         ),
                       )}
                     </td>
-                    <td className="px-4 py-3 text-right font-semibold text-gray-900">
+                    <td className="px-3 py-2 text-right font-semibold text-gray-900 tabular-nums">
                       {formatPercent(
                         displayItems.reduce(
                           (sum, item) => sum + (item.projectedWeight ?? 0),
@@ -649,7 +683,7 @@ function ExecuteRebalancePage(): React.ReactElement {
                         ),
                       )}
                     </td>
-                    <td className="px-4 py-3"></td>
+                    <td className="px-3 py-2"></td>
                   </tr>
                 </tfoot>
               </table>
@@ -809,9 +843,10 @@ function ExecuteRebalancePage(): React.ReactElement {
             <CashSummaryPanel
               currentMarketValue={cashSummary.currentMarketValue}
               currentCash={cashSummary.currentCash}
-              targetCash={cashSummary.targetCash}
               cashFromSales={cashSummary.cashFromSales}
               cashForPurchases={cashSummary.cashForPurchases}
+              netImpact={cashSummary.netImpact}
+              projectedCash={cashSummary.projectedCash}
               currency={execution.currency}
             />
           </div>


### PR DESCRIPTION
## Summary
- CASH row now mirrors `cashSummary.netImpact` exactly (was showing the row's own stale `deltaValue`) — green/red signed, with a red "Deposit" sub-line under After % when a shortfall requires funding.
- `CashSummaryPanel` is a collapsible disclosure (accessible button + `aria-expanded`, not native `<details>`) with a compact 6-card stat strip (Current Cash / From Sales / For Purchases / Net Impact / Projected Cash / Projected Value); collapsed state still shows the Net Impact + Projected Cash headline. Takes `netImpact`/`projectedCash` as props from the hook instead of recomputing them locally — single source of truth shared with the table.
- Execution table: reordered to Asset | Price | Current | Target | After % | Delta, dropped duplicate copy-arrow glyphs (values are now directly clickable), merged the read-only Target column into the editable one (plan weight shown as a clickable sub-line), added sticky header + sticky Asset column for scroll, tighter `table-fixed` column widths, `tabular-nums` on numerics.
- Ad-hoc executions (no model/plan) hide the redundant "All -> Target" button behind a single "Reset" action; plan/model executions keep the full bulk-button set.

## Test plan
- [x] `yarn test` — 229 suites / 2205 tests green, including new coverage: cash-row mirrors netImpact (both signs) + Deposit sub-line, column header order, ad-hoc vs plan-mode button sets, CashSummaryPanel collapse/expand + headline visibility
- [x] `yarn prettier`, `yarn lint`, `yarn typecheck` all clean
- [ ] Browser-verify in dev server (coordinator)