### PR TITLE
feat(rebalance): relative ±10pp delta slider with center detent

### DIFF
--- a/__tests__/pages/rebalance/execute-slider.test.tsx
+++ b/__tests__/pages/rebalance/execute-slider.test.tsx
@@ -219,6 +219,8 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
 
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
     expect(slider).toHaveAttribute("step", "5")
+    expect(slider).toHaveAttribute("min", "-10")
+    expect(slider).toHaveAttribute("max", "10")
   })
 
   it("switching the step toggle updates the slider step attr and numeric input step attr", () => {
@@ -244,32 +246,139 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     expect(numeric).toHaveAttribute("step", "0.01")
   })
 
-  it("dragging a row's slider to 15 with 5% step calls targetChange with 0.15", () => {
+  it("centers the slider at delta 0 when effectiveTarget equals snapshotWeight", () => {
     render(<ExecuteRebalancePage />)
 
+    // QUAL: snapshotWeight 0.5, effectiveTarget 0.5 -> unchanged -> delta 0
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
-    fireEvent.change(slider, { target: { value: "15" } })
+    expect(slider).toHaveValue("0")
+  })
+
+  it("derives the slider's displayed delta from effectiveTarget - snapshotWeight after a re-render", () => {
+    const { rerender } = render(<ExecuteRebalancePage />)
+
+    // Simulate the parent state updating after a targetChange call: QUAL's
+    // effectiveTarget moves to snapshotWeight (0.5) + 4pp = 0.54.
+    executionState.displayItems = executionState.displayItems.map((item) => {
+      const typed = item as { assetId: string; effectiveTarget: number }
+      return typed.assetId === "asset-qual"
+        ? { ...typed, effectiveTarget: 0.54 }
+        : typed
+    })
+    executionState.activeItems = executionState.displayItems
+    rerender(<ExecuteRebalancePage />)
+
+    const slider = screen.getByRole("slider", { name: "QUAL target weight" })
+    expect(slider).toHaveValue("4")
+  })
+
+  it("sliding to +5 with the 5% step active calls targetChange with current + 5pp as a fraction", () => {
+    render(<ExecuteRebalancePage />)
+
+    // QUAL current weight is 50% (snapshotWeight 0.5).
+    const slider = screen.getByRole("slider", { name: "QUAL target weight" })
+    fireEvent.change(slider, { target: { value: "5" } })
 
     expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
       "asset-qual",
-      0.15,
+      0.55,
     )
   })
 
-  it("snaps an off-step slider value to the nearest step before calling targetChange", () => {
+  it("snaps an off-step slider delta to the nearest step before calling targetChange", () => {
     render(<ExecuteRebalancePage />)
 
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
-    fireEvent.change(slider, { target: { value: "17" } })
+    // Raw delta 7 snaps to nearest multiple of 5 -> 5 -> current(50) + 5 = 55
+    fireEvent.change(slider, { target: { value: "7" } })
 
-    // 17 snapped to nearest multiple of 5 => 15 => 0.15
     expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
       "asset-qual",
-      0.15,
+      0.55,
     )
   })
 
-  it("disables the slider on an excluded row, mirroring the numeric input", () => {
+  it("clamps the resulting target to 0 when a low-weight row is slid to the -10 edge", () => {
+    const execution = makeExecution()
+    execution.items[0].snapshotWeight = 0.02
+    execution.items[0].effectiveTarget = 0.02
+    executionState.execution = execution
+    executionState.displayItems = displayItemsFor(execution)
+    executionState.activeItems = executionState.displayItems
+
+    render(<ExecuteRebalancePage />)
+
+    const slider = screen.getByRole("slider", { name: "QUAL target weight" })
+    fireEvent.change(slider, { target: { value: "-10" } })
+
+    // current(2) - 10 = -8, clamped to 0
+    expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
+      "asset-qual",
+      0,
+    )
+  })
+
+  it("pins the slider thumb at the +10 edge when the numeric input's real delta exceeds the range", () => {
+    const { rerender } = render(<ExecuteRebalancePage />)
+
+    // QUAL current weight is 50%; type a target 25pp above current (75%) —
+    // a delta far outside the +-10pp slider track.
+    const numeric = screen.getByRole("spinbutton", {
+      name: "QUAL target weight percent",
+    })
+    fireEvent.change(numeric, { target: { value: "75" } })
+    expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
+      "asset-qual",
+      0.75,
+    )
+
+    // Simulate the parent state applying that change.
+    executionState.displayItems = executionState.displayItems.map((item) => {
+      const typed = item as { assetId: string; effectiveTarget: number }
+      return typed.assetId === "asset-qual"
+        ? { ...typed, effectiveTarget: 0.75 }
+        : typed
+    })
+    executionState.activeItems = executionState.displayItems
+    rerender(<ExecuteRebalancePage />)
+
+    const slider = screen.getByRole("slider", { name: "QUAL target weight" })
+    expect(slider).toHaveValue("10")
+
+    const numericAfter = screen.getByRole("spinbutton", {
+      name: "QUAL target weight percent",
+    })
+    expect(numericAfter).toHaveValue(75)
+  })
+
+  it("renders a signed, color-coded delta label next to the slider", () => {
+    const execution = makeExecution()
+    // QUAL: +4pp (green), EXCL stays excluded/unchanged (neutral)
+    execution.items[0].effectiveTarget = 0.54
+    executionState.execution = execution
+    executionState.displayItems = displayItemsFor(execution)
+    executionState.activeItems = executionState.displayItems
+
+    const { rerender } = render(<ExecuteRebalancePage />)
+
+    expect(screen.getByText("+4.0 → 54.00%")).toHaveClass("text-green-600")
+    // Excluded row (EXCL) keeps its current weight -> delta 0 -> neutral.
+    expect(screen.getByText("0.0 → 20.00%")).toHaveClass("text-gray-500")
+
+    // Sanity: negative delta renders red.
+    executionState.displayItems = executionState.displayItems.map((item) => {
+      const typed = item as { assetId: string; effectiveTarget: number }
+      return typed.assetId === "asset-qual"
+        ? { ...typed, effectiveTarget: 0.47 }
+        : typed
+    })
+    executionState.activeItems = executionState.displayItems
+    rerender(<ExecuteRebalancePage />)
+
+    expect(screen.getByText("-3.0 → 47.00%")).toHaveClass("text-red-600")
+  })
+
+  it("disables the slider on an excluded row and centers it at delta 0", () => {
     render(<ExecuteRebalancePage />)
 
     const slider = screen.getByRole("slider", { name: "EXCL target weight" })
@@ -277,6 +386,7 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
       name: "EXCL target weight percent",
     })
     expect(slider).toBeDisabled()
+    expect(slider).toHaveValue("0")
     expect(numeric).toBeDisabled()
   })
 

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -34,6 +34,19 @@ function snapToStep(value: number, step: number): number {
   return Math.round(snapped * 100) / 100
 }
 
+/** How far the slider range extends either side of "unchanged" (0). */
+const DELTA_RANGE_PP = 10
+
+/** Formats a percentage-point delta with an explicit "+" for positive values
+ * (negative values already carry their sign from `toFixed`; zero gets no
+ * sign). `fractionDigits` controls precision — 1 for the visible label,
+ * 0 for the terser `aria-valuetext`. */
+function formatSignedPp(value: number, fractionDigits: number): string {
+  const rounded = Number(value.toFixed(fractionDigits))
+  const sign = rounded > 0 ? "+" : ""
+  return `${sign}${rounded.toFixed(fractionDigits)}`
+}
+
 /** Builds a minimal Asset for PriceChartPopup from a rebalance display row.
  * The execution DTO only carries id/code/name/price — market and category
  * are never resolved server-side for this flow, so a placeholder satisfies
@@ -480,6 +493,31 @@ function ExecuteRebalancePage(): React.ReactElement {
                             ? "bg-red-50"
                             : "bg-white"
 
+                    // Delta-slider semantics: the slider expresses target
+                    // weight as an offset from CURRENT weight, not an
+                    // absolute 0-100 value — typical edits are a few points,
+                    // so the full track resolves them precisely. Excluded
+                    // rows are forced to delta 0 (centered, disabled) since
+                    // they keep their current weight regardless of any
+                    // stale effectiveTarget. Real delta can exceed the
+                    // +-10pp track (e.g. a big absolute edit via the numeric
+                    // input) — the slider THUMB pins at the edge while the
+                    // numeric input keeps showing the real, uncapped value.
+                    const currentPct = item.snapshotWeight * 100
+                    const realDeltaPct = item.isExcluded
+                      ? 0
+                      : item.effectiveTarget * 100 - currentPct
+                    const sliderDeltaPct = Math.min(
+                      DELTA_RANGE_PP,
+                      Math.max(-DELTA_RANGE_PP, realDeltaPct),
+                    )
+                    const deltaLabelClass =
+                      realDeltaPct === 0
+                        ? "text-gray-500"
+                        : realDeltaPct > 0
+                          ? "text-green-600"
+                          : "text-red-600"
+
                     return (
                       <tr key={item.assetId} className={rowClass}>
                         <td className="px-2 py-2 text-center">
@@ -572,25 +610,41 @@ function ExecuteRebalancePage(): React.ReactElement {
                         </td>
                         <td className="px-3 py-2">
                           <div className="flex items-center justify-end gap-2">
-                            <input
-                              type="range"
-                              min={0}
-                              max={100}
-                              step={sliderStep}
-                              value={item.effectiveTarget * 100}
-                              onChange={(e) => {
-                                const raw = parseFloat(e.target.value)
-                                if (Number.isNaN(raw)) return
-                                const snapped = snapToStep(raw, sliderStep)
-                                handlers.targetChange(
-                                  item.assetId,
-                                  snapped / 100,
-                                )
-                              }}
-                              disabled={item.isExcluded}
-                              aria-label={`${item.assetCode || item.assetId} target weight`}
-                              className="w-14 sm:w-20 min-w-[56px] h-2 accent-invest-500 disabled:opacity-40 disabled:cursor-not-allowed"
-                            />
+                            <div className="relative w-14 sm:w-20 min-w-[56px]">
+                              {/* Center detent — marks "unchanged from current
+                                  weight" (delta 0) at the track midpoint. */}
+                              <span
+                                aria-hidden="true"
+                                className="pointer-events-none absolute top-1/2 left-1/2 z-0 h-2.5 w-px -translate-x-1/2 -translate-y-1/2 bg-gray-400"
+                              />
+                              <input
+                                type="range"
+                                min={-DELTA_RANGE_PP}
+                                max={DELTA_RANGE_PP}
+                                step={sliderStep}
+                                value={sliderDeltaPct}
+                                onChange={(e) => {
+                                  const raw = parseFloat(e.target.value)
+                                  if (Number.isNaN(raw)) return
+                                  const snappedDelta = snapToStep(
+                                    raw,
+                                    sliderStep,
+                                  )
+                                  const newTargetPct = Math.min(
+                                    100,
+                                    Math.max(0, currentPct + snappedDelta),
+                                  )
+                                  handlers.targetChange(
+                                    item.assetId,
+                                    newTargetPct / 100,
+                                  )
+                                }}
+                                disabled={item.isExcluded}
+                                aria-label={`${item.assetCode || item.assetId} target weight`}
+                                aria-valuetext={`${formatSignedPp(sliderDeltaPct, 0)} percentage points, target ${formatPercent(item.effectiveTarget)}`}
+                                className="relative z-10 w-full h-2 accent-invest-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                              />
+                            </div>
                             <input
                               type="number"
                               min="0"
@@ -611,6 +665,13 @@ function ExecuteRebalancePage(): React.ReactElement {
                                     : "border-gray-300"
                               }`}
                             />
+                          </div>
+                          <div
+                            className={`text-right text-[11px] tabular-nums ${deltaLabelClass}`}
+                          >
+                            {formatSignedPp(realDeltaPct, 1)}
+                            {" → "}
+                            {formatPercent(item.effectiveTarget)}
                           </div>
                           <button
                             type="button"


### PR DESCRIPTION
## Summary

Redesigns the per-row target-weight slider on the rebalance-execute page from an absolute 0-100% range to a relative delta-from-current control:

- Slider range is now **-10 … +10 percentage points**, centered on 0 = "unchanged from current weight" — the old absolute 0-100 range gave only ~10% of the track to typical 1-10pp edits.
- Slider value = `effectiveTarget - snapshotWeight` (as pp), clamped to the ±10pp track. Real deltas beyond that range (e.g. a large absolute edit via the numeric input) pin the thumb at the nearest edge — the numeric input stays the uncapped source of truth.
- On slider change: reads the raw delta, snaps it via the existing step-toggle logic, adds it to the row's current weight, clamps the result to [0, 100], then calls `targetChange` with the same fraction signature as before.
- Added a CSS-only center detent (a thin absolutely-positioned tick) marking the 0 midpoint of the track.
- Added a compact, color-coded delta label next to the slider (e.g. `+4.0 → 54.00%`), green for positive, red for negative, gray for unchanged.
- Numeric input semantics are unchanged (still absolute target %, still calls `targetChange` directly) — slider and numeric input stay in sync because both derive from `item.effectiveTarget`.
- Excluded/PRIVATE rows render disabled and pinned at delta 0.
- Added `aria-valuetext` on the slider describing the delta and resulting target for screen readers.

## Test plan

- [x] `__tests__/pages/rebalance/execute-slider.test.tsx` rewritten for delta semantics (red → green): center-at-zero, delta-derived value after re-render, +5pp slide → correct fraction, off-step snap, low-weight clamp to 0, pin-at-edge with numeric input staying uncapped, color-coded delta label (positive/negative/neutral), excluded-row disabled+centered, step-toggle attrs.
- [x] Full suite: `yarn test` — 229 suites / 2210 tests passing.
- [x] `yarn prettier` (includes `yarn lint`) — clean, no new warnings.
- [x] `yarn typecheck` — clean.