### PR TITLE
fix(rebalance): epsilon-zero delta display; half-up label rounding

### DIFF
--- a/__tests__/pages/rebalance/execute-slider.test.tsx
+++ b/__tests__/pages/rebalance/execute-slider.test.tsx
@@ -378,6 +378,38 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     expect(screen.getByText("-3.0 → 47.00%")).toHaveClass("text-red-600")
   })
 
+  it("treats a float-noise effectiveTarget residual as exactly zero delta", () => {
+    const execution = makeExecution()
+    // Seeded effectiveTarget carries a 1e-9 float residual over
+    // snapshotWeight (0.5) — far below any real edit — so the label, its
+    // color, and the slider must all read "unchanged".
+    execution.items[0].effectiveTarget = 0.5 + 1e-9
+    executionState.execution = execution
+    executionState.displayItems = displayItemsFor(execution)
+    executionState.activeItems = executionState.displayItems
+
+    render(<ExecuteRebalancePage />)
+
+    expect(screen.getByText("0.0 → 50.00%")).toHaveClass("text-gray-500")
+    const slider = screen.getByRole("slider", { name: "QUAL target weight" })
+    expect(slider).toHaveValue("0")
+  })
+
+  it("rounds a half-way delta up rather than truncating due to float representation", () => {
+    const execution = makeExecution()
+    // snapshotWeight 0.5 (50%), effectiveTarget 0.7415 (74.15%) -> a raw
+    // delta of 24.15pp, which (24.15).toFixed(1) mis-rounds down to "24.1"
+    // because of how 24.15 is represented in binary floating point.
+    execution.items[0].effectiveTarget = 0.7415
+    executionState.execution = execution
+    executionState.displayItems = displayItemsFor(execution)
+    executionState.activeItems = executionState.displayItems
+
+    render(<ExecuteRebalancePage />)
+
+    expect(screen.getByText("+24.2 → 74.15%")).toHaveClass("text-green-600")
+  })
+
   it("disables the slider on an excluded row and centers it at delta 0", () => {
     render(<ExecuteRebalancePage />)
 

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -865,6 +865,64 @@ describe("useRebalanceExecution", () => {
     expect(total).toBeCloseTo(1, 5)
   })
 
+  it("landing with no overrides never yields a nonzero deltaQuantity from proportional-scaling float noise", async () => {
+    // Three equal-weight holdings whose planTargetWeight mirrors current
+    // weight (as an AD_HOC execution seeds it) sum to 0.8999999999999999 in
+    // floating point rather than an exact 0.9 — the proportional-scaling
+    // formula (planTargetWeight / totalPlanTargetWeights * availableForAssets)
+    // then lands effectiveTarget a few 1e-15 pp off snapshotWeight even
+    // though nothing was edited. deltaQuantity rounds that residual to a
+    // whole share, which must resolve to 0 (not a phantom +/-1) so the
+    // "Delta" column stays neutral on landing.
+    const exec = makeExecution({
+      totalPortfolioValue: 10000,
+      snapshotCashValue: 1000,
+      items: [
+        makeItem({
+          id: "a",
+          assetId: "a-asset",
+          assetCode: "AAA",
+          snapshotWeight: 0.3,
+          snapshotValue: 3000,
+          planTargetWeight: 0.3,
+          snapshotPrice: 100,
+        }),
+        makeItem({
+          id: "b",
+          assetId: "b-asset",
+          assetCode: "BBB",
+          snapshotWeight: 0.3,
+          snapshotValue: 3000,
+          planTargetWeight: 0.3,
+          snapshotPrice: 100,
+        }),
+        makeItem({
+          id: "c",
+          assetId: "c-asset",
+          assetCode: "CCC",
+          snapshotWeight: 0.3,
+          snapshotValue: 3000,
+          planTargetWeight: 0.3,
+          snapshotPrice: 100,
+        }),
+        makeCashItem({
+          assetId: "cash",
+          snapshotWeight: 0.1,
+          snapshotValue: 1000,
+          planTargetWeight: 0.1,
+        }),
+      ],
+    })
+
+    const { result } = await renderWithExecution(exec)
+
+    for (const item of result.current.displayItems) {
+      if (!item.isCash) {
+        expect(item.deltaQuantity).toBe(0)
+      }
+    }
+  })
+
   it("internal shuffle funded by an offsetting sale leaves projected total and untouched rows' weight unchanged", async () => {
     // Sell 300 from X, buy 300 into Y — self-funded, cash stays positive and
     // unchanged, so the projected total should equal the snapshot total and

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -37,12 +37,43 @@ function snapToStep(value: number, step: number): number {
 /** How far the slider range extends either side of "unchanged" (0). */
 const DELTA_RANGE_PP = 10
 
+/** Deltas at or under this magnitude (percentage points) are treated as
+ * exactly zero for label color, label text, and slider centering. The
+ * seeded `effectiveTarget` is derived from a proportional-scaling formula
+ * (planTargetWeight / totalPlanTargetWeights * availableForAssets) that is
+ * mathematically equal to `snapshotWeight` on an unedited landing but lands
+ * a hair off it in floating point (residuals around 1e-9–1e-13 pp) — that
+ * noise must not flip the sign-based color/label. A genuine edit is at
+ * least an order of magnitude larger than this threshold. */
+const DELTA_EPSILON_PP = 0.005
+
+/** Snaps a delta whose magnitude is float noise (below DELTA_EPSILON_PP) to
+ * exactly zero, so every consumer — label color, label text, and slider
+ * centering — agrees on "unchanged" from a single source. */
+function snapEpsilonZero(deltaPct: number): number {
+  return Math.abs(deltaPct) < DELTA_EPSILON_PP ? 0 : deltaPct
+}
+
+/** Rounds half-away-from-zero to `fractionDigits`, correcting for cases
+ * where native `toFixed` under-rounds a value due to its binary
+ * floating-point representation (e.g. (24.15).toFixed(1) === "24.1", not
+ * the expected "24.2", because the nearest double to the literal 24.15 is
+ * actually ~24.149999999999998579). The small additive epsilon is far
+ * larger than that representation error but far smaller than the display
+ * precision, so it only ever nudges genuine half-way values. */
+function roundHalfUp(value: number, fractionDigits: number): number {
+  const factor = 10 ** fractionDigits
+  const sign = value < 0 ? -1 : 1
+  return (sign * Math.round(Math.abs(value) * factor + 1e-9)) / factor
+}
+
 /** Formats a percentage-point delta with an explicit "+" for positive values
  * (negative values already carry their sign from `toFixed`; zero gets no
- * sign). `fractionDigits` controls precision — 1 for the visible label,
- * 0 for the terser `aria-valuetext`. */
+ * sign). `fractionDigits` controls precision — 2 when the 0.01% slider step
+ * is active, 1 otherwise for the visible label; 0 for the terser
+ * `aria-valuetext`. */
 function formatSignedPp(value: number, fractionDigits: number): string {
-  const rounded = Number(value.toFixed(fractionDigits))
+  const rounded = roundHalfUp(value, fractionDigits)
   const sign = rounded > 0 ? "+" : ""
   return `${sign}${rounded.toFixed(fractionDigits)}`
 }
@@ -506,7 +537,7 @@ function ExecuteRebalancePage(): React.ReactElement {
                     const currentPct = item.snapshotWeight * 100
                     const realDeltaPct = item.isExcluded
                       ? 0
-                      : item.effectiveTarget * 100 - currentPct
+                      : snapEpsilonZero(item.effectiveTarget * 100 - currentPct)
                     const sliderDeltaPct = Math.min(
                       DELTA_RANGE_PP,
                       Math.max(-DELTA_RANGE_PP, realDeltaPct),
@@ -669,7 +700,10 @@ function ExecuteRebalancePage(): React.ReactElement {
                           <div
                             className={`text-right text-[11px] tabular-nums ${deltaLabelClass}`}
                           >
-                            {formatSignedPp(realDeltaPct, 1)}
+                            {formatSignedPp(
+                              realDeltaPct,
+                              sliderStep === 0.01 ? 2 : 1,
+                            )}
                             {" → "}
                             {formatPercent(item.effectiveTarget)}
                           </div>


### PR DESCRIPTION
## Summary
- Delta labels on the rebalance execute page (ad-hoc landing) were showing red/green for effectively-zero deltas: the seeded `effectiveTarget` carries float residual vs `snapshotWeight` from the proportional-scaling formula, and sign-based coloring fired on that noise. Added a `DELTA_EPSILON_PP` (0.005pp) threshold via `snapEpsilonZero`, applied once at the `realDeltaPct` computation site so label color, label text, and slider centering all agree.
- Delta labels mis-rounded half-way values (e.g. 24.15 → "24.1" instead of "24.2") because native `toFixed` under-rounds due to binary floating-point representation. Added `roundHalfUp` (half-away-from-zero with a corrective epsilon) and wired the label to use 2dp when the 0.01% slider step is active, 1dp otherwise.
- Investigated whether row background tint (bg-green-50/bg-red-50, keyed on `deltaQuantity`) shows the same landing-residual bug — confirmed it does not: `deltaQuantity = Math.round(deltaValue / price)` already rounds float noise (~1e-13 pp in a realistic landing scenario) down to exactly 0 shares, so no additional epsilon was needed there. Added a regression test (`useRebalanceExecution.test.ts`) proving this.

Note: this was originally targeting PR #1109, but that PR merged before this fix landed — this is a fresh PR off current `main` with just the fix commit.

## Test plan
- [x] `yarn test` — 229 suites / 2213 tests pass, including 3 new tests (2 page-level epsilon/rounding, 1 hook-level landing-residual regression)
- [x] `yarn prettier` (includes `yarn lint`) — clean
- [x] `yarn typecheck` — clean