### PR TITLE
feat(rebalance): select-all, per-row reset, re-anchoring slider, trade column split

### DIFF
--- a/__tests__/pages/rebalance/execute-slider.test.tsx
+++ b/__tests__/pages/rebalance/execute-slider.test.tsx
@@ -174,6 +174,13 @@ function displayItemsFor(execution: ExecutionDto): unknown[] {
     return {
       ...item,
       effectiveTarget: item.effectiveTarget,
+      // Baseline for the per-row reset + Trade column's delta-vs-original
+      // label. These fixtures never mutate snapshotWeight after construction
+      // — only `effectiveTarget` — so using it as the seeded "original" keeps
+      // the vs-original delta numerically identical to the old vs-current
+      // one in every test below, which is exactly the intended baseline for
+      // a freshly-loaded, never-touched row.
+      originalTarget: item.snapshotWeight,
       deltaValue: item.deltaValue,
       deltaQuantity: item.deltaQuantity,
       isExcluded: item.excluded,
@@ -217,10 +224,12 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
       "false",
     )
 
+    // QUAL's target is 50% (unedited) — with no explicit anchor pinned yet,
+    // the slider's +-10pp window is centered on that live target.
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
     expect(slider).toHaveAttribute("step", "5")
-    expect(slider).toHaveAttribute("min", "-10")
-    expect(slider).toHaveAttribute("max", "10")
+    expect(slider).toHaveAttribute("min", "40")
+    expect(slider).toHaveAttribute("max", "60")
   })
 
   it("switching the step toggle updates the slider step attr and numeric input step attr", () => {
@@ -246,19 +255,21 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     expect(numeric).toHaveAttribute("step", "0.01")
   })
 
-  it("centers the slider at delta 0 when effectiveTarget equals snapshotWeight", () => {
+  it("sits at the live target (50%) when no explicit anchor has been pinned yet", () => {
     render(<ExecuteRebalancePage />)
 
-    // QUAL: snapshotWeight 0.5, effectiveTarget 0.5 -> unchanged -> delta 0
+    // QUAL: snapshotWeight 0.5, effectiveTarget 0.5 — the slider's value is
+    // now the ABSOLUTE target (not a delta from current weight).
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
-    expect(slider).toHaveValue("0")
+    expect(slider).toHaveValue("50")
   })
 
-  it("derives the slider's displayed delta from effectiveTarget - snapshotWeight after a re-render", () => {
+  it("recenters the slider's +-10pp window on the live effectiveTarget after an external state update", () => {
     const { rerender } = render(<ExecuteRebalancePage />)
 
     // Simulate the parent state updating after a targetChange call: QUAL's
-    // effectiveTarget moves to snapshotWeight (0.5) + 4pp = 0.54.
+    // effectiveTarget moves to 0.54. No user gesture pinned an anchor, so
+    // the window follows the new target automatically.
     executionState.displayItems = executionState.displayItems.map((item) => {
       const typed = item as { assetId: string; effectiveTarget: number }
       return typed.assetId === "asset-qual"
@@ -269,15 +280,18 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     rerender(<ExecuteRebalancePage />)
 
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
-    expect(slider).toHaveValue("4")
+    expect(slider).toHaveValue("54")
+    expect(slider).toHaveAttribute("min", "44")
+    expect(slider).toHaveAttribute("max", "64")
   })
 
-  it("sliding to +5 with the 5% step active calls targetChange with current + 5pp as a fraction", () => {
+  it("sliding to 55% (within the anchor's +-10pp window) calls targetChange with 0.55 directly", () => {
     render(<ExecuteRebalancePage />)
 
-    // QUAL current weight is 50% (snapshotWeight 0.5).
+    // The slider now carries the ABSOLUTE target percent, not an offset —
+    // no more "current + delta" arithmetic on the read side.
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
-    fireEvent.change(slider, { target: { value: "5" } })
+    fireEvent.change(slider, { target: { value: "55" } })
 
     expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
       "asset-qual",
@@ -285,12 +299,12 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     )
   })
 
-  it("snaps an off-step slider delta to the nearest step before calling targetChange", () => {
+  it("snaps an off-step slider value to the nearest step before calling targetChange", () => {
     render(<ExecuteRebalancePage />)
 
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
-    // Raw delta 7 snaps to nearest multiple of 5 -> 5 -> current(50) + 5 = 55
-    fireEvent.change(slider, { target: { value: "7" } })
+    // Raw value 57 snaps to the nearest multiple of 5 -> 55.
+    fireEvent.change(slider, { target: { value: "57" } })
 
     expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
       "asset-qual",
@@ -298,7 +312,7 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     )
   })
 
-  it("clamps the resulting target to 0 when a low-weight row is slid to the -10 edge", () => {
+  it("clamps the resulting target to 0 when the slider is dragged below 0%", () => {
     const execution = makeExecution()
     execution.items[0].snapshotWeight = 0.02
     execution.items[0].effectiveTarget = 0.02
@@ -311,18 +325,18 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
     fireEvent.change(slider, { target: { value: "-10" } })
 
-    // current(2) - 10 = -8, clamped to 0
     expect(executionState.handlers.targetChange).toHaveBeenCalledWith(
       "asset-qual",
       0,
     )
   })
 
-  it("pins the slider thumb at the +10 edge when the numeric input's real delta exceeds the range", () => {
+  it("re-anchors (no longer pins to an edge) when the numeric input's target is far from the current anchor", () => {
     const { rerender } = render(<ExecuteRebalancePage />)
 
-    // QUAL current weight is 50%; type a target 25pp above current (75%) —
-    // a delta far outside the +-10pp slider track.
+    // QUAL current target is 50%; type a target 25pp above it (75%) — far
+    // outside the ORIGINAL +-10pp window. Change 4 explicitly drops the old
+    // edge-pinning behavior: the window re-anchors on 75 instead.
     const numeric = screen.getByRole("spinbutton", {
       name: "QUAL target weight percent",
     })
@@ -332,7 +346,9 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
       0.75,
     )
 
-    // Simulate the parent state applying that change.
+    // Simulate the parent state applying that change (the numeric input's
+    // own re-anchor call already fired synchronously above, against the
+    // page's real internal state).
     executionState.displayItems = executionState.displayItems.map((item) => {
       const typed = item as { assetId: string; effectiveTarget: number }
       return typed.assetId === "asset-qual"
@@ -343,7 +359,9 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     rerender(<ExecuteRebalancePage />)
 
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
-    expect(slider).toHaveValue("10")
+    expect(slider).toHaveValue("75")
+    expect(slider).toHaveAttribute("min", "65")
+    expect(slider).toHaveAttribute("max", "85")
 
     const numericAfter = screen.getByRole("spinbutton", {
       name: "QUAL target weight percent",
@@ -351,9 +369,9 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     expect(numericAfter).toHaveValue(75)
   })
 
-  it("renders a signed, color-coded delta label next to the slider", () => {
+  it("renders a signed, color-coded delta-vs-original label in the Trade column", () => {
     const execution = makeExecution()
-    // QUAL: +4pp (green), EXCL stays excluded/unchanged (neutral)
+    // QUAL: +4pp vs its seeded original (snapshotWeight 0.5) -> green.
     execution.items[0].effectiveTarget = 0.54
     executionState.execution = execution
     executionState.displayItems = displayItemsFor(execution)
@@ -361,9 +379,12 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
 
     const { rerender } = render(<ExecuteRebalancePage />)
 
-    expect(screen.getByText("+4.0 → 54.00%")).toHaveClass("text-green-600")
-    // Excluded row (EXCL) keeps its current weight -> delta 0 -> neutral.
-    expect(screen.getByText("0.0 → 20.00%")).toHaveClass("text-gray-500")
+    expect(screen.getByText("+4.0")).toHaveClass("text-green-600")
+    // Excluded row (EXCL) never shows a delta label — the Trade column
+    // falls back to a plain dash for excluded rows.
+    const exclRow = screen.getByText("EXCL").closest("tr")!
+    expect(exclRow.textContent).toContain("-")
+    expect(exclRow.textContent).not.toMatch(/[+-]\d/)
 
     // Sanity: negative delta renders red.
     executionState.displayItems = executionState.displayItems.map((item) => {
@@ -375,7 +396,7 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     executionState.activeItems = executionState.displayItems
     rerender(<ExecuteRebalancePage />)
 
-    expect(screen.getByText("-3.0 → 47.00%")).toHaveClass("text-red-600")
+    expect(screen.getByText("-3.0")).toHaveClass("text-red-600")
   })
 
   it("treats a float-noise effectiveTarget residual as exactly zero delta", () => {
@@ -390,16 +411,17 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
 
     render(<ExecuteRebalancePage />)
 
-    expect(screen.getByText("0.0 → 50.00%")).toHaveClass("text-gray-500")
+    expect(screen.getByText("0.0")).toHaveClass("text-gray-500")
     const slider = screen.getByRole("slider", { name: "QUAL target weight" })
-    expect(slider).toHaveValue("0")
+    expect(slider).toHaveValue("50")
   })
 
   it("rounds a half-way delta up rather than truncating due to float representation", () => {
     const execution = makeExecution()
-    // snapshotWeight 0.5 (50%), effectiveTarget 0.7415 (74.15%) -> a raw
-    // delta of 24.15pp, which (24.15).toFixed(1) mis-rounds down to "24.1"
-    // because of how 24.15 is represented in binary floating point.
+    // snapshotWeight 0.5 (50%, also the seeded original), effectiveTarget
+    // 0.7415 (74.15%) -> a raw delta of 24.15pp, which (24.15).toFixed(1)
+    // mis-rounds down to "24.1" because of how 24.15 is represented in
+    // binary floating point.
     execution.items[0].effectiveTarget = 0.7415
     executionState.execution = execution
     executionState.displayItems = displayItemsFor(execution)
@@ -407,18 +429,20 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
 
     render(<ExecuteRebalancePage />)
 
-    expect(screen.getByText("+24.2 → 74.15%")).toHaveClass("text-green-600")
+    expect(screen.getByText("+24.2")).toHaveClass("text-green-600")
   })
 
-  it("disables the slider on an excluded row and centers it at delta 0", () => {
+  it("disables the slider on an excluded row, sitting at its own (unchanged) target", () => {
     render(<ExecuteRebalancePage />)
 
+    // EXCL's target equals its current weight (20%) — excluded rows keep
+    // their current weight regardless of any stale effectiveTarget.
     const slider = screen.getByRole("slider", { name: "EXCL target weight" })
     const numeric = screen.getByRole("spinbutton", {
       name: "EXCL target weight percent",
     })
     expect(slider).toBeDisabled()
-    expect(slider).toHaveValue("0")
+    expect(slider).toHaveValue("20")
     expect(numeric).toBeDisabled()
   })
 

--- a/src/__tests__/pages/rebalance/execute/index.test.tsx
+++ b/src/__tests__/pages/rebalance/execute/index.test.tsx
@@ -1,12 +1,20 @@
 import React from "react"
-import { render, screen, fireEvent, within } from "@testing-library/react"
-import ExecuteRebalancePage from "@pages/rebalance/execute/index"
+import { render, screen, fireEvent, within, act } from "@testing-library/react"
+import ExecuteRebalancePage, {
+  buildDraftContext,
+} from "@pages/rebalance/execute/index"
 import { useRebalanceExecution } from "@hooks/useRebalanceExecution"
 import type {
   DisplayItem,
   UseRebalanceExecutionResult,
 } from "@hooks/useRebalanceExecution"
 import type { ExecutionDto } from "types/rebalance"
+import { setPageContext } from "@components/features/chat/pageContextBus"
+
+jest.mock("@components/features/chat/pageContextBus", () => ({
+  setPageContext: jest.fn(),
+}))
+const mockSetPageContext = setPageContext as jest.Mock
 
 // --- Mocks ---
 
@@ -76,6 +84,10 @@ function makeItem(overrides: Partial<DisplayItem> = {}): DisplayItem {
     planTargetWeight: overrides.planTargetWeight ?? 0.6,
     returnAdjustedTarget: overrides.returnAdjustedTarget ?? 0.58,
     effectiveTarget: overrides.effectiveTarget ?? 0.6,
+    // Defaults to effectiveTarget (i.e. "no edit yet") unless a test is
+    // specifically exercising a row that's diverged from its seeded value.
+    originalTarget:
+      overrides.originalTarget ?? overrides.effectiveTarget ?? 0.6,
     hasOverride: overrides.hasOverride ?? false,
     deltaValue: overrides.deltaValue ?? 1000,
     deltaQuantity: overrides.deltaQuantity ?? 10,
@@ -123,12 +135,38 @@ function makeExecution(overrides: Partial<ExecutionDto> = {}): ExecutionDto {
   } as ExecutionDto
 }
 
+/** Default jest.fn()s for every hook handler — a test that wants to assert
+ * a specific call passes `overrides.handlers` with just that one key; it's
+ * deep-merged over these defaults below rather than replacing the whole
+ * handlers map (which would silently null out the rest). */
+function makeDefaultHandlers(): UseRebalanceExecutionResult["handlers"] {
+  return {
+    initialize: jest.fn(),
+    save: jest.fn().mockResolvedValue(true),
+    refresh: jest.fn(),
+    commit: jest.fn(),
+    targetChange: jest.fn(),
+    excludeToggle: jest.fn(),
+    setIncludeAll: jest.fn(),
+    setAllToCurrent: jest.fn(),
+    setAllToTarget: jest.fn(),
+    setAllToZero: jest.fn(),
+    setAllToAdjusted: jest.fn(),
+    setToCurrent: jest.fn(),
+    setToTarget: jest.fn(),
+    resetTarget: jest.fn(),
+    setError: jest.fn(),
+  }
+}
+
 function mockHookResult(
   displayItems: DisplayItem[],
-  overrides: Partial<UseRebalanceExecutionResult> = {},
-): void {
+  overrides: Partial<Omit<UseRebalanceExecutionResult, "handlers">> & {
+    handlers?: Partial<UseRebalanceExecutionResult["handlers"]>
+  } = {},
+): UseRebalanceExecutionResult {
   const execution = makeExecution()
-  mockUseRebalanceExecution.mockReturnValue({
+  const result = {
     execution,
     displayItems,
     activeItems: displayItems.filter(
@@ -154,29 +192,18 @@ function mockHookResult(
       hasChanges: false,
       error: null,
     },
-    handlers: {
-      initialize: jest.fn(),
-      save: jest.fn().mockResolvedValue(true),
-      refresh: jest.fn(),
-      commit: jest.fn(),
-      targetChange: jest.fn(),
-      excludeToggle: jest.fn(),
-      setAllToCurrent: jest.fn(),
-      setAllToTarget: jest.fn(),
-      setAllToZero: jest.fn(),
-      setAllToAdjusted: jest.fn(),
-      setToCurrent: jest.fn(),
-      setToTarget: jest.fn(),
-      setError: jest.fn(),
-    },
     createdExecutionId: null,
     ...overrides,
-  } as UseRebalanceExecutionResult)
+    handlers: { ...makeDefaultHandlers(), ...overrides.handlers },
+  } as UseRebalanceExecutionResult
+  mockUseRebalanceExecution.mockReturnValue(result)
+  return result
 }
 
 describe("ExecuteRebalancePage", () => {
   beforeEach(() => {
     mockUseRebalanceExecution.mockReset()
+    mockSetPageContext.mockReset()
   })
 
   it("does not render an Adjusted column or an 'All -> Adjusted' bulk button", () => {
@@ -275,7 +302,7 @@ describe("ExecuteRebalancePage", () => {
     expect(query).toMatch(/DRAFT/)
   })
 
-  it("renders the configuration table columns in Asset, Price, Current, Target, After %, Delta order", () => {
+  it("renders the configuration table columns with Target adjacent to After %, trade breakdown split into its own Trade column", () => {
     mockHookResult([makeItem()])
     render(<ExecuteRebalancePage />)
 
@@ -292,7 +319,7 @@ describe("ExecuteRebalancePage", () => {
       "Current",
       "Target",
       "After %",
-      "Delta",
+      "Trade",
     ])
   })
 
@@ -387,5 +414,447 @@ describe("ExecuteRebalancePage", () => {
     expect(
       screen.queryByRole("button", { name: "Reset" }),
     ).not.toBeInTheDocument()
+  })
+
+  // --- Select-all checkbox (Change 1) ---
+
+  describe("select-all include checkbox", () => {
+    it("is checked, not indeterminate, when every eligible row is included", () => {
+      mockHookResult([
+        makeItem({ assetId: "a1", isExcluded: false }),
+        makeItem({ assetId: "a2", isExcluded: false }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      const checkbox = screen.getByLabelText("Include all") as HTMLInputElement
+      expect(checkbox.checked).toBe(true)
+      expect(checkbox.indeterminate).toBe(false)
+    })
+
+    it("is unchecked, not indeterminate, when every eligible row is excluded", () => {
+      mockHookResult([
+        makeItem({ assetId: "a1", isExcluded: true, excluded: true }),
+        makeItem({ assetId: "a2", isExcluded: true, excluded: true }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      const checkbox = screen.getByLabelText("Include all") as HTMLInputElement
+      expect(checkbox.checked).toBe(false)
+      expect(checkbox.indeterminate).toBe(false)
+    })
+
+    it("is indeterminate when some eligible rows are included and some excluded", () => {
+      mockHookResult([
+        makeItem({ assetId: "a1", isExcluded: false }),
+        makeItem({ assetId: "a2", isExcluded: true, excluded: true }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      const checkbox = screen.getByLabelText("Include all") as HTMLInputElement
+      expect(checkbox.checked).toBe(false)
+      expect(checkbox.indeterminate).toBe(true)
+    })
+
+    it("ignores locked (PRIVATE/server-locked) rows entirely — they never drive checked/indeterminate", () => {
+      mockHookResult([
+        makeItem({ assetId: "a1", isExcluded: false }),
+        makeItem({
+          assetId: "locked-1",
+          assetCode: "PRIV",
+          locked: true,
+          isExcluded: true,
+          excluded: true,
+        }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      // Only "a1" is eligible and it's included -> checked, despite the
+      // locked row being excluded.
+      const checkbox = screen.getByLabelText("Include all") as HTMLInputElement
+      expect(checkbox.checked).toBe(true)
+      expect(checkbox.indeterminate).toBe(false)
+    })
+
+    it("clicking calls handlers.setIncludeAll with the opposite of the current checked state, and never toggles a locked row's own checkbox", () => {
+      const setIncludeAll = jest.fn()
+      mockHookResult(
+        [
+          makeItem({ assetId: "a1", assetCode: "AAPL", isExcluded: false }),
+          makeItem({
+            assetId: "locked-1",
+            assetCode: "PRIV",
+            locked: true,
+            isExcluded: true,
+            excluded: true,
+          }),
+        ],
+        { handlers: { setIncludeAll } },
+      )
+      render(<ExecuteRebalancePage />)
+
+      fireEvent.click(screen.getByLabelText("Include all"))
+      // All eligible rows are currently included (only a1 counts) -> click
+      // flips to "exclude all".
+      expect(setIncludeAll).toHaveBeenCalledWith(false)
+
+      // The locked row's own row-level checkbox is disabled — never wired to
+      // excludeToggle by a stray click.
+      const lockedCheckbox = screen.getByTitle(
+        "Locked — not eligible for execution",
+      ) as HTMLInputElement
+      expect(lockedCheckbox).toBeDisabled()
+    })
+  })
+
+  // --- Per-row reset (Change 3) ---
+
+  describe("per-row reset to original", () => {
+    it("is disabled when the target still matches the original seeded weight", () => {
+      mockHookResult([
+        makeItem({
+          assetId: "a1",
+          assetCode: "AAPL",
+          effectiveTarget: 0.6,
+          originalTarget: 0.6,
+        }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      expect(screen.getByLabelText("Reset AAPL weight")).toBeDisabled()
+    })
+
+    it("is enabled when the target has diverged from the original, and clicking resets it", () => {
+      const resetTarget = jest.fn()
+      mockHookResult(
+        [
+          makeItem({
+            assetId: "a1",
+            assetCode: "AAPL",
+            effectiveTarget: 0.6,
+            originalTarget: 0.5,
+          }),
+        ],
+        { handlers: { resetTarget } },
+      )
+      render(<ExecuteRebalancePage />)
+
+      const resetButton = screen.getByLabelText("Reset AAPL weight")
+      expect(resetButton).toBeEnabled()
+
+      fireEvent.click(resetButton)
+      expect(resetTarget).toHaveBeenCalledWith("a1")
+    })
+  })
+
+  // --- Slider re-anchoring (Change 4) ---
+
+  describe("slider re-anchoring", () => {
+    /** A live-updating hook mock: `targetChange` actually mutates the
+     * backing items array (closed over), so a subsequent re-render (however
+     * triggered) picks up the new `effectiveTarget` — needed to observe the
+     * slider's min/max/value react to a committed edit, not just a mocked
+     * call. */
+    function renderLive(initialItems: DisplayItem[]): {
+      handlers: UseRebalanceExecutionResult["handlers"]
+    } {
+      let items = initialItems
+      // Computed ONCE — the page's `useEffect(() => setSliderAnchors({}),
+      // [execution])` treats a new `execution` reference as "full data
+      // reload, drop all anchors". A fresh object per render (the mistake
+      // this comment is guarding against) makes that effect fire on every
+      // render and infinite-loop the test.
+      const stableExecution = makeExecution()
+      // Assigned after the initial render — `targetChange` re-renders through
+      // it so the controlled slider/input's DOM value stays in sync with the
+      // mutated `items`, same as production (where `targetChange` calls a
+      // real `setState` that re-renders before the next native event fires).
+      // Without this, React's controlled-input reconciliation reverts the
+      // DOM's `value` back to the stale prop once the event handler returns,
+      // since no state changed and no re-render occurred.
+      let doRerender: (() => void) | null = null
+      const handlers: UseRebalanceExecutionResult["handlers"] = {
+        ...makeDefaultHandlers(),
+        targetChange: jest.fn((assetId: string, value: number) => {
+          items = items.map((i) =>
+            i.assetId === assetId ? { ...i, effectiveTarget: value } : i,
+          )
+          doRerender?.()
+        }),
+      }
+      mockUseRebalanceExecution.mockImplementation(
+        () =>
+          ({
+            execution: stableExecution,
+            displayItems: items,
+            activeItems: [],
+            cashSummary: {
+              currentMarketValue: 10000,
+              currentCash: 1000,
+              targetCash: 1000,
+              cashFromSales: 0,
+              cashForPurchases: 0,
+              netImpact: 0,
+              projectedCash: 1000,
+            },
+            brokers: [],
+            selectedBrokerId: undefined,
+            setSelectedBrokerId: jest.fn(),
+            states: {
+              loading: false,
+              saving: false,
+              refreshing: false,
+              committing: false,
+              hasChanges: false,
+              error: null,
+            },
+            createdExecutionId: null,
+            handlers,
+          }) as UseRebalanceExecutionResult,
+      )
+      const { rerender } = render(<ExecuteRebalancePage />)
+      doRerender = () => rerender(<ExecuteRebalancePage />)
+      return { handlers }
+    }
+
+    it("numeric-input commit re-anchors immediately: 20% -> 5% gives range [0,15], value 5", () => {
+      renderLive([
+        makeItem({
+          assetId: "a1",
+          assetCode: "AAPL",
+          snapshotWeight: 0.2,
+          effectiveTarget: 0.2,
+          originalTarget: 0.2,
+        }),
+      ])
+
+      fireEvent.change(screen.getByLabelText("AAPL target weight percent"), {
+        target: { value: "5" },
+      })
+
+      const slider = screen.getByLabelText(
+        "AAPL target weight",
+      ) as HTMLInputElement
+      expect(Number(slider.min)).toBe(0)
+      expect(Number(slider.max)).toBe(15)
+      expect(Number(slider.value)).toBe(5)
+    })
+
+    it("typed 25% anchors at 25 with range [15,35] — no more edge-pinning", () => {
+      renderLive([
+        makeItem({
+          assetId: "a1",
+          assetCode: "AAPL",
+          snapshotWeight: 0.2,
+          effectiveTarget: 0.2,
+          originalTarget: 0.2,
+        }),
+      ])
+
+      fireEvent.change(screen.getByLabelText("AAPL target weight percent"), {
+        target: { value: "25" },
+      })
+
+      const slider = screen.getByLabelText(
+        "AAPL target weight",
+      ) as HTMLInputElement
+      expect(Number(slider.min)).toBe(15)
+      expect(Number(slider.max)).toBe(35)
+      expect(Number(slider.value)).toBe(25)
+    })
+
+    it("holds the anchor fixed during an active drag, then re-anchors on pointer-up", () => {
+      renderLive([
+        makeItem({
+          assetId: "a1",
+          assetCode: "AAPL",
+          snapshotWeight: 0.2,
+          effectiveTarget: 0.2,
+          originalTarget: 0.2,
+        }),
+      ])
+      const slider = screen.getByLabelText(
+        "AAPL target weight",
+      ) as HTMLInputElement
+
+      fireEvent.pointerDown(slider)
+      // 25 lands exactly on the default 5-point slider step grid, so
+      // snapToStep is a no-op here — keeps the assertion arithmetic simple.
+      fireEvent.change(slider, { target: { value: "25" } })
+      // Still mid-drag — range must not have shifted off the pre-drag anchor (20).
+      expect(Number(slider.min)).toBe(10)
+      expect(Number(slider.max)).toBe(30)
+
+      fireEvent.pointerUp(slider)
+      // Gesture complete — next render anchors on the committed value (25).
+      expect(Number(slider.min)).toBe(15)
+      expect(Number(slider.max)).toBe(35)
+      expect(Number(slider.value)).toBe(25)
+    })
+
+    it("debounces keyboard/arrow-driven changes, re-anchoring ~400ms after the last one", () => {
+      jest.useFakeTimers()
+      try {
+        renderLive([
+          makeItem({
+            assetId: "a1",
+            assetCode: "AAPL",
+            snapshotWeight: 0.2,
+            effectiveTarget: 0.2,
+            originalTarget: 0.2,
+          }),
+        ])
+        const slider = screen.getByLabelText(
+          "AAPL target weight",
+        ) as HTMLInputElement
+
+        // No pointerdown -> keyboard path. Range must not jump immediately.
+        fireEvent.change(slider, { target: { value: "25" } })
+        expect(Number(slider.min)).toBe(10)
+        expect(Number(slider.max)).toBe(30)
+
+        act(() => {
+          jest.advanceTimersByTime(400)
+        })
+
+        expect(Number(slider.min)).toBe(15)
+        expect(Number(slider.max)).toBe(35)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+  })
+
+  // --- Delta-vs-original label (Change 4) ---
+
+  it("Trade column's pp delta label shows change vs the ORIGINAL seeded weight, not vs current", () => {
+    mockHookResult([
+      makeItem({
+        assetId: "a1",
+        assetCode: "AAPL",
+        snapshotWeight: 0.25,
+        originalTarget: 0.2,
+        effectiveTarget: 0.3,
+        deltaQuantity: 5,
+        deltaValue: 500,
+      }),
+    ])
+    render(<ExecuteRebalancePage />)
+
+    const row = screen.getByText("AAPL").closest("tr")!
+    // vs original (20% -> 30%) = +10.0, NOT vs current (25% -> 30%) = +5.0.
+    // Default slider step is 5, so the label renders at 1 fraction digit.
+    expect(within(row).getByText("+10.0")).toBeInTheDocument()
+    expect(within(row).queryByText("+5.0")).not.toBeInTheDocument()
+  })
+
+  // --- Live draft context published to the Chat FAB (Change 5) ---
+
+  describe("draft context published to the Chat FAB", () => {
+    it("publishes a summary mentioning changed rows and cash summary, and clears it on unmount", () => {
+      mockHookResult([
+        makeItem({
+          assetId: "a1",
+          assetCode: "AAPL",
+          snapshotWeight: 0.2,
+          originalTarget: 0.2,
+          effectiveTarget: 0.3,
+        }),
+      ])
+      const { unmount } = render(<ExecuteRebalancePage />)
+
+      const lastCall =
+        mockSetPageContext.mock.calls[mockSetPageContext.mock.calls.length - 1]
+      expect(lastCall[0]).toContain("DRAFT")
+      expect(lastCall[0]).toContain("AAPL")
+
+      unmount()
+      const finalCall =
+        mockSetPageContext.mock.calls[mockSetPageContext.mock.calls.length - 1]
+      expect(finalCall[0]).toBeNull()
+    })
+  })
+})
+
+// --- buildDraftContext (pure serializer) ---
+
+describe("buildDraftContext", () => {
+  it("lists only changed rows, counts unchanged rows, and frames the summary as a draft", () => {
+    const execution = makeExecution({ id: "exec-9", mode: "REBALANCE" })
+    const items: DisplayItem[] = [
+      makeItem({
+        assetId: "changed-1",
+        assetCode: "AAPL",
+        snapshotWeight: 0.2,
+        originalTarget: 0.2,
+        effectiveTarget: 0.3,
+        projectedWeight: 0.28,
+        deltaQuantity: 12,
+        deltaValue: 1200,
+      }),
+      makeItem({
+        assetId: "unchanged-1",
+        assetCode: "MSFT",
+        snapshotWeight: 0.4,
+        originalTarget: 0.4,
+        effectiveTarget: 0.4,
+      }),
+      makeItem({
+        assetId: "excluded-1",
+        assetCode: "TSLA",
+        snapshotWeight: 0.1,
+        originalTarget: 0.1,
+        effectiveTarget: 0.1,
+        excluded: true,
+        isExcluded: true,
+      }),
+    ]
+    const cashSummary = {
+      currentMarketValue: 10000,
+      currentCash: 1000,
+      targetCash: 900,
+      cashFromSales: 0,
+      cashForPurchases: 1200,
+      netImpact: -1200,
+      projectedCash: -200,
+    }
+
+    const text = buildDraftContext(execution, items, cashSummary)
+
+    expect(text).toMatch(/DRAFT/)
+    expect(text).toContain("exec-9")
+    expect(text).toContain("AAPL")
+    expect(text).toContain("30.00%")
+    expect(text).not.toContain("MSFT")
+    expect(text).toContain("TSLA")
+    expect(text).toContain("excluded")
+    expect(text).toContain("Unchanged rows: 1")
+    expect(text).toContain("-1,200.00")
+    expect(text).toContain("DEPOSIT REQUIRED")
+  })
+
+  it("reports zero changed rows plainly when nothing has been edited", () => {
+    const execution = makeExecution()
+    const items: DisplayItem[] = [
+      makeItem({
+        assetId: "a1",
+        snapshotWeight: 0.5,
+        originalTarget: 0.5,
+        effectiveTarget: 0.5,
+      }),
+    ]
+    const cashSummary = {
+      currentMarketValue: 10000,
+      currentCash: 1000,
+      targetCash: 1000,
+      cashFromSales: 0,
+      cashForPurchases: 0,
+      netImpact: 0,
+      projectedCash: 1000,
+    }
+
+    const text = buildDraftContext(execution, items, cashSummary)
+
+    expect(text).toContain("Changed rows (0)")
+    expect(text).not.toContain("DEPOSIT REQUIRED")
   })
 })

--- a/src/__tests__/pages/rebalance/execute/index.test.tsx
+++ b/src/__tests__/pages/rebalance/execute/index.test.tsx
@@ -103,6 +103,8 @@ function makeItem(overrides: Partial<DisplayItem> = {}): DisplayItem {
       overrides.projectedWeight === undefined
         ? 0.65
         : overrides.projectedWeight,
+    isPrivate: overrides.isPrivate,
+    isImmune: overrides.isImmune ?? false,
     ...overrides,
   } as DisplayItem
 }
@@ -503,6 +505,60 @@ describe("ExecuteRebalancePage", () => {
         "Locked — not eligible for execution",
       ) as HTMLInputElement
       expect(lockedCheckbox).toBeDisabled()
+    })
+
+    it("ignores isPrivate rows entirely — they never drive checked/indeterminate", () => {
+      mockHookResult([
+        makeItem({ assetId: "a1", isExcluded: false }),
+        makeItem({
+          assetId: "cpf-1",
+          assetCode: "CPF",
+          isPrivate: true,
+          isImmune: true,
+          isExcluded: true,
+          excluded: true,
+        }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      // Only "a1" is eligible and it's included -> checked, despite the
+      // PRIVATE row being excluded.
+      const checkbox = screen.getByLabelText("Include all") as HTMLInputElement
+      expect(checkbox.checked).toBe(true)
+      expect(checkbox.indeterminate).toBe(false)
+    })
+
+    it("clicking never toggles an isPrivate row's own checkbox — it's disabled with a non-tradeable title/aria-label", () => {
+      const setIncludeAll = jest.fn()
+      mockHookResult(
+        [
+          makeItem({ assetId: "a1", assetCode: "AAPL", isExcluded: false }),
+          makeItem({
+            assetId: "cpf-1",
+            assetCode: "CPF",
+            isPrivate: true,
+            isImmune: true,
+            isExcluded: true,
+            excluded: true,
+          }),
+        ],
+        { handlers: { setIncludeAll } },
+      )
+      render(<ExecuteRebalancePage />)
+
+      fireEvent.click(screen.getByLabelText("Include all"))
+      // Only a1 is eligible and currently included -> click flips to
+      // "exclude all"; the isPrivate row plays no part in that decision.
+      expect(setIncludeAll).toHaveBeenCalledWith(false)
+
+      const privateCheckbox = screen.getByLabelText(
+        "Non-tradeable asset — always excluded",
+      ) as HTMLInputElement
+      expect(privateCheckbox).toBeDisabled()
+      expect(privateCheckbox.checked).toBe(true)
+      expect(privateCheckbox.title).toBe(
+        "Non-tradeable asset — always excluded",
+      )
     })
   })
 

--- a/src/components/features/chat/ChatFab.tsx
+++ b/src/components/features/chat/ChatFab.tsx
@@ -11,6 +11,7 @@ import {
   saveChatCorner,
 } from "@components/features/chat/chatPosition"
 import { onChatOpen } from "@components/features/chat/chatBus"
+import { onPageContextChange } from "@components/features/chat/pageContextBus"
 
 export default function ChatFab(): React.ReactElement {
   const [isOpen, setIsOpen] = useState(false)
@@ -32,11 +33,19 @@ export default function ChatFab(): React.ReactElement {
   const router = useRouter()
   const pageContext = getPageContext(router.pathname)
   const routeParams = router.query
+
+  // Live, page-published context (e.g. the current in-progress draft
+  // rebalance) — see pageContextBus.ts. Generic: any page can publish, this
+  // component just folds whatever is current into the outgoing payload.
+  const [livePageContext, setLivePageContext] = useState<string | null>(null)
+  useEffect(() => onPageContextChange(setLivePageContext), [])
+
   const context = useMemo(() => {
     const ctx: Record<string, unknown> = {
       page: pageContext.page,
       description: pageContext.description,
     }
+    if (livePageContext) ctx.currentState = livePageContext
     // Include dynamic route params for specificity. Managed (shared)
     // portfolios are routed as /holdings/{portfolio.id}?byId=1 — in that
     // case the dynamic [code] segment is actually the portfolio id, so
@@ -52,7 +61,7 @@ export default function ChatFab(): React.ReactElement {
     if (routeParams.id) ctx.entityId = routeParams.id
     if (routeParams.modelId) ctx.modelId = routeParams.modelId
     return ctx
-  }, [pageContext.page, pageContext.description, routeParams])
+  }, [pageContext.page, pageContext.description, routeParams, livePageContext])
   const { messages, isLoading, sendMessage, clearMessages, cancel } =
     useChat(context)
 

--- a/src/components/features/chat/__tests__/ChatFab.test.tsx
+++ b/src/components/features/chat/__tests__/ChatFab.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { render, screen, fireEvent } from "@testing-library/react"
 import ChatFab from "../ChatFab"
+import { setPageContext } from "../pageContextBus"
 
 // react-markdown / remark-gfm mocked globally in jest.setup.js
 
@@ -16,6 +17,10 @@ describe("ChatFab", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     window.localStorage.removeItem("bc-chat-corner")
+    // pageContextBus retains its last-published value across renders (by
+    // design — see its module doc) so a leftover from another test/page
+    // would otherwise leak in here.
+    setPageContext(null)
   })
 
   it("renders the FAB button", () => {
@@ -65,5 +70,59 @@ describe("ChatFab", () => {
     // Toggle back to compact
     fireEvent.click(screen.getByLabelText("Expand chat"))
     expect(panel.className).toContain("w-96")
+  })
+
+  // --- Live page-context injection (pageContextBus) ---
+
+  it("includes a page's published context as context.currentState in the outgoing query payload", () => {
+    setPageContext("DRAFT rebalance: AAPL 20% -> 30%")
+    render(<ChatFab />)
+    fireEvent.click(screen.getByLabelText("Chat"))
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "does this trade make sense?" },
+    })
+    fireEvent.submit(screen.getByRole("textbox").closest("form")!)
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/agent/query/stream",
+      expect.objectContaining({
+        body: expect.stringContaining(
+          '"currentState":"DRAFT rebalance: AAPL 20% -> 30%"',
+        ),
+      }),
+    )
+  })
+
+  it("omits context.currentState from the outgoing payload when nothing has been published", () => {
+    render(<ChatFab />)
+    fireEvent.click(screen.getByLabelText("Chat"))
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "show my portfolios" },
+    })
+    fireEvent.submit(screen.getByRole("textbox").closest("form")!)
+
+    const call = (global.fetch as jest.Mock).mock.calls[0]
+    const body = JSON.parse(call[1].body)
+    expect(body.context).not.toHaveProperty("currentState")
+  })
+
+  it("picks up a context published AFTER mount (subscribe delivers the retained current value, and later updates arrive live)", () => {
+    render(<ChatFab />)
+    // Published after ChatFab has already mounted/subscribed.
+    setPageContext("DRAFT rebalance: cash short by 200.00")
+    fireEvent.click(screen.getByLabelText("Chat"))
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "what's the cash situation?" },
+    })
+    fireEvent.submit(screen.getByRole("textbox").closest("form")!)
+
+    const call = (global.fetch as jest.Mock).mock.calls[0]
+    const body = JSON.parse(call[1].body)
+    expect(body.context.currentState).toBe(
+      "DRAFT rebalance: cash short by 200.00",
+    )
   })
 })

--- a/src/components/features/chat/pageContextBus.ts
+++ b/src/components/features/chat/pageContextBus.ts
@@ -1,0 +1,48 @@
+/**
+ * Tiny window-event bus that lets the currently-mounted page publish a live
+ * text summary of its own client-side state (e.g. an in-progress draft
+ * rebalance) so the global ChatFab can fold it into outgoing agent queries
+ * — without lifting page state into a context provider shared by the whole
+ * app. Mirrors `chatBus.ts`'s pub/sub idiom, which already solves the same
+ * "talk to the FAB without prop-drilling through _app" problem for
+ * open-with-prompt requests.
+ *
+ * Unlike chatBus's fire-and-forget events, this retains the last-published
+ * value (`current`) and delivers it synchronously to a new subscriber. That
+ * matters here because `<Component>` (the page) mounts — and its effects
+ * run — before `<ChatFab>` in `_app.tsx`'s render tree, so a plain
+ * dispatch-only event fired from the page's mount effect would be missed by
+ * ChatFab's own mount effect subscribing a tick later.
+ *
+ * Any page can publish; ChatFab treats it generically. A page MUST clear
+ * its context (call with `null`) on unmount — ChatFab is mounted once in
+ * `_app` and persists across navigation, so a page that forgets to clear
+ * leaks its context into whatever page the user lands on next.
+ */
+const EVENT = "bc:page-context"
+
+let current: string | null = null
+
+export function setPageContext(text: string | null): void {
+  current = text
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new CustomEvent<string | null>(EVENT, { detail: text }))
+}
+
+export function getPageContext(): string | null {
+  return current
+}
+
+/** Subscribes to page-context changes, immediately delivering the current
+ * value (see module doc for why). Returns an unsubscribe function. */
+export function onPageContextChange(
+  handler: (text: string | null) => void,
+): () => void {
+  handler(current)
+  if (typeof window === "undefined") return () => {}
+  const listener = (e: Event): void => {
+    handler((e as CustomEvent<string | null>).detail ?? null)
+  }
+  window.addEventListener(EVENT, listener)
+  return () => window.removeEventListener(EVENT, listener)
+}

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -1128,4 +1128,143 @@ describe("useRebalanceExecution", () => {
     const item2 = result.current.displayItems.find((i) => i.assetId === "a2")
     expect(item2?.isExcluded).toBe(true)
   })
+
+  // --- originalTarget seeding + per-row reset ---
+
+  it("seeds originalTarget from the loaded execution's effectiveTarget, independent of hasOverride", async () => {
+    const exec = makeExecution({
+      items: [
+        makeItem({
+          assetId: "a1",
+          hasOverride: true,
+          effectiveTarget: 0.75,
+        }),
+        makeItem({ assetId: "a2", effectiveTarget: 0.4, hasOverride: false }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+
+    const { result } = await renderWithExecution(exec)
+
+    expect(
+      result.current.displayItems.find((i) => i.assetId === "a1")
+        ?.originalTarget,
+    ).toBe(0.75)
+    expect(
+      result.current.displayItems.find((i) => i.assetId === "a2")
+        ?.originalTarget,
+    ).toBe(0.4)
+  })
+
+  it("seeds originalTarget from the return-adjusted target on a newly-created execution", async () => {
+    const exec = makeExecution({
+      id: "new-exec-1",
+      items: [
+        makeItem({
+          assetId: "a1",
+          returnAdjustedTarget: 0.55,
+          effectiveTarget: 0.6,
+        }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: exec }),
+    })
+
+    const { result } = renderHook(() =>
+      useRebalanceExecution({
+        planId: "plan-1",
+        portfolioIds: ["portfolio-1"],
+      }),
+    )
+    await act(async () => {})
+
+    // Non-cash item seeded from returnAdjustedTarget (matches the applied
+    // override); cash has none, so it falls back to its own effectiveTarget.
+    expect(
+      result.current.displayItems.find((i) => i.assetId === "a1")
+        ?.originalTarget,
+    ).toBe(0.55)
+    expect(
+      result.current.displayItems.find((i) => i.assetId === "cash")
+        ?.originalTarget,
+    ).toBe(exec.items.find((i) => i.assetId === "cash")!.effectiveTarget)
+  })
+
+  it("resetTarget restores a single row's target to its seeded original, undoing any later edits", async () => {
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "a1", effectiveTarget: 0.5 }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      result.current.handlers.targetChange("a1", 0.9)
+    })
+    expect(
+      result.current.displayItems.find((i) => i.assetId === "a1")
+        ?.effectiveTarget,
+    ).toBe(0.9)
+
+    act(() => {
+      result.current.handlers.resetTarget("a1")
+    })
+    expect(
+      result.current.displayItems.find((i) => i.assetId === "a1")
+        ?.effectiveTarget,
+    ).toBe(0.5)
+  })
+
+  // --- setIncludeAll (select-all header checkbox) ---
+
+  it("setIncludeAll(false) excludes every non-cash, non-locked row and leaves locked rows untouched", async () => {
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "a1", excluded: false, locked: false }),
+        makeItem({ assetId: "a2", excluded: false, locked: false }),
+        makeItem({ assetId: "locked-1", excluded: false, locked: true }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      result.current.handlers.setIncludeAll(false)
+    })
+
+    const byId = (id: string): boolean | undefined =>
+      result.current.displayItems.find((i) => i.assetId === id)?.isExcluded
+    expect(byId("a1")).toBe(true)
+    expect(byId("a2")).toBe(true)
+    // Locked row's exclusion is never touched by the bulk action.
+    expect(byId("locked-1")).toBe(false)
+    // Cash isn't a toggleable row either.
+    expect(byId("cash")).toBe(false)
+  })
+
+  it("setIncludeAll(true) re-includes previously-excluded eligible rows, still leaving locked rows alone", async () => {
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "a1", excluded: true }),
+        makeItem({ assetId: "a2", excluded: true }),
+        makeItem({ assetId: "locked-1", excluded: true, locked: true }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      result.current.handlers.setIncludeAll(true)
+    })
+
+    const byId = (id: string): boolean | undefined =>
+      result.current.displayItems.find((i) => i.assetId === id)?.isExcluded
+    expect(byId("a1")).toBe(false)
+    expect(byId("a2")).toBe(false)
+    expect(byId("locked-1")).toBe(true)
+  })
 })

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -32,6 +32,7 @@ const makeItem = (
   sortOrder: overrides.sortOrder ?? 0,
   isCash: overrides.isCash ?? false,
   rationale: overrides.rationale ?? undefined,
+  isPrivate: overrides.isPrivate,
 })
 
 const makeCashItem = (
@@ -1247,11 +1248,48 @@ describe("useRebalanceExecution", () => {
   })
 
   it("setIncludeAll(true) re-includes previously-excluded eligible rows, still leaving locked rows alone", async () => {
+    // a1/a2 start included at load (NOT server-excluded) and are excluded
+    // locally by the user mid-session — this is what the test exercises:
+    // a locally-excluded row is re-includable. A row that was ALREADY
+    // excluded=true in the server payload at load is a different case (the
+    // isPrivate-undefined fallback immunity — see the PRIVATE-row tests
+    // below), so it's deliberately not used here.
     const exec = makeExecution({
       items: [
-        makeItem({ assetId: "a1", excluded: true }),
-        makeItem({ assetId: "a2", excluded: true }),
+        makeItem({ assetId: "a1", excluded: false }),
+        makeItem({ assetId: "a2", excluded: false }),
         makeItem({ assetId: "locked-1", excluded: true, locked: true }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      result.current.handlers.excludeToggle("a1")
+      result.current.handlers.excludeToggle("a2")
+    })
+
+    act(() => {
+      result.current.handlers.setIncludeAll(true)
+    })
+
+    const byId = (id: string): boolean | undefined =>
+      result.current.displayItems.find((i) => i.assetId === id)?.isExcluded
+    expect(byId("a1")).toBe(false)
+    expect(byId("a2")).toBe(false)
+    expect(byId("locked-1")).toBe(true)
+  })
+
+  // --- PRIVATE row immunity (isPrivate) ---
+
+  it("setIncludeAll(true) never re-includes an isPrivate row, even from an indeterminate mixed state", async () => {
+    // a1 carries an explicit isPrivate: false (a real, current-backend
+    // response) so it's unambiguously a normal row, distinct from the
+    // isPrivate-undefined fallback case covered separately below.
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "a1", excluded: true, isPrivate: false }),
+        makeItem({ assetId: "cpf-1", excluded: true, isPrivate: true }),
         makeCashItem({ assetId: "cash" }),
       ],
     })
@@ -1264,7 +1302,147 @@ describe("useRebalanceExecution", () => {
     const byId = (id: string): boolean | undefined =>
       result.current.displayItems.find((i) => i.assetId === id)?.isExcluded
     expect(byId("a1")).toBe(false)
-    expect(byId("a2")).toBe(false)
-    expect(byId("locked-1")).toBe(true)
+    // The isPrivate row stays excluded regardless of direction.
+    expect(byId("cpf-1")).toBe(true)
+  })
+
+  it("setIncludeAll(false) leaves an isPrivate row excluded (no-op, already excluded)", async () => {
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "a1", excluded: false }),
+        makeItem({ assetId: "cpf-1", excluded: true, isPrivate: true }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      result.current.handlers.setIncludeAll(false)
+    })
+
+    const byId = (id: string): boolean | undefined =>
+      result.current.displayItems.find((i) => i.assetId === id)?.isExcluded
+    expect(byId("a1")).toBe(true)
+    expect(byId("cpf-1")).toBe(true)
+  })
+
+  it("excludeToggle is a no-op for an isPrivate row (belt-and-braces against a stray call)", async () => {
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "cpf-1", excluded: true, isPrivate: true }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      result.current.handlers.excludeToggle("cpf-1")
+    })
+
+    const item = result.current.displayItems.find((i) => i.assetId === "cpf-1")
+    expect(item?.isExcluded).toBe(true)
+    expect(result.current.states.hasChanges).toBe(false)
+  })
+
+  it("fallback (no isPrivate field anywhere): setIncludeAll(true) leaves a row that arrived server-excluded at load untouched", async () => {
+    // Old backend hasn't deployed isPrivate yet — every item has
+    // isPrivate === undefined. The row that was excluded=true in the
+    // server payload at load time must stay immune to the bulk toggle,
+    // same as a real isPrivate row would be. a1 arrived included at load,
+    // so it's a normal row under the same fallback — it toggles freely.
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "a1", excluded: false }),
+        makeItem({ assetId: "cpf-1", excluded: true }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      result.current.handlers.setIncludeAll(true)
+    })
+
+    const byId = (id: string): boolean | undefined =>
+      result.current.displayItems.find((i) => i.assetId === id)?.isExcluded
+    expect(byId("a1")).toBe(false)
+    // Was server-excluded at load, isPrivate undefined -> immune fallback.
+    expect(byId("cpf-1")).toBe(true)
+  })
+
+  it("fallback: a row that was NOT excluded at load (isPrivate undefined) is a normal toggleable row", async () => {
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "a1", excluded: false }),
+        makeItem({ assetId: "a2", excluded: false }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(exec)
+
+    act(() => {
+      result.current.handlers.setIncludeAll(false)
+    })
+
+    const byId = (id: string): boolean | undefined =>
+      result.current.displayItems.find((i) => i.assetId === id)?.isExcluded
+    expect(byId("a1")).toBe(true)
+    expect(byId("a2")).toBe(true)
+  })
+
+  it("handleSave omits isPrivate rows from itemUpdates", async () => {
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "a1", excluded: false }),
+        makeItem({ assetId: "cpf-1", excluded: true, isPrivate: true }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(
+      exec,
+      {},
+      { ok: true, data: { data: exec } },
+    )
+
+    act(() => {
+      result.current.handlers.targetChange("a1", 0.7)
+    })
+
+    await act(async () => {
+      await result.current.handlers.save()
+    })
+
+    const putCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([url, opts]) =>
+        url === "/api/rebalance/executions/exec-1" && opts?.method === "PUT",
+    )
+    expect(putCall).toBeDefined()
+    const body = JSON.parse(putCall![1].body)
+    const cpfUpdate = body.itemUpdates.find(
+      (u: { assetId: string }) => u.assetId === "cpf-1",
+    )
+    expect(cpfUpdate).toBeUndefined()
+    const a1Update = body.itemUpdates.find(
+      (u: { assetId: string }) => u.assetId === "a1",
+    )
+    expect(a1Update).toBeDefined()
+  })
+
+  it("displayItems flags isImmune for an isPrivate row and for a fallback server-excluded-at-load row, but not for a normal row", async () => {
+    const exec = makeExecution({
+      items: [
+        makeItem({ assetId: "a1", excluded: false }),
+        makeItem({ assetId: "cpf-1", excluded: true, isPrivate: true }),
+        makeItem({ assetId: "fallback-1", excluded: true }),
+        makeCashItem({ assetId: "cash" }),
+      ],
+    })
+    const { result } = await renderWithExecution(exec)
+
+    const byId = (id: string): boolean | undefined =>
+      result.current.displayItems.find((i) => i.assetId === id)?.isImmune
+    expect(byId("a1")).toBe(false)
+    expect(byId("cpf-1")).toBe(true)
+    expect(byId("fallback-1")).toBe(true)
   })
 })

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -37,6 +37,17 @@ export interface DisplayItem extends ExecutionItemDto {
    * meaningful.
    */
   projectedWeight: number | null
+  /**
+   * True when this row must never be flipped by the select-all bulk toggle:
+   * either the server has explicitly marked it `isPrivate` (e.g. CPF — a
+   * server-side lock makes un-exclude a no-op anyway, so the UI must never
+   * imply otherwise), or — transitionally, against a backend that hasn't
+   * deployed `isPrivate` yet (`isPrivate === undefined` on every item) — it
+   * arrived excluded=true in the server payload when the execution was
+   * loaded. Does NOT disable the per-row checkbox by itself; only
+   * `isPrivate === true` does that (see the page component).
+   */
+  isImmune: boolean
 }
 
 export interface CashSummary {
@@ -145,6 +156,15 @@ export function useRebalanceExecution(
     Record<string, number>
   >({})
 
+  // Asset ids that arrived excluded=true in the server payload the moment
+  // the execution was loaded/created (re-captured on refresh, same cadence
+  // as originalTargets). Backs the transitional isPrivate-undefined fallback
+  // in setIncludeAll: against a backend that hasn't deployed `isPrivate` yet,
+  // a row the server itself excluded at load (e.g. an un-flagged PRIVATE/CPF
+  // asset) stays immune to the bulk select-all toggle rather than being
+  // silently force-included.
+  const [initialExcluded, setInitialExcluded] = useState<Set<string>>(new Set())
+
   // Broker selection (settlement account auto-defaults on backend)
   const [selectedBrokerId, setSelectedBrokerId] = useState<string | undefined>(
     undefined,
@@ -221,6 +241,13 @@ export function useRebalanceExecution(
         setLocalOverrides(overrides)
         setLocalExclusions(exclusions)
         setOriginalTargets(original)
+        setInitialExcluded(
+          new Set(
+            data.data.items
+              .filter((item: ExecutionItemDto) => item.excluded)
+              .map((item: ExecutionItemDto) => item.assetId),
+          ),
+        )
       } catch (err) {
         console.error("Failed to load execution:", err)
         setError(toErrorMessage(err, "Failed to load execution"))
@@ -282,6 +309,13 @@ export function useRebalanceExecution(
         })
         setLocalOverrides(adjustedOverrides)
         setOriginalTargets(original)
+        setInitialExcluded(
+          new Set(
+            data.data.items
+              .filter((item: ExecutionItemDto) => item.excluded)
+              .map((item: ExecutionItemDto) => item.assetId),
+          ),
+        )
         // Signal that the page should update the URL
         setCreatedExecutionId(data.data.id)
       } catch (err) {
@@ -328,13 +362,17 @@ export function useRebalanceExecution(
 
     setSaving(true)
     try {
-      const itemUpdates: ExecutionItemUpdate[] = execution.items.map(
-        (item) => ({
+      // PRIVATE rows are omitted entirely: the server ignores exclusion
+      // changes on them anyway (it never un-excludes a non-tradeable asset),
+      // so sending them is pure noise — and it keeps the payload honest
+      // about what this save can actually affect.
+      const itemUpdates: ExecutionItemUpdate[] = execution.items
+        .filter((item) => item.isPrivate !== true)
+        .map((item) => ({
           assetId: item.assetId,
           effectiveTargetOverride: localOverrides[item.assetId],
           excluded: localExclusions[item.assetId] ?? item.excluded,
-        }),
-      )
+        }))
 
       const response = await fetch(
         `/api/rebalance/executions/${execution.id}`,
@@ -404,6 +442,13 @@ export function useRebalanceExecution(
       setLocalOverrides(overrides)
       setLocalExclusions(exclusions)
       setOriginalTargets(original)
+      setInitialExcluded(
+        new Set(
+          data.data.items
+            .filter((item: ExecutionItemDto) => item.excluded)
+            .map((item: ExecutionItemDto) => item.assetId),
+        ),
+      )
       setHasChanges(false)
     } catch (err) {
       console.error("Failed to refresh:", err)
@@ -423,10 +468,18 @@ export function useRebalanceExecution(
     [],
   )
 
-  const handleExcludeToggle = useCallback((assetId: string): void => {
-    setLocalExclusions((prev) => ({ ...prev, [assetId]: !prev[assetId] }))
-    setHasChanges(true)
-  }, [])
+  const handleExcludeToggle = useCallback(
+    (assetId: string): void => {
+      // Belt-and-braces: the per-row checkbox is disabled for isPrivate rows
+      // at the UI layer, but guard here too in case a caller wires the
+      // handler directly — a PRIVATE row must never be force-included.
+      const item = execution?.items.find((i) => i.assetId === assetId)
+      if (item?.isPrivate === true) return
+      setLocalExclusions((prev) => ({ ...prev, [assetId]: !prev[assetId] }))
+      setHasChanges(true)
+    },
+    [execution],
+  )
 
   const handleSetIncludeAll = useCallback(
     (included: boolean): void => {
@@ -439,13 +492,23 @@ export function useRebalanceExecution(
           // changes on them, so leaving local state alone keeps the select-all
           // checkbox's semantics honest about what it actually affects.
           if (item.isCash || item.locked) return
+          // PRIVATE rows are never toggled by the bulk action, in either
+          // direction — same rationale as `locked` above, but keyed on the
+          // explicit isPrivate flag. Transitionally (old backend, isPrivate
+          // undefined on every item), a row that arrived excluded=true at
+          // load is treated the same way, since it's very likely an
+          // un-flagged PRIVATE/CPF asset the server itself already excluded.
+          const immune =
+            item.isPrivate === true ||
+            (item.isPrivate === undefined && initialExcluded.has(item.assetId))
+          if (immune) return
           next[item.assetId] = !included
         })
         return next
       })
       setHasChanges(true)
     },
-    [execution],
+    [execution, initialExcluded],
   )
 
   const handleResetTarget = useCallback(
@@ -606,7 +669,16 @@ export function useRebalanceExecution(
 
     const base = execution.items.map((item) => {
       const isCash = item.isCash ?? false
-      const isExcluded = localExclusions[item.assetId] ?? item.excluded
+      // PRIVATE rows are always excluded, regardless of local state — belt
+      // for the case local state briefly diverges (e.g. a stray toggle
+      // slips past the disabled UI before a re-render lands).
+      const isExcluded =
+        item.isPrivate === true
+          ? true
+          : (localExclusions[item.assetId] ?? item.excluded)
+      const isImmune =
+        item.isPrivate === true ||
+        (item.isPrivate === undefined && initialExcluded.has(item.assetId))
 
       let effectiveTarget: number
       if (isCash) {
@@ -637,6 +709,7 @@ export function useRebalanceExecution(
         deltaQuantity,
         isExcluded,
         isCash,
+        isImmune,
         // Fallback covers the render that lands between `setExecution` and
         // the paired `setOriginalTargets` call (both fire from the same
         // async handler, but state updates aren't batched across `await`
@@ -706,7 +779,13 @@ export function useRebalanceExecution(
       netImpact,
       projectedCash,
     }
-  }, [execution, localOverrides, localExclusions, originalTargets])
+  }, [
+    execution,
+    localOverrides,
+    localExclusions,
+    originalTargets,
+    initialExcluded,
+  ])
 
   const displayItems = computed.items
 

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -18,6 +18,15 @@ export interface DisplayItem extends ExecutionItemDto {
   deltaQuantity: number
   isExcluded: boolean
   isCash: boolean
+  /**
+   * The target weight this row was seeded with when the execution was
+   * loaded/created (or last refreshed) — captured once and held stable
+   * across the session regardless of subsequent edits. This is the "original"
+   * a per-row reset returns to; distinct from `planTargetWeight` (the
+   * model's static target, unaffected by return-adjustment or prior
+   * overrides on a reloaded execution).
+   */
+  originalTarget: number
   /** snapshotValue + deltaValue (cash row: currentCash + netImpact, clamped to >= 0) */
   projectedValue: number
   /**
@@ -82,12 +91,21 @@ export interface UseRebalanceExecutionResult {
     >
     targetChange: (assetId: string, value: number) => void
     excludeToggle: (assetId: string) => void
+    /**
+     * Sets exclusion for every non-cash, non-locked row in one pass — backs
+     * the select-all header checkbox. Locked (server-enforced, e.g. PRIVATE)
+     * rows are never touched: the server ignores exclusion changes on them
+     * anyway, so leaving their local state alone keeps the UI honest.
+     */
+    setIncludeAll: (included: boolean) => void
     setAllToCurrent: () => void
     setAllToTarget: () => void
     setAllToZero: () => void
     setAllToAdjusted: () => void
     setToCurrent: (assetId: string, currentWeight: number) => void
     setToTarget: (assetId: string) => void
+    /** Resets a single row's target back to its seeded `originalTarget`. */
+    resetTarget: (assetId: string) => void
     setError: (msg: string | null) => void
   }
   /** Set after a new execution is created so the page can update the URL */
@@ -117,6 +135,14 @@ export function useRebalanceExecution(
   >({})
   const [localExclusions, setLocalExclusions] = useState<
     Record<string, boolean>
+  >({})
+
+  // Baseline target weight per row, captured once when the execution is
+  // loaded/created (and re-captured on refresh) — never mutated by edits.
+  // Backs the per-row "reset to original" affordance and the Trade column's
+  // delta-vs-original label.
+  const [originalTargets, setOriginalTargets] = useState<
+    Record<string, number>
   >({})
 
   // Broker selection (settlement account auto-defaults on backend)
@@ -182,6 +208,7 @@ export function useRebalanceExecution(
         // Initialize local state from execution items
         const overrides: Record<string, number | undefined> = {}
         const exclusions: Record<string, boolean> = {}
+        const original: Record<string, number> = {}
         data.data.items.forEach((item: ExecutionItemDto) => {
           if (item.hasOverride) {
             overrides[item.assetId] = item.effectiveTarget
@@ -189,9 +216,11 @@ export function useRebalanceExecution(
           if (item.excluded) {
             exclusions[item.assetId] = true
           }
+          original[item.assetId] = item.effectiveTarget
         })
         setLocalOverrides(overrides)
         setLocalExclusions(exclusions)
+        setOriginalTargets(original)
       } catch (err) {
         console.error("Failed to load execution:", err)
         setError(toErrorMessage(err, "Failed to load execution"))
@@ -240,12 +269,19 @@ export function useRebalanceExecution(
         // executions have no returnAdjustedTarget, so this is a no-op there —
         // items are already seeded with zero deltas).
         const adjustedOverrides: Record<string, number> = {}
+        const original: Record<string, number> = {}
         data.data.items.forEach((item: ExecutionItemDto) => {
           if (!item.isCash && item.returnAdjustedTarget != null) {
             adjustedOverrides[item.assetId] = item.returnAdjustedTarget
           }
+          // Original = whatever the row is actually seeded with (the
+          // return-adjusted target when applied, else the server's own
+          // effectiveTarget — e.g. cash, or ad-hoc items with none).
+          original[item.assetId] =
+            adjustedOverrides[item.assetId] ?? item.effectiveTarget
         })
         setLocalOverrides(adjustedOverrides)
+        setOriginalTargets(original)
         // Signal that the page should update the URL
         setCreatedExecutionId(data.data.id)
       } catch (err) {
@@ -355,6 +391,7 @@ export function useRebalanceExecution(
       // Re-initialize local state
       const overrides: Record<string, number | undefined> = {}
       const exclusions: Record<string, boolean> = {}
+      const original: Record<string, number> = {}
       data.data.items.forEach((item: ExecutionItemDto) => {
         if (item.hasOverride) {
           overrides[item.assetId] = item.effectiveTarget
@@ -362,9 +399,11 @@ export function useRebalanceExecution(
         if (item.excluded) {
           exclusions[item.assetId] = true
         }
+        original[item.assetId] = item.effectiveTarget
       })
       setLocalOverrides(overrides)
       setLocalExclusions(exclusions)
+      setOriginalTargets(original)
       setHasChanges(false)
     } catch (err) {
       console.error("Failed to refresh:", err)
@@ -388,6 +427,36 @@ export function useRebalanceExecution(
     setLocalExclusions((prev) => ({ ...prev, [assetId]: !prev[assetId] }))
     setHasChanges(true)
   }, [])
+
+  const handleSetIncludeAll = useCallback(
+    (included: boolean): void => {
+      if (!execution) return
+      setLocalExclusions((prev) => {
+        const next = { ...prev }
+        execution.items.forEach((item) => {
+          // Cash isn't a toggleable row; locked (server-enforced) rows are
+          // never touched by the bulk action — the server ignores exclusion
+          // changes on them, so leaving local state alone keeps the select-all
+          // checkbox's semantics honest about what it actually affects.
+          if (item.isCash || item.locked) return
+          next[item.assetId] = !included
+        })
+        return next
+      })
+      setHasChanges(true)
+    },
+    [execution],
+  )
+
+  const handleResetTarget = useCallback(
+    (assetId: string): void => {
+      const original = originalTargets[assetId]
+      if (original === undefined) return
+      setLocalOverrides((prev) => ({ ...prev, [assetId]: original }))
+      setHasChanges(true)
+    },
+    [originalTargets],
+  )
 
   const handleSetAllToCurrent = useCallback((): void => {
     if (!execution) return
@@ -568,6 +637,12 @@ export function useRebalanceExecution(
         deltaQuantity,
         isExcluded,
         isCash,
+        // Fallback covers the render that lands between `setExecution` and
+        // the paired `setOriginalTargets` call (both fire from the same
+        // async handler, but state updates aren't batched across `await`
+        // boundaries in every React version) — the server's own
+        // `effectiveTarget` is the right seed value regardless.
+        originalTarget: originalTargets[item.assetId] ?? item.effectiveTarget,
       }
     })
 
@@ -631,7 +706,7 @@ export function useRebalanceExecution(
       netImpact,
       projectedCash,
     }
-  }, [execution, localOverrides, localExclusions])
+  }, [execution, localOverrides, localExclusions, originalTargets])
 
   const displayItems = computed.items
 
@@ -680,12 +755,14 @@ export function useRebalanceExecution(
       commit: handleCommit,
       targetChange: handleTargetChange,
       excludeToggle: handleExcludeToggle,
+      setIncludeAll: handleSetIncludeAll,
       setAllToCurrent: handleSetAllToCurrent,
       setAllToTarget: handleSetAllToTarget,
       setAllToZero: handleSetAllToZero,
       setAllToAdjusted: handleSetAllToAdjusted,
       setToCurrent: handleSetToCurrent,
       setToTarget: handleSetToTarget,
+      resetTarget: handleResetTarget,
       setError,
     },
     createdExecutionId,

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react"
+import React, { useState, useMemo, useEffect, useRef, useCallback } from "react"
 import {
   formatCurrency,
   formatPercent,
@@ -12,9 +12,11 @@ import { TableSkeletonLoader } from "@components/ui/SkeletonLoader"
 import CashSummaryPanel from "@components/features/rebalance/execution/CashSummaryPanel"
 import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
 import AssetInsightPopup from "@components/features/rebalance/models/AssetInsightPopup"
+import { setPageContext } from "@components/features/chat/pageContextBus"
 import {
   useRebalanceExecution,
   DisplayItem,
+  CashSummary,
 } from "@hooks/useRebalanceExecution"
 import { Asset } from "types/beancounter"
 import { ExecutionDto } from "types/rebalance"
@@ -34,8 +36,19 @@ function snapToStep(value: number, step: number): number {
   return Math.round(snapped * 100) / 100
 }
 
-/** How far the slider range extends either side of "unchanged" (0). */
+/** How far the slider's range extends either side of its anchor (the row's
+ * target value as of the last completed edit gesture) — see the "Slider
+ * anchor" state block in the page component for the full re-anchoring
+ * design. Bounds are then clamped into [0, 100], so the window can be
+ * asymmetric near the floor/ceiling (anchor 5 -> range 0-15, not -5-15). */
 const DELTA_RANGE_PP = 10
+
+/** Quiet period after the last keyboard/arrow-driven slider change before
+ * the slider re-anchors. Long enough that a burst of arrow-key presses
+ * doesn't shift the range out from under the user mid-adjustment; short
+ * enough that the range settles promptly once they stop. Drag gestures
+ * re-anchor immediately on pointer-up instead of waiting on this timer. */
+const REANCHOR_DEBOUNCE_MS = 400
 
 /** Deltas at or under this magnitude (percentage points) are treated as
  * exactly zero for label color, label text, and slider centering. The
@@ -155,6 +168,82 @@ Style: Clear, direct, evidence-based. No filler.`
   }
 }
 
+/** A row counts as "changed" for the draft-context summary when it's been
+ * excluded, or its target has moved off the row's current weight by more
+ * than float noise. Mirrors the epsilon rule the table itself uses for
+ * delta-label coloring, so the FAB's notion of "changed" matches what's
+ * visually tinted on screen. */
+function isRowChanged(item: DisplayItem): boolean {
+  if (item.isCash) return false
+  if (item.isExcluded) return true
+  return (
+    snapEpsilonZero(item.effectiveTarget * 100 - item.snapshotWeight * 100) !==
+    0
+  )
+}
+
+/**
+ * Compact plain-text summary of the current (client-only, unsaved-included)
+ * draft rebalance state — published to the global Chat FAB via
+ * `pageContextBus` so "what am I looking at" / "does this make sense"
+ * questions are answered against what's actually on screen, not the
+ * last-saved server snapshot. Only *changed* rows are itemised (unchanged
+ * rows are just counted) so the block stays small regardless of portfolio
+ * size — cheap enough to rebuild on every edit.
+ */
+export function buildDraftContext(
+  execution: ExecutionDto,
+  displayItems: DisplayItem[],
+  cashSummary: CashSummary,
+): string {
+  const nonCashItems = displayItems.filter((item) => !item.isCash)
+  const changed = nonCashItems.filter(isRowChanged)
+  const unchangedCount = nonCashItems.length - changed.length
+
+  const portfolioLabel = execution.name || execution.modelName || "Ad-hoc"
+  const lines: string[] = [
+    "DRAFT portfolio rebalance under consideration — nothing has been executed yet.",
+    `Execution: ${execution.id} (${execution.mode}${
+      execution.modelName ? `, model ${execution.modelName}` : ""
+    })`,
+    `Portfolio: ${portfolioLabel} (${execution.portfolioIds.join(", ") || "unknown"})`,
+    `Changed rows (${changed.length}):`,
+  ]
+
+  if (changed.length === 0) {
+    lines.push("- none yet — all targets still match current holdings")
+  } else {
+    for (const item of changed) {
+      const code = item.assetCode || item.assetId
+      if (item.isExcluded) {
+        lines.push(
+          `- ${code}: excluded from execution — held at current ${formatPercent(item.snapshotWeight)}`,
+        )
+        continue
+      }
+      const afterText =
+        item.projectedWeight != null
+          ? formatPercent(item.projectedWeight)
+          : "n/a"
+      lines.push(
+        `- ${code}: ${formatPercent(item.snapshotWeight)} -> ${formatPercent(item.effectiveTarget)} target (after ${afterText}), ` +
+          `qty ${item.deltaQuantity > 0 ? "+" : ""}${item.deltaQuantity}, value ${formatSignedNumber(item.deltaValue)} ${execution.currency}`,
+      )
+    }
+  }
+
+  lines.push(`Unchanged rows: ${unchangedCount}`)
+  lines.push(
+    `Cash: net impact ${formatSignedNumber(cashSummary.netImpact)} ${execution.currency}, ` +
+      `projected cash ${formatCurrency(cashSummary.projectedCash)} ${execution.currency}` +
+      (cashSummary.projectedCash < 0
+        ? " — DEPOSIT REQUIRED to fund this draft"
+        : ""),
+  )
+
+  return lines.join("\n")
+}
+
 function ExecuteRebalancePage(): React.ReactElement {
   const router = useRouter()
   const {
@@ -227,6 +316,118 @@ function ExecuteRebalancePage(): React.ReactElement {
       )
     }
   }, [createdExecutionId, executionId, source, router])
+
+  // --- Slider anchor state ---
+  //
+  // Per-assetId "anchor" (percent, 0-100) each row's slider range is
+  // centered on: min = max(0, anchor-10), max = min(100, anchor+10). Chosen
+  // to live in the PAGE (not the hook) — it's pure input-widget presentation
+  // state with no bearing on save/refresh/commit payloads, same footing as
+  // `sliderStep` just above.
+  //
+  // At rest, anchor === the row's current target (no explicit entry falls
+  // back to `item.effectiveTarget * 100` below). A stored entry only
+  // diverges from the live target mid-drag, where it must stay FIXED so the
+  // range doesn't shift under the user's thumb — re-anchoring happens on
+  // gesture-complete: pointer-up for drag, blur/400ms-debounce for
+  // keyboard/arrows, immediately for a numeric-input commit.
+  const [sliderAnchors, setSliderAnchors] = useState<Record<string, number>>({})
+  const draggingRef = useRef<Record<string, boolean>>({})
+  const debounceTimersRef = useRef<
+    Record<string, ReturnType<typeof setTimeout>>
+  >({})
+
+  const reanchor = useCallback((assetId: string, pct: number): void => {
+    setSliderAnchors((prev) => ({ ...prev, [assetId]: pct }))
+  }, [])
+
+  const clearAnchor = useCallback((assetId: string): void => {
+    setSliderAnchors((prev) => {
+      if (!(assetId in prev)) return prev
+      const next = { ...prev }
+      delete next[assetId]
+      return next
+    })
+  }, [])
+
+  const scheduleReanchor = useCallback(
+    (assetId: string, pct: number): void => {
+      const timers = debounceTimersRef.current
+      if (timers[assetId]) clearTimeout(timers[assetId])
+      timers[assetId] = setTimeout(() => {
+        reanchor(assetId, pct)
+        delete timers[assetId]
+      }, REANCHOR_DEBOUNCE_MS)
+    },
+    [reanchor],
+  )
+
+  // Any full data round-trip (load/create/save/refresh) replaces `execution`
+  // with a new object — a clean signal to drop all anchors and let every
+  // row re-derive from its (possibly server-reset) target on next render.
+  //
+  // The functional-update + "return prev when already empty" guard is
+  // load-bearing, not style: a bare `setSliderAnchors({})` hands React a
+  // fresh object literal every time this effect fires — including on
+  // mount, when there's nothing to clear — and a *different reference* is
+  // always a real state change to React (no structural comparison), so it
+  // schedules a re-render even though nothing observable changed. Pages
+  // Router rebuilds its router object on every render (see the URL-update
+  // effect below), so that extra, otherwise-harmless re-render was enough
+  // to re-fire `router.replace` a second time — the exact replaceState-loop
+  // shape as BC-VIEW-60.
+  useEffect(() => {
+    // Reacting to an external system's identity change (`execution`, from
+    // the data-fetching hook) — not derivable in render. The no-op guard
+    // (return `prev` unchanged when already empty) is what keeps this from
+    // cascading; see the block comment above for why that guard matters.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSliderAnchors((prev) => (Object.keys(prev).length === 0 ? prev : {}))
+  }, [execution])
+
+  // Flush pending debounce timers on unmount so no `setState` fires after
+  // the page has gone away.
+  useEffect(() => {
+    const timers = debounceTimersRef.current
+    return () => {
+      Object.values(timers).forEach((t) => clearTimeout(t))
+    }
+  }, [])
+
+  // --- Select-all (include/exclude column header) ---
+  const selectAllRef = useRef<HTMLInputElement>(null)
+  const eligibleItems = useMemo(
+    () => displayItems.filter((item) => !item.isCash && !item.locked),
+    [displayItems],
+  )
+  const eligibleIncludedCount = eligibleItems.filter(
+    (item) => !item.isExcluded,
+  ).length
+  const allIncluded =
+    eligibleItems.length > 0 && eligibleIncludedCount === eligibleItems.length
+  const someIncluded = eligibleIncludedCount > 0
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someIncluded && !allIncluded
+    }
+  }, [someIncluded, allIncluded])
+
+  // --- Live draft context for the global Chat FAB (pageContextBus) ---
+  const draftContext = useMemo(
+    () =>
+      execution
+        ? buildDraftContext(execution, displayItems, cashSummary)
+        : null,
+    [execution, displayItems, cashSummary],
+  )
+  useEffect(() => {
+    setPageContext(draftContext)
+  }, [draftContext])
+  // Clear on unmount only — ChatFab persists across navigation in `_app`,
+  // so a page that never clears leaks its context into the next page.
+  useEffect(() => {
+    return () => setPageContext(null)
+  }, [])
 
   if (states.loading) {
     return (
@@ -372,7 +573,10 @@ function ExecuteRebalancePage(): React.ReactElement {
                 <div className="flex gap-2">
                   {isAdHoc ? (
                     <button
-                      onClick={handlers.setAllToCurrent}
+                      onClick={() => {
+                        handlers.setAllToCurrent()
+                        setSliderAnchors({})
+                      }}
                       className="px-3 py-1 text-xs text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
                       title="Reset all target weights to current holdings"
                     >
@@ -381,14 +585,20 @@ function ExecuteRebalancePage(): React.ReactElement {
                   ) : (
                     <>
                       <button
-                        onClick={handlers.setAllToCurrent}
+                        onClick={() => {
+                          handlers.setAllToCurrent()
+                          setSliderAnchors({})
+                        }}
                         className="px-3 py-1 text-xs text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
                         title="Set all % to current weights (no changes)"
                       >
                         All &rarr; Current
                       </button>
                       <button
-                        onClick={handlers.setAllToTarget}
+                        onClick={() => {
+                          handlers.setAllToTarget()
+                          setSliderAnchors({})
+                        }}
                         className="px-3 py-1 text-xs text-gray-600 bg-white border border-gray-300 rounded hover:bg-gray-50"
                         title="Reset all to target weights from model"
                       >
@@ -397,7 +607,10 @@ function ExecuteRebalancePage(): React.ReactElement {
                     </>
                   )}
                   <button
-                    onClick={handlers.setAllToZero}
+                    onClick={() => {
+                      handlers.setAllToZero()
+                      setSliderAnchors({})
+                    }}
                     className="px-3 py-1 text-xs text-red-600 bg-white border border-red-300 rounded hover:bg-red-50"
                     title="Set all assets to 0% (sell everything)"
                   >
@@ -451,9 +664,16 @@ function ExecuteRebalancePage(): React.ReactElement {
                 <thead className="bg-gray-50">
                   <tr>
                     <th className="sticky top-0 z-20 bg-gray-50 px-2 py-2 text-center text-xs font-medium text-gray-500 uppercase">
-                      <span title="Exclude from execution">
-                        <i className="fas fa-ban"></i>
-                      </span>
+                      <input
+                        ref={selectAllRef}
+                        type="checkbox"
+                        checked={allIncluded}
+                        onChange={() => handlers.setIncludeAll(!allIncluded)}
+                        disabled={eligibleItems.length === 0}
+                        aria-label="Include all"
+                        title="Include/exclude all eligible rows"
+                        className="h-4 w-4 text-gray-600 rounded border-gray-300 focus:ring-gray-500 disabled:opacity-40"
+                      />
                     </th>
                     <th className="sticky top-0 left-0 z-30 bg-gray-50 px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">
                       {"Asset"}
@@ -478,7 +698,7 @@ function ExecuteRebalancePage(): React.ReactElement {
                       {"After %"}
                     </th>
                     <th className="sticky top-0 z-20 bg-gray-50 px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">
-                      {"Delta"}
+                      {"Trade"}
                     </th>
                   </tr>
                 </thead>
@@ -524,30 +744,51 @@ function ExecuteRebalancePage(): React.ReactElement {
                             ? "bg-red-50"
                             : "bg-white"
 
-                    // Delta-slider semantics: the slider expresses target
-                    // weight as an offset from CURRENT weight, not an
-                    // absolute 0-100 value — typical edits are a few points,
-                    // so the full track resolves them precisely. Excluded
-                    // rows are forced to delta 0 (centered, disabled) since
-                    // they keep their current weight regardless of any
-                    // stale effectiveTarget. Real delta can exceed the
-                    // +-10pp track (e.g. a big absolute edit via the numeric
-                    // input) — the slider THUMB pins at the edge while the
-                    // numeric input keeps showing the real, uncapped value.
-                    const currentPct = item.snapshotWeight * 100
-                    const realDeltaPct = item.isExcluded
+                    // Slider semantics: the range now tracks an absolute
+                    // target percent, windowed to +-DELTA_RANGE_PP either
+                    // side of the row's "anchor" (see the anchor state block
+                    // above the early returns) — re-anchored on gesture-
+                    // complete rather than pinned to the current weight.
+                    const targetPct = item.effectiveTarget * 100
+                    const originalPct = item.originalTarget * 100
+
+                    const anchorPct = sliderAnchors[item.assetId] ?? targetPct
+                    const sliderMin = Math.max(0, anchorPct - DELTA_RANGE_PP)
+                    const sliderMax = Math.min(100, anchorPct + DELTA_RANGE_PP)
+                    // Rounded to 2dp — `targetPct` inherits the same
+                    // proportional-scaling float noise documented on
+                    // DELTA_EPSILON_PP above (residuals around 1e-9–1e-13
+                    // pp). The delta label already snaps that noise to zero;
+                    // the slider's raw `value` attribute needs its own
+                    // rounding since it renders `targetPct` directly rather
+                    // than through a comparison.
+                    const sliderValue =
+                      Math.round(
+                        Math.min(sliderMax, Math.max(sliderMin, targetPct)) *
+                          100,
+                      ) / 100
+
+                    // Delta-vs-ORIGINAL (not vs current) drives the Trade
+                    // column's pp label — the cumulative, meaningful number
+                    // once a row's been edited more than once in the
+                    // session. Excluded rows keep their current weight
+                    // regardless of any stale effectiveTarget, so they never
+                    // show a delta.
+                    const deltaVsOriginalPct = item.isExcluded
                       ? 0
-                      : snapEpsilonZero(item.effectiveTarget * 100 - currentPct)
-                    const sliderDeltaPct = Math.min(
-                      DELTA_RANGE_PP,
-                      Math.max(-DELTA_RANGE_PP, realDeltaPct),
-                    )
+                      : snapEpsilonZero(targetPct - originalPct)
                     const deltaLabelClass =
-                      realDeltaPct === 0
+                      deltaVsOriginalPct === 0
                         ? "text-gray-500"
-                        : realDeltaPct > 0
+                        : deltaVsOriginalPct > 0
                           ? "text-green-600"
                           : "text-red-600"
+
+                    // Per-row reset (Change 3) is only actionable once the
+                    // target has actually moved off its seeded original —
+                    // independent of exclusion, which is a separate control.
+                    const targetChangedFromOriginal =
+                      snapEpsilonZero(targetPct - originalPct) !== 0
 
                     return (
                       <tr key={item.assetId} className={rowClass}>
@@ -556,14 +797,17 @@ function ExecuteRebalancePage(): React.ReactElement {
                             <input
                               type="checkbox"
                               checked={item.isExcluded}
+                              disabled={item.locked}
                               onChange={() =>
                                 handlers.excludeToggle(item.assetId)
                               }
-                              className="h-4 w-4 text-gray-600 rounded border-gray-300 focus:ring-gray-500"
+                              className="h-4 w-4 text-gray-600 rounded border-gray-300 focus:ring-gray-500 disabled:opacity-40"
                               title={
-                                item.isExcluded
-                                  ? "Include in execution"
-                                  : "Exclude from execution"
+                                item.locked
+                                  ? "Locked — not eligible for execution"
+                                  : item.isExcluded
+                                    ? "Include in execution"
+                                    : "Exclude from execution"
                               }
                             />
                           )}
@@ -620,12 +864,13 @@ function ExecuteRebalancePage(): React.ReactElement {
                         <td className="px-3 py-2 text-right tabular-nums">
                           <button
                             type="button"
-                            onClick={() =>
+                            onClick={() => {
                               handlers.setToCurrent(
                                 item.assetId,
                                 item.snapshotWeight,
                               )
-                            }
+                              clearAnchor(item.assetId)
+                            }}
                             title="Set target to current weight"
                             className={`block w-full text-right hover:underline ${
                               isCash ? "text-blue-900" : "text-gray-900"
@@ -642,37 +887,92 @@ function ExecuteRebalancePage(): React.ReactElement {
                         <td className="px-3 py-2">
                           <div className="flex items-center justify-end gap-2">
                             <div className="relative w-14 sm:w-20 min-w-[56px]">
-                              {/* Center detent — marks "unchanged from current
-                                  weight" (delta 0) at the track midpoint. */}
-                              <span
-                                aria-hidden="true"
-                                className="pointer-events-none absolute top-1/2 left-1/2 z-0 h-2.5 w-px -translate-x-1/2 -translate-y-1/2 bg-gray-400"
-                              />
                               <input
                                 type="range"
-                                min={-DELTA_RANGE_PP}
-                                max={DELTA_RANGE_PP}
+                                min={sliderMin}
+                                max={sliderMax}
                                 step={sliderStep}
-                                value={sliderDeltaPct}
+                                value={sliderValue}
+                                onPointerDown={() => {
+                                  draggingRef.current[item.assetId] = true
+                                  // Explicitly pin the anchor to the
+                                  // pre-drag target. Without this, the
+                                  // no-explicit-anchor fallback below
+                                  // (`sliderAnchors[id] ?? targetPct`) would
+                                  // keep tracking the LIVE target on every
+                                  // drag tick — sliding the range under the
+                                  // thumb instead of holding it fixed.
+                                  reanchor(item.assetId, targetPct)
+                                }}
+                                onPointerUp={(e) => {
+                                  draggingRef.current[item.assetId] = false
+                                  const val = Math.min(
+                                    100,
+                                    Math.max(
+                                      0,
+                                      (e.target as HTMLInputElement)
+                                        .valueAsNumber,
+                                    ),
+                                  )
+                                  reanchor(item.assetId, val)
+                                }}
+                                onPointerCancel={() => {
+                                  draggingRef.current[item.assetId] = false
+                                }}
                                 onChange={(e) => {
                                   const raw = parseFloat(e.target.value)
                                   if (Number.isNaN(raw)) return
-                                  const snappedDelta = snapToStep(
-                                    raw,
-                                    sliderStep,
-                                  )
-                                  const newTargetPct = Math.min(
+                                  const snapped = snapToStep(raw, sliderStep)
+                                  const clamped = Math.min(
                                     100,
-                                    Math.max(0, currentPct + snappedDelta),
+                                    Math.max(0, snapped),
                                   )
+                                  if (!draggingRef.current[item.assetId]) {
+                                    // Keyboard/arrow path: pin the anchor to
+                                    // where it was BEFORE this keystroke (so
+                                    // the range doesn't jump on every press
+                                    // while we wait out the debounce below) —
+                                    // only on the first press of a burst;
+                                    // once pinned, later presses in the same
+                                    // burst leave it alone.
+                                    if (
+                                      sliderAnchors[item.assetId] === undefined
+                                    ) {
+                                      reanchor(item.assetId, anchorPct)
+                                    }
+                                  }
                                   handlers.targetChange(
                                     item.assetId,
-                                    newTargetPct / 100,
+                                    clamped / 100,
                                   )
+                                  // Drag gestures re-anchor on pointer-up
+                                  // above; this path is the keyboard/arrow
+                                  // case, which debounces instead so a burst
+                                  // of key presses doesn't shift the range
+                                  // mid-adjustment.
+                                  if (!draggingRef.current[item.assetId]) {
+                                    scheduleReanchor(item.assetId, clamped)
+                                  }
+                                }}
+                                onBlur={(e) => {
+                                  const timers = debounceTimersRef.current
+                                  if (timers[item.assetId]) {
+                                    clearTimeout(timers[item.assetId])
+                                    delete timers[item.assetId]
+                                  }
+                                  const val = Math.min(
+                                    100,
+                                    Math.max(
+                                      0,
+                                      (e.target as HTMLInputElement)
+                                        .valueAsNumber,
+                                    ),
+                                  )
+                                  reanchor(item.assetId, val)
                                 }}
                                 disabled={item.isExcluded}
                                 aria-label={`${item.assetCode || item.assetId} target weight`}
-                                aria-valuetext={`${formatSignedPp(sliderDeltaPct, 0)} percentage points, target ${formatPercent(item.effectiveTarget)}`}
+                                aria-valuetext={`${formatPercent(item.effectiveTarget)} target (${formatSignedPp(deltaVsOriginalPct, 0)}pp vs original)`}
                                 className="relative z-10 w-full h-2 accent-invest-500 disabled:opacity-40 disabled:cursor-not-allowed"
                               />
                             </div>
@@ -685,6 +985,10 @@ function ExecuteRebalancePage(): React.ReactElement {
                               onChange={(e) => {
                                 const val = parseFloat(e.target.value) || 0
                                 handlers.targetChange(item.assetId, val / 100)
+                                // Numeric entry re-anchors immediately — the
+                                // user just told us exactly where they want
+                                // to be, so the +-10pp window should follow.
+                                reanchor(item.assetId, val)
                               }}
                               disabled={item.isExcluded}
                               aria-label={`${item.assetCode || item.assetId} target weight percent`}
@@ -696,20 +1000,26 @@ function ExecuteRebalancePage(): React.ReactElement {
                                     : "border-gray-300"
                               }`}
                             />
-                          </div>
-                          <div
-                            className={`text-right text-[11px] tabular-nums ${deltaLabelClass}`}
-                          >
-                            {formatSignedPp(
-                              realDeltaPct,
-                              sliderStep === 0.01 ? 2 : 1,
-                            )}
-                            {" → "}
-                            {formatPercent(item.effectiveTarget)}
+                            <button
+                              type="button"
+                              onClick={() => {
+                                handlers.resetTarget(item.assetId)
+                                clearAnchor(item.assetId)
+                              }}
+                              disabled={!targetChangedFromOriginal}
+                              title="Reset to original weight"
+                              aria-label={`Reset ${item.assetCode || item.assetId} weight`}
+                              className="text-gray-400 hover:text-invest-600 disabled:opacity-0 disabled:pointer-events-none p-0.5"
+                            >
+                              <i className="fas fa-rotate-left text-xs"></i>
+                            </button>
                           </div>
                           <button
                             type="button"
-                            onClick={() => handlers.setToTarget(item.assetId)}
+                            onClick={() => {
+                              handlers.setToTarget(item.assetId)
+                              clearAnchor(item.assetId)
+                            }}
                             title="Reset target to plan weight"
                             className="block w-full text-right text-[11px] text-gray-400 hover:text-invest-600 hover:underline mt-0.5"
                           >
@@ -733,9 +1043,17 @@ function ExecuteRebalancePage(): React.ReactElement {
                         </td>
                         <td className="px-3 py-2 text-right tabular-nums">
                           {isCash ? (
-                            <span className={cashDeltaClass}>
-                              {formatSignedNumber(cashSummary.netImpact)}
-                            </span>
+                            <>
+                              <span className={cashDeltaClass}>
+                                {formatSignedNumber(cashSummary.netImpact)}
+                              </span>
+                              <div className={`text-[11px] ${deltaLabelClass}`}>
+                                {formatSignedPp(
+                                  deltaVsOriginalPct,
+                                  sliderStep === 0.01 ? 2 : 1,
+                                )}
+                              </div>
+                            </>
                           ) : item.isExcluded ? (
                             <span className="text-gray-400">-</span>
                           ) : (
@@ -746,6 +1064,12 @@ function ExecuteRebalancePage(): React.ReactElement {
                               </div>
                               <div className="text-xs text-gray-500">
                                 {formatSignedNumber(item.deltaValue)}
+                              </div>
+                              <div className={`text-[11px] ${deltaLabelClass}`}>
+                                {formatSignedPp(
+                                  deltaVsOriginalPct,
+                                  sliderStep === 0.01 ? 2 : 1,
+                                )}
                               </div>
                             </>
                           )}

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -397,7 +397,10 @@ function ExecuteRebalancePage(): React.ReactElement {
   // --- Select-all (include/exclude column header) ---
   const selectAllRef = useRef<HTMLInputElement>(null)
   const eligibleItems = useMemo(
-    () => displayItems.filter((item) => !item.isCash && !item.locked),
+    () =>
+      displayItems.filter(
+        (item) => !item.isCash && !item.locked && !item.isImmune,
+      ),
     [displayItems],
   )
   const eligibleIncludedCount = eligibleItems.filter(
@@ -797,17 +800,24 @@ function ExecuteRebalancePage(): React.ReactElement {
                             <input
                               type="checkbox"
                               checked={item.isExcluded}
-                              disabled={item.locked}
+                              disabled={item.locked || item.isPrivate === true}
                               onChange={() =>
                                 handlers.excludeToggle(item.assetId)
                               }
                               className="h-4 w-4 text-gray-600 rounded border-gray-300 focus:ring-gray-500 disabled:opacity-40"
+                              aria-label={
+                                item.isPrivate === true
+                                  ? "Non-tradeable asset — always excluded"
+                                  : undefined
+                              }
                               title={
-                                item.locked
-                                  ? "Locked — not eligible for execution"
-                                  : item.isExcluded
-                                    ? "Include in execution"
-                                    : "Exclude from execution"
+                                item.isPrivate === true
+                                  ? "Non-tradeable asset — always excluded"
+                                  : item.locked
+                                    ? "Locked — not eligible for execution"
+                                    : item.isExcluded
+                                      ? "Include in execution"
+                                      : "Exclude from execution"
                               }
                             />
                           )}

--- a/types/rebalance.d.ts
+++ b/types/rebalance.d.ts
@@ -391,6 +391,15 @@ export interface ExecutionItemDto {
   isCash?: boolean
   /** Rationale for why this asset is in the model */
   rationale?: string
+  /**
+   * Non-tradeable asset (e.g. CPF) the server always excludes from
+   * execution — un-exclude requests are silently ignored server-side.
+   * Optional so the UI degrades gracefully against a backend that hasn't
+   * deployed the field yet; see the initial-excluded-at-load fallback in
+   * `useRebalanceExecution`. Absent/undefined does NOT mean "not private" —
+   * it means "unknown, use the fallback."
+   */
+  isPrivate?: boolean
 }
 
 export interface CashSummaryDto {


### PR DESCRIPTION
Follow-on refinement round on the rebalance execute editor (#1110 merged
underneath this — this PR targets `main` directly).

## Summary

Four pieces of user feedback plus a fifth request from the coordinator:

1. **Select-all checkbox** in the include/exclude column header — tri-state
   (checked/unchecked/indeterminate) over non-cash, non-locked rows. Locked
   (PRIVATE/server-enforced) rows are never toggled by it — the server
   ignores exclusion changes on them anyway, so this keeps the UI honest.
2. **Column re-org** — Target (slider + input only) now sits directly next
   to After %, matching content/formatting. Trade breakdown (qty, value,
   delta-pp) moved into its own **Trade** column (renamed from Delta).
3. **Per-row reset** — a small ↺ icon next to the target input, enabled
   only when the row's target has diverged (epsilon-aware) from its seeded
   `originalTarget`, resetting just that row.
4. **Slider re-anchoring** — the slider's range is now the current target
   ±10pp (clamped into [0, 100], so it can be asymmetric near the floor/
   ceiling), not a fixed window off the original current weight. The anchor
   stays fixed during an active drag and re-anchors on pointer-up, blur, or
   a ~400ms debounce for keyboard/arrow edits, and immediately on a numeric
   input commit. The delta-pp label (now in the Trade column) reads change
   vs the seeded *original*, not vs current weight — no more edge-pinning.
5. **Chat FAB draft-context injection** — the global chat FAB can now
   surface the live (unsaved) draft rebalance state. Added a small
   `pageContextBus` (mirrors the existing `chatBus` window-event pub/sub
   idiom already used for open-with-prompt requests) that any page can
   publish a text summary to; `ChatFab` folds it into `context.currentState`
   on outgoing agent queries. The execute page publishes a compact
   `buildDraftContext()` summary (changed rows only, cash summary, framed
   as an unexecuted draft) and clears it on unmount.

## Notable fix found along the way

The anchor-reset effect (`useEffect(() => setSliderAnchors({}), [execution])`)
initially handed React a fresh object literal on every fire, including on
mount — a different reference is always a real state change to React, so it
scheduled an extra re-render even when nothing observable changed. Combined
with Pages Router rebuilding its router object every render, that extra
render was enough to double-fire `router.replace` in the URL-update effect —
the same replaceState-loop shape as BC-VIEW-60. Fixed with a functional
update that returns `prev` unchanged when there's nothing to clear.

## Test plan

- [x] `yarn test` — 2236 tests pass (229 suites), including new coverage for
      select-all (3 states + locked-row immunity), per-row reset, slider
      re-anchoring (numeric commit / drag-hold / keyboard-debounce), the
      delta-vs-original label, and the FAB context bus (publish/omit/clear).
- [x] `yarn prettier` (format + eslint + markdownlint) — clean
- [x] `yarn lint` — 0 errors (1 pre-existing unrelated warning)
- [x] `yarn typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)