### PR TITLE
feat(rebalance): wizard starts execution against approved plan

### DIFF
--- a/src/components/features/rebalance/wizard/RebalanceWizardContainer.tsx
+++ b/src/components/features/rebalance/wizard/RebalanceWizardContainer.tsx
@@ -7,7 +7,12 @@ import SelectModelStep from "./steps/SelectModelStep"
 import SelectPortfoliosStep from "./steps/SelectPortfoliosStep"
 import ConfigureScenarioStep from "./steps/ConfigureScenarioStep"
 import ReviewStep from "./steps/ReviewStep"
-import { ModelDto, RebalanceScenario, CreatePlanRequest } from "types/rebalance"
+import {
+  ModelDto,
+  RebalanceScenario,
+  CreatePlanRequest,
+  CreateExecutionRequest,
+} from "types/rebalance"
 import { useDialogSubmit } from "@hooks/useDialogSubmit"
 
 interface RebalanceWizardContainerProps {
@@ -32,7 +37,12 @@ const RebalanceWizardContainer: React.FC<RebalanceWizardContainerProps> = ({
     isSubmitting,
     submitError: error,
     handleSubmit: dialogSubmit,
-  } = useDialogSubmit({ fallbackError: "Failed to create plan" })
+  } = useDialogSubmit({ fallbackError: "Failed to complete wizard" })
+
+  // A model with an approved plan (currentPlanId) can go straight to an
+  // execution against it; one without needs a draft plan created first (see
+  // handleSubmit below for why the two paths differ).
+  const hasApprovedPlan = Boolean(selectedModel?.currentPlanId)
 
   // Steps configuration
   const steps = useMemo(
@@ -83,12 +93,51 @@ const RebalanceWizardContainer: React.FC<RebalanceWizardContainerProps> = ({
     }
 
     await dialogSubmit(async () => {
+      if (selectedModel.currentPlanId) {
+        // The model already has an approved plan — skip plan creation
+        // entirely and go straight to an execution against it, carrying the
+        // portfolios/scenario/cashDelta collected in steps 2-3. (A
+        // wizard-created plan would be DRAFT and empty, and an empty plan
+        // can't be approved, so this path only applies when a plan is
+        // already approved.)
+        const payload: CreateExecutionRequest = {
+          planId: selectedModel.currentPlanId,
+          portfolioIds: selectedPortfolioIds,
+          name: planName.trim(),
+          mode: scenario,
+          cashDelta:
+            scenario === "REBALANCE" && cashDelta ? cashDelta : undefined,
+          investmentAmount:
+            scenario === "INVEST_CASH" && cashDelta ? cashDelta : undefined,
+        }
+
+        const response = await fetch("/api/rebalance/executions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        })
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}))
+          throw new Error(
+            errorData.detail ||
+              errorData.message ||
+              "Failed to start execution",
+          )
+        }
+
+        const result = await response.json()
+        await router.push(`/rebalance/execute?executionId=${result.data.id}`)
+        return
+      }
+
       // svc-rebalance only creates plans nested under a model
       // (POST /models/{modelId}/plans) — there is no top-level "bind this
       // plan to these portfolios with a scenario" endpoint. CreatePlanRequest
       // only accepts description/sourcePlanId/assets, so the portfolios,
       // scenario and cashDelta collected in steps 2-3 have no home here; they
-      // apply later, at execution time (see /rebalance/execute).
+      // apply later, at execution time (see /rebalance/execute), once this
+      // draft plan has assets and is approved.
       const payload: CreatePlanRequest = {
         description: planName.trim(),
       }
@@ -198,8 +247,10 @@ const RebalanceWizardContainer: React.FC<RebalanceWizardContainerProps> = ({
             {isSubmitting ? (
               <span className="flex items-center">
                 <Spinner className="mr-2" />
-                {"Creating..."}
+                {hasApprovedPlan ? "Starting..." : "Creating..."}
               </span>
+            ) : hasApprovedPlan ? (
+              "Start Execution"
             ) : (
               "Create Plan"
             )}

--- a/src/components/features/rebalance/wizard/__tests__/RebalanceWizardContainer.test.tsx
+++ b/src/components/features/rebalance/wizard/__tests__/RebalanceWizardContainer.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
-import { ModelDto } from "types/rebalance"
+import { ModelDto, RebalanceScenario } from "types/rebalance"
 
 const mockPush = jest.fn()
 jest.mock("next/router", () => ({
@@ -20,14 +20,22 @@ const testModel: ModelDto = {
   updatedAt: "2025-01-01",
 }
 
+const testModelWithApprovedPlan: ModelDto = {
+  ...testModel,
+  id: "model-2",
+  currentPlanId: "plan-approved-1",
+}
+
 // The wizard steps are exercised elsewhere (model list, portfolio picker,
 // scenario form) — stubbing them here keeps this test focused on the
-// container's own responsibility: building the create-plan request and
-// handling the response, not re-testing each step's own UI.
+// container's own responsibility: building the create-plan/create-execution
+// request and handling the response, not re-testing each step's own UI.
+let modelToSelect: ModelDto = testModel
+
 jest.mock("../steps/SelectModelStep", () => ({
   __esModule: true,
   default: ({ onSelect }: { onSelect: (model: ModelDto) => void }) => (
-    <button onClick={() => onSelect(testModel)}>select-model</button>
+    <button onClick={() => onSelect(modelToSelect)}>select-model</button>
   ),
 }))
 jest.mock("../steps/SelectPortfoliosStep", () => ({
@@ -38,7 +46,23 @@ jest.mock("../steps/SelectPortfoliosStep", () => ({
 }))
 jest.mock("../steps/ConfigureScenarioStep", () => ({
   __esModule: true,
-  default: () => <div>configure-scenario</div>,
+  default: ({
+    onScenarioChange,
+    onCashDeltaChange,
+  }: {
+    onScenarioChange: (scenario: RebalanceScenario) => void
+    onCashDeltaChange: (delta: number) => void
+  }) => (
+    <div>
+      <button onClick={() => onScenarioChange("REBALANCE")}>
+        set-scenario-rebalance
+      </button>
+      <button onClick={() => onScenarioChange("INVEST_CASH")}>
+        set-scenario-invest-cash
+      </button>
+      <button onClick={() => onCashDeltaChange(5000)}>set-cash-delta</button>
+    </div>
+  ),
 }))
 jest.mock("../steps/ReviewStep", () => ({
   __esModule: true,
@@ -58,10 +82,14 @@ describe("RebalanceWizardContainer submit", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    modelToSelect = testModel
     global.fetch = mockFetch
   })
 
-  const driveToReview = (): void => {
+  const driveToReview = (options?: {
+    scenarioButton?: string
+    setCashDelta?: boolean
+  }): void => {
     render(<RebalanceWizardContainer />)
 
     fireEvent.click(screen.getByText("select-model"))
@@ -70,62 +98,163 @@ describe("RebalanceWizardContainer submit", () => {
     fireEvent.click(screen.getByText("select-portfolio"))
     fireEvent.click(screen.getByText("Next")) // -> step 3
 
+    if (options?.scenarioButton) {
+      fireEvent.click(screen.getByText(options.scenarioButton))
+    }
+    if (options?.setCashDelta) {
+      fireEvent.click(screen.getByText("set-cash-delta"))
+    }
+
     fireEvent.click(screen.getByText("Next")) // -> step 4 (review)
 
     fireEvent.click(screen.getByText("set-plan-name"))
   }
 
-  it("posts to the per-model plans endpoint (not the orphaned top-level /plans route)", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ data: { id: "plan-99" } }),
+  describe("model without an approved plan", () => {
+    it("posts to the per-model plans endpoint (not the orphaned top-level /plans route)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: "plan-99" } }),
+      })
+
+      driveToReview()
+      fireEvent.click(screen.getByText("Create Plan"))
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/rebalance/models/model-1/plans",
+          expect.objectContaining({ method: "POST" }),
+        )
+      })
+
+      // Only description survives the mapping — CreatePlanRequest has no
+      // portfolios/scenario/cashDelta field to carry the rest.
+      const [, init] = mockFetch.mock.calls[0]
+      expect(JSON.parse(init.body)).toEqual({ description: "My Plan" })
     })
 
-    driveToReview()
-    fireEvent.click(screen.getByText("Create Plan"))
+    it("redirects to the per-model plan detail page on success", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: "plan-99" } }),
+      })
 
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(
-        "/api/rebalance/models/model-1/plans",
-        expect.objectContaining({ method: "POST" }),
+      driveToReview()
+      fireEvent.click(screen.getByText("Create Plan"))
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(
+          "/rebalance/models/model-1/plans/plan-99",
+        )
+      })
+    })
+
+    it("never calls the orphaned top-level /api/rebalance/plans route", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: "plan-99" } }),
+      })
+
+      driveToReview()
+      fireEvent.click(screen.getByText("Create Plan"))
+
+      await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+      expect(mockFetch).not.toHaveBeenCalledWith(
+        "/api/rebalance/plans",
+        expect.anything(),
       )
     })
-
-    // Only description survives the mapping — CreatePlanRequest has no
-    // portfolios/scenario/cashDelta field to carry the rest.
-    const [, init] = mockFetch.mock.calls[0]
-    expect(JSON.parse(init.body)).toEqual({ description: "My Plan" })
   })
 
-  it("redirects to the per-model plan detail page on success", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ data: { id: "plan-99" } }),
+  describe("model with an approved plan", () => {
+    beforeEach(() => {
+      modelToSelect = testModelWithApprovedPlan
     })
 
-    driveToReview()
-    fireEvent.click(screen.getByText("Create Plan"))
+    it("posts portfolios/scenario/cashDelta to /api/rebalance/executions in REBALANCE mode and redirects to the execute page", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: "execution-1" } }),
+      })
 
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith(
-        "/rebalance/models/model-1/plans/plan-99",
+      driveToReview({
+        scenarioButton: "set-scenario-rebalance",
+        setCashDelta: true,
+      })
+      fireEvent.click(screen.getByText("Start Execution"))
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/rebalance/executions",
+          expect.objectContaining({ method: "POST" }),
+        )
+      })
+
+      const [, init] = mockFetch.mock.calls[0]
+      expect(JSON.parse(init.body)).toEqual({
+        planId: "plan-approved-1",
+        portfolioIds: ["portfolio-1"],
+        name: "My Plan",
+        mode: "REBALANCE",
+        cashDelta: 5000,
+      })
+
+      expect(mockFetch).not.toHaveBeenCalledWith(
+        expect.stringContaining("/plans"),
+        expect.anything(),
       )
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(
+          "/rebalance/execute?executionId=execution-1",
+        )
+      })
     })
-  })
 
-  it("never calls the orphaned top-level /api/rebalance/plans route", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ data: { id: "plan-99" } }),
+    it("posts investmentAmount (not cashDelta) to /api/rebalance/executions in INVEST_CASH mode", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: "execution-2" } }),
+      })
+
+      driveToReview({
+        scenarioButton: "set-scenario-invest-cash",
+        setCashDelta: true,
+      })
+      fireEvent.click(screen.getByText("Start Execution"))
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/rebalance/executions",
+          expect.objectContaining({ method: "POST" }),
+        )
+      })
+
+      const [, init] = mockFetch.mock.calls[0]
+      expect(JSON.parse(init.body)).toEqual({
+        planId: "plan-approved-1",
+        portfolioIds: ["portfolio-1"],
+        name: "My Plan",
+        mode: "INVEST_CASH",
+        investmentAmount: 5000,
+      })
     })
 
-    driveToReview()
-    fireEvent.click(screen.getByText("Create Plan"))
+    it("shows an error and does not navigate when the executions POST fails", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ message: "Server error" }),
+      })
 
-    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
-    expect(mockFetch).not.toHaveBeenCalledWith(
-      "/api/rebalance/plans",
-      expect.anything(),
-    )
+      driveToReview({ scenarioButton: "set-scenario-rebalance" })
+      fireEvent.click(screen.getByText("Start Execution"))
+
+      await waitFor(() => {
+        expect(screen.getByText("Server error")).toBeInTheDocument()
+      })
+
+      expect(mockPush).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/components/features/rebalance/wizard/steps/ReviewStep.tsx
+++ b/src/components/features/rebalance/wizard/steps/ReviewStep.tsx
@@ -20,6 +20,8 @@ const ReviewStep: React.FC<ReviewStepProps> = ({
   cashDelta,
   planCurrency,
 }) => {
+  const hasApprovedPlan = Boolean(selectedModel?.currentPlanId)
+
   return (
     <div className="space-y-6">
       <div>
@@ -93,9 +95,9 @@ const ReviewStep: React.FC<ReviewStepProps> = ({
           <i className="fas fa-info-circle text-blue-500 mt-0.5"></i>
           <div className="text-sm text-blue-700">
             <p>
-              {
-                "After creating the plan, you can review the calculated items, adjust exclusions, set execution prices, and execute when ready."
-              }
+              {hasApprovedPlan
+                ? "This will start an execution against the model's approved plan for the selected portfolios and scenario."
+                : "This model has no approved plan yet, so a draft plan will be created first. Your selected portfolios, scenario and cash settings aren't stored on the plan — they'll apply later when you run an execution against it."}
             </p>
           </div>
         </div>

--- a/types/rebalance.d.ts
+++ b/types/rebalance.d.ts
@@ -190,7 +190,10 @@ export interface RebalanceCalculationResponse {
 // === Execution Types (persisted rebalance configurations) ===
 
 export type ExecutionPlanStatus =
-  "DRAFT" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED"
+  | "DRAFT"
+  | "IN_PROGRESS"
+  | "COMPLETED"
+  | "CANCELLED"
 
 export type ExecutionMode = "REBALANCE" | "INVEST_CASH" | "AD_HOC"
 
@@ -291,6 +294,8 @@ export interface CreateExecutionRequest {
   mode?: ExecutionMode
   /** Amount of cash to invest (only used in INVEST_CASH mode) */
   investmentAmount?: number
+  /** Cash to deploy/remove (only used in REBALANCE mode; defaults to 0) */
+  cashDelta?: number
   /** When true, only consider positions from transactions tagged with this model's ID */
   filterByModel?: boolean
   /** Required for AD_HOC mode — the portfolio's report currency */


### PR DESCRIPTION
## Summary

- Wizard collects portfolios, scenario, and cashDelta across all steps
- If model has `currentPlanId` (approved plan), threads collected data into `POST /executions`
- Redirects to `/rebalance/execute?executionId=` to show execution status
- Models without approved plan retain draft-plan flow with updated ReviewStep copy

## Test plan

- [x] ReviewStep displays "model is not approved yet" when no `currentPlanId`
- [x] ReviewStep shows execution button when `currentPlanId` is set
- [x] Wizard execution threads all collected state into POST body
- [x] API response extraction: pull `executionId` and redirect
- [x] Happy path verified in RebalanceWizardContainer.test.tsx
