### PR TITLE
feat(independence): residence + benefits-start phase pickers on Phases tab

### DIFF
--- a/src/components/features/independence/composite/BenefitsStartPhasePicker.tsx
+++ b/src/components/features/independence/composite/BenefitsStartPhasePicker.tsx
@@ -1,0 +1,139 @@
+import React, { useId, useState } from "react"
+import { mutate } from "swr"
+import type { RetirementPlan } from "types/independence"
+import { toPlanRequestPayload } from "@utils/independence/planHelpers"
+import { useCompositeProjectionContext } from "./CompositeProjectionContext"
+
+/** Same SWR key the Independence page uses to list plans (src/pages/independence/index.tsx). */
+const PLANS_KEY = "/api/independence/plans"
+
+function getPlanName(plans: RetirementPlan[], planId: string): string {
+  return plans.find((p) => p.id === planId)?.name ?? "Unknown Plan"
+}
+
+async function updateBenefitsStartAge(
+  plan: RetirementPlan,
+  benefitsStartAge: number,
+): Promise<void> {
+  // Full-plan echo: svc-retire's PATCH replaces every field it receives and
+  // defaults the ones it doesn't, so a {benefitsStartAge}-only body 400s
+  // (name/monthlyExpenses required) or clobbers settings.
+  const response = await fetch(`/api/independence/plans/${plan.id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...toPlanRequestPayload(plan), benefitsStartAge }),
+  })
+  if (!response.ok) {
+    throw new Error("Failed to update benefits start age")
+  }
+}
+
+/**
+ * Second phase-boundary lever on the composite Phases tab (sibling of
+ * {@link ResidencePhasePicker}): pick the retirement phase in which NZ
+ * Super / government benefits start paying.
+ *
+ * Unlike the per-property residence picker, this writes
+ * `benefitsStartAge = selected phase's fromAge` to EVERY distinct phase
+ * plan — the composite engine gates social security per phase plan, not
+ * per composite, so all phase plans must agree for the projection to
+ * reflect the choice. The plan-level `benefitsStartAge` editable via
+ * EditPlanDetailsModal remains the single-phase fallback and is untouched
+ * outside of this control's "current state" derivation.
+ *
+ * There is no "clear" option: the backend PATCH null-coalesces
+ * `benefitsStartAge` on update, so sending `null`/`undefined` would keep
+ * the existing value rather than clearing it.
+ */
+export default function BenefitsStartPhasePicker(): React.ReactElement | null {
+  const { plans, phases } = useCompositeProjectionContext()
+  const [saving, setSaving] = useState(false)
+  // Rendered twice per page (desktop + mobile FlipCard) — a static id would
+  // duplicate in the DOM, so derive a unique one per instance.
+  const selectId = useId()
+
+  if (phases.length === 0) {
+    return null
+  }
+
+  // Distinct phase plans, in first-occurrence phase order.
+  const distinctPlanIds = Array.from(new Set(phases.map((p) => p.planId)))
+  const phasePlans = distinctPlanIds
+    .map((id) => plans.find((p) => p.id === id))
+    .filter((p): p is RetirementPlan => p !== undefined)
+
+  const values = phasePlans.map((p) => p.benefitsStartAge)
+  const allNullish = values.every((v) => v === undefined || v === null)
+  const allEqual = values.every((v) => v === values[0])
+
+  const matchedPhase =
+    !allNullish && allEqual
+      ? phases.find((p) => p.fromAge === values[0])
+      : undefined
+
+  let selectedValue: string
+  let disabledOptionValue: string | undefined
+  let disabledOptionLabel: string | undefined
+
+  if (matchedPhase) {
+    selectedValue = String(matchedPhase.fromAge)
+  } else if (allNullish) {
+    selectedValue = "not-set"
+    disabledOptionValue = "not-set"
+    disabledOptionLabel = "Not set (starts at retirement)"
+  } else if (allEqual) {
+    selectedValue = `custom-${values[0]}`
+    disabledOptionValue = `custom-${values[0]}`
+    disabledOptionLabel = `From age ${values[0]}`
+  } else {
+    selectedValue = "mixed"
+    disabledOptionValue = "mixed"
+    disabledOptionLabel = "Mixed"
+  }
+
+  const handleChange = async (value: string): Promise<void> => {
+    const fromAge = Number(value)
+    setSaving(true)
+    try {
+      for (const phasePlan of phasePlans) {
+        // Sequential updates are fine here — fan-out is small (one per phase plan).
+        await updateBenefitsStartAge(phasePlan, fromAge)
+      }
+      await mutate(PLANS_KEY)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor={selectId}
+        className="block text-sm font-medium text-gray-700"
+      >
+        NZ Super / benefits start
+      </label>
+      <select
+        id={selectId}
+        aria-label="NZ Super / benefits start"
+        value={selectedValue}
+        disabled={saving}
+        onChange={(e) => {
+          void handleChange(e.target.value)
+        }}
+        className="px-2 py-1 border border-gray-300 rounded text-sm focus:ring-1 focus:ring-independence-500 focus:border-independence-500 disabled:opacity-50"
+      >
+        {disabledOptionValue && (
+          <option value={disabledOptionValue} disabled>
+            {disabledOptionLabel}
+          </option>
+        )}
+        {phases.map((phase) => (
+          <option key={phase.planId} value={String(phase.fromAge)}>
+            {getPlanName(plans, phase.planId)} — from age {phase.fromAge}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/src/components/features/independence/composite/ResidencePhasePicker.tsx
+++ b/src/components/features/independence/composite/ResidencePhasePicker.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from "react"
+import type { PropertyIncomeRequest, RetirementPlan } from "types/independence"
+import { usePropertyIncomes } from "@utils/independence/usePropertyIncomes"
+import { usePrivateAssetConfigs } from "@utils/assets/usePrivateAssetConfigs"
+import { useCompositeProjectionContext } from "./CompositeProjectionContext"
+
+/** `<select>` value representing "no owner-occupy phase selected". */
+const RENTED_THROUGHOUT = ""
+
+function getPlanName(plans: RetirementPlan[], planId: string): string {
+  return plans.find((p) => p.id === planId)?.name ?? "Unknown Plan"
+}
+
+/**
+ * Per-rental-property residence phase picker on the composite Phases tab.
+ *
+ * For each rental property (private asset config with isPrimaryResidence
+ * false), the user chooses either "Rented throughout" or the retirement
+ * phase in which they will move in and owner-occupy. Picking a phase
+ * persists `occupiedFromAge = phase.fromAge` via the plan-scoped properties
+ * endpoint (svc-retire #166); the backend suppresses rental income in
+ * projections from that age onward. Picking "Rented throughout" deletes any
+ * existing property-income row for that asset.
+ *
+ * The canonical plan for property rows is `phases[0].planId` — svc-retire
+ * merges owner-occupancy across all phase plans, and the first phase's plan
+ * is the canonical store for it.
+ */
+export default function ResidencePhasePicker(): React.ReactElement | null {
+  const { plans, phases } = useCompositeProjectionContext()
+  const canonicalPlanId = phases[0]?.planId
+
+  const {
+    configs,
+    assetNames,
+    isLoading: configsLoading,
+  } = usePrivateAssetConfigs()
+  const {
+    isLoading: incomesLoading,
+    savePropertyIncome,
+    deletePropertyIncome,
+    getPropertyIncomeForAsset,
+  } = usePropertyIncomes(canonicalPlanId)
+
+  const [savingAssetIds, setSavingAssetIds] = useState<Set<string>>(new Set())
+
+  // Rental properties only: pensions/policies (e.g. CPF) also live in
+  // PrivateAssetConfig, and a zero-rent property has no income to suppress.
+  const rentalProperties = configs.filter(
+    (c) => !c.isPrimaryResidence && !c.isPension && c.monthlyRentalIncome > 0,
+  )
+
+  if (phases.length === 0 || rentalProperties.length === 0) {
+    return null
+  }
+
+  const setSaving = (assetId: string, saving: boolean): void => {
+    setSavingAssetIds((prev) => {
+      const next = new Set(prev)
+      if (saving) {
+        next.add(assetId)
+      } else {
+        next.delete(assetId)
+      }
+      return next
+    })
+  }
+
+  const handleChange = async (
+    assetId: string,
+    value: string,
+  ): Promise<void> => {
+    setSaving(assetId, true)
+    try {
+      if (value === RENTED_THROUGHOUT) {
+        if (getPropertyIncomeForAsset(assetId)) {
+          await deletePropertyIncome(assetId)
+        }
+        return
+      }
+
+      const config = configs.find((c) => c.assetId === assetId)
+      if (!config) return
+
+      const fromAge = Number(value)
+      const request: PropertyIncomeRequest = {
+        assetId,
+        assetName: assetNames[assetId],
+        monthlyRentalIncome: config.monthlyRentalIncome,
+        rentalCurrency: config.rentalCurrency,
+        liquidationPriority: config.liquidationPriority,
+        isPrimaryResidence: false,
+        occupiedFromAge: fromAge,
+      }
+      await savePropertyIncome(request)
+    } finally {
+      setSaving(assetId, false)
+    }
+  }
+
+  const isLoading = configsLoading || incomesLoading
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium text-gray-700 mb-2">
+        Residence Phase
+      </h3>
+      <p className="text-xs text-gray-500 mb-2">
+        Choose the phase in which you move into each rental property, or leave
+        it rented throughout.
+      </p>
+      <div className="border border-gray-200 rounded-lg divide-y divide-gray-100">
+        {rentalProperties.map((config) => {
+          const row = getPropertyIncomeForAsset(config.assetId)
+          const occupiedFromAge = row?.occupiedFromAge
+          const hasOccupiedFromAge =
+            occupiedFromAge !== undefined && occupiedFromAge !== null
+          const matchedPhase = hasOccupiedFromAge
+            ? phases.find((p) => p.fromAge === occupiedFromAge)
+            : undefined
+          const selectedValue = !hasOccupiedFromAge
+            ? RENTED_THROUGHOUT
+            : matchedPhase
+              ? String(occupiedFromAge)
+              : `custom-${occupiedFromAge}`
+
+          const assetLabel = assetNames[config.assetId] || config.assetId
+          const saving = savingAssetIds.has(config.assetId)
+
+          return (
+            <div
+              key={config.assetId}
+              className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-sm min-w-0"
+            >
+              <div className="min-w-0">
+                <span className="font-medium text-gray-700 truncate">
+                  {assetLabel}
+                </span>
+                <span className="ml-2 text-xs text-gray-500">
+                  {config.rentalCurrency}{" "}
+                  {config.monthlyRentalIncome.toLocaleString()}/mo
+                </span>
+              </div>
+              <select
+                aria-label={`${assetLabel} residence phase`}
+                value={selectedValue}
+                disabled={isLoading || saving}
+                onChange={(e) => {
+                  void handleChange(config.assetId, e.target.value)
+                }}
+                className="px-2 py-1 border border-gray-300 rounded text-sm focus:ring-1 focus:ring-independence-500 focus:border-independence-500 disabled:opacity-50"
+              >
+                <option value={RENTED_THROUGHOUT}>Rented throughout</option>
+                {phases.map((phase) => (
+                  <option key={phase.planId} value={String(phase.fromAge)}>
+                    {getPlanName(plans, phase.planId)} — from age{" "}
+                    {phase.fromAge}
+                  </option>
+                ))}
+                {hasOccupiedFromAge && !matchedPhase && (
+                  <option value={`custom-${occupiedFromAge}`} disabled>
+                    From age {occupiedFromAge}
+                  </option>
+                )}
+              </select>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/independence/composite/__tests__/BenefitsStartPhasePicker.test.tsx
+++ b/src/components/features/independence/composite/__tests__/BenefitsStartPhasePicker.test.tsx
@@ -1,0 +1,261 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import type { CompositePhase, RetirementPlan } from "types/independence"
+import {
+  CompositeProjectionProvider,
+  type CompositeProjectionValue,
+} from "../CompositeProjectionContext"
+
+const mutateMock = jest.fn()
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+  mutate: (...args: unknown[]) => mutateMock(...args),
+}))
+
+import BenefitsStartPhasePicker from "../BenefitsStartPhasePicker"
+
+function makePlan(overrides: Partial<RetirementPlan> = {}): RetirementPlan {
+  return {
+    id: "p1",
+    name: "Asia Plan",
+    planningHorizonYears: 30,
+    monthlyExpenses: 5000,
+    expensesCurrency: "NZD",
+    cashReturnRate: 0.015,
+    equityReturnRate: 0.07,
+    housingReturnRate: 0.04,
+    inflationRate: 0.025,
+    feeRate: 0.001,
+    investmentTaxRate: 0.28,
+    cashAllocation: 0.2,
+    equityAllocation: 0.8,
+    housingAllocation: 0,
+    pensionMonthly: 0,
+    socialSecurityMonthly: 1000,
+    benefitsStartAge: undefined,
+    otherIncomeMonthly: 0,
+    workingIncomeMonthly: 0,
+    workingExpensesMonthly: 0,
+    taxesMonthly: 0,
+    bonusMonthly: 0,
+    investmentAllocationPercent: 0.8,
+    ...overrides,
+  } as RetirementPlan
+}
+
+const defaultPhases: CompositePhase[] = [
+  { planId: "p1", fromAge: 60, toAge: 75 },
+  { planId: "p2", fromAge: 75 },
+]
+
+function makeCtx(
+  overrides: Partial<CompositeProjectionValue> = {},
+): CompositeProjectionValue {
+  return {
+    plans: [
+      makePlan({ id: "p1", name: "Asia Plan" }),
+      makePlan({ id: "p2", name: "Europe Plan" }),
+    ],
+    phases: defaultPhases,
+    setPhases: jest.fn(),
+    displayCurrency: "USD",
+    setDisplayCurrency: jest.fn(),
+    excludedPlanIds: new Set<string>(),
+    toggleExclusion: jest.fn(),
+    compositeNarrative: "",
+    setCompositeNarrative: jest.fn(),
+    compositeWorkScenarioId: undefined,
+    setCompositeWorkScenarioId: jest.fn(),
+    projection: undefined,
+    scenarios: undefined,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  }
+}
+
+function renderWithCtx(
+  ctxOverrides: Partial<CompositeProjectionValue> = {},
+): void {
+  const ctx = makeCtx(ctxOverrides)
+  render(
+    <CompositeProjectionProvider value={ctx}>
+      <BenefitsStartPhasePicker />
+    </CompositeProjectionProvider>,
+  )
+}
+
+describe("BenefitsStartPhasePicker", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+  })
+
+  it("renders null when there are no phases", () => {
+    const { container } = render(
+      <CompositeProjectionProvider value={makeCtx({ phases: [] })}>
+        <BenefitsStartPhasePicker />
+      </CompositeProjectionProvider>,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders one option per distinct phase plan, plus a disabled 'Not set' option when all plans are null", () => {
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement
+    const options = Array.from(select.querySelectorAll("option"))
+    // disabled "Not set" + Asia Plan (60) + Europe Plan (75)
+    expect(options).toHaveLength(3)
+    expect(options[0]).toHaveTextContent("Not set (starts at retirement)")
+    expect(options[0]).toBeDisabled()
+    expect(options[1]).toHaveTextContent(/Asia Plan/)
+    expect(options[1]).toHaveTextContent(/from age 60/)
+    expect(options[2]).toHaveTextContent(/Europe Plan/)
+    expect(options[2]).toHaveTextContent(/from age 75/)
+    expect(select.value).toBe("not-set")
+  })
+
+  it("selects the matching phase when all phase plans agree with a phase's fromAge, without a disabled option", () => {
+    renderWithCtx({
+      plans: [
+        makePlan({ id: "p1", name: "Asia Plan", benefitsStartAge: 75 }),
+        makePlan({ id: "p2", name: "Europe Plan", benefitsStartAge: 75 }),
+      ],
+    })
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement
+    const options = Array.from(select.querySelectorAll("option"))
+    expect(options).toHaveLength(2)
+    expect(select.value).toBe("75")
+  })
+
+  it("shows a disabled 'From age N' option when all plans agree but match no phase", () => {
+    renderWithCtx({
+      plans: [
+        makePlan({ id: "p1", name: "Asia Plan", benefitsStartAge: 68 }),
+        makePlan({ id: "p2", name: "Europe Plan", benefitsStartAge: 68 }),
+      ],
+    })
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement
+    const options = Array.from(select.querySelectorAll("option"))
+    expect(options).toHaveLength(3)
+    const extra = options.find((o) => o.textContent?.includes("68"))
+    expect(extra).toBeDefined()
+    expect(extra).toBeDisabled()
+    expect(select.value).toBe("custom-68")
+  })
+
+  it("shows a disabled 'Mixed' option when phase plans disagree", () => {
+    renderWithCtx({
+      plans: [
+        makePlan({ id: "p1", name: "Asia Plan", benefitsStartAge: 60 }),
+        makePlan({ id: "p2", name: "Europe Plan", benefitsStartAge: 75 }),
+      ],
+    })
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement
+    const options = Array.from(select.querySelectorAll("option"))
+    expect(options.some((o) => o.textContent === "Mixed")).toBe(true)
+    const mixedOption = options.find((o) => o.textContent === "Mixed")
+    expect(mixedOption).toBeDisabled()
+    expect(select.value).toBe("mixed")
+  })
+
+  it("picking a phase PATCHes every distinct phase plan with benefitsStartAge = phase.fromAge", async () => {
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox")
+    fireEvent.change(select, { target: { value: "75" } })
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+
+    const fetchMock = global.fetch as jest.Mock
+    const urls = fetchMock.mock.calls.map((c) => c[0])
+    expect(urls).toEqual([
+      "/api/independence/plans/p1",
+      "/api/independence/plans/p2",
+    ])
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(init.method).toBe("PATCH")
+      const body = JSON.parse(init.body)
+      // Overridden field...
+      expect(body.benefitsStartAge).toBe(75)
+      // ...plus a full plan echo: svc-retire's PATCH replaces every field it
+      // receives and defaults absent ones, so a partial body would 400
+      // (name/monthlyExpenses required) or silently reset plan settings.
+      expect(body.name).toMatch(/Plan$/)
+      expect(body.monthlyExpenses).toBe(5000)
+      expect(body.expensesCurrency).toBe("NZD")
+      expect(body.planningHorizonYears).toBe(30)
+      expect(body.feeRate).toBe(0.001)
+    }
+  })
+
+  it("dedupes phase plans that share a planId — one update per distinct plan", async () => {
+    renderWithCtx({
+      phases: [
+        { planId: "p1", fromAge: 60, toAge: 65 },
+        { planId: "p1", fromAge: 65, toAge: 75 },
+        { planId: "p2", fromAge: 75 },
+      ],
+    })
+
+    const select = screen.getByRole("combobox")
+    fireEvent.change(select, { target: { value: "75" } })
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it("triggers plans revalidation after a successful update", async () => {
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox")
+    fireEvent.change(select, { target: { value: "75" } })
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalledWith("/api/independence/plans")
+    })
+  })
+
+  it("disables the select while saving", async () => {
+    const resolvers: Array<() => void> = []
+    global.fetch = jest.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(() =>
+            resolve({ ok: true, json: () => Promise.resolve({}) }),
+          )
+        }),
+    )
+
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement
+    fireEvent.change(select, { target: { value: "75" } })
+
+    await waitFor(() => {
+      expect(select).toBeDisabled()
+    })
+
+    // Component awaits sequentially — resolve each fetch as it appears.
+    resolvers.shift()?.()
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+    resolvers.shift()?.()
+
+    await waitFor(() => {
+      expect(select).not.toBeDisabled()
+    })
+  })
+})

--- a/src/components/features/independence/composite/__tests__/PhasesTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/PhasesTab.test.tsx
@@ -32,6 +32,26 @@ jest.mock("@hooks/usePrivacyMode", () => ({
   usePrivacyMode: () => ({ hideValues: false }),
 }))
 
+// Stub ResidencePhasePicker — its own hook wiring is covered by
+// ResidencePhasePicker.test.tsx; here we only assert PhasesTab renders it.
+jest.mock("../ResidencePhasePicker", () => ({
+  __esModule: true,
+  default: (): React.ReactElement => (
+    <div data-testid="residence-phase-picker">ResidencePhasePicker stub</div>
+  ),
+}))
+
+// Stub BenefitsStartPhasePicker — its own hook wiring is covered by
+// BenefitsStartPhasePicker.test.tsx; here we only assert PhasesTab renders it.
+jest.mock("../BenefitsStartPhasePicker", () => ({
+  __esModule: true,
+  default: (): React.ReactElement => (
+    <div data-testid="benefits-start-phase-picker">
+      BenefitsStartPhasePicker stub
+    </div>
+  ),
+}))
+
 import PhasesTab from "../tabs/PhasesTab"
 
 const defaultPhases: CompositePhase[] = [
@@ -128,6 +148,20 @@ describe("PhasesTab", () => {
   it("renders PhaseConfigList in both desktop and mobile layouts", () => {
     renderWithCtx()
     const stubs = screen.getAllByTestId("phase-config-list")
+    // desktop layout + mobile flip card (front face)
+    expect(stubs.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("renders ResidencePhasePicker below the phase list in both layouts", () => {
+    renderWithCtx()
+    const stubs = screen.getAllByTestId("residence-phase-picker")
+    // desktop layout + mobile flip card (front face)
+    expect(stubs.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("renders BenefitsStartPhasePicker below ResidencePhasePicker in both layouts", () => {
+    renderWithCtx()
+    const stubs = screen.getAllByTestId("benefits-start-phase-picker")
     // desktop layout + mobile flip card (front face)
     expect(stubs.length).toBeGreaterThanOrEqual(2)
   })

--- a/src/components/features/independence/composite/__tests__/ResidencePhasePicker.test.tsx
+++ b/src/components/features/independence/composite/__tests__/ResidencePhasePicker.test.tsx
@@ -1,0 +1,331 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import type { CompositePhase, PlanPropertyIncome } from "types/independence"
+import type { PrivateAssetConfig } from "types/beancounter"
+import {
+  CompositeProjectionProvider,
+  type CompositeProjectionValue,
+} from "../CompositeProjectionContext"
+
+const savePropertyIncome = jest.fn()
+const deletePropertyIncome = jest.fn()
+const getPropertyIncomeForAsset = jest.fn()
+
+jest.mock("@utils/independence/usePropertyIncomes", () => ({
+  usePropertyIncomes: jest.fn(() => ({
+    propertyIncomes: [],
+    isLoading: false,
+    error: undefined,
+    savePropertyIncome,
+    deletePropertyIncome,
+    getPropertyIncomeForAsset,
+    getTotalRentalByCurrency: jest.fn(() => ({})),
+    getPropertiesByLiquidationOrder: jest.fn(() => []),
+  })),
+}))
+
+const usePrivateAssetConfigsMock = jest.fn()
+jest.mock("@utils/assets/usePrivateAssetConfigs", () => ({
+  usePrivateAssetConfigs: (): unknown => usePrivateAssetConfigsMock(),
+}))
+
+import ResidencePhasePicker from "../ResidencePhasePicker"
+
+function makeConfig(
+  overrides: Partial<PrivateAssetConfig> = {},
+): PrivateAssetConfig {
+  return {
+    assetId: "asset-1",
+    monthlyRentalIncome: 2000,
+    rentalCurrency: "SGD",
+    countryCode: "SG",
+    monthlyManagementFee: 0,
+    managementFeePercent: 0,
+    monthlyBodyCorporateFee: 0,
+    annualPropertyTax: 0,
+    annualInsurance: 0,
+    monthlyOtherExpenses: 0,
+    deductIncomeTax: false,
+    isPrimaryResidence: false,
+    liquidationPriority: 1,
+    transactionDayOfMonth: 1,
+    autoGenerateTransactions: false,
+    isPension: false,
+    createdDate: "2025-01-01",
+    updatedDate: "2025-01-01",
+    ...overrides,
+  }
+}
+
+function makePropertyIncome(
+  overrides: Partial<PlanPropertyIncome> = {},
+): PlanPropertyIncome {
+  return {
+    id: "pi-1",
+    planId: "p1",
+    assetId: "asset-1",
+    assetName: "Rental Condo",
+    monthlyRentalIncome: 2000,
+    rentalCurrency: "SGD",
+    isPrimaryResidence: false,
+    liquidationPriority: 1,
+    createdDate: "2025-01-01",
+    updatedDate: "2025-01-01",
+    ...overrides,
+  }
+}
+
+const defaultPhases: CompositePhase[] = [
+  { planId: "p1", fromAge: 60, toAge: 75 },
+  { planId: "p2", fromAge: 75 },
+]
+
+function makeCtx(
+  overrides: Partial<CompositeProjectionValue> = {},
+): CompositeProjectionValue {
+  return {
+    plans: [
+      // Minimal RetirementPlan shape — only fields the component reads.
+      { id: "p1", name: "Asia Plan" } as never,
+      { id: "p2", name: "Europe Plan" } as never,
+    ],
+    phases: defaultPhases,
+    setPhases: jest.fn(),
+    displayCurrency: "USD",
+    setDisplayCurrency: jest.fn(),
+    excludedPlanIds: new Set<string>(),
+    toggleExclusion: jest.fn(),
+    compositeNarrative: "",
+    setCompositeNarrative: jest.fn(),
+    compositeWorkScenarioId: undefined,
+    setCompositeWorkScenarioId: jest.fn(),
+    projection: undefined,
+    scenarios: undefined,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  }
+}
+
+function renderWithCtx(
+  ctxOverrides: Partial<CompositeProjectionValue> = {},
+): void {
+  const ctx = makeCtx(ctxOverrides)
+  render(
+    <CompositeProjectionProvider value={ctx}>
+      <ResidencePhasePicker />
+    </CompositeProjectionProvider>,
+  )
+}
+
+describe("ResidencePhasePicker", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getPropertyIncomeForAsset.mockReturnValue(undefined)
+    usePrivateAssetConfigsMock.mockReturnValue({
+      configs: [makeConfig()],
+      assetNames: { "asset-1": "Rental Condo" },
+      isLoading: false,
+      error: undefined,
+      saveConfig: jest.fn(),
+      deleteConfig: jest.fn(),
+      getConfigForAsset: jest.fn(),
+      getTotalRentalByCurrency: jest.fn(() => ({})),
+      getNetRentalByCurrency: jest.fn(() => ({})),
+      getConfigsByLiquidationOrder: jest.fn(() => []),
+      isComposite: jest.fn(() => false),
+      getCompositeConfigs: jest.fn(() => []),
+      getCompositeTotal: jest.fn(() => 0),
+      getCompositeLiquidTotal: jest.fn(() => 0),
+    })
+  })
+
+  it("renders one row per rental property, excluding primary residence", () => {
+    usePrivateAssetConfigsMock.mockReturnValue({
+      ...usePrivateAssetConfigsMock(),
+      configs: [
+        makeConfig({ assetId: "asset-1" }),
+        makeConfig({ assetId: "asset-2", isPrimaryResidence: true }),
+      ],
+      assetNames: { "asset-1": "Rental Condo", "asset-2": "Home" },
+    })
+
+    renderWithCtx()
+
+    expect(screen.getAllByRole("combobox")).toHaveLength(1)
+    expect(screen.getByText("Rental Condo")).toBeInTheDocument()
+    expect(screen.queryByText("Home")).not.toBeInTheDocument()
+  })
+
+  it("excludes pension configs and zero-rent properties", () => {
+    usePrivateAssetConfigsMock.mockReturnValue({
+      ...usePrivateAssetConfigsMock(),
+      configs: [
+        makeConfig({ assetId: "asset-1" }),
+        makeConfig({ assetId: "cpf-1", isPension: true }),
+        makeConfig({ assetId: "asset-3", monthlyRentalIncome: 0 }),
+      ],
+      assetNames: {
+        "asset-1": "Rental Condo",
+        "cpf-1": "CPF",
+        "asset-3": "Empty Section",
+      },
+    })
+
+    renderWithCtx()
+
+    expect(screen.getAllByRole("combobox")).toHaveLength(1)
+    expect(screen.getByText("Rental Condo")).toBeInTheDocument()
+    expect(screen.queryByText("CPF")).not.toBeInTheDocument()
+    expect(screen.queryByText("Empty Section")).not.toBeInTheDocument()
+  })
+
+  it("renders null when there are no phases", () => {
+    const { container } = render(
+      <CompositeProjectionProvider value={makeCtx({ phases: [] })}>
+        <ResidencePhasePicker />
+      </CompositeProjectionProvider>,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders null when there are no rental properties", () => {
+    usePrivateAssetConfigsMock.mockReturnValue({
+      ...usePrivateAssetConfigsMock(),
+      configs: [],
+    })
+
+    const { container } = renderWithCtxAndCapture()
+    expect(container).toBeEmptyDOMElement()
+
+    function renderWithCtxAndCapture(): ReturnType<typeof render> {
+      const ctx = makeCtx()
+      return render(
+        <CompositeProjectionProvider value={ctx}>
+          <ResidencePhasePicker />
+        </CompositeProjectionProvider>,
+      )
+    }
+  })
+
+  it("select includes a placeholder option plus one option per phase", () => {
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox")
+    const options = Array.from(select.querySelectorAll("option"))
+    // "Rented throughout" + Asia Plan (60) + Europe Plan (75)
+    expect(options).toHaveLength(3)
+    expect(options[0]).toHaveTextContent("Rented throughout")
+    expect(options[0]).toHaveValue("")
+    expect(options[1]).toHaveTextContent(/Asia Plan/)
+    expect(options[1]).toHaveTextContent(/from age 60/)
+    expect(options[2]).toHaveTextContent(/Europe Plan/)
+    expect(options[2]).toHaveTextContent(/from age 75/)
+  })
+
+  it("derives the current selection from occupiedFromAge", () => {
+    getPropertyIncomeForAsset.mockReturnValue(
+      makePropertyIncome({ occupiedFromAge: 75 }),
+    )
+
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement
+    expect(select.value).toBe("75")
+  })
+
+  it("shows an extra disabled option when occupiedFromAge doesn't match any phase", () => {
+    getPropertyIncomeForAsset.mockReturnValue(
+      makePropertyIncome({ occupiedFromAge: 68 }),
+    )
+
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement
+    const options = Array.from(select.querySelectorAll("option"))
+    expect(options).toHaveLength(4)
+    const extra = options.find((o) => o.textContent?.includes("68"))
+    expect(extra).toBeDefined()
+    expect(extra).toBeDisabled()
+    expect(select.value).toBe("custom-68")
+  })
+
+  it("picking a phase calls savePropertyIncome with occupiedFromAge and mirrored amount fields", async () => {
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox")
+    fireEvent.change(select, { target: { value: "75" } })
+
+    await waitFor(() => {
+      expect(savePropertyIncome).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetId: "asset-1",
+          assetName: "Rental Condo",
+          monthlyRentalIncome: 2000,
+          rentalCurrency: "SGD",
+          liquidationPriority: 1,
+          isPrimaryResidence: false,
+          occupiedFromAge: 75,
+        }),
+      )
+    })
+  })
+
+  it('picking "Rented throughout" deletes an existing row', async () => {
+    getPropertyIncomeForAsset.mockReturnValue(
+      makePropertyIncome({ occupiedFromAge: 75 }),
+    )
+
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox")
+    fireEvent.change(select, { target: { value: "" } })
+
+    await waitFor(() => {
+      expect(deletePropertyIncome).toHaveBeenCalledWith("asset-1")
+    })
+  })
+
+  it('picking "Rented throughout" is a no-op when no row exists', async () => {
+    getPropertyIncomeForAsset.mockReturnValue(undefined)
+
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox")
+    // Already "Rented throughout" — re-picking it should still fire onChange
+    // (placeholder option is present in the DOM, not removed on selection).
+    fireEvent.change(select, { target: { value: "" } })
+
+    await waitFor(() => {
+      expect(select).toBeInTheDocument()
+    })
+    expect(deletePropertyIncome).not.toHaveBeenCalled()
+    expect(savePropertyIncome).not.toHaveBeenCalled()
+  })
+
+  it("re-picking after selection still fires onChange (placeholder option present)", async () => {
+    getPropertyIncomeForAsset.mockReturnValue(
+      makePropertyIncome({ occupiedFromAge: 60 }),
+    )
+
+    renderWithCtx()
+
+    const select = screen.getByRole("combobox")
+    const options = Array.from(select.querySelectorAll("option"))
+    // Placeholder ("Rented throughout") must be present alongside the
+    // currently-selected phase option, else re-selecting the same value
+    // wouldn't fire a change event in a real browser.
+    expect(options.some((o) => o.textContent === "Rented throughout")).toBe(
+      true,
+    )
+
+    // Re-picking "Rented throughout" while a row exists should delete it —
+    // proves the onChange handler fires even though the placeholder was
+    // already rendered (not swapped in dynamically).
+    fireEvent.change(select, { target: { value: "" } })
+    await waitFor(() => {
+      expect(deletePropertyIncome).toHaveBeenCalledWith("asset-1")
+    })
+  })
+})

--- a/src/components/features/independence/composite/tabs/PhasesTab.tsx
+++ b/src/components/features/independence/composite/tabs/PhasesTab.tsx
@@ -1,5 +1,7 @@
 import React from "react"
 import PhaseConfigList from "../../PhaseConfigList"
+import ResidencePhasePicker from "../ResidencePhasePicker"
+import BenefitsStartPhasePicker from "../BenefitsStartPhasePicker"
 import FlipCard from "@components/ui/FlipCard"
 import Spinner from "@components/ui/Spinner"
 import Alert from "@components/ui/Alert"
@@ -75,7 +77,7 @@ export default function PhasesTab(): React.ReactElement {
           className="hidden lg:flex gap-6"
           data-testid="phases-desktop-layout"
         >
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0 space-y-4">
             <PhaseConfigList
               plans={plans}
               phases={phases}
@@ -83,6 +85,8 @@ export default function PhasesTab(): React.ReactElement {
               onExclude={toggleExclusion}
               excludedPlanIds={excludedPlanIds}
             />
+            <ResidencePhasePicker />
+            <BenefitsStartPhasePicker />
           </div>
           <div className="w-72 shrink-0">
             <NarrativeField
@@ -99,13 +103,17 @@ export default function PhasesTab(): React.ReactElement {
             frontLabel="Phases"
             backLabel="Narrative"
             front={
-              <PhaseConfigList
-                plans={plans}
-                phases={phases}
-                onPhaseChange={setPhases}
-                onExclude={toggleExclusion}
-                excludedPlanIds={excludedPlanIds}
-              />
+              <div className="space-y-4">
+                <PhaseConfigList
+                  plans={plans}
+                  phases={phases}
+                  onPhaseChange={setPhases}
+                  onExclude={toggleExclusion}
+                  excludedPlanIds={excludedPlanIds}
+                />
+                <ResidencePhasePicker />
+                <BenefitsStartPhasePicker />
+              </div>
             }
             back={
               <NarrativeField

--- a/src/lib/utils/independence/planHelpers.ts
+++ b/src/lib/utils/independence/planHelpers.ts
@@ -3,7 +3,57 @@ import {
   AssetDisposal,
   LifeEvent,
   ManualAssetCategory,
+  RetirementPlan,
 } from "types/independence"
+
+/**
+ * Echo a plan's full mutable state as a PlanRequest payload.
+ *
+ * svc-retire's PATCH /plans/{id} consumes a full PlanRequest: every
+ * non-null field REPLACES the stored value and absent fields fall back to
+ * request defaults (e.g. planningHorizonYears 25, expensesCurrency "USD",
+ * feeRate 0) — a partial body silently clobbers plan settings. Any caller
+ * updating a single field must spread this payload and override just the
+ * fields it means to change.
+ */
+export function toPlanRequestPayload(
+  plan: RetirementPlan,
+): Record<string, unknown> {
+  return {
+    name: plan.name,
+    planningHorizonYears: plan.planningHorizonYears,
+    monthlyExpenses: plan.monthlyExpenses,
+    expensesCurrency: plan.expensesCurrency,
+    targetBalance: plan.targetBalance ?? null,
+    cashReturnRate: plan.cashReturnRate,
+    equityReturnRate: plan.equityReturnRate,
+    housingReturnRate: plan.housingReturnRate,
+    inflationRate: plan.inflationRate,
+    feeRate: plan.feeRate ?? 0,
+    investmentTaxRate: plan.investmentTaxRate ?? 0,
+    cashAllocation: plan.cashAllocation,
+    equityAllocation: plan.equityAllocation,
+    housingAllocation: plan.housingAllocation,
+    pensionMonthly: plan.pensionMonthly,
+    socialSecurityMonthly: plan.socialSecurityMonthly,
+    benefitsStartAge: plan.benefitsStartAge ?? null,
+    otherIncomeMonthly: plan.otherIncomeMonthly,
+    workingIncomeMonthly: plan.workingIncomeMonthly,
+    workingExpensesMonthly: plan.workingExpensesMonthly,
+    taxesMonthly: plan.taxesMonthly,
+    bonusMonthly: plan.bonusMonthly,
+    investmentAllocationPercent: plan.investmentAllocationPercent,
+    lifeEvents: plan.lifeEvents ?? null,
+    excludedPortfolioIds: parseExcludedPortfolioIds(plan.excludedPortfolioIds),
+    excludedRentalAssetIds: parseExcludedRentalAssetIds(
+      plan.excludedRentalAssetIds,
+    ),
+    country: plan.country ?? null,
+    narrative: plan.narrative ?? null,
+    primaryStrategy: plan.primaryStrategy ?? null,
+    headlineMetric: plan.headlineMetric ?? null,
+  }
+}
 
 /**
  * Serialise the wizard's life-events array for the plan-update payload.

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -81,6 +81,10 @@ export interface RetirementPlan {
   equityReturnRate: number
   housingReturnRate: number
   inflationRate: number
+  /** Always serialized by svc-retire; optional only to spare legacy fixtures. */
+  feeRate?: number
+  /** Always serialized by svc-retire; optional only to spare legacy fixtures. */
+  investmentTaxRate?: number
   cashAllocation: number
   equityAllocation: number
   housingAllocation: number
@@ -1016,6 +1020,12 @@ export interface PlanPropertyIncome {
   rentalCurrency: string
   isPrimaryResidence: boolean
   liquidationPriority: number
+  /**
+   * Age from which the owner occupies this property (owner-occupy from this
+   * retirement phase onward). Rental income is suppressed in projections
+   * from this age. Undefined/null means the property is rented throughout.
+   */
+  occupiedFromAge?: number
   createdDate: string
   updatedDate: string
 }
@@ -1027,6 +1037,12 @@ export interface PropertyIncomeRequest {
   rentalCurrency?: string
   isPrimaryResidence?: boolean
   liquidationPriority?: number
+  /**
+   * Age from which the owner occupies this property (owner-occupy from this
+   * retirement phase onward). Rental income is suppressed in projections
+   * from this age. Omitting this field clears it to null (rented throughout).
+   */
+  occupiedFromAge?: number
 }
 
 export interface PropertyIncomeResponse {


### PR DESCRIPTION
## Summary
bc-view side of monowai/svc-retire#162 (backend PR monowai/svc-retire#166).

- **ResidencePhasePicker** (composite Phases tab): per rental property choose "Rented throughout" or the phase the owner moves in — saves `occupiedFromAge = phase.fromAge` through the plan-scoped `/plans/{id}/properties` endpoints; projections then suppress that property's rental from the occupancy boundary. Pensions (CPF) and zero-rent configs filtered out.
- **BenefitsStartPhasePicker**: choose the phase NZ Super / benefits start; writes `benefitsStartAge = phase.fromAge` to every phase plan using a full-plan echo (`toPlanRequestPayload`) because svc-retire's PATCH replaces absent fields with request defaults (see monowai/bc-view#1118 for the pre-existing scenario-save clobber this exposed).
- Types: `occupiedFromAge` on `PlanPropertyIncome`/`PropertyIncomeRequest`; `feeRate`/`investmentTaxRate` declared on `RetirementPlan`.

## Testing
- 2274+ unit tests green; prettier/lint/typecheck clean.
- Browser-verified on local worktree stack (svc-retire#166 backend): residence pick → POST 201 → persisted; revert → DELETE 204; re-pick fires (placeholder-option rule); benefits pick → three PATCH 200s, DB confirms `benefits_start_age=72` on all phase plans with per-phase expenses/rates intact; PhaseConfigList fromAge editing regression-checked.

## Out of scope
- Rent-amount source reconciliation: monowai/svc-retire#165
- Scenario-save partial-PATCH clobber: monowai/bc-view#1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
