### PR TITLE
fix(independence): full-plan echo on every plan PATCH — stop silent field resets

### DIFF
--- a/src/components/features/independence/WizardContainer.tsx
+++ b/src/components/features/independence/WizardContainer.tsx
@@ -25,8 +25,9 @@ import { toDecimal } from "@lib/independence/conversions"
 import {
   serializeAssetDisposals,
   serializeLifeEvents,
+  toPlanRequestPayload,
 } from "@lib/independence/planHelpers"
-import { WizardFormData, PlanRequest } from "types/independence"
+import { WizardFormData, RetirementPlan } from "types/independence"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
 import { generatePhasedPlans } from "@lib/onboarding/generatePhasedPlans"
@@ -34,11 +35,87 @@ import { generatePhasedPlans } from "@lib/onboarding/generatePhasedPlans"
 interface WizardContainerProps {
   planId?: string
   initialData?: Partial<WizardFormData>
+  /**
+   * Full backend plan record, edit mode only. svc-retire's PATCH
+   * /plans/{id} consumes a full PlanRequest — see {@link buildWizardPlanRequest}.
+   */
+  plan?: RetirementPlan | null
+}
+
+/**
+ * Builds the PlanRequest body the wizard submits on Save.
+ *
+ * In edit mode, svc-retire's PATCH /plans/{id} replaces every field it
+ * receives and defaults the ones it doesn't. The wizard never surfaces
+ * feeRate, investmentTaxRate, investmentAllocationPercent or the
+ * working-phase fields (workingIncomeMonthly/workingExpensesMonthly/
+ * taxesMonthly/bonusMonthly — managed via work scenarios) as overrides, so
+ * omitting them from the body silently reset them to backend defaults (0 /
+ * 0.80) on every wizard save. Spread the full-plan echo first (edit mode
+ * only — there's no stored plan yet on create), then layer the wizard's
+ * own fields on top.
+ */
+export function buildWizardPlanRequest(
+  formData: WizardFormData,
+  ctx: {
+    isEditMode: boolean
+    plan?: RetirementPlan | null
+    planningHorizonYears: number
+    clientId?: string
+  },
+): Record<string, unknown> {
+  const monthlyExpenses = formData.expenses.reduce(
+    (sum, expense) => sum + expense.monthlyAmount,
+    0,
+  )
+
+  // Filter out zero-value manual assets before sending. An empty object
+  // is sent explicitly (not null) so the backend distinguishes "user
+  // cleared all categories" from "field omitted" and wipes the stored
+  // value — see PlanService.updatePlan PATCH semantics.
+  const manualAssets = formData.manualAssets
+    ? Object.fromEntries(
+        Object.entries(formData.manualAssets).filter(([, value]) => value > 0),
+      )
+    : {}
+
+  return {
+    ...(ctx.isEditMode && ctx.plan ? toPlanRequestPayload(ctx.plan) : {}),
+    name: formData.planName,
+    planningHorizonYears: ctx.planningHorizonYears,
+    monthlyExpenses,
+    expensesCurrency: formData.expensesCurrency,
+    targetBalance: formData.targetBalance ?? null,
+    cashReturnRate: toDecimal(formData.cashReturnRate),
+    equityReturnRate: toDecimal(formData.equityReturnRate),
+    housingReturnRate: toDecimal(formData.housingReturnRate),
+    inflationRate: toDecimal(formData.inflationRate),
+    cashAllocation: toDecimal(formData.cashAllocation),
+    equityAllocation: toDecimal(formData.equityAllocation),
+    housingAllocation: toDecimal(formData.housingAllocation),
+    pensionMonthly: formData.pensionMonthly,
+    socialSecurityMonthly: formData.socialSecurityMonthly,
+    benefitsStartAge: formData.benefitsStartAge,
+    otherIncomeMonthly: formData.otherIncomeMonthly,
+    // Always send the JSON-serialised array (incl. "[]") so the
+    // backend distinguishes "list cleared" from "field omitted".
+    lifeEvents: serializeLifeEvents(formData.lifeEvents),
+    assetDisposals: serializeAssetDisposals(formData.assetDisposals),
+    manualAssets,
+    excludedPortfolioIds: formData.excludedPortfolioIds || [],
+    excludedRentalAssetIds: formData.excludedRentalAssetIds || [],
+    country: formData.country?.trim() || undefined,
+    narrative: formData.narrative?.trim() || undefined,
+    primaryStrategy: formData.primaryStrategy || undefined,
+    headlineMetric: formData.headlineMetric || undefined,
+    ...(!ctx.isEditMode && { clientId: ctx.clientId?.trim() || undefined }),
+  }
 }
 
 export default function WizardContainer({
   planId,
   initialData,
+  plan,
 }: WizardContainerProps): React.ReactElement {
   const isEditMode = Boolean(planId)
   const router = useRouter()
@@ -177,57 +254,14 @@ export default function WizardContainer({
       const settingsTargetAge = settings?.targetIndependenceAge ?? 65
       const planningHorizonYears = settingsLifeExpectancy - settingsTargetAge
 
-      // Calculate total monthly expenses
-      const monthlyExpenses = formData.expenses.reduce(
-        (sum, expense) => sum + expense.monthlyAmount,
-        0,
-      )
-
-      // Filter out zero-value manual assets before sending. An empty object
-      // is sent explicitly (not null) so the backend distinguishes "user
-      // cleared all categories" from "field omitted" and wipes the stored
-      // value — see PlanService.updatePlan PATCH semantics.
-      const manualAssets = formData.manualAssets
-        ? Object.fromEntries(
-            Object.entries(formData.manualAssets).filter(
-              ([, value]) => value > 0,
-            ),
-          )
-        : {}
-
       // Backend stores decimals (0.07 for 7%), so convert from percentage
       // yearOfBirth and lifeExpectancy are now user-level settings, not plan-level
-      // Working-phase fields are managed via work scenarios, not the plan wizard
-      const planRequest: PlanRequest = {
-        name: formData.planName,
+      const planRequest = buildWizardPlanRequest(formData, {
+        isEditMode,
+        plan,
         planningHorizonYears,
-        monthlyExpenses,
-        expensesCurrency: formData.expensesCurrency,
-        targetBalance: formData.targetBalance ?? null,
-        cashReturnRate: toDecimal(formData.cashReturnRate),
-        equityReturnRate: toDecimal(formData.equityReturnRate),
-        housingReturnRate: toDecimal(formData.housingReturnRate),
-        inflationRate: toDecimal(formData.inflationRate),
-        cashAllocation: toDecimal(formData.cashAllocation),
-        equityAllocation: toDecimal(formData.equityAllocation),
-        housingAllocation: toDecimal(formData.housingAllocation),
-        pensionMonthly: formData.pensionMonthly,
-        socialSecurityMonthly: formData.socialSecurityMonthly,
-        benefitsStartAge: formData.benefitsStartAge,
-        otherIncomeMonthly: formData.otherIncomeMonthly,
-        // Always send the JSON-serialised array (incl. "[]") so the
-        // backend distinguishes "list cleared" from "field omitted".
-        lifeEvents: serializeLifeEvents(formData.lifeEvents),
-        assetDisposals: serializeAssetDisposals(formData.assetDisposals),
-        manualAssets,
-        excludedPortfolioIds: formData.excludedPortfolioIds || [],
-        excludedRentalAssetIds: formData.excludedRentalAssetIds || [],
-        country: formData.country?.trim() || undefined,
-        narrative: formData.narrative?.trim() || undefined,
-        primaryStrategy: formData.primaryStrategy || undefined,
-        headlineMetric: formData.headlineMetric || undefined,
-        ...(!isEditMode && { clientId: clientId.trim() || undefined }),
-      }
+        clientId,
+      })
 
       const url = isEditMode
         ? `/api/independence/plans/${planId}`

--- a/src/components/features/independence/__tests__/WizardContainer.test.tsx
+++ b/src/components/features/independence/__tests__/WizardContainer.test.tsx
@@ -8,7 +8,8 @@ import {
   expensesStepSchema,
   defaultWizardValues,
 } from "@lib/independence/schema"
-import { WizardFormData } from "types/independence"
+import { WizardFormData, RetirementPlan } from "types/independence"
+import { buildWizardPlanRequest } from "../WizardContainer"
 
 // Mock SWR
 const mockCategories = {
@@ -135,5 +136,125 @@ describe("ExpensesStep - Custom Category", () => {
     expect(customExpense).toBeDefined()
     expect(customExpense.categoryName).toBe("Pet Insurance")
     expect(customExpense.monthlyAmount).toBe(75)
+  })
+})
+
+describe("buildWizardPlanRequest", () => {
+  // Regression #1118: svc-retire's PATCH /plans/{id} consumes a full
+  // PlanRequest — any field the wizard doesn't explicitly override falls
+  // back to backend defaults and REPLACES the stored value. The wizard
+  // never surfaces feeRate/investmentTaxRate/investmentAllocationPercent or
+  // the working-phase fields as overrides, so omitting them from the body
+  // silently reset them on every edit-mode save.
+  const formData: WizardFormData = {
+    ...defaultWizardValues,
+    planName: "My Plan",
+    expensesCurrency: "NZD",
+    cashReturnRate: 3,
+    equityReturnRate: 7,
+    housingReturnRate: 4,
+    inflationRate: 2.5,
+    cashAllocation: 30,
+    equityAllocation: 70,
+    housingAllocation: 0,
+    pensionMonthly: 800,
+    socialSecurityMonthly: 200,
+    otherIncomeMonthly: 100,
+    expenses: [
+      {
+        categoryLabelId: "housing",
+        categoryName: "Housing",
+        monthlyAmount: 2000,
+      },
+    ],
+    manualAssets: { CASH: 0, EQUITY: 0, ETF: 0, MUTUAL_FUND: 0, RE: 0 },
+    lifeEvents: [],
+    assetDisposals: [],
+    contributions: [],
+    selectedPortfolioIds: [],
+  } as WizardFormData
+
+  const plan: RetirementPlan = {
+    id: "p1",
+    ownerId: "u1",
+    name: "My Plan",
+    planningHorizonYears: 30,
+    lifeExpectancy: 90,
+    monthlyExpenses: 2000,
+    expensesCurrency: "NZD",
+    cashReturnRate: 0.03,
+    equityReturnRate: 0.07,
+    housingReturnRate: 0.04,
+    inflationRate: 0.025,
+    feeRate: 0.001,
+    investmentTaxRate: 0.28,
+    cashAllocation: 0.3,
+    equityAllocation: 0.7,
+    housingAllocation: 0,
+    pensionMonthly: 800,
+    socialSecurityMonthly: 200,
+    otherIncomeMonthly: 100,
+    workingIncomeMonthly: 9000,
+    workingExpensesMonthly: 4000,
+    taxesMonthly: 1500,
+    bonusMonthly: 300,
+    investmentAllocationPercent: 0.65,
+    isPrimary: true,
+    createdDate: "2026-01-01",
+    updatedDate: "2026-01-01",
+  } as RetirementPlan
+
+  it("echoes the stored plan's feeRate/investmentTaxRate/investmentAllocationPercent and working-phase fields in edit mode", () => {
+    const payload = buildWizardPlanRequest(formData, {
+      isEditMode: true,
+      plan,
+      planningHorizonYears: 30,
+    })
+    expect(payload.feeRate).toBe(0.001)
+    expect(payload.investmentTaxRate).toBe(0.28)
+    expect(payload.investmentAllocationPercent).toBe(0.65)
+    expect(payload.workingIncomeMonthly).toBe(9000)
+    expect(payload.workingExpensesMonthly).toBe(4000)
+    expect(payload.taxesMonthly).toBe(1500)
+    expect(payload.bonusMonthly).toBe(300)
+  })
+
+  it("still overrides the wizard-editable fields on top of the full-plan echo", () => {
+    const payload = buildWizardPlanRequest(
+      { ...formData, planName: "Renamed Plan", pensionMonthly: 1200 },
+      { isEditMode: true, plan, planningHorizonYears: 30 },
+    )
+    expect(payload.name).toBe("Renamed Plan")
+    expect(payload.pensionMonthly).toBe(1200)
+    expect(payload.monthlyExpenses).toBe(2000)
+  })
+
+  it("sends no plan echo (and no clientId override key) in create mode", () => {
+    const payload = buildWizardPlanRequest(formData, {
+      isEditMode: false,
+      plan: null,
+      planningHorizonYears: 30,
+    })
+    expect(payload.feeRate).toBeUndefined()
+    expect(payload.workingIncomeMonthly).toBeUndefined()
+    expect(payload.name).toBe("My Plan")
+  })
+
+  it("includes clientId in create mode, omits it in edit mode", () => {
+    const created = buildWizardPlanRequest(formData, {
+      isEditMode: false,
+      plan: null,
+      planningHorizonYears: 30,
+      clientId: "client-1",
+    })
+    expect(created.clientId).toBe("client-1")
+
+    const updated = buildWizardPlanRequest(formData, {
+      isEditMode: true,
+      plan,
+      planningHorizonYears: 30,
+      clientId: "client-1",
+    })
+    expect("clientId" in updated).toBe(false)
   })
 })

--- a/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
+++ b/src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts
@@ -3,6 +3,7 @@ import {
   applyRealReturn,
   blendedReturnRate,
   scenarioToPayload,
+  scenarioToPlanUpdatePayload,
   type ScenarioPayloadCtx,
 } from "../scenarioToPayload"
 import type { ScenarioState } from "../types"
@@ -20,6 +21,8 @@ const plan: RetirementPlan = {
   equityReturnRate: 0.07,
   housingReturnRate: 0.04,
   inflationRate: 0.025,
+  feeRate: 0.001,
+  investmentTaxRate: 0.28,
   cashAllocation: 0.3,
   equityAllocation: 0.7,
   housingAllocation: 0,
@@ -243,5 +246,87 @@ describe("applyRealReturn", () => {
     expect(r.cashReturnRate).toBeCloseTo(0.037, 5)
     expect(r.equityReturnRate).toBeCloseTo(0.077, 5)
     expect(r.housingReturnRate).toBe(0.04)
+  })
+})
+
+describe("scenarioToPlanUpdatePayload", () => {
+  // Regression #1118: svc-retire's PATCH /plans/{id} consumes a full
+  // PlanRequest — any field absent from the body falls back to backend
+  // defaults (planningHorizonYears 25, expensesCurrency "USD", feeRate 0,
+  // investmentTaxRate 0, investmentAllocationPercent 0.80) and REPLACES the
+  // stored value. The plan-save path must echo every unrelated field
+  // alongside its intended overrides.
+  it("echoes full plan settings the scenario save doesn't intend to change", () => {
+    const payload = scenarioToPlanUpdatePayload(scenario, plan, null)
+    expect(payload.planningHorizonYears).toBe(30)
+    expect(payload.expensesCurrency).toBe("SGD")
+    expect(payload.feeRate).toBe(0.001)
+    expect(payload.investmentTaxRate).toBe(0.28)
+    expect(payload.investmentAllocationPercent).toBe(0.8)
+  })
+
+  it("overrides name, income fields and inflation from the scenario / plan", () => {
+    const payload = scenarioToPlanUpdatePayload(
+      { ...scenario, monthlyExpenses: 6000, otherIncomeMonthly: 150 },
+      plan,
+      null,
+    )
+    expect(payload.name).toBe("Test plan")
+    expect(payload.monthlyExpenses).toBe(6000)
+    expect(payload.pensionMonthly).toBe(800)
+    expect(payload.socialSecurityMonthly).toBe(200)
+    expect(payload.otherIncomeMonthly).toBe(150)
+    expect(payload.inflationRate).toBe(0.025)
+  })
+
+  it("threads applyRealReturn's rates rather than the raw plan rates", () => {
+    const payload = scenarioToPlanUpdatePayload(
+      { ...scenario, realReturn: 0.04 },
+      plan,
+      null,
+    )
+    expect(payload.cashReturnRate).toBeCloseTo(0.037, 5)
+    expect(payload.equityReturnRate).toBeCloseTo(0.077, 5)
+    expect(payload.housingReturnRate).toBe(0.04)
+  })
+
+  it("carries plan allocations through unchanged (not scenario-controlled)", () => {
+    const payload = scenarioToPlanUpdatePayload(scenario, plan, null)
+    expect(payload.cashAllocation).toBe(0.3)
+    expect(payload.equityAllocation).toBe(0.7)
+    expect(payload.housingAllocation).toBe(0)
+  })
+
+  it("falls back to the plan's own exclusions when pendingExclusions is null", () => {
+    const payload = scenarioToPlanUpdatePayload(scenario, {
+      ...plan,
+      excludedPortfolioIds: ["pf-1"],
+      excludedRentalAssetIds: ["ra-1"],
+    })
+    expect(payload.excludedPortfolioIds).toEqual(["pf-1"])
+    expect(payload.excludedRentalAssetIds).toEqual(["ra-1"])
+  })
+
+  it("prefers pendingExclusions over the plan's stored exclusions", () => {
+    const payload = scenarioToPlanUpdatePayload(
+      scenario,
+      { ...plan, excludedPortfolioIds: ["pf-1"] },
+      {
+        excludedPortfolioIds: ["pf-2"],
+        excludedRentalAssetIds: ["ra-2"],
+      },
+    )
+    expect(payload.excludedPortfolioIds).toEqual(["pf-2"])
+    expect(payload.excludedRentalAssetIds).toEqual(["ra-2"])
+  })
+
+  it("partially applies pendingExclusions, falling back per-field to the plan", () => {
+    const payload = scenarioToPlanUpdatePayload(
+      scenario,
+      { ...plan, excludedRentalAssetIds: ["ra-1"] },
+      { excludedPortfolioIds: ["pf-2"] },
+    )
+    expect(payload.excludedPortfolioIds).toEqual(["pf-2"])
+    expect(payload.excludedRentalAssetIds).toEqual(["ra-1"])
   })
 })

--- a/src/components/features/independence/scenario/scenarioToPayload.ts
+++ b/src/components/features/independence/scenario/scenarioToPayload.ts
@@ -1,4 +1,9 @@
 import type { RetirementPlan } from "types/independence"
+import {
+  parseExcludedPortfolioIds,
+  parseExcludedRentalAssetIds,
+  toPlanRequestPayload,
+} from "@lib/independence/planHelpers"
 import type { RentalIncomeData } from "../useUnifiedProjection"
 import type { ScenarioState } from "./types"
 
@@ -161,6 +166,57 @@ export function applyRealReturn(
     cashReturnRate: plan.cashReturnRate + delta,
     equityReturnRate: plan.equityReturnRate + delta,
     housingReturnRate: plan.housingReturnRate,
+  }
+}
+
+/**
+ * Optional exclusion overrides pending in the Edit Plan Details modal — not
+ * part of ScenarioState (they're plan-level filters, not what-if levers).
+ * When a field is absent/undefined here, the plan's own stored value carries
+ * forward; pass `null`/omit entirely when there are no pending edits.
+ */
+export interface PendingPlanExclusions {
+  excludedPortfolioIds?: string[]
+  excludedRentalAssetIds?: string[]
+}
+
+/**
+ * Translates a ScenarioState + plan into the JSON body for the plan-root
+ * PATCH (`/api/independence/plans/{id}`) issued by the scenario Save flow.
+ *
+ * svc-retire's PATCH /plans/{id} consumes a full PlanRequest: every field
+ * absent from the body falls back to backend defaults (planningHorizonYears
+ * 25, expensesCurrency "USD", feeRate 0, investmentTaxRate 0,
+ * investmentAllocationPercent 0.80, working income/expenses/taxes/bonus 0)
+ * and REPLACES the
+ * stored value — see toPlanRequestPayload. This spreads that full-plan echo
+ * and layers only the fields the scenario save actually intends to change:
+ * name, the income/expense sliders, inflation, applyRealReturn's derived
+ * rates, and pending exclusion edits.
+ */
+export function scenarioToPlanUpdatePayload(
+  scenario: ScenarioState,
+  plan: RetirementPlan,
+  pendingExclusions?: PendingPlanExclusions | null,
+): Record<string, unknown> {
+  const rates = applyRealReturn(scenario, plan)
+  return {
+    ...toPlanRequestPayload(plan),
+    name: plan.name,
+    monthlyExpenses: scenario.monthlyExpenses,
+    pensionMonthly: scenario.pensionMonthly,
+    socialSecurityMonthly: scenario.socialSecurityMonthly,
+    otherIncomeMonthly: scenario.otherIncomeMonthly,
+    inflationRate: scenario.inflation,
+    equityReturnRate: rates.equityReturnRate,
+    cashReturnRate: rates.cashReturnRate,
+    housingReturnRate: rates.housingReturnRate,
+    excludedPortfolioIds:
+      pendingExclusions?.excludedPortfolioIds ??
+      parseExcludedPortfolioIds(plan.excludedPortfolioIds),
+    excludedRentalAssetIds:
+      pendingExclusions?.excludedRentalAssetIds ??
+      parseExcludedRentalAssetIds(plan.excludedRentalAssetIds),
   }
 }
 

--- a/src/lib/utils/independence/planHelpers.test.ts
+++ b/src/lib/utils/independence/planHelpers.test.ts
@@ -1,5 +1,131 @@
-import { LifeEvent } from "types/independence"
-import { normalizeAllocation, serializeLifeEvents } from "./planHelpers"
+import { LifeEvent, RetirementPlan } from "types/independence"
+import {
+  normalizeAllocation,
+  serializeLifeEvents,
+  toPlanRequestPayload,
+} from "./planHelpers"
+
+const plan: RetirementPlan = {
+  id: "p1",
+  ownerId: "u1",
+  name: "Test plan",
+  planningHorizonYears: 30,
+  lifeExpectancy: 90,
+  monthlyExpenses: 5000,
+  expensesCurrency: "NZD",
+  targetBalance: 1_500_000,
+  cashReturnRate: 0.03,
+  equityReturnRate: 0.07,
+  housingReturnRate: 0.04,
+  inflationRate: 0.025,
+  feeRate: 0.001,
+  investmentTaxRate: 0.28,
+  cashAllocation: 0.3,
+  equityAllocation: 0.7,
+  housingAllocation: 0,
+  pensionMonthly: 800,
+  socialSecurityMonthly: 200,
+  benefitsStartAge: 67,
+  otherIncomeMonthly: 100,
+  workingIncomeMonthly: 500,
+  workingExpensesMonthly: 200,
+  taxesMonthly: 50,
+  bonusMonthly: 25,
+  investmentAllocationPercent: 0.8,
+  lifeEvents: undefined,
+  excludedPortfolioIds: ["pf-1"],
+  excludedRentalAssetIds: ["ra-1"],
+  country: "NZ",
+  narrative: "Retire early",
+  primaryStrategy: "FIRE",
+  headlineMetric: "INCOME_COVERAGE",
+  isPrimary: true,
+  createdDate: "2026-01-01",
+  updatedDate: "2026-01-01",
+} as RetirementPlan
+
+describe("toPlanRequestPayload", () => {
+  it("echoes every mutable plan field the backend PlanRequest expects", () => {
+    const payload = toPlanRequestPayload(plan)
+    expect(payload).toMatchObject({
+      name: "Test plan",
+      planningHorizonYears: 30,
+      monthlyExpenses: 5000,
+      expensesCurrency: "NZD",
+      targetBalance: 1_500_000,
+      cashReturnRate: 0.03,
+      equityReturnRate: 0.07,
+      housingReturnRate: 0.04,
+      inflationRate: 0.025,
+      feeRate: 0.001,
+      investmentTaxRate: 0.28,
+      cashAllocation: 0.3,
+      equityAllocation: 0.7,
+      housingAllocation: 0,
+      pensionMonthly: 800,
+      socialSecurityMonthly: 200,
+      benefitsStartAge: 67,
+      otherIncomeMonthly: 100,
+      workingIncomeMonthly: 500,
+      workingExpensesMonthly: 200,
+      taxesMonthly: 50,
+      bonusMonthly: 25,
+      investmentAllocationPercent: 0.8,
+      excludedPortfolioIds: ["pf-1"],
+      excludedRentalAssetIds: ["ra-1"],
+      country: "NZ",
+      narrative: "Retire early",
+      primaryStrategy: "FIRE",
+      headlineMetric: "INCOME_COVERAGE",
+    })
+  })
+
+  it("null-coalesces optional fields that are absent on the plan", () => {
+    const payload = toPlanRequestPayload({
+      ...plan,
+      targetBalance: undefined,
+      benefitsStartAge: undefined,
+      lifeEvents: undefined,
+      country: undefined,
+      narrative: undefined,
+      primaryStrategy: undefined,
+      headlineMetric: undefined,
+      excludedPortfolioIds: undefined,
+      excludedRentalAssetIds: undefined,
+    })
+    expect(payload.targetBalance).toBeNull()
+    expect(payload.benefitsStartAge).toBeNull()
+    expect(payload.lifeEvents).toBeNull()
+    expect(payload.country).toBeNull()
+    expect(payload.narrative).toBeNull()
+    expect(payload.primaryStrategy).toBeNull()
+    expect(payload.headlineMetric).toBeNull()
+    // Exclusions null-coalesce to an empty array, not null — see
+    // parseExcludedPortfolioIds/parseExcludedRentalAssetIds.
+    expect(payload.excludedPortfolioIds).toEqual([])
+    expect(payload.excludedRentalAssetIds).toEqual([])
+  })
+
+  it("defaults feeRate/investmentTaxRate to 0 when absent, distinct from an explicit 0", () => {
+    const payload = toPlanRequestPayload({
+      ...plan,
+      feeRate: undefined,
+      investmentTaxRate: undefined,
+    })
+    expect(payload.feeRate).toBe(0)
+    expect(payload.investmentTaxRate).toBe(0)
+  })
+
+  it("parses excludedPortfolioIds / excludedRentalAssetIds from a JSON string", () => {
+    const payload = toPlanRequestPayload({
+      ...plan,
+      excludedPortfolioIds: JSON.stringify(["pf-9"]),
+      excludedRentalAssetIds: JSON.stringify(["ra-9"]),
+    } as unknown as RetirementPlan)
+    expect(payload.excludedPortfolioIds).toEqual(["pf-9"])
+    expect(payload.excludedRentalAssetIds).toEqual(["ra-9"])
+  })
+})
 
 describe("normalizeAllocation", () => {
   it("returns values summing to 100 when CPF reduces raw sum below 100", () => {

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -29,7 +29,10 @@ import {
   ScenarioBar,
 } from "@components/features/independence"
 import { useScenario } from "@components/features/independence/scenario/useScenario"
-import { applyRealReturn } from "@components/features/independence/scenario/scenarioToPayload"
+import {
+  applyRealReturn,
+  scenarioToPlanUpdatePayload,
+} from "@components/features/independence/scenario/scenarioToPayload"
 import {
   defaultStrategyView,
   type StrategyView,
@@ -49,8 +52,6 @@ import Alert from "@components/ui/Alert"
 import Spinner from "@components/ui/Spinner"
 import {
   parseManualAssets,
-  parseExcludedPortfolioIds,
-  parseExcludedRentalAssetIds,
   hasManualAssets,
   manualAssetsToSlices,
 } from "@lib/independence/planHelpers"
@@ -775,35 +776,18 @@ function PlanView(): React.ReactElement {
     if (!plan) return
     setIsSaving(true)
     try {
-      const rates = applyRealReturn(scenario, plan)
-      // Allocations come from `plan` (not scenario) because they're not
-      // slider-controlled — the Real Return slider adjusts per-asset return
-      // rates via applyRealReturn, but the cash/equity/housing mix stays
-      // as the user configured it in the plan settings. Exclusions take
-      // pendingExclusions (set by the modal) when present, otherwise carry
-      // forward whatever the plan already has.
-      const updates = {
-        name: plan.name,
-        monthlyExpenses: scenario.monthlyExpenses,
-        pensionMonthly: scenario.pensionMonthly,
-        socialSecurityMonthly: scenario.socialSecurityMonthly,
-        benefitsStartAge: plan.benefitsStartAge,
-        otherIncomeMonthly: scenario.otherIncomeMonthly,
-        inflationRate: scenario.inflation,
-        targetBalance: plan.targetBalance,
-        equityReturnRate: rates.equityReturnRate,
-        cashReturnRate: rates.cashReturnRate,
-        housingReturnRate: rates.housingReturnRate,
-        equityAllocation: plan.equityAllocation,
-        cashAllocation: plan.cashAllocation,
-        housingAllocation: plan.housingAllocation,
-        excludedPortfolioIds:
-          pendingExclusions?.excludedPortfolioIds ??
-          parseExcludedPortfolioIds(plan.excludedPortfolioIds),
-        excludedRentalAssetIds:
-          pendingExclusions?.excludedRentalAssetIds ??
-          parseExcludedRentalAssetIds(plan.excludedRentalAssetIds),
-      }
+      // Full-plan echo: svc-retire's PATCH replaces every field it receives
+      // and defaults the ones it doesn't, so a partial body silently resets
+      // settings like planningHorizonYears/expensesCurrency/feeRate. Only
+      // name, the income/expense sliders, inflation, applyRealReturn's
+      // derived rates and pending exclusions are overridden here — every
+      // other field (including allocations, which aren't slider-controlled)
+      // is echoed straight back from `plan`.
+      const updates = scenarioToPlanUpdatePayload(
+        scenario,
+        plan,
+        pendingExclusions,
+      )
 
       if (mode === "update") {
         const response = await fetch(`/api/independence/plans/${plan.id}`, {

--- a/src/pages/independence/wizard/[planId].tsx
+++ b/src/pages/independence/wizard/[planId].tsx
@@ -165,6 +165,7 @@ function EditPlanWizard(): React.ReactElement {
             key={`${planId}-${plan.updatedDate}`}
             planId={planId as string}
             initialData={initialData}
+            plan={plan}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

svc-retire's `PATCH /plans/{id}` consumes a full `PlanRequest` — any field
absent from the request body falls back to backend defaults and REPLACES
the stored value. Several plan-save call sites in bc-view only sent the
fields they meant to change, so every save silently reset unrelated plan
settings (`planningHorizonYears` → 25, `expensesCurrency` → "USD",
`feeRate`/`investmentTaxRate` → 0, `investmentAllocationPercent` → 0.80,
working-phase fields → 0).

The canonical fix (`toPlanRequestPayload(plan)` in
`src/lib/utils/independence/planHelpers.ts`) already existed and echoes
every mutable plan field. This PR migrates the remaining partial-PATCH call
sites to spread that full-plan echo underneath their intended overrides.

## Sites migrated

| Site | Before | After |
|---|---|---|
| `src/pages/independence/plans/[id].tsx` `handleSaveScenario` | Hand-built `updates` object with ~12 explicit fields; everything else (feeRate, investmentTaxRate, investmentAllocationPercent, working*, taxesMonthly, bonusMonthly, country, narrative, primaryStrategy, headlineMetric, lifeEvents, manualAssets…) fell back to backend defaults on every scenario save | Extracted `scenarioToPlanUpdatePayload(scenario, plan, pendingExclusions)` in `scenario/scenarioToPayload.ts` — spreads `toPlanRequestPayload(plan)` then layers name/income/inflation/rates/exclusions overrides |
| `src/components/features/independence/WizardContainer.tsx` `handleSubmitPlan` (edit mode) | `planRequest` omitted `feeRate`, `investmentTaxRate`, `investmentAllocationPercent`, and the working-phase fields entirely — every wizard edit-save silently reset them | Extracted `buildWizardPlanRequest(formData, ctx)` — spreads `toPlanRequestPayload(plan)` in edit mode (new `plan` prop threaded from `wizard/[planId].tsx`), then layers the wizard's own overrides on top. Create mode (no stored plan) is unaffected |
| `src/components/features/independence/composite/BenefitsStartPhasePicker.tsx` | Already spreads `toPlanRequestPayload(plan)` | No change — left as reference implementation |

Out of scope (verified, not plan-root `PATCH`): work-scenario PATCHes
(`WorkScenarioBanner.tsx`, `ScenarioEditor`/`ScenarioList.tsx`,
`useIndependenceSettings.ts`), `/api/me` PATCH (`OnboardingWizard.tsx`,
`independence/setup.tsx`), and sub-resource routes (`/expenses`,
`/properties`, `/phases`, `/transfer`, `/primary`) which are POST/DELETE,
not plan-root PATCH.

## Testing

- `src/components/features/independence/scenario/__tests__/scenarioToPayload.test.ts` —
  new `scenarioToPlanUpdatePayload` specs (full-plan echo, override
  precedence, exclusion fallback/merge)
- `src/components/features/independence/__tests__/WizardContainer.test.tsx` —
  new `buildWizardPlanRequest` specs (edit-mode echo of feeRate/
  investmentTaxRate/investmentAllocationPercent/working-phase fields,
  override precedence, create-mode has no echo/clientId)
- `src/lib/utils/independence/planHelpers.test.ts` — new `toPlanRequestPayload`
  specs (full echo, null-coalescing, feeRate/investmentTaxRate default-0,
  JSON-string exclusion parsing)

### Checklist

- [x] `yarn test` (2289 tests, 233 suites)
- [x] `yarn prettier`
- [x] `yarn lint`
- [x] `yarn typecheck`

Closes #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
