### PR TITLE
feat: lifestyle mood board in expenses step

### DIFF
--- a/src/components/features/independence/__fixtures__/lifestyleCatalog.ts
+++ b/src/components/features/independence/__fixtures__/lifestyleCatalog.ts
@@ -1,0 +1,358 @@
+import type {
+  LifestyleCatalogResponse,
+  LifestyleCategory,
+} from "types/independence"
+
+/**
+ * Realistic Lifestyle Mood Board catalog fixture — 8 categories in
+ * sortOrder (priority) sequence, mirroring the svc-retire `GET
+ * /lifestyle/catalog` contract (see svc-retire#167). Round, synthetic
+ * numbers only.
+ *
+ * NOTE: `makeLifestyleCatalog` lives alongside the repo's other
+ * independence fixtures in `__fixtures__/` (see `monteCarloResult.ts`)
+ * rather than in `types/independence.d.ts` — `.d.ts` files are
+ * declaration-only and are stripped by TypeScript before Jest ever sees
+ * them, so a runtime factory placed there would not be importable in
+ * tests. The interfaces themselves (`LifestyleTier`, `LifestyleCategory`,
+ * `LifestyleCatalogResponse`) do live in `types/independence.d.ts` per the
+ * issue.
+ */
+
+const DEFAULT_CATEGORIES: LifestyleCategory[] = [
+  {
+    key: "housing",
+    displayName: "Home Base",
+    emoji: "🏠",
+    categoryLabelId: "cat-housing",
+    sortOrder: 1,
+    tiers: [
+      {
+        label: "Modest",
+        emoji: "🏢",
+        monthlyAmount: 1200,
+        description: "Tidy apartment or downsized townhouse.",
+        reserve: false,
+      },
+      {
+        label: "Comfortable",
+        emoji: "🏡",
+        monthlyAmount: 2200,
+        description: "Family home kept, garden, spare room.",
+        reserve: false,
+      },
+      {
+        label: "Premium Spot",
+        emoji: "🌊",
+        monthlyAmount: 4000,
+        description: "The view suburb or beach town.",
+        reserve: false,
+      },
+      {
+        label: "Luxury",
+        emoji: "🏰",
+        monthlyAmount: 7000,
+        description: "Luxury home, possibly two.",
+        reserve: false,
+      },
+    ],
+  },
+  {
+    key: "groceries",
+    displayName: "Home Table",
+    emoji: "🛒",
+    categoryLabelId: "cat-groceries",
+    sortOrder: 2,
+    tiers: [
+      {
+        label: "Budget",
+        emoji: "🥫",
+        monthlyAmount: 600,
+        description: "Meal-planned, seasonal, supermarket specials.",
+        reserve: false,
+      },
+      {
+        label: "Quality",
+        emoji: "🥦",
+        monthlyAmount: 900,
+        description: "Good produce, farmers market weekends.",
+        reserve: false,
+      },
+      {
+        label: "Organic",
+        emoji: "🍓",
+        monthlyAmount: 1200,
+        description: "Organic staples, market hauls.",
+        reserve: false,
+      },
+      {
+        label: "Gourmet",
+        emoji: "🧀",
+        monthlyAmount: 1600,
+        description: "Specialty grocers, premium cuts.",
+        reserve: false,
+      },
+    ],
+  },
+  {
+    key: "transport",
+    displayName: "Getting Around",
+    emoji: "🚗",
+    categoryLabelId: "cat-transport",
+    sortOrder: 3,
+    tiers: [
+      {
+        label: "Public + Feet",
+        emoji: "🚌",
+        monthlyAmount: 200,
+        description: "Public transport, e-bike, occasional rideshare.",
+        reserve: false,
+      },
+      {
+        label: "Reliable Car",
+        emoji: "🚙",
+        monthlyAmount: 550,
+        description: "One dependable car, kept long.",
+        reserve: false,
+      },
+      {
+        label: "New EV",
+        emoji: "⚡",
+        monthlyAmount: 950,
+        description: "Late-model EV, replaced on schedule.",
+        reserve: false,
+      },
+      {
+        label: "Two + Toy",
+        emoji: "🏎️",
+        monthlyAmount: 1800,
+        description: "Two cars, one of them the fun one.",
+        reserve: false,
+      },
+    ],
+  },
+  {
+    key: "health",
+    displayName: "Health & Wellness",
+    emoji: "🩺",
+    categoryLabelId: "cat-health",
+    sortOrder: 4,
+    tiers: [
+      {
+        label: "Public",
+        emoji: "🏥",
+        monthlyAmount: 250,
+        description: "Public system plus basics.",
+        reserve: false,
+      },
+      {
+        label: "Insured",
+        emoji: "🛡️",
+        monthlyAmount: 550,
+        description: "Private health insurance, gym membership.",
+        reserve: false,
+      },
+      {
+        label: "Comprehensive",
+        emoji: "💪",
+        monthlyAmount: 900,
+        description: "Comprehensive cover, gym + classes for two.",
+        reserve: false,
+      },
+      {
+        label: "Premium",
+        emoji: "💆",
+        monthlyAmount: 1400,
+        description: "Top-tier cover, specialists on demand.",
+        reserve: false,
+      },
+      {
+        label: "Concierge",
+        emoji: "🧬",
+        monthlyAmount: 3000,
+        description: "Concierge medicine, longevity clinic.",
+        reserve: true,
+      },
+    ],
+  },
+  {
+    key: "leisure",
+    displayName: "Hobbies & Play",
+    emoji: "⛳",
+    categoryLabelId: "cat-leisure",
+    sortOrder: 5,
+    tiers: [
+      {
+        label: "Outdoors",
+        emoji: "🥾",
+        monthlyAmount: 150,
+        description: "Walking tracks, fishing, gardening.",
+        reserve: false,
+      },
+      {
+        label: "Clubs",
+        emoji: "🎾",
+        monthlyAmount: 450,
+        description: "A club membership plus classes and gear.",
+        reserve: false,
+      },
+      {
+        label: "Serious Hobby",
+        emoji: "⛳",
+        monthlyAmount: 1100,
+        description: "The hobby done properly, full kit and coaching.",
+        reserve: false,
+      },
+      {
+        label: "Toys",
+        emoji: "🛥️",
+        monthlyAmount: 2500,
+        description: "The boat. Or the classic car.",
+        reserve: false,
+      },
+      {
+        label: "No Limits",
+        emoji: "🚁",
+        monthlyAmount: 6000,
+        description: "Yacht share, heli-ski weeks, expedition trips.",
+        reserve: true,
+      },
+    ],
+  },
+  {
+    key: "flights",
+    displayName: "Flying",
+    emoji: "✈️",
+    categoryLabelId: "cat-flights",
+    sortOrder: 6,
+    tiers: [
+      {
+        label: "No Flying",
+        emoji: "🏠",
+        monthlyAmount: 0,
+        description: "Holidays by road, rail and ferry.",
+        reserve: false,
+      },
+      {
+        label: "Economy",
+        emoji: "🎒",
+        monthlyAmount: 300,
+        description: "Economy fares, flexible dates.",
+        reserve: false,
+      },
+      {
+        label: "Premium Econ",
+        emoji: "💺",
+        monthlyAmount: 650,
+        description: "Premium economy on the long hauls.",
+        reserve: false,
+      },
+      {
+        label: "Business",
+        emoji: "🥂",
+        monthlyAmount: 1500,
+        description: "Lie-flat business class on every long-haul.",
+        reserve: false,
+      },
+      {
+        label: "First",
+        emoji: "👑",
+        monthlyAmount: 3500,
+        description: "First class or points-splurge suites.",
+        reserve: true,
+      },
+    ],
+  },
+  {
+    key: "stays",
+    displayName: "Travel Stays",
+    emoji: "🏕️",
+    categoryLabelId: "cat-stays",
+    sortOrder: 7,
+    tiers: [
+      {
+        label: "Tent & DOC",
+        emoji: "⛺",
+        monthlyAmount: 120,
+        description: "Tent, campgrounds, freedom camping.",
+        reserve: false,
+      },
+      {
+        label: "Campervan",
+        emoji: "🚐",
+        monthlyAmount: 450,
+        description: "Rented campervan road trips.",
+        reserve: false,
+      },
+      {
+        label: "Hotels 3-4 star",
+        emoji: "🏨",
+        monthlyAmount: 1000,
+        description: "Comfortable hotels and Airbnbs.",
+        reserve: false,
+      },
+      {
+        label: "Boutique 5 star",
+        emoji: "🌴",
+        monthlyAmount: 2400,
+        description: "Boutique lodges and five-star resorts.",
+        reserve: false,
+      },
+      {
+        label: "Private Villa",
+        emoji: "🏝️",
+        monthlyAmount: 6000,
+        description: "Private villas with staff, overwater suites.",
+        reserve: true,
+      },
+    ],
+  },
+  {
+    key: "dining",
+    displayName: "Eating Out",
+    emoji: "🍽️",
+    categoryLabelId: "cat-dining",
+    sortOrder: 8,
+    tiers: [
+      {
+        label: "Home Cook",
+        emoji: "🍳",
+        monthlyAmount: 150,
+        description: "Cooking at home is the hobby.",
+        reserve: false,
+      },
+      {
+        label: "Cafes",
+        emoji: "☕",
+        monthlyAmount: 450,
+        description: "Weekly cafe brunches and casual dinners out.",
+        reserve: false,
+      },
+      {
+        label: "Restaurants",
+        emoji: "🍷",
+        monthlyAmount: 1000,
+        description: "Proper restaurants a couple of times a week.",
+        reserve: false,
+      },
+      {
+        label: "Fine Dining",
+        emoji: "⭐",
+        monthlyAmount: 2200,
+        description: "Degustations, hatted/starred rooms.",
+        reserve: false,
+      },
+    ],
+  },
+]
+
+export function makeLifestyleCatalog(
+  overrides: Partial<LifestyleCatalogResponse> = {},
+): LifestyleCatalogResponse {
+  return {
+    householdSize: 2,
+    currency: "USD",
+    categories: DEFAULT_CATEGORIES,
+    ...overrides,
+  }
+}

--- a/src/components/features/independence/__tests__/ExpensesStep.test.tsx
+++ b/src/components/features/independence/__tests__/ExpensesStep.test.tsx
@@ -146,15 +146,28 @@ describe("ExpensesStep", () => {
     ).toBeInTheDocument()
   })
 
-  it("shows total monthly expenses", () => {
+  it("shows total monthly expenses hero on the Detailed tab", () => {
+    render(
+      <TestWrapper>
+        <div />
+      </TestWrapper>,
+    )
+    goToDetailedTab()
+
+    expect(screen.getByText(/total monthly expenses/i)).toBeInTheDocument()
+    expect(screen.getByText("$0")).toBeInTheDocument()
+  })
+
+  it("hides the total monthly expenses hero on the Mood Board tab — the board header is the single total", () => {
     render(
       <TestWrapper>
         <div />
       </TestWrapper>,
     )
 
-    expect(screen.getByText(/total monthly expenses/i)).toBeInTheDocument()
-    expect(screen.getByText("$0")).toBeInTheDocument()
+    expect(
+      screen.queryByText(/total monthly expenses/i),
+    ).not.toBeInTheDocument()
   })
 
   describe("Tab defaults", () => {
@@ -411,9 +424,9 @@ describe("ExpensesStep", () => {
         screen.getByRole("button", { name: /Comfortable.*2,200/i }),
       )
 
-      // Total monthly expenses hero should reflect the picked tier
+      // Board header total should reflect the picked tier
       await waitFor(() => {
-        expect(screen.getAllByText("$2,200").length).toBeGreaterThan(0)
+        expect(screen.getAllByText(/\$2,200/).length).toBeGreaterThan(0)
       })
     })
 
@@ -435,7 +448,7 @@ describe("ExpensesStep", () => {
       fireEvent.click(screen.getByRole("button", { name: /mood board/i }))
 
       await waitFor(() => {
-        expect(screen.getByText(/you today.*1,500.*\/mo/i)).toBeInTheDocument()
+        expect(screen.getByText(/now.*1,500/i)).toBeInTheDocument()
       })
 
       fireEvent.click(
@@ -443,12 +456,12 @@ describe("ExpensesStep", () => {
       )
 
       await waitFor(() => {
-        expect(screen.getAllByText("$2,200").length).toBeGreaterThan(0)
+        expect(screen.getAllByText(/\$2,200/).length).toBeGreaterThan(0)
       })
 
-      // "you today" must still show the original 1,500 snapshot, not the
-      // freshly-seeded 2,200 board value.
-      expect(screen.getByText(/you today.*1,500.*\/mo/i)).toBeInTheDocument()
+      // The "now" anchor must still show the original 1,500 snapshot, not
+      // the freshly-seeded 2,200 board value.
+      expect(screen.getByText(/now.*1,500/i)).toBeInTheDocument()
     })
   })
 })

--- a/src/components/features/independence/__tests__/ExpensesStep.test.tsx
+++ b/src/components/features/independence/__tests__/ExpensesStep.test.tsx
@@ -9,8 +9,9 @@ import {
   defaultWizardValues,
 } from "@lib/independence/schema"
 import { WizardFormData } from "types/independence"
+import { makeLifestyleCatalog } from "../__fixtures__/lifestyleCatalog"
 
-// Mock SWR for categories
+// Mock SWR for categories + lifestyle catalog, keyed by request key
 const mockCategories = {
   data: [
     {
@@ -37,28 +38,44 @@ const mockCategories = {
   ],
 }
 
-let swrMockReturn = {
+const mockCatalog = makeLifestyleCatalog()
+
+let categoriesSwrReturn = {
   data: null as typeof mockCategories | null,
+  error: null,
+  isLoading: true,
+}
+let catalogSwrReturn = {
+  data: null as typeof mockCatalog | null,
   error: null,
   isLoading: true,
 }
 
 jest.mock("swr", () => ({
   __esModule: true,
-  default: () => swrMockReturn,
+  default: (key: string) => {
+    if (typeof key === "string" && key.includes("lifestyle-catalog")) {
+      return catalogSwrReturn
+    }
+    return categoriesSwrReturn
+  },
 }))
 
 interface TestWrapperProps {
   children: React.ReactNode
   workingExpenses?: WizardFormData["workingExpenses"]
+  expenses?: WizardFormData["expenses"]
 }
 
-const TestWrapper: React.FC<TestWrapperProps> = ({ workingExpenses = [] }) => {
+const TestWrapper: React.FC<TestWrapperProps> = ({
+  workingExpenses = [],
+  expenses = [],
+}) => {
   const methods = useForm<WizardFormData>({
     resolver: yupResolver(expensesStepSchema) as any,
     defaultValues: {
       ...defaultWizardValues,
-      expenses: [],
+      expenses,
       workingExpenses,
     },
     mode: "onBlur",
@@ -78,9 +95,14 @@ const TestWrapper: React.FC<TestWrapperProps> = ({ workingExpenses = [] }) => {
   )
 }
 
+const goToDetailedTab = (): void => {
+  fireEvent.click(screen.getByRole("button", { name: /detailed/i }))
+}
+
 describe("ExpensesStep", () => {
   beforeEach(() => {
-    swrMockReturn = { data: null, error: null, isLoading: true }
+    categoriesSwrReturn = { data: null, error: null, isLoading: true }
+    catalogSwrReturn = { data: null, error: null, isLoading: true }
   })
 
   it("renders the expenses step header", () => {
@@ -95,45 +117,6 @@ describe("ExpensesStep", () => {
     ).toBeInTheDocument()
   })
 
-  it("shows loading state initially when no categories loaded", () => {
-    render(
-      <TestWrapper>
-        <div />
-      </TestWrapper>,
-    )
-
-    expect(screen.getByText(/loading categories/i)).toBeInTheDocument()
-  })
-
-  it("shows add custom category button", () => {
-    render(
-      <TestWrapper>
-        <div />
-      </TestWrapper>,
-    )
-
-    expect(
-      screen.getByRole("button", { name: /add custom category/i }),
-    ).toBeInTheDocument()
-  })
-
-  it("shows custom category input when button clicked", async () => {
-    render(
-      <TestWrapper>
-        <div />
-      </TestWrapper>,
-    )
-
-    const addButton = screen.getByRole("button", {
-      name: /add custom category/i,
-    })
-    fireEvent.click(addButton)
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(/category name/i)).toBeInTheDocument()
-    })
-  })
-
   it("shows total monthly expenses", () => {
     render(
       <TestWrapper>
@@ -145,146 +128,264 @@ describe("ExpensesStep", () => {
     expect(screen.getByText("$0")).toBeInTheDocument()
   })
 
-  describe("Copy from working expenses", () => {
-    const workingExpenses = [
-      {
-        categoryLabelId: "cat-1",
-        categoryName: "Housing",
-        monthlyAmount: 2500,
-      },
-      { categoryLabelId: "cat-2", categoryName: "Food", monthlyAmount: 800 },
-      {
-        categoryLabelId: "cat-3",
-        categoryName: "Transport",
-        monthlyAmount: 500,
-      },
-    ]
-
-    beforeEach(() => {
-      swrMockReturn = { data: mockCategories, error: null, isLoading: false }
-    })
-
-    it("copies working expenses at default 80%", async () => {
-      render(
-        <TestWrapper workingExpenses={workingExpenses}>
-          <div />
-        </TestWrapper>,
-      )
-
-      // Categories load synchronously via mock, fields should appear
-      await waitFor(() => {
-        expect(screen.getByText("Housing")).toBeInTheDocument()
-      })
-
-      // Banner should be visible
-      expect(screen.getByText(/working expenses on file/i)).toBeInTheDocument()
-
-      // Default is 80% (MathInput is textbox)
-      const percentInput = screen.getByLabelText(/copy percentage/i)
-      expect(percentInput).toHaveValue("80")
-
-      // Click Apply
-      fireEvent.click(screen.getByRole("button", { name: /apply/i }))
-
-      // Housing: round(2500*80/100)=2000, Food: round(800*80/100)=640, Transport: round(500*80/100)=400
-      // Total = 3040
-      await waitFor(() => {
-        expect(screen.getByText("$3,040")).toBeInTheDocument()
-      })
-    })
-
-    it("copies working expenses at custom percentage", async () => {
-      render(
-        <TestWrapper workingExpenses={workingExpenses}>
-          <div />
-        </TestWrapper>,
-      )
-
-      // Wait for categories to load
-      await waitFor(() => {
-        expect(screen.getByText("Housing")).toBeInTheDocument()
-      })
-
-      // Change to 70% (MathInput fires onChange with parsed number on change)
-      const percentInput = screen.getByLabelText(/copy percentage/i)
-      fireEvent.change(percentInput, { target: { value: "70" } })
-      fireEvent.blur(percentInput)
-
-      fireEvent.click(screen.getByRole("button", { name: /apply/i }))
-
-      // Housing: round(2500*70/100)=1750, Food: round(800*70/100)=560, Transport: round(500*70/100)=350
-      // Total = 2660
-      await waitFor(() => {
-        expect(screen.getByText("$2,660")).toBeInTheDocument()
-      })
-    })
-
-    it("hides banner when no working expenses exist", async () => {
+  describe("Tab defaults", () => {
+    it("defaults to the Mood Board tab for a plan with no retirement expenses yet", () => {
       render(
         <TestWrapper>
           <div />
         </TestWrapper>,
       )
 
-      // Wait for categories to load
-      await waitFor(() => {
-        expect(screen.getByText("Housing")).toBeInTheDocument()
-      })
-
+      expect(screen.getByRole("button", { name: /mood board/i })).toHaveClass(
+        "bg-white",
+      )
       expect(
-        screen.queryByText(/working expenses on file/i),
+        screen.queryByRole("button", { name: /add custom category/i }),
       ).not.toBeInTheDocument()
     })
 
-    it("shows re-apply button after initial apply and re-applies at same percent", async () => {
+    it("defaults to the Detailed tab when the plan already has expense amounts", () => {
       render(
-        <TestWrapper workingExpenses={workingExpenses}>
+        <TestWrapper
+          expenses={[
+            {
+              categoryLabelId: "cat-1",
+              categoryName: "Housing",
+              monthlyAmount: 2000,
+            },
+          ]}
+        >
           <div />
         </TestWrapper>,
       )
 
-      // Wait for categories to load
-      await waitFor(() => {
-        expect(screen.getByText("Housing")).toBeInTheDocument()
-      })
+      expect(screen.getByRole("button", { name: /detailed/i })).toHaveClass(
+        "bg-white",
+      )
+    })
+  })
 
-      // Apply at 80% via banner
-      fireEvent.click(screen.getByRole("button", { name: /^apply$/i }))
-      await waitFor(() => {
-        expect(screen.getByText("$3,040")).toBeInTheDocument()
-      })
+  describe("Detailed tab (existing rows behaviour, unchanged)", () => {
+    it("shows add custom category button", () => {
+      render(
+        <TestWrapper>
+          <div />
+        </TestWrapper>,
+      )
+      goToDetailedTab()
 
-      // Banner copy section is gone (expenses no longer all zero), re-apply button appears
       expect(
-        screen.queryByText(/working expenses on file/i),
-      ).not.toBeInTheDocument()
-      expect(
-        screen.getByRole("button", { name: /re-apply working expenses/i }),
+        screen.getByRole("button", { name: /add custom category/i }),
       ).toBeInTheDocument()
+    })
 
-      // Re-apply at same 80% keeps same total
-      fireEvent.click(
-        screen.getByRole("button", { name: /re-apply working expenses/i }),
+    it("shows loading state initially when no categories loaded", () => {
+      render(
+        <TestWrapper>
+          <div />
+        </TestWrapper>,
       )
+      goToDetailedTab()
+
+      expect(screen.getByText(/loading categories/i)).toBeInTheDocument()
+    })
+
+    it("shows custom category input when button clicked", async () => {
+      render(
+        <TestWrapper>
+          <div />
+        </TestWrapper>,
+      )
+      goToDetailedTab()
+
+      const addButton = screen.getByRole("button", {
+        name: /add custom category/i,
+      })
+      fireEvent.click(addButton)
+
       await waitFor(() => {
-        expect(screen.getByText("$3,040")).toBeInTheDocument()
+        expect(
+          screen.getByPlaceholderText(/category name/i),
+        ).toBeInTheDocument()
       })
     })
 
-    it("hides re-apply button when no working expenses", async () => {
+    describe("Copy from working expenses", () => {
+      const workingExpenses = [
+        {
+          categoryLabelId: "cat-1",
+          categoryName: "Housing",
+          monthlyAmount: 2500,
+        },
+        { categoryLabelId: "cat-2", categoryName: "Food", monthlyAmount: 800 },
+        {
+          categoryLabelId: "cat-3",
+          categoryName: "Transport",
+          monthlyAmount: 500,
+        },
+      ]
+
+      beforeEach(() => {
+        categoriesSwrReturn = {
+          data: mockCategories,
+          error: null,
+          isLoading: false,
+        }
+      })
+
+      it("copies working expenses at default 80%", async () => {
+        render(
+          <TestWrapper workingExpenses={workingExpenses}>
+            <div />
+          </TestWrapper>,
+        )
+        goToDetailedTab()
+
+        await waitFor(() => {
+          expect(screen.getByText("Housing")).toBeInTheDocument()
+        })
+
+        expect(
+          screen.getByText(/working expenses on file/i),
+        ).toBeInTheDocument()
+
+        const percentInput = screen.getByLabelText(/copy percentage/i)
+        expect(percentInput).toHaveValue("80")
+
+        fireEvent.click(screen.getByRole("button", { name: /apply/i }))
+
+        await waitFor(() => {
+          expect(screen.getByText("$3,040")).toBeInTheDocument()
+        })
+      })
+
+      it("copies working expenses at custom percentage", async () => {
+        render(
+          <TestWrapper workingExpenses={workingExpenses}>
+            <div />
+          </TestWrapper>,
+        )
+        goToDetailedTab()
+
+        await waitFor(() => {
+          expect(screen.getByText("Housing")).toBeInTheDocument()
+        })
+
+        const percentInput = screen.getByLabelText(/copy percentage/i)
+        fireEvent.change(percentInput, { target: { value: "70" } })
+        fireEvent.blur(percentInput)
+
+        fireEvent.click(screen.getByRole("button", { name: /apply/i }))
+
+        await waitFor(() => {
+          expect(screen.getByText("$2,660")).toBeInTheDocument()
+        })
+      })
+
+      it("hides banner when no working expenses exist", async () => {
+        render(
+          <TestWrapper>
+            <div />
+          </TestWrapper>,
+        )
+        goToDetailedTab()
+
+        await waitFor(() => {
+          expect(screen.getByText("Housing")).toBeInTheDocument()
+        })
+
+        expect(
+          screen.queryByText(/working expenses on file/i),
+        ).not.toBeInTheDocument()
+      })
+
+      it("shows re-apply button after initial apply and re-applies at same percent", async () => {
+        render(
+          <TestWrapper workingExpenses={workingExpenses}>
+            <div />
+          </TestWrapper>,
+        )
+        goToDetailedTab()
+
+        await waitFor(() => {
+          expect(screen.getByText("Housing")).toBeInTheDocument()
+        })
+
+        fireEvent.click(screen.getByRole("button", { name: /^apply$/i }))
+        await waitFor(() => {
+          expect(screen.getByText("$3,040")).toBeInTheDocument()
+        })
+
+        expect(
+          screen.queryByText(/working expenses on file/i),
+        ).not.toBeInTheDocument()
+        expect(
+          screen.getByRole("button", { name: /re-apply working expenses/i }),
+        ).toBeInTheDocument()
+
+        fireEvent.click(
+          screen.getByRole("button", { name: /re-apply working expenses/i }),
+        )
+        await waitFor(() => {
+          expect(screen.getByText("$3,040")).toBeInTheDocument()
+        })
+      })
+
+      it("hides re-apply button when no working expenses", async () => {
+        render(
+          <TestWrapper>
+            <div />
+          </TestWrapper>,
+        )
+        goToDetailedTab()
+
+        await waitFor(() => {
+          expect(screen.getByText("Housing")).toBeInTheDocument()
+        })
+
+        expect(
+          screen.queryByRole("button", { name: /re-apply working expenses/i }),
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("Mood Board tab", () => {
+    beforeEach(() => {
+      categoriesSwrReturn = {
+        data: mockCategories,
+        error: null,
+        isLoading: false,
+      }
+      catalogSwrReturn = { data: mockCatalog, error: null, isLoading: false }
+    })
+
+    it("renders the lifestyle catalog categories", () => {
       render(
         <TestWrapper>
           <div />
         </TestWrapper>,
       )
 
-      await waitFor(() => {
-        expect(screen.getByText("Housing")).toBeInTheDocument()
-      })
+      expect(screen.getByTestId("lifestyle-mood-board")).toBeInTheDocument()
+      expect(screen.getAllByTestId("lifestyle-category-name").length).toBe(8)
+    })
 
-      expect(
-        screen.queryByRole("button", { name: /re-apply working expenses/i }),
-      ).not.toBeInTheDocument()
+    it("clicking a tier seeds the shared expenses field array", async () => {
+      render(
+        <TestWrapper>
+          <div />
+        </TestWrapper>,
+      )
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Comfortable.*2,200/i }),
+      )
+
+      // Total monthly expenses hero should reflect the picked tier
+      await waitFor(() => {
+        expect(screen.getAllByText("$2,200").length).toBeGreaterThan(0)
+      })
     })
   })
 })

--- a/src/components/features/independence/__tests__/ExpensesStep.test.tsx
+++ b/src/components/features/independence/__tests__/ExpensesStep.test.tsx
@@ -35,6 +35,13 @@ const mockCategories = {
       sortOrder: 3,
       description: "Car, public transport",
     },
+    {
+      id: "cat-housing",
+      ownerId: "SYSTEM",
+      name: "Home Base",
+      sortOrder: 4,
+      description: "Lifestyle board housing category",
+    },
   ],
 }
 
@@ -51,9 +58,12 @@ let catalogSwrReturn = {
   isLoading: true,
 }
 
+const swrKeySpy = jest.fn()
+
 jest.mock("swr", () => ({
   __esModule: true,
   default: (key: string) => {
+    swrKeySpy(key)
     if (typeof key === "string" && key.includes("lifestyle-catalog")) {
       return catalogSwrReturn
     }
@@ -65,11 +75,13 @@ interface TestWrapperProps {
   children: React.ReactNode
   workingExpenses?: WizardFormData["workingExpenses"]
   expenses?: WizardFormData["expenses"]
+  expensesCurrency?: string
 }
 
 const TestWrapper: React.FC<TestWrapperProps> = ({
   workingExpenses = [],
   expenses = [],
+  expensesCurrency = "NZD",
 }) => {
   const methods = useForm<WizardFormData>({
     resolver: yupResolver(expensesStepSchema) as any,
@@ -77,6 +89,7 @@ const TestWrapper: React.FC<TestWrapperProps> = ({
       ...defaultWizardValues,
       expenses,
       workingExpenses,
+      expensesCurrency,
     },
     mode: "onBlur",
   })
@@ -103,6 +116,22 @@ describe("ExpensesStep", () => {
   beforeEach(() => {
     categoriesSwrReturn = { data: null, error: null, isLoading: true }
     catalogSwrReturn = { data: null, error: null, isLoading: true }
+    swrKeySpy.mockClear()
+  })
+
+  it("fetches the lifestyle catalog scoped to the plan's expenses currency", () => {
+    render(
+      <TestWrapper expensesCurrency="SGD">
+        <div />
+      </TestWrapper>,
+    )
+
+    const catalogKeyCall = swrKeySpy.mock.calls.find(
+      ([key]) => typeof key === "string" && key.includes("lifestyle-catalog"),
+    )
+    expect(catalogKeyCall?.[0]).toBe(
+      "/api/independence/lifestyle-catalog?currency=SGD",
+    )
   })
 
   it("renders the expenses step header", () => {
@@ -386,6 +415,40 @@ describe("ExpensesStep", () => {
       await waitFor(() => {
         expect(screen.getAllByText("$2,200").length).toBeGreaterThan(0)
       })
+    })
+
+    it("keeps the 'you today' anchor fixed after a tier click seeds mood-board rows", async () => {
+      render(
+        <TestWrapper
+          expenses={[
+            {
+              categoryLabelId: "cat-housing",
+              categoryName: "Home Base",
+              monthlyAmount: 1500,
+            },
+          ]}
+        >
+          <div />
+        </TestWrapper>,
+      )
+
+      fireEvent.click(screen.getByRole("button", { name: /mood board/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/you today.*1,500.*\/mo/i)).toBeInTheDocument()
+      })
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Comfortable.*2,200/i }),
+      )
+
+      await waitFor(() => {
+        expect(screen.getAllByText("$2,200").length).toBeGreaterThan(0)
+      })
+
+      // "you today" must still show the original 1,500 snapshot, not the
+      // freshly-seeded 2,200 board value.
+      expect(screen.getByText(/you today.*1,500.*\/mo/i)).toBeInTheDocument()
     })
   })
 })

--- a/src/components/features/independence/__tests__/LifestyleMoodBoard.test.tsx
+++ b/src/components/features/independence/__tests__/LifestyleMoodBoard.test.tsx
@@ -75,7 +75,7 @@ describe("LifestyleMoodBoard", () => {
     expect(upgradedCount).toBeGreaterThan(0)
   })
 
-  it("shows a 'you today' chip and highlights the nearest tier on initial mount", () => {
+  it("shows a quiet 'now $X' chip and highlights the nearest tier on initial mount", () => {
     renderBoard([
       {
         categoryLabelId: "cat-housing",
@@ -84,7 +84,9 @@ describe("LifestyleMoodBoard", () => {
       },
     ])
 
-    expect(screen.getByText(/you today.*2,100.*\/mo/i)).toBeInTheDocument()
+    const nowChip = screen.getByText(/now.*2,100/i)
+    expect(nowChip).toBeInTheDocument()
+    expect(nowChip).toHaveClass("text-[11px]", "text-gray-400")
     // 2100 is nearest to Comfortable (2200)
     const nearest = screen.getByTestId("lifestyle-tier-nearest-housing-1")
     expect(nearest).toBeInTheDocument()
@@ -154,7 +156,7 @@ describe("LifestyleMoodBoard", () => {
       />,
     )
 
-    expect(screen.getByText(/you today.*1,500.*\/mo/i)).toBeInTheDocument()
+    expect(screen.getByText(/now.*1,500/i)).toBeInTheDocument()
 
     // Simulate the board writing a picked tier's amount (2,200) back into
     // the live `expenses` prop, while the frozen snapshot stays behind.
@@ -180,10 +182,8 @@ describe("LifestyleMoodBoard", () => {
       />,
     )
 
-    expect(screen.getByText(/you today.*1,500.*\/mo/i)).toBeInTheDocument()
-    expect(
-      screen.queryByText(/you today.*2,200.*\/mo/i),
-    ).not.toBeInTheDocument()
+    expect(screen.getByText(/now.*1,500/i)).toBeInTheDocument()
+    expect(screen.queryByText(/now.*2,200/i)).not.toBeInTheDocument()
   })
 
   it("marks a category's chip as custom once its picked amount is edited away from the tier anchor", () => {
@@ -209,6 +209,37 @@ describe("LifestyleMoodBoard", () => {
 
     expect(
       screen.getByTestId("lifestyle-chip-custom-housing"),
+    ).toBeInTheDocument()
+  })
+
+  it("renders each tier chip as a single line combining emoji, label and price", () => {
+    renderBoard()
+
+    const chip = screen.getByTestId("lifestyle-tier-housing-0")
+    expect(chip).toHaveClass("whitespace-nowrap")
+    expect(chip.textContent).toBe("🏢Modest·$1,200")
+    expect(chip.children.length).toBeLessThanOrEqual(4)
+  })
+
+  it("renders the reserve tier chip inline in the same wrap container as regular tiers", () => {
+    renderBoard()
+
+    const reserveChip = screen.getAllByTestId("lifestyle-tier-reserve")[0]
+    const regularChip = screen.getByTestId("lifestyle-tier-health-0")
+    expect(reserveChip.parentElement).toBe(regularChip.parentElement)
+  })
+
+  it("shows no per-card description until a tier is actively picked", () => {
+    renderBoard()
+
+    expect(
+      screen.queryByText(/family home kept, garden, spare room/i),
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: /Comfortable.*2,200/i }))
+
+    expect(
+      screen.getByText(/family home kept, garden, spare room/i),
     ).toBeInTheDocument()
   })
 })

--- a/src/components/features/independence/__tests__/LifestyleMoodBoard.test.tsx
+++ b/src/components/features/independence/__tests__/LifestyleMoodBoard.test.tsx
@@ -1,0 +1,130 @@
+import React from "react"
+import { render, screen, fireEvent, RenderResult } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import LifestyleMoodBoard from "../steps/LifestyleMoodBoard"
+import { makeLifestyleCatalog } from "../__fixtures__/lifestyleCatalog"
+import { ExpenseFormEntry, TierSelectionChange } from "types/independence"
+
+const catalog = makeLifestyleCatalog()
+
+function renderBoard(
+  expenses: ExpenseFormEntry[] = [],
+  onSelectionChange: (change: TierSelectionChange) => void = jest.fn(),
+): RenderResult {
+  return render(
+    <LifestyleMoodBoard
+      categories={catalog.categories}
+      currency={catalog.currency}
+      expenses={expenses}
+      onSelectionChange={onSelectionChange}
+    />,
+  )
+}
+
+describe("LifestyleMoodBoard", () => {
+  it("renders all catalog categories in sortOrder", () => {
+    renderBoard()
+    const headings = screen.getAllByTestId("lifestyle-category-name")
+    expect(headings.map((h) => h.textContent?.trim())).toEqual([
+      "🏠 Home Base",
+      "🛒 Home Table",
+      "🚗 Getting Around",
+      "🩺 Health & Wellness",
+      "⛳ Hobbies & Play",
+      "✈️ Flying",
+      "🏕️ Travel Stays",
+      "🍽️ Eating Out",
+    ])
+  })
+
+  it("renders reserve tiers with a gold ✦ marker", () => {
+    renderBoard()
+    // Health's 5th tier ("Concierge") is a reserve tier
+    expect(screen.getByText(/Concierge/)).toBeInTheDocument()
+    const reserveTiers = screen.getAllByTestId("lifestyle-tier-reserve")
+    expect(reserveTiers.length).toBeGreaterThan(0)
+  })
+
+  it("clicking a tier switches to board mode and reports the selection", () => {
+    const onSelectionChange = jest.fn()
+    renderBoard([], onSelectionChange)
+
+    fireEvent.click(screen.getByRole("button", { name: /Comfortable.*2,200/i }))
+
+    expect(onSelectionChange).toHaveBeenCalled()
+    const lastCall =
+      onSelectionChange.mock.calls[onSelectionChange.mock.calls.length - 1][0]
+    expect(lastCall.selection.housing).toBe(1)
+    expect(lastCall.pickedKeys).toContain("housing")
+  })
+
+  it("moving the budget slider applies a greedy fit across all categories", () => {
+    const onSelectionChange = jest.fn()
+    renderBoard([], onSelectionChange)
+
+    const slider = screen.getByLabelText(/monthly budget/i)
+    fireEvent.change(slider, { target: { value: "20000" } })
+
+    expect(onSelectionChange).toHaveBeenCalled()
+    const lastCall =
+      onSelectionChange.mock.calls[onSelectionChange.mock.calls.length - 1][0]
+    // With a generous budget, several categories should be upgraded above tier 0
+    const upgradedCount = Object.values(
+      lastCall.selection as Record<string, number>,
+    ).filter((idx) => idx > 0).length
+    expect(upgradedCount).toBeGreaterThan(0)
+  })
+
+  it("shows a 'you today' chip and highlights the nearest tier on initial mount", () => {
+    renderBoard([
+      {
+        categoryLabelId: "cat-housing",
+        categoryName: "Home Base",
+        monthlyAmount: 2100,
+      },
+    ])
+
+    expect(screen.getByText(/you today.*2,100.*\/mo/i)).toBeInTheDocument()
+    // 2100 is nearest to Comfortable (2200)
+    const nearest = screen.getByTestId("lifestyle-tier-nearest-housing-1")
+    expect(nearest).toBeInTheDocument()
+  })
+
+  it("shows the delta between board total and current total in the header", () => {
+    renderBoard([
+      {
+        categoryLabelId: "cat-housing",
+        categoryName: "Home Base",
+        monthlyAmount: 1200,
+      },
+    ])
+
+    expect(screen.getByText(/current spend/i)).toBeInTheDocument()
+  })
+
+  it("marks a category's chip as custom once its picked amount is edited away from the tier anchor", () => {
+    const onSelectionChange = jest.fn()
+    const { rerender } = renderBoard([], onSelectionChange)
+
+    fireEvent.click(screen.getByRole("button", { name: /Comfortable.*2,200/i }))
+
+    rerender(
+      <LifestyleMoodBoard
+        categories={catalog.categories}
+        currency={catalog.currency}
+        expenses={[
+          {
+            categoryLabelId: "cat-housing",
+            categoryName: "Home Base",
+            monthlyAmount: 2350,
+          },
+        ]}
+        onSelectionChange={onSelectionChange}
+      />,
+    )
+
+    expect(
+      screen.getByTestId("lifestyle-chip-custom-housing"),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/features/independence/__tests__/LifestyleMoodBoard.test.tsx
+++ b/src/components/features/independence/__tests__/LifestyleMoodBoard.test.tsx
@@ -102,6 +102,90 @@ describe("LifestyleMoodBoard", () => {
     expect(screen.getByText(/current spend/i)).toBeInTheDocument()
   })
 
+  it("renders amounts using the currency echoed back by the catalog response, not a hardcoded one", () => {
+    render(
+      <LifestyleMoodBoard
+        categories={catalog.categories}
+        currency="SGD"
+        expenses={[]}
+        onSelectionChange={jest.fn()}
+      />,
+    )
+
+    expect(screen.getAllByText(/S\$1,200/).length).toBeGreaterThan(0)
+  })
+
+  it("has a tooltip near the header delta explaining what it's compared against", () => {
+    renderBoard([
+      {
+        categoryLabelId: "cat-housing",
+        categoryName: "Home Base",
+        monthlyAmount: 1200,
+      },
+    ])
+
+    fireEvent.mouseEnter(screen.getByText(/what is this delta/i))
+
+    expect(
+      screen.getByText(/board categories only.*excludes utilities/i),
+    ).toBeInTheDocument()
+  })
+
+  it("keeps the 'you today' chip and nearest-tier highlight pinned to the initial snapshot, not live expenses", () => {
+    const { rerender } = render(
+      <LifestyleMoodBoard
+        categories={catalog.categories}
+        currency={catalog.currency}
+        expenses={[
+          {
+            categoryLabelId: "cat-housing",
+            categoryName: "Home Base",
+            monthlyAmount: 1500,
+          },
+        ]}
+        expensesSnapshot={[
+          {
+            categoryLabelId: "cat-housing",
+            categoryName: "Home Base",
+            monthlyAmount: 1500,
+          },
+        ]}
+        onSelectionChange={jest.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/you today.*1,500.*\/mo/i)).toBeInTheDocument()
+
+    // Simulate the board writing a picked tier's amount (2,200) back into
+    // the live `expenses` prop, while the frozen snapshot stays behind.
+    rerender(
+      <LifestyleMoodBoard
+        categories={catalog.categories}
+        currency={catalog.currency}
+        expenses={[
+          {
+            categoryLabelId: "cat-housing",
+            categoryName: "Home Base",
+            monthlyAmount: 2200,
+          },
+        ]}
+        expensesSnapshot={[
+          {
+            categoryLabelId: "cat-housing",
+            categoryName: "Home Base",
+            monthlyAmount: 1500,
+          },
+        ]}
+        onSelectionChange={jest.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/you today.*1,500.*\/mo/i)).toBeInTheDocument()
+    expect(
+      screen.queryByText(/you today.*2,200.*\/mo/i),
+    ).not.toBeInTheDocument()
+  })
+
   it("marks a category's chip as custom once its picked amount is edited away from the tier anchor", () => {
     const onSelectionChange = jest.fn()
     const { rerender } = renderBoard([], onSelectionChange)

--- a/src/components/features/independence/__tests__/WizardContainer.test.tsx
+++ b/src/components/features/independence/__tests__/WizardContainer.test.tsx
@@ -81,6 +81,10 @@ describe("ExpensesStep - Custom Category", () => {
       />,
     )
 
+    // New plan (no expenses yet) defaults to the Mood Board tab; switch to
+    // Detailed to exercise the custom-category rows workflow.
+    fireEvent.click(screen.getByRole("button", { name: /detailed/i }))
+
     // Wait for categories to load and Housing to appear
     await waitFor(() => {
       expect(screen.getByText("Housing")).toBeInTheDocument()

--- a/src/components/features/independence/steps/ExpensesStep.tsx
+++ b/src/components/features/independence/steps/ExpensesStep.tsx
@@ -224,82 +224,86 @@ export default function ExpensesStep({
         <p className="text-sm text-gray-600">{msg.description}</p>
       </div>
 
-      {/* Hero: Total monthly expenses */}
-      <div className="rounded-xl border border-independence-200 bg-independence-50 p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <p className="text-sm font-semibold text-independence-700">
-              {msg.totalLabel}
-            </p>
-            <p className="mt-0.5 text-xs text-independence-500 max-w-xs leading-relaxed">
-              {msg.totalHelper}
-            </p>
+      {/* Hero: Total monthly expenses — Detailed tab only. On the Mood
+          Board tab, the board header's own total is the single focal
+          number for that view. */}
+      {activeTab === "detailed" && (
+        <div className="rounded-xl border border-independence-200 bg-independence-50 p-5">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-independence-700">
+                {msg.totalLabel}
+              </p>
+              <p className="mt-0.5 text-xs text-independence-500 max-w-xs leading-relaxed">
+                {msg.totalHelper}
+              </p>
+            </div>
+            <div className="shrink-0 text-right">
+              <p className="text-3xl font-bold tabular-nums text-independence-800">
+                ${totalMonthlyExpenses.toLocaleString()}
+              </p>
+              <p className="text-xs text-independence-500 mt-0.5">per month</p>
+            </div>
           </div>
-          <div className="shrink-0 text-right">
-            <p className="text-3xl font-bold tabular-nums text-independence-800">
-              ${totalMonthlyExpenses.toLocaleString()}
-            </p>
-            <p className="text-xs text-independence-500 mt-0.5">per month</p>
-          </div>
-        </div>
 
-        {/* Copy from working — surfaced when relevant */}
-        {canCopyFromWorking && (
-          <div className="mt-4 pt-4 border-t border-independence-200">
-            <p className="text-xs text-independence-600 mb-2.5 font-medium">
-              <i className="fas fa-copy mr-1.5"></i>
-              You have working expenses on file — pre-fill from those?
-            </p>
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-sm text-independence-700">Apply at</span>
-              <div className="flex items-center gap-1">
-                <MathInput
-                  value={copyPercent}
-                  onChange={setCopyPercent}
-                  min={10}
-                  max={100}
-                  placeholder="80"
-                  aria-label="Copy percentage"
-                  className="w-16 px-2 py-1 text-sm text-center border border-independence-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
-                />
-                <span className="text-sm text-independence-700">%</span>
+          {/* Copy from working — surfaced when relevant */}
+          {canCopyFromWorking && (
+            <div className="mt-4 pt-4 border-t border-independence-200">
+              <p className="text-xs text-independence-600 mb-2.5 font-medium">
+                <i className="fas fa-copy mr-1.5"></i>
+                You have working expenses on file — pre-fill from those?
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm text-independence-700">Apply at</span>
+                <div className="flex items-center gap-1">
+                  <MathInput
+                    value={copyPercent}
+                    onChange={setCopyPercent}
+                    min={10}
+                    max={100}
+                    placeholder="80"
+                    aria-label="Copy percentage"
+                    className="w-16 px-2 py-1 text-sm text-center border border-independence-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                  />
+                  <span className="text-sm text-independence-700">%</span>
+                </div>
+                <span className="text-sm text-independence-500">
+                  of working expenses
+                </span>
+                <button
+                  type="button"
+                  onClick={() => applyCopyFromWorking(copyPercent)}
+                  className="px-3 py-1.5 text-sm bg-independence-600 text-white rounded-lg hover:bg-independence-700 font-medium transition-colors"
+                >
+                  Apply
+                </button>
               </div>
-              <span className="text-sm text-independence-500">
-                of working expenses
-              </span>
+            </div>
+          )}
+
+          {/* Copy success flash */}
+          {copyApplied && (
+            <div className="mt-3 flex items-center gap-1.5 text-sm text-independence-700">
+              <i className="fas fa-check-circle"></i>
+              <span>Working expenses applied at {copyPercent}%</span>
+            </div>
+          )}
+
+          {/* Repeat copy trigger when already applied */}
+          {hasWorkingExpenses && !canCopyFromWorking && (
+            <div className="mt-4 pt-3 border-t border-independence-200">
               <button
                 type="button"
                 onClick={() => applyCopyFromWorking(copyPercent)}
-                className="px-3 py-1.5 text-sm bg-independence-600 text-white rounded-lg hover:bg-independence-700 font-medium transition-colors"
+                className="text-xs text-independence-600 hover:text-independence-800 flex items-center gap-1.5"
               >
-                Apply
+                <i className="fas fa-copy"></i>
+                Re-apply working expenses at {copyPercent}%
               </button>
             </div>
-          </div>
-        )}
-
-        {/* Copy success flash */}
-        {copyApplied && (
-          <div className="mt-3 flex items-center gap-1.5 text-sm text-independence-700">
-            <i className="fas fa-check-circle"></i>
-            <span>Working expenses applied at {copyPercent}%</span>
-          </div>
-        )}
-
-        {/* Repeat copy trigger when already applied */}
-        {hasWorkingExpenses && !canCopyFromWorking && (
-          <div className="mt-4 pt-3 border-t border-independence-200">
-            <button
-              type="button"
-              onClick={() => applyCopyFromWorking(copyPercent)}
-              className="text-xs text-independence-600 hover:text-independence-800 flex items-center gap-1.5"
-            >
-              <i className="fas fa-copy"></i>
-              Re-apply working expenses at {copyPercent}%
-            </button>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
 
       {/* Tabs: Mood Board (default for new plans) | Detailed (tune-at-the-end rows) */}
       <div className="flex rounded-lg bg-gray-100 p-0.5 w-fit">

--- a/src/components/features/independence/steps/ExpensesStep.tsx
+++ b/src/components/features/independence/steps/ExpensesStep.tsx
@@ -13,6 +13,7 @@ import { simpleFetcher } from "@utils/api/fetchHelper"
 import {
   WizardFormData,
   CategoryLabelsResponse,
+  ExpenseFormEntry,
   LifestyleCatalogResponse,
   TierSelectionChange,
 } from "types/independence"
@@ -34,7 +35,7 @@ interface ExpensesStepProps {
 type ExpensesTab = "board" | "detailed"
 
 const categoriesKey = "/api/independence/categories"
-const lifestyleCatalogKey = "/api/independence/lifestyle-catalog"
+const lifestyleCatalogBaseKey = "/api/independence/lifestyle-catalog"
 
 export default function ExpensesStep({
   control,
@@ -48,6 +49,14 @@ export default function ExpensesStep({
     name: "expenses",
   })
   const hasInitialized = useRef(false)
+  // "You today" anchor: frozen once, on mount, before any mood-board
+  // seeding writes rows back into the shared `expenses` field array. The
+  // mood board reads this instead of live field values so its chips,
+  // nearest-tier highlight and header delta don't drift once the board
+  // starts writing its own picks into the form.
+  const [expensesSnapshot] = useState<ExpenseFormEntry[]>(
+    () => getValues("expenses") || [],
+  )
   const [showAddCustom, setShowAddCustom] = useState(false)
   const [customCategoryName, setCustomCategoryName] = useState("")
   const [copyPercent, setCopyPercent] = useState(80)
@@ -65,6 +74,16 @@ export default function ExpensesStep({
     categoriesKey,
     simpleFetcher(categoriesKey),
   )
+
+  // Scope the catalog to the plan's own currency — svc-retire converts and
+  // rounds the tier amounts server-side and echoes back the `currency` it
+  // used; the mood board only ever renders that echoed value, it never
+  // converts or reformats amounts itself.
+  const expensesCurrency =
+    useWatch({ control, name: "expensesCurrency" }) || "USD"
+  const lifestyleCatalogKey = `${lifestyleCatalogBaseKey}?currency=${encodeURIComponent(
+    expensesCurrency,
+  )}`
   const { data: catalogData } = useSwr<LifestyleCatalogResponse>(
     lifestyleCatalogKey,
     simpleFetcher(lifestyleCatalogKey),
@@ -316,6 +335,7 @@ export default function ExpensesStep({
             categories={lifestyleCategories}
             currency={catalogData?.currency || "USD"}
             expenses={expenses}
+            expensesSnapshot={expensesSnapshot}
             onSelectionChange={handleBoardSelectionChange}
           />
         ) : (

--- a/src/components/features/independence/steps/ExpensesStep.tsx
+++ b/src/components/features/independence/steps/ExpensesStep.tsx
@@ -10,10 +10,16 @@ import {
 } from "react-hook-form"
 import useSwr from "swr"
 import { simpleFetcher } from "@utils/api/fetchHelper"
-import { WizardFormData, CategoryLabelsResponse } from "types/independence"
+import {
+  WizardFormData,
+  CategoryLabelsResponse,
+  LifestyleCatalogResponse,
+  TierSelectionChange,
+} from "types/independence"
 import { wizardMessages } from "@lib/independence/messages"
 import MathInput from "@components/ui/MathInput"
 import Spinner from "@components/ui/Spinner"
+import LifestyleMoodBoard from "./LifestyleMoodBoard"
 
 const msg = wizardMessages.steps.expenses
 
@@ -25,7 +31,10 @@ interface ExpensesStepProps {
   isEditMode?: boolean
 }
 
+type ExpensesTab = "board" | "detailed"
+
 const categoriesKey = "/api/independence/categories"
+const lifestyleCatalogKey = "/api/independence/lifestyle-catalog"
 
 export default function ExpensesStep({
   control,
@@ -43,11 +52,24 @@ export default function ExpensesStep({
   const [customCategoryName, setCustomCategoryName] = useState("")
   const [copyPercent, setCopyPercent] = useState(80)
   const [copyApplied, setCopyApplied] = useState(false)
+  // Mood Board is the default surface for a plan with no retirement
+  // expenses recorded yet; an edit-mode plan with real amounts opens on
+  // Detailed. Computed once at mount — later tab switches are the user's.
+  const [activeTab, setActiveTab] = useState<ExpensesTab>(() => {
+    const initialExpenses = getValues("expenses") || []
+    const allZero = initialExpenses.every((e) => (e?.monthlyAmount || 0) === 0)
+    return allZero ? "board" : "detailed"
+  })
 
   const { data: categoriesData } = useSwr<CategoryLabelsResponse>(
     categoriesKey,
     simpleFetcher(categoriesKey),
   )
+  const { data: catalogData } = useSwr<LifestyleCatalogResponse>(
+    lifestyleCatalogKey,
+    simpleFetcher(lifestyleCatalogKey),
+  )
+  const lifestyleCategories = catalogData?.categories || []
 
   const categories = categoriesData?.data || []
   const systemCategories = categories.filter(
@@ -112,6 +134,44 @@ export default function ExpensesStep({
     setValue("expenses", updated)
     setCopyApplied(true)
     setTimeout(() => setCopyApplied(false), 3000)
+  }
+
+  // Board tier picks (slider fit or a direct click) write into the shared
+  // `expenses` field array — one row per lifestyle category, matched by
+  // categoryLabelId. Only categories the user has explicitly picked are
+  // written; untouched categories keep whatever value they already had
+  // (still visible on the board via the nearest-tier highlight).
+  const handleBoardSelectionChange = (change: TierSelectionChange): void => {
+    const currentExpenses = getValues("expenses") || []
+    const updated = [...currentExpenses]
+    const indexByLabel = new Map(
+      updated.map((e, idx) => [e.categoryLabelId, idx]),
+    )
+
+    change.pickedKeys.forEach((key) => {
+      const category = lifestyleCategories.find((c) => c.key === key)
+      const tierIdx = change.selection[key]
+      const tier = category?.tiers[tierIdx]
+      if (!category || !tier) return
+
+      const existingIdx = indexByLabel.get(category.categoryLabelId)
+      if (existingIdx !== undefined) {
+        updated[existingIdx] = {
+          ...updated[existingIdx],
+          categoryName: category.displayName,
+          monthlyAmount: tier.monthlyAmount,
+        }
+      } else {
+        updated.push({
+          categoryLabelId: category.categoryLabelId,
+          categoryName: category.displayName,
+          monthlyAmount: tier.monthlyAmount,
+        })
+        indexByLabel.set(category.categoryLabelId, updated.length - 1)
+      }
+    })
+
+    setValue("expenses", updated)
   }
 
   const handleAddCustomCategory = (): void => {
@@ -222,153 +282,202 @@ export default function ExpensesStep({
         )}
       </div>
 
+      {/* Tabs: Mood Board (default for new plans) | Detailed (tune-at-the-end rows) */}
+      <div className="flex rounded-lg bg-gray-100 p-0.5 w-fit">
+        <button
+          type="button"
+          onClick={() => setActiveTab("board")}
+          className={`px-4 py-1.5 text-sm rounded-md font-medium transition-colors ${
+            activeTab === "board"
+              ? "bg-white text-independence-700 shadow-sm"
+              : "text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          <i className="fas fa-palette mr-1.5"></i>
+          Mood Board
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("detailed")}
+          className={`px-4 py-1.5 text-sm rounded-md font-medium transition-colors ${
+            activeTab === "detailed"
+              ? "bg-white text-independence-700 shadow-sm"
+              : "text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          <i className="fas fa-list mr-1.5"></i>
+          Detailed
+        </button>
+      </div>
+
+      {activeTab === "board" &&
+        (lifestyleCategories.length > 0 ? (
+          <LifestyleMoodBoard
+            categories={lifestyleCategories}
+            currency={catalogData?.currency || "USD"}
+            expenses={expenses}
+            onSelectionChange={handleBoardSelectionChange}
+          />
+        ) : (
+          <div className="flex flex-col items-center justify-center py-8 rounded-lg border-2 border-dashed border-gray-200">
+            <Spinner size="lg" className="text-gray-300 mb-2" />
+            <p className="text-sm text-gray-400">Loading lifestyle catalog…</p>
+          </div>
+        ))}
+
       {/* Breakdown */}
-      <div>
-        <p className="text-xs text-gray-500 mb-3">
-          Adjust amounts by category to check nothing is missing:
-        </p>
+      {activeTab === "detailed" && (
+        <div>
+          <p className="text-xs text-gray-500 mb-3">
+            Adjust amounts by category to check nothing is missing:
+          </p>
 
-        <div className="space-y-2">
-          {fields.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 rounded-lg border-2 border-dashed border-gray-200">
-              <Spinner size="lg" className="text-gray-300 mb-2" />
-              <p className="text-sm text-gray-400">Loading categories…</p>
-            </div>
-          ) : (
-            fields.map((field, index) => {
-              const description = getCategoryDescription(field.categoryLabelId)
-              const isCustom = isCustomCategory(field.categoryLabelId)
-              const amount = expenses[index]?.monthlyAmount || 0
+          <div className="space-y-2">
+            {fields.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-8 rounded-lg border-2 border-dashed border-gray-200">
+                <Spinner size="lg" className="text-gray-300 mb-2" />
+                <p className="text-sm text-gray-400">Loading categories…</p>
+              </div>
+            ) : (
+              fields.map((field, index) => {
+                const description = getCategoryDescription(
+                  field.categoryLabelId,
+                )
+                const isCustom = isCustomCategory(field.categoryLabelId)
+                const amount = expenses[index]?.monthlyAmount || 0
 
-              return (
-                <div
-                  key={field.id}
-                  className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-colors ${
-                    amount > 0
-                      ? "bg-independence-50 border border-independence-100"
-                      : "bg-gray-50 border border-transparent hover:bg-gray-100"
-                  }`}
-                >
-                  {/* Category label */}
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-gray-900 truncate">
-                        {expenses[index]?.categoryName || field.categoryName}
-                      </span>
-                      {isCustom && (
-                        <>
-                          <span className="shrink-0 text-xs bg-independence-100 text-independence-700 px-2 py-0.5 rounded-full">
-                            Custom
-                          </span>
-                          <button
-                            type="button"
-                            onClick={() => remove(index)}
-                            className="shrink-0 p-0.5 text-red-400 hover:text-red-600 rounded"
-                            title="Remove"
-                            aria-label="Remove custom category"
-                          >
-                            <i className="fas fa-times text-xs"></i>
-                          </button>
-                        </>
+                return (
+                  <div
+                    key={field.id}
+                    className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-colors ${
+                      amount > 0
+                        ? "bg-independence-50 border border-independence-100"
+                        : "bg-gray-50 border border-transparent hover:bg-gray-100"
+                    }`}
+                  >
+                    {/* Category label */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-gray-900 truncate">
+                          {expenses[index]?.categoryName || field.categoryName}
+                        </span>
+                        {isCustom && (
+                          <>
+                            <span className="shrink-0 text-xs bg-independence-100 text-independence-700 px-2 py-0.5 rounded-full">
+                              Custom
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => remove(index)}
+                              className="shrink-0 p-0.5 text-red-400 hover:text-red-600 rounded"
+                              title="Remove"
+                              aria-label="Remove custom category"
+                            >
+                              <i className="fas fa-times text-xs"></i>
+                            </button>
+                          </>
+                        )}
+                      </div>
+                      {description && (
+                        <p className="text-xs text-gray-400 mt-0.5 truncate">
+                          {description}
+                        </p>
                       )}
                     </div>
-                    {description && (
-                      <p className="text-xs text-gray-400 mt-0.5 truncate">
-                        {description}
-                      </p>
-                    )}
-                  </div>
 
-                  {/* Amount input */}
-                  <div className="shrink-0 w-32">
-                    <div className="relative">
-                      <span className="absolute left-3 top-2.5 text-xs text-gray-400 pointer-events-none">
-                        $
-                      </span>
-                      <Controller
-                        name={`expenses.${index}.monthlyAmount`}
-                        control={control}
-                        render={({ field: inputField }) => (
-                          <MathInput
-                            value={inputField.value || 0}
-                            onChange={inputField.onChange}
-                            placeholder="0"
-                            min={0}
-                            step={50}
-                            className={`w-full pl-7 pr-3 py-2 text-sm text-right border rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500 ${
-                              errors.expenses?.[index]?.monthlyAmount
-                                ? "border-red-400"
-                                : amount > 0
-                                  ? "border-independence-200 bg-white"
-                                  : "border-gray-200 bg-white"
-                            }`}
-                          />
-                        )}
-                      />
+                    {/* Amount input */}
+                    <div className="shrink-0 w-32">
+                      <div className="relative">
+                        <span className="absolute left-3 top-2.5 text-xs text-gray-400 pointer-events-none">
+                          $
+                        </span>
+                        <Controller
+                          name={`expenses.${index}.monthlyAmount`}
+                          control={control}
+                          render={({ field: inputField }) => (
+                            <MathInput
+                              value={inputField.value || 0}
+                              onChange={inputField.onChange}
+                              placeholder="0"
+                              min={0}
+                              step={50}
+                              className={`w-full pl-7 pr-3 py-2 text-sm text-right border rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500 ${
+                                errors.expenses?.[index]?.monthlyAmount
+                                  ? "border-red-400"
+                                  : amount > 0
+                                    ? "border-independence-200 bg-white"
+                                    : "border-gray-200 bg-white"
+                              }`}
+                            />
+                          )}
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
-              )
-            })
-          )}
-        </div>
+                )
+              })
+            )}
+          </div>
 
-        {/* Add custom category */}
-        <div className="mt-3">
-          {showAddCustom ? (
-            <div className="flex items-center gap-2 p-3 bg-independence-50 rounded-lg border border-independence-200">
-              <input
-                type="text"
-                value={customCategoryName}
-                onChange={(e) => setCustomCategoryName(e.target.value)}
-                placeholder="Category name (e.g. Golf, Travel)"
-                className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
-                autoFocus
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault()
-                    handleAddCustomCategory()
-                  }
-                  if (e.key === "Escape") {
+          {/* Add custom category */}
+          <div className="mt-3">
+            {showAddCustom ? (
+              <div className="flex items-center gap-2 p-3 bg-independence-50 rounded-lg border border-independence-200">
+                <input
+                  type="text"
+                  value={customCategoryName}
+                  onChange={(e) => setCustomCategoryName(e.target.value)}
+                  placeholder="Category name (e.g. Golf, Travel)"
+                  className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault()
+                      handleAddCustomCategory()
+                    }
+                    if (e.key === "Escape") {
+                      setShowAddCustom(false)
+                      setCustomCategoryName("")
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={handleAddCustomCategory}
+                  className="px-3 py-1.5 text-sm bg-independence-600 text-white rounded-lg hover:bg-independence-700"
+                >
+                  Add
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
                     setShowAddCustom(false)
                     setCustomCategoryName("")
-                  }
-                }}
-              />
+                  }}
+                  className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700"
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
               <button
                 type="button"
-                onClick={handleAddCustomCategory}
-                className="px-3 py-1.5 text-sm bg-independence-600 text-white rounded-lg hover:bg-independence-700"
+                onClick={() => setShowAddCustom(true)}
+                className="w-full py-2.5 text-sm border-2 border-dashed border-gray-200 text-gray-400 rounded-lg hover:border-independence-300 hover:text-independence-600 hover:bg-independence-50 transition-colors"
               >
-                Add
+                <i className="fas fa-plus mr-1.5"></i>
+                Add custom category
               </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setShowAddCustom(false)
-                  setCustomCategoryName("")
-                }}
-                className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700"
-              >
-                Cancel
-              </button>
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setShowAddCustom(true)}
-              className="w-full py-2.5 text-sm border-2 border-dashed border-gray-200 text-gray-400 rounded-lg hover:border-independence-300 hover:text-independence-600 hover:bg-independence-50 transition-colors"
-            >
-              <i className="fas fa-plus mr-1.5"></i>
-              Add custom category
-            </button>
+            )}
+          </div>
+
+          {errors.expenses && !Array.isArray(errors.expenses) && (
+            <p className="mt-2 text-sm text-red-600">
+              {errors.expenses.message}
+            </p>
           )}
         </div>
-
-        {errors.expenses && !Array.isArray(errors.expenses) && (
-          <p className="mt-2 text-sm text-red-600">{errors.expenses.message}</p>
-        )}
-      </div>
+      )}
 
       {/* Skip hint */}
       {(!isEditMode || totalMonthlyExpenses === 0) && (

--- a/src/components/features/independence/steps/LifestyleMoodBoard.tsx
+++ b/src/components/features/independence/steps/LifestyleMoodBoard.tsx
@@ -262,9 +262,9 @@ export default function LifestyleMoodBoard({
                 </span>
                 <div className="flex items-center gap-1.5">
                   {anchorAmount > 0 && (
-                    <span className="text-xs text-gray-500">
-                      you today: {symbol}
-                      {anchorAmount.toLocaleString()}/mo
+                    <span className="text-[11px] text-gray-400">
+                      now {symbol}
+                      {anchorAmount.toLocaleString()}
                     </span>
                   )}
                   {isCustom && (
@@ -292,7 +292,7 @@ export default function LifestyleMoodBoard({
                           : `lifestyle-tier-${category.key}-${idx}`
                       }
                       onClick={() => handleTierClick(category, idx)}
-                      className={`flex-1 min-w-[64px] rounded-lg border px-1.5 py-1.5 text-center text-[11px] transition-colors ${
+                      className={`flex items-center gap-1 whitespace-nowrap rounded-lg border px-2 py-1.5 text-xs transition-colors ${
                         active
                           ? "border-independence-500 bg-independence-50 text-independence-800"
                           : nearest
@@ -300,19 +300,16 @@ export default function LifestyleMoodBoard({
                             : "border-gray-200 text-gray-500 hover:bg-gray-50"
                       } ${tier.reserve ? "border-dashed border-amber-300" : ""}`}
                     >
-                      <span className="block text-base leading-none">
-                        {tier.emoji}
-                      </span>
-                      <span className="block mt-1 font-medium">
-                        {tier.label}
-                        {tier.reserve && (
-                          <span className="text-amber-500"> ✦</span>
-                        )}
-                      </span>
-                      <span className="block text-gray-400">
+                      <span>{tier.emoji}</span>
+                      <span className="font-medium">{tier.label}</span>
+                      <span aria-hidden="true">·</span>
+                      <span className="text-gray-600">
                         {symbol}
                         {tier.monthlyAmount.toLocaleString()}
                       </span>
+                      {tier.reserve && (
+                        <span className="text-amber-500">✦</span>
+                      )}
                       {nearest && (
                         <span
                           data-testid={`lifestyle-tier-nearest-${category.key}-${idx}`}
@@ -326,9 +323,11 @@ export default function LifestyleMoodBoard({
                 })}
               </div>
 
-              <p className="text-[11px] text-gray-400 leading-relaxed">
-                {category.tiers[selectedIdx].description}
-              </p>
+              {picked && mode === "board" && (
+                <p className="text-xs text-gray-500">
+                  {category.tiers[selectedIdx].description}
+                </p>
+              )}
             </div>
           )
         })}

--- a/src/components/features/independence/steps/LifestyleMoodBoard.tsx
+++ b/src/components/features/independence/steps/LifestyleMoodBoard.tsx
@@ -11,11 +11,21 @@ import {
   lifestyleHeadline,
   nearestTierIndex,
 } from "@lib/independence/lifestyleBoard"
+import InfoTooltip from "@components/ui/Tooltip"
 
 interface LifestyleMoodBoardProps {
   categories: LifestyleCategory[]
   currency: string
   expenses: ExpenseFormEntry[]
+  /**
+   * Expense rows snapshotted once, at Expenses-step mount, before the
+   * board seeds any rows back into the form. Powers the "you today" chip,
+   * the nearest-tier highlight and the header delta so they stay fixed
+   * for the rest of the session instead of drifting once the board writes
+   * its own picks into the live `expenses` prop. Falls back to `expenses`
+   * when the caller doesn't supply one (e.g. standalone component tests).
+   */
+  expensesSnapshot?: ExpenseFormEntry[]
   onSelectionChange: (change: TierSelectionChange) => void
 }
 
@@ -52,8 +62,11 @@ export default function LifestyleMoodBoard({
   categories,
   currency,
   expenses,
+  expensesSnapshot,
   onSelectionChange,
 }: LifestyleMoodBoardProps): React.ReactElement {
+  const anchorExpenses = expensesSnapshot ?? expenses
+
   const sortedCategories = useMemo(
     () => [...categories].sort((a, b) => a.sortOrder - b.sortOrder),
     [categories],
@@ -122,7 +135,7 @@ export default function LifestyleMoodBoard({
 
   const boardTotal = boardMonthlyTotal(sortedCategories, selection)
   const existingTotal = sortedCategories.reduce(
-    (sum, c) => sum + existingAmountFor(c.categoryLabelId, expenses),
+    (sum, c) => sum + existingAmountFor(c.categoryLabelId, anchorExpenses),
     0,
   )
   const hasExisting = existingTotal > 0
@@ -142,7 +155,10 @@ export default function LifestyleMoodBoard({
               <p className="mt-1 text-xs text-independence-600">
                 Board is {symbol}
                 {Math.abs(delta).toLocaleString()}/mo{" "}
-                {delta >= 0 ? "above" : "below"} your current spend
+                {delta >= 0 ? "above" : "below"} your current spend{" "}
+                <InfoTooltip text="Compared against your current spend in board categories only — excludes Utilities and custom rows.">
+                  <span className="sr-only">What is this delta?</span>
+                </InfoTooltip>
               </p>
             )}
           </div>
@@ -212,17 +228,25 @@ export default function LifestyleMoodBoard({
         {sortedCategories.map((category) => {
           const selectedIdx = selection[category.key] ?? 0
           const picked = pickedKeys.has(category.key)
-          const existingAmount = existingAmountFor(
+          // "You today" chip + nearest-tier highlight read the frozen
+          // snapshot so they don't drift once the board seeds its own
+          // picks back into the live `expenses` prop.
+          const anchorAmount = existingAmountFor(
+            category.categoryLabelId,
+            anchorExpenses,
+          )
+          const nearestIdx =
+            anchorAmount > 0
+              ? nearestTierIndex(anchorAmount, category.tiers)
+              : null
+          // Custom-chip detection stays on the live value — it reflects a
+          // hand-edit made via the Detailed tab after a tier was picked.
+          const liveAmount = existingAmountFor(
             category.categoryLabelId,
             expenses,
           )
-          const nearestIdx =
-            existingAmount > 0
-              ? nearestTierIndex(existingAmount, category.tiers)
-              : null
           const isCustom =
-            picked &&
-            isCustomAmount(existingAmount, category.tiers[selectedIdx])
+            picked && isCustomAmount(liveAmount, category.tiers[selectedIdx])
 
           return (
             <div
@@ -237,10 +261,10 @@ export default function LifestyleMoodBoard({
                   {category.emoji} {category.displayName}
                 </span>
                 <div className="flex items-center gap-1.5">
-                  {existingAmount > 0 && (
+                  {anchorAmount > 0 && (
                     <span className="text-xs text-gray-500">
                       you today: {symbol}
-                      {existingAmount.toLocaleString()}/mo
+                      {anchorAmount.toLocaleString()}/mo
                     </span>
                   )}
                   {isCustom && (

--- a/src/components/features/independence/steps/LifestyleMoodBoard.tsx
+++ b/src/components/features/independence/steps/LifestyleMoodBoard.tsx
@@ -1,0 +1,314 @@
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import {
+  ExpenseFormEntry,
+  LifestyleCategory,
+  TierSelectionChange,
+} from "types/independence"
+import {
+  boardMonthlyTotal,
+  fitToBudget,
+  isCustomAmount,
+  lifestyleHeadline,
+  nearestTierIndex,
+} from "@lib/independence/lifestyleBoard"
+
+interface LifestyleMoodBoardProps {
+  categories: LifestyleCategory[]
+  currency: string
+  expenses: ExpenseFormEntry[]
+  onSelectionChange: (change: TierSelectionChange) => void
+}
+
+type Mode = "budget" | "board"
+
+const MIN_BUDGET = 1000
+const MAX_BUDGET = 32000
+const BUDGET_STEP = 100
+
+const currencySymbol = (currency: string): string => {
+  switch (currency) {
+    case "USD":
+      return "$"
+    case "SGD":
+      return "S$"
+    case "EUR":
+      return "€"
+    default:
+      return "$"
+  }
+}
+
+/** Sum of monthlyAmount across all rows matching a categoryLabelId. */
+function existingAmountFor(
+  categoryLabelId: string,
+  expenses: ExpenseFormEntry[],
+): number {
+  return expenses
+    .filter((e) => e.categoryLabelId === categoryLabelId)
+    .reduce((sum, e) => sum + (e.monthlyAmount || 0), 0)
+}
+
+export default function LifestyleMoodBoard({
+  categories,
+  currency,
+  expenses,
+  onSelectionChange,
+}: LifestyleMoodBoardProps): React.ReactElement {
+  const sortedCategories = useMemo(
+    () => [...categories].sort((a, b) => a.sortOrder - b.sortOrder),
+    [categories],
+  )
+
+  const hasInitialized = useRef(false)
+
+  const [mode, setMode] = useState<Mode>("budget")
+  const [budget, setBudget] = useState<number>(8000)
+  const [selection, setSelection] = useState<Record<string, number>>({})
+  const [pickedKeys, setPickedKeys] = useState<Set<string>>(new Set())
+
+  const symbol = currencySymbol(currency)
+
+  // Seed the board from existing expense values on mount: each category
+  // starts at its nearest tier match to the existing amount (if any),
+  // without marking it "picked" — that only happens on explicit board
+  // interaction.
+  useEffect(() => {
+    if (hasInitialized.current || sortedCategories.length === 0) return
+    hasInitialized.current = true
+
+    const seeded: Record<string, number> = {}
+    sortedCategories.forEach((c) => {
+      const existing = existingAmountFor(c.categoryLabelId, expenses)
+      seeded[c.key] = existing > 0 ? nearestTierIndex(existing, c.tiers) : 0
+    })
+    setSelection(seeded)
+    const total = boardMonthlyTotal(sortedCategories, seeded)
+    setBudget(Math.max(MIN_BUDGET, Math.min(MAX_BUDGET, total || 8000)))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sortedCategories])
+
+  const emitChange = (
+    nextSelection: Record<string, number>,
+    nextPicked: Set<string>,
+  ): void => {
+    onSelectionChange({
+      selection: nextSelection,
+      pickedKeys: Array.from(nextPicked),
+    })
+  }
+
+  const handleBudgetChange = (value: number): void => {
+    setBudget(value)
+    setMode("budget")
+    const fitted = fitToBudget(sortedCategories, value)
+    setSelection(fitted)
+    const nextPicked = new Set(sortedCategories.map((c) => c.key))
+    setPickedKeys(nextPicked)
+    emitChange(fitted, nextPicked)
+  }
+
+  const handleTierClick = (
+    category: LifestyleCategory,
+    tierIndex: number,
+  ): void => {
+    setMode("board")
+    const nextSelection = { ...selection, [category.key]: tierIndex }
+    const nextPicked = new Set(pickedKeys)
+    nextPicked.add(category.key)
+    setSelection(nextSelection)
+    setPickedKeys(nextPicked)
+    emitChange(nextSelection, nextPicked)
+  }
+
+  const boardTotal = boardMonthlyTotal(sortedCategories, selection)
+  const existingTotal = sortedCategories.reduce(
+    (sum, c) => sum + existingAmountFor(c.categoryLabelId, expenses),
+    0,
+  )
+  const hasExisting = existingTotal > 0
+  const delta = boardTotal - existingTotal
+  const headline = lifestyleHeadline(boardTotal)
+
+  return (
+    <div className="space-y-5" data-testid="lifestyle-mood-board">
+      <div className="rounded-xl border border-independence-200 bg-independence-50 p-5">
+        <div className="flex flex-wrap items-baseline justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold text-independence-700">
+              This board reads as a{" "}
+              <span className="font-bold">{headline}</span> retirement
+            </p>
+            {hasExisting && (
+              <p className="mt-1 text-xs text-independence-600">
+                Board is {symbol}
+                {Math.abs(delta).toLocaleString()}/mo{" "}
+                {delta >= 0 ? "above" : "below"} your current spend
+              </p>
+            )}
+          </div>
+          <div className="shrink-0 text-right">
+            <p className="text-2xl font-bold tabular-nums text-independence-800">
+              {symbol}
+              {boardTotal.toLocaleString()}
+              <span className="text-sm font-normal text-independence-500">
+                {" "}
+                /mo
+              </span>
+            </p>
+            <p className="text-xs text-independence-500">
+              {symbol}
+              {(boardTotal * 12).toLocaleString()} /yr
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <div className="flex rounded-lg bg-white border border-independence-200 p-0.5">
+            <button
+              type="button"
+              onClick={() => setMode("budget")}
+              className={`px-3 py-1.5 text-xs rounded-md font-medium ${
+                mode === "budget"
+                  ? "bg-independence-600 text-white"
+                  : "text-independence-600"
+              }`}
+            >
+              Budget → Board
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("board")}
+              className={`px-3 py-1.5 text-xs rounded-md font-medium ${
+                mode === "board"
+                  ? "bg-independence-600 text-white"
+                  : "text-independence-600"
+              }`}
+            >
+              Board → Budget
+            </button>
+          </div>
+
+          <div className="flex-1 min-w-[200px] flex items-center gap-2">
+            <input
+              type="range"
+              aria-label="Monthly budget"
+              min={MIN_BUDGET}
+              max={MAX_BUDGET}
+              step={BUDGET_STEP}
+              value={budget}
+              disabled={mode === "board"}
+              onChange={(e) => handleBudgetChange(Number(e.target.value))}
+              className="w-full"
+            />
+            <span className="text-xs tabular-nums text-independence-600 w-20 text-right">
+              {symbol}
+              {budget.toLocaleString()}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {sortedCategories.map((category) => {
+          const selectedIdx = selection[category.key] ?? 0
+          const picked = pickedKeys.has(category.key)
+          const existingAmount = existingAmountFor(
+            category.categoryLabelId,
+            expenses,
+          )
+          const nearestIdx =
+            existingAmount > 0
+              ? nearestTierIndex(existingAmount, category.tiers)
+              : null
+          const isCustom =
+            picked &&
+            isCustomAmount(existingAmount, category.tiers[selectedIdx])
+
+          return (
+            <div
+              key={category.key}
+              className="rounded-lg border border-gray-200 bg-white p-3 space-y-2"
+            >
+              <div className="flex items-center justify-between">
+                <span
+                  className="text-sm font-semibold text-gray-900"
+                  data-testid="lifestyle-category-name"
+                >
+                  {category.emoji} {category.displayName}
+                </span>
+                <div className="flex items-center gap-1.5">
+                  {existingAmount > 0 && (
+                    <span className="text-xs text-gray-500">
+                      you today: {symbol}
+                      {existingAmount.toLocaleString()}/mo
+                    </span>
+                  )}
+                  {isCustom && (
+                    <span
+                      data-testid={`lifestyle-chip-custom-${category.key}`}
+                      className="text-xs bg-independence-100 text-independence-700 px-2 py-0.5 rounded-full"
+                    >
+                      Custom
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex gap-1.5 flex-wrap">
+                {category.tiers.map((tier, idx) => {
+                  const active = idx === selectedIdx
+                  const nearest = !picked && idx === nearestIdx
+                  return (
+                    <button
+                      key={tier.label}
+                      type="button"
+                      data-testid={
+                        tier.reserve
+                          ? "lifestyle-tier-reserve"
+                          : `lifestyle-tier-${category.key}-${idx}`
+                      }
+                      onClick={() => handleTierClick(category, idx)}
+                      className={`flex-1 min-w-[64px] rounded-lg border px-1.5 py-1.5 text-center text-[11px] transition-colors ${
+                        active
+                          ? "border-independence-500 bg-independence-50 text-independence-800"
+                          : nearest
+                            ? "border-dashed border-independence-300 bg-independence-50/50 text-gray-600"
+                            : "border-gray-200 text-gray-500 hover:bg-gray-50"
+                      } ${tier.reserve ? "border-dashed border-amber-300" : ""}`}
+                    >
+                      <span className="block text-base leading-none">
+                        {tier.emoji}
+                      </span>
+                      <span className="block mt-1 font-medium">
+                        {tier.label}
+                        {tier.reserve && (
+                          <span className="text-amber-500"> ✦</span>
+                        )}
+                      </span>
+                      <span className="block text-gray-400">
+                        {symbol}
+                        {tier.monthlyAmount.toLocaleString()}
+                      </span>
+                      {nearest && (
+                        <span
+                          data-testid={`lifestyle-tier-nearest-${category.key}-${idx}`}
+                          className="sr-only"
+                        >
+                          nearest
+                        </span>
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
+
+              <p className="text-[11px] text-gray-400 leading-relaxed">
+                {category.tiers[selectedIdx].description}
+              </p>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/utils/api/__tests__/routes/lifestyle-catalog.route.test.ts
+++ b/src/lib/utils/api/__tests__/routes/lifestyle-catalog.route.test.ts
@@ -1,0 +1,110 @@
+import lifestyleCatalogHandler from "@pages/api/independence/lifestyle-catalog"
+
+jest.mock("@lib/auth0", () => ({
+  auth0: {
+    getSession: jest.fn().mockResolvedValue({ user: { sub: "test-user" } }),
+    getAccessToken: jest.fn().mockResolvedValue({ token: "test-token" }),
+  },
+}))
+
+jest.mock("@utils/api/fetchHelper", () => ({
+  requestInit: jest.fn(
+    (token: string, method: string) =>
+      ({
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+      }) as unknown,
+  ),
+}))
+
+jest.mock("@utils/api/responseWriter", () => {
+  const handleResponse = jest
+    .fn()
+    .mockImplementation(
+      (_response: Response, res: { status: jest.Mock; json: jest.Mock }) => {
+        res.status(200).json({ data: {} })
+      },
+    )
+  return {
+    __esModule: true,
+    default: handleResponse,
+    handleResponse,
+    fetchError: jest.fn(
+      (
+        _req: unknown,
+        res: { status: jest.Mock; json: jest.Mock },
+        error: { message: string },
+      ) => {
+        res.status(500).json({ error: error.message })
+      },
+    ),
+  }
+})
+
+jest.mock("@utils/api/bcConfig", () => ({
+  getRetireUrl: (path: string): string => `http://retire.test${path}`,
+}))
+
+const mockFetch = jest
+  .fn()
+  .mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
+global.fetch = mockFetch as unknown as typeof fetch
+
+function makeReq(method: string): {
+  method: string
+  query: Record<string, string>
+  headers: Record<string, string>
+} {
+  return { method, query: {}, headers: {} }
+}
+
+function makeRes(): {
+  status: jest.Mock
+  end: jest.Mock
+  json: jest.Mock
+  setHeader: jest.Mock
+} {
+  return {
+    status: jest.fn().mockReturnThis(),
+    end: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("/api/independence/lifestyle-catalog route", () => {
+  it("proxies GET to backend /lifestyle/catalog", async () => {
+    const req = makeReq("GET")
+    const res = makeRes()
+
+    await lifestyleCatalogHandler(
+      req as unknown as Parameters<typeof lifestyleCatalogHandler>[0],
+      res as unknown as Parameters<typeof lifestyleCatalogHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://retire.test/lifestyle/catalog",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    )
+  })
+
+  it("rejects POST with 405", async () => {
+    const req = makeReq("POST")
+    const res = makeRes()
+
+    await lifestyleCatalogHandler(
+      req as unknown as Parameters<typeof lifestyleCatalogHandler>[0],
+      res as unknown as Parameters<typeof lifestyleCatalogHandler>[1],
+    )
+
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", ["GET"])
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/utils/api/__tests__/routes/lifestyle-catalog.route.test.ts
+++ b/src/lib/utils/api/__tests__/routes/lifestyle-catalog.route.test.ts
@@ -50,12 +50,15 @@ const mockFetch = jest
   .mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
 global.fetch = mockFetch as unknown as typeof fetch
 
-function makeReq(method: string): {
+function makeReq(
+  method: string,
+  query: Record<string, string> = {},
+): {
   method: string
   query: Record<string, string>
   headers: Record<string, string>
 } {
-  return { method, query: {}, headers: {} }
+  return { method, query, headers: {} }
 }
 
 function makeRes(): {
@@ -88,6 +91,23 @@ describe("/api/independence/lifestyle-catalog route", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       "http://retire.test/lifestyle/catalog",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    )
+  })
+
+  it("forwards the currency query param to the backend catalog URL", async () => {
+    const req = makeReq("GET", { currency: "SGD" })
+    const res = makeRes()
+
+    await lifestyleCatalogHandler(
+      req as unknown as Parameters<typeof lifestyleCatalogHandler>[0],
+      res as unknown as Parameters<typeof lifestyleCatalogHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://retire.test/lifestyle/catalog?currency=SGD",
       expect.objectContaining({
         method: "GET",
       }),

--- a/src/lib/utils/independence/__tests__/lifestyleBoard.test.ts
+++ b/src/lib/utils/independence/__tests__/lifestyleBoard.test.ts
@@ -1,0 +1,109 @@
+import {
+  fitToBudget,
+  categoryMonthlyTotal,
+  boardMonthlyTotal,
+  lifestyleHeadline,
+  isCustomAmount,
+  nearestTierIndex,
+} from "../lifestyleBoard"
+import { makeLifestyleCatalog } from "@components/features/independence/__fixtures__/lifestyleCatalog"
+
+describe("lifestyleBoard", () => {
+  const catalog = makeLifestyleCatalog()
+  const categories = catalog.categories
+
+  describe("fitToBudget", () => {
+    it("returns the cheapest tier for every category at the floor budget", () => {
+      const floor = categoryMonthlyTotal(categories, () => 0)
+      const result = fitToBudget(categories, floor)
+      categories.forEach((c) => {
+        expect(result[c.key]).toBe(0)
+      })
+    })
+
+    it("upgrades higher-priority (lower sortOrder) categories before lower-priority ones of similar cost", () => {
+      // groceries (sortOrder 2, high weight) and dining (sortOrder 8, low
+      // weight) both have a ~$300 first-upgrade delta. The weighted score
+      // (delta / weight) favours groceries, so it should be upgraded
+      // first when only one $300ish upgrade fits the budget.
+      const floor = categoryMonthlyTotal(categories, () => 0)
+      const result = fitToBudget(categories, floor + 300)
+      expect(result.groceries).toBeGreaterThan(0)
+      expect(result.dining).toBe(0)
+    })
+
+    it("never selects a reserve tier before all non-reserve tiers are maxed for a huge budget bump relative to peers", () => {
+      // At a budget that easily affords one small upgrade, reserve tiers
+      // (penalised 3x) should not be picked over a cheaper non-reserve
+      // upgrade elsewhere.
+      const floor = categoryMonthlyTotal(categories, () => 0)
+      const result = fitToBudget(categories, floor + 400)
+      const health = categories.find((c) => c.key === "health")!
+      expect(result.health).toBeLessThan(health.tiers.length - 1) // not at reserve tier
+    })
+
+    it("only reaches a reserve tier once the budget is large enough", () => {
+      const ceiling = categoryMonthlyTotal(
+        categories,
+        (c) => c.tiers.length - 1,
+      )
+      const result = fitToBudget(categories, ceiling)
+      const health = categories.find((c) => c.key === "health")!
+      expect(result.health).toBe(health.tiers.length - 1)
+    })
+
+    it("never exceeds the given budget", () => {
+      const budget = 5000
+      const result = fitToBudget(categories, budget)
+      const spent = boardMonthlyTotal(categories, result)
+      expect(spent).toBeLessThanOrEqual(budget)
+    })
+  })
+
+  describe("boardMonthlyTotal / categoryMonthlyTotal", () => {
+    it("sums the selected tier cost per category", () => {
+      const selection = Object.fromEntries(categories.map((c) => [c.key, 0]))
+      const total = boardMonthlyTotal(categories, selection)
+      const expected = categories.reduce(
+        (s, c) => s + c.tiers[0].monthlyAmount,
+        0,
+      )
+      expect(total).toBe(expected)
+    })
+  })
+
+  describe("lifestyleHeadline", () => {
+    it.each([
+      [1000, "Lean & Intentional"],
+      [8000, "Comfortable"],
+      [30000, "High Flyer"],
+    ])("labels %i/mo as %s", (amount, label) => {
+      expect(lifestyleHeadline(amount)).toBe(label)
+    })
+  })
+
+  describe("isCustomAmount", () => {
+    it("is false when the amount matches the selected tier anchor", () => {
+      const housing = categories.find((c) => c.key === "housing")!
+      expect(
+        isCustomAmount(housing.tiers[1].monthlyAmount, housing.tiers[1]),
+      ).toBe(false)
+    })
+
+    it("is true when the amount was edited away from the tier anchor", () => {
+      const housing = categories.find((c) => c.key === "housing")!
+      expect(
+        isCustomAmount(housing.tiers[1].monthlyAmount + 37, housing.tiers[1]),
+      ).toBe(true)
+    })
+  })
+
+  describe("nearestTierIndex", () => {
+    it("finds the closest tier by absolute distance", () => {
+      const housing = categories.find((c) => c.key === "housing")!
+      // Between Modest(1200) and Comfortable(2200), 1700 is closer to Comfortable? No, exactly mid — pick lower tier on tie.
+      expect(nearestTierIndex(1250, housing.tiers)).toBe(0)
+      expect(nearestTierIndex(2100, housing.tiers)).toBe(1)
+    })
+  })
+})

--- a/src/lib/utils/independence/lifestyleBoard.ts
+++ b/src/lib/utils/independence/lifestyleBoard.ts
@@ -1,0 +1,150 @@
+import { LifestyleCategory, LifestyleTier } from "types/independence"
+
+/**
+ * Pure logic for the Lifestyle Mood Board (ExpensesStep). Kept independent
+ * of React so the greedy budget-fit algorithm, custom-amount detection and
+ * lifestyle headline banding can be unit tested directly.
+ *
+ * Ported from bc-claude/playgrounds/lifestyle-mood-board.html.
+ */
+
+/** Map of category `key` -> selected tier index. */
+export type TierSelection = Record<string, number>
+
+/**
+ * Upgrade priority weight for a category: higher sortOrder (lower
+ * priority) categories get a proportionally smaller weight, mirroring the
+ * playground's hand-tuned weights (housing highest, dining lowest) while
+ * deriving purely from the catalog's own `sortOrder` — no hardcoded keys.
+ */
+function priorityWeight(
+  category: LifestyleCategory,
+  categories: LifestyleCategory[],
+): number {
+  const maxSortOrder = Math.max(...categories.map((c) => c.sortOrder))
+  return maxSortOrder - category.sortOrder + 1
+}
+
+/** A tier is a "reserve" (5th, high-flyer) tier — deprioritised by the fitter. */
+function isReserveTier(
+  category: LifestyleCategory,
+  tierIndex: number,
+): boolean {
+  return category.tiers[tierIndex]?.reserve === true
+}
+
+/**
+ * Greedy budget-fit: start every category at its cheapest tier, then
+ * repeatedly upgrade whichever single-step upgrade has the best
+ * cost-per-priority score (delta / weight), applying a 3x penalty to
+ * reserve-tier upgrades, until no further upgrade fits the budget.
+ */
+export function fitToBudget(
+  categories: LifestyleCategory[],
+  budget: number,
+): TierSelection {
+  const selection: TierSelection = {}
+  categories.forEach((c) => {
+    selection[c.key] = 0
+  })
+
+  let spent = categories.reduce((s, c) => s + c.tiers[0].monthlyAmount, 0)
+
+  let improved = true
+  while (improved) {
+    improved = false
+    const options = categories
+      .filter((c) => selection[c.key] < c.tiers.length - 1)
+      .map((c) => {
+        const nextIdx = selection[c.key] + 1
+        const delta =
+          c.tiers[nextIdx].monthlyAmount -
+          c.tiers[selection[c.key]].monthlyAmount
+        const penalty = isReserveTier(c, nextIdx) ? 3 : 1
+        const weight = priorityWeight(c, categories)
+        return { key: c.key, delta, score: (delta / weight) * penalty }
+      })
+      .filter((o) => spent + o.delta <= budget)
+      .sort((a, b) => a.score - b.score)
+
+    if (options.length > 0) {
+      selection[options[0].key] += 1
+      spent += options[0].delta
+      improved = true
+    }
+  }
+
+  return selection
+}
+
+/** Monthly cost of a single category at the given selected tier index. */
+export function categoryCost(
+  category: LifestyleCategory,
+  tierIndex: number,
+): number {
+  return category.tiers[tierIndex]?.monthlyAmount ?? 0
+}
+
+/**
+ * Total monthly cost across categories using a tier-index picker function
+ * — handy for computing floor ("cheapest tier everywhere") or ceiling
+ * ("priciest tier everywhere") totals in tests without building a full
+ * TierSelection map.
+ */
+export function categoryMonthlyTotal(
+  categories: LifestyleCategory[],
+  tierIndexFor: (category: LifestyleCategory) => number,
+): number {
+  return categories.reduce(
+    (sum, c) => sum + categoryCost(c, tierIndexFor(c)),
+    0,
+  )
+}
+
+/** Total monthly cost across categories for a given TierSelection. */
+export function boardMonthlyTotal(
+  categories: LifestyleCategory[],
+  selection: TierSelection,
+): number {
+  return categoryMonthlyTotal(categories, (c) => selection[c.key] ?? 0)
+}
+
+const HEADLINE_BANDS: Array<{ ceiling: number; label: string }> = [
+  { ceiling: 4500, label: "Lean & Intentional" },
+  { ceiling: 7000, label: "Simple Comforts" },
+  { ceiling: 10500, label: "Comfortable" },
+  { ceiling: 15000, label: "Premium" },
+  { ceiling: 20000, label: "Luxurious" },
+  { ceiling: 26000, label: "No Compromises" },
+]
+
+/** Lifestyle headline band for a given total monthly spend. */
+export function lifestyleHeadline(monthlyTotal: number): string {
+  const band = HEADLINE_BANDS.find((b) => monthlyTotal < b.ceiling)
+  return band ? band.label : "High Flyer"
+}
+
+/**
+ * True when a row's stored amount doesn't match its picked tier's anchor
+ * — i.e. it was hand-edited via the Detailed tab.
+ */
+export function isCustomAmount(amount: number, tier: LifestyleTier): boolean {
+  return amount !== tier.monthlyAmount
+}
+
+/** Index of the tier whose monthlyAmount is closest to `amount` (ties favour the lower/cheaper tier). */
+export function nearestTierIndex(
+  amount: number,
+  tiers: LifestyleTier[],
+): number {
+  let bestIdx = 0
+  let bestDistance = Infinity
+  tiers.forEach((tier, idx) => {
+    const distance = Math.abs(tier.monthlyAmount - amount)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      bestIdx = idx
+    }
+  })
+  return bestIdx
+}

--- a/src/pages/api/independence/lifestyle-catalog.ts
+++ b/src/pages/api/independence/lifestyle-catalog.ts
@@ -1,0 +1,6 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getRetireUrl } from "@utils/api/bcConfig"
+
+export default createApiHandler({
+  url: getRetireUrl("/lifestyle/catalog"),
+})

--- a/src/pages/api/independence/lifestyle-catalog.ts
+++ b/src/pages/api/independence/lifestyle-catalog.ts
@@ -1,6 +1,20 @@
+import { NextApiRequest } from "next"
 import { createApiHandler } from "@utils/api/createApiHandler"
 import { getRetireUrl } from "@utils/api/bcConfig"
 
+/**
+ * Forward the plan's `expensesCurrency` through to svc-retire so the
+ * catalog can be returned pre-converted for that currency (svc-retire
+ * #170). The frontend never converts/reformats amounts itself — it's a
+ * pure pass-through of whatever `currency` the response echoes back.
+ */
+function catalogUrl(req: NextApiRequest): string {
+  const base = getRetireUrl("/lifestyle/catalog")
+  const raw = req.query.currency
+  const currency = Array.isArray(raw) ? raw[0] : raw
+  return currency ? `${base}?currency=${encodeURIComponent(currency)}` : base
+}
+
 export default createApiHandler({
-  url: getRetireUrl("/lifestyle/catalog"),
+  url: catalogUrl,
 })

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -246,6 +246,43 @@ export interface CategoryLabelsResponse {
   data: CategoryLabel[]
 }
 
+// ============ Lifestyle Mood Board ============
+export interface LifestyleTier {
+  label: string
+  emoji: string
+  monthlyAmount: number
+  description: string
+  reserve: boolean
+}
+
+export interface LifestyleCategory {
+  key: string
+  displayName: string
+  emoji: string
+  categoryLabelId: string
+  sortOrder: number
+  tiers: LifestyleTier[]
+}
+
+export interface LifestyleCatalogResponse {
+  householdSize: number
+  currency: string
+  categories: LifestyleCategory[]
+}
+
+/**
+ * Emitted by LifestyleMoodBoard whenever the tier selection changes (slider
+ * fit or a direct tier click). `selection` maps catalog category `key` ->
+ * chosen tier index. `pickedKeys` are the categories the user has
+ * explicitly set via the board (as opposed to ones still only reflecting
+ * the pre-existing expense's nearest-tier match) — used to gate custom-
+ * amount detection.
+ */
+export interface TierSelectionChange {
+  selection: Record<string, number>
+  pickedKeys: string[]
+}
+
 // ============ Quick Scenarios ============
 export interface QuickScenario {
   id: string


### PR DESCRIPTION
## Summary

Adds a "Lifestyle Mood Board" to the independence wizard's `ExpensesStep`:

- New **Mood Board** / **Detailed** tabs. Mood Board is the default for a plan with no retirement expenses recorded yet; Detailed (the existing per-category rows UI) is unchanged and is the default once real amounts exist.
- Mood Board renders the 8 lifestyle categories from the new `GET /lifestyle/catalog` svc-retire endpoint (proxied via `/api/independence/lifestyle-catalog`), in `sortOrder` (priority) order.
- Two interaction modes: **Budget → Board** (slider; greedy fit that upgrades the cheapest-per-priority-weighted delta, with a 3x penalty on reserve/5th tiers) and **Board → Budget** (clicking a tier directly; clicking always switches into this mode).
- Reserve (5th) tiers render with a gold dashed border and a ✦ suffix.
- Running monthly + annual total and a lifestyle headline band (Lean & Intentional → High Flyer).
- **Existing Expense Values**: on initial mount, any pre-existing `PlanExpense` amount renders as a "you today: $X/mo" marker with its nearest tier highlighted, and the header shows the delta between the board total and the current total — all before the user touches anything.
- **Custom detection**: once a category has been explicitly picked via the board, if its stored amount is later edited away from that tier's anchor (e.g. via the Detailed tab), the chip shows a "Custom" badge instead of a tier match.
- Picking a tier (or moving the slider) writes directly into the shared `expenses` field array (one row per catalog category, matched by `categoryLabelId`); existing rows for categories not present in the catalog are preserved. Save path (`POST/PATCH /plans/{id}/expenses`) is unchanged.

Types (`LifestyleTier`, `LifestyleCategory`, `LifestyleCatalogResponse`, `TierSelectionChange`) added to `types/independence.d.ts`. A `makeLifestyleCatalog` fixture lives alongside the repo's other independence fixtures in `src/components/features/independence/__fixtures__/` (see divergence note below).

## Tests added

- `src/lib/utils/independence/__tests__/lifestyleBoard.test.ts` — pure logic: greedy budget fit (priority weighting + reserve-tier penalty, budget ceiling respected), lifestyle headline banding, custom-amount detection, nearest-tier matching.
- `src/lib/utils/api/__tests__/routes/lifestyle-catalog.route.test.ts` — API route proxies GET to svc-retire, rejects other methods with 405.
- `src/components/features/independence/__tests__/LifestyleMoodBoard.test.tsx` — renders all 8 categories in sortOrder, reserve-tier marker, tier click reports selection, budget slider applies greedy fit, "you today" chip + nearest-tier highlight + total delta on mount, custom chip once a picked amount diverges from its tier anchor.
- `src/components/features/independence/__tests__/ExpensesStep.test.tsx` — extended for tab defaults (Mood Board for zero-expense plans, Detailed for plans with existing amounts) and Mood Board → field-array seeding; all pre-existing Detailed-tab behaviour (copy-from-working, custom category rows) preserved unchanged (now reached via the Detailed tab).
- `src/components/features/independence/__tests__/WizardContainer.test.tsx` — updated to switch to the Detailed tab before exercising the custom-category workflow.

All tests were written and run RED (confirmed failing — missing module errors) before implementation.

## Gates

`yarn test` (2299/2299 passed), `yarn prettier` (clean), `yarn lint` (0 errors — 1 pre-existing unrelated warning), `yarn typecheck` (clean).

## Honesty / stop conditions

- **No browser/live UI verification was performed.** The backend dependency (svc-retire `GET /lifestyle/catalog`) is not yet merged, so there is nothing live to hit; only Jest/RTL component and unit tests were run. No screenshots are included.
- Dark-mode CSS-var/`.dark`-scope styling was **not** applied — the existing `ExpensesStep.tsx` and its sibling wizard-step components use plain Tailwind colour utilities with no dark-mode infrastructure anywhere in this component tree (no `darkMode` config, no `dark:` classes used anywhere under `src/components/features/independence/`). The new components follow that same existing convention rather than introducing a new one.
- `makeLifestyleCatalog` was placed in `src/components/features/independence/__fixtures__/lifestyleCatalog.ts` (matching the repo's existing fixture convention, e.g. `monteCarloResult.ts`) rather than in `types/independence.d.ts` — `.d.ts` files are declaration-only and stripped by TypeScript before Jest sees them, so a runtime factory function placed there would not be importable at test time. The type *interfaces* themselves are in `types/independence.d.ts` as specified.

## Dependency

Requires **monowai/svc-retire#167** (`GET /lifestyle/catalog`) to be merged and deployed before this is functional end-to-end. This PR is safe to merge ahead of that — it degrades gracefully to a "Loading lifestyle catalog…" state if the endpoint isn't available.

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkPPsAmWzHF3R4r4Dy391j


## Follow-up commit — #1122 polish

Also **Closes #1122** — mood board polish from live browser verification, added on top of this PR's branch:

- **Currency pass-through**: catalog is now fetched as `/api/independence/lifestyle-catalog?currency=<plan.expensesCurrency>` (route forwards `?currency=` to svc-retire's `/lifestyle/catalog`). The board renders whatever `currency` the response echoes back — no client-side conversion/reformatting, pure pass-through (svc-retire#170, in flight; degrades to unscoped USD catalog until that ships).
- **"You today" anchor**: expense-row amounts are now snapshotted once in `ExpensesStep` on mount (`useState` lazy initializer), before any mood-board seeding runs. `LifestyleMoodBoard` uses that frozen snapshot for the "you today" chips, nearest-tier highlight, and header delta, so they no longer drift once a tier click writes the board's own picks back into the live `expenses` field array. Custom-chip detection still reads live values (unchanged behaviour).
- **Delta tooltip**: added an `InfoTooltip` next to the header delta clarifying "Compared against your current spend in board categories only — excludes Utilities and custom rows."

Gates: `yarn test` (2305/2305 passed), `yarn prettier`/`yarn lint` (0 errors, 1 pre-existing unrelated warning), `yarn typecheck` (clean).
