### PR TITLE
chore(fantail): add fantail.yaml service definition

### DIFF
--- a/fantail.yaml
+++ b/fantail.yaml
@@ -1,0 +1,22 @@
+# fantail service definition — discovered by `fantail` (see monowai/fantail)
+description: Next.js frontend
+command: ["yarn", "dev"]
+profile: local                   # env from .env.local (next dev)
+# .env.e2e holds TEST-RUNNER vars only (E2E_BASE_URL, E2E_API_BASE, test-user
+# creds). playwright.config.ts loads it itself via dotenv; `next dev` ignores
+# it and reads .env.local for server config. Injecting it here just keeps
+# bcc-launched child tooling (agent-driven runs etc.) on the same e2e config.
+# For a true e2e SERVER profile (different backend URLs for the dev server),
+# create a separate file and point --set env_file= at it.
+env_file: .env.e2e
+env:
+  PORT: "${self.port}"        # next dev honours PORT — instance offsets apply
+port: 3000
+# no health url: TCP check on port 3000
+wants:
+  - service: svc-data            # peer check at the instance's effective port
+  - tcp: localhost:5672          # rabbit — CSV imports (shared infra, static)
+
+# untracked runtime files copied into worktrees on start (fantail worktree fallback)
+runtime_config:
+  - ".env*"


### PR DESCRIPTION
Checks in the `fantail.yaml` bc-view has been running from locally
(previously untracked), so `fantail start bc-view` works from a clean
checkout instead of depending on a file that only existed on one machine.

No hot reload block here, and none needed — `next dev` already has Fast
Refresh. This is purely the service definition: `yarn dev`, `PORT` wired to
`${self.port}` so instance offsets reach the dev server, TCP health on 3000,
and `wants:` probes for svc-data and RabbitMQ.

`runtime_config: [".env*"]` is what lets fantail copy the untracked env files
from the primary checkout into a worktree on start, which is how agent
worktrees get a runnable bc-view without a manual copy step.

Scope note: this branch contains **only** `fantail.yaml`. The unrelated
in-flight edits under `src/` in the working tree were deliberately left
unstaged.
