### PR TITLE
feat(independence): show what a plan supports as a lifestyle

### DIFF
--- a/fantail.yaml
+++ b/fantail.yaml
@@ -1,0 +1,22 @@
+# fantail service definition — discovered by `fantail` (see monowai/fantail)
+description: Next.js frontend
+command: ["yarn", "dev"]
+profile: local                   # env from .env.local (next dev)
+# .env.e2e holds TEST-RUNNER vars only (E2E_BASE_URL, E2E_API_BASE, test-user
+# creds). playwright.config.ts loads it itself via dotenv; `next dev` ignores
+# it and reads .env.local for server config. Injecting it here just keeps
+# bcc-launched child tooling (agent-driven runs etc.) on the same e2e config.
+# For a true e2e SERVER profile (different backend URLs for the dev server),
+# create a separate file and point --set env_file= at it.
+env_file: .env.e2e
+env:
+  PORT: "${self.port}"        # next dev honours PORT — instance offsets apply
+port: 3000
+# no health url: TCP check on port 3000
+wants:
+  - service: svc-data            # peer check at the instance's effective port
+  - tcp: localhost:5672          # rabbit — CSV imports (shared infra, static)
+
+# untracked runtime files copied into worktrees on start (fantail worktree fallback)
+runtime_config:
+  - ".env*"

--- a/src/components/features/independence/CompositeTab.tsx
+++ b/src/components/features/independence/CompositeTab.tsx
@@ -15,6 +15,8 @@ import StressTestTab from "./composite/tabs/StressTestTab"
 import YearByYearTab from "./composite/tabs/YearByYearTab"
 import FiOverviewTab from "./composite/tabs/FiOverviewTab"
 import NetWorthTab from "./composite/tabs/NetWorthTab"
+import SummaryTab from "./composite/tabs/SummaryTab"
+import { compositeOutlook } from "@lib/independence/compositeOutlook"
 
 interface CompositeTabProps {
   plans: RetirementPlan[]
@@ -22,7 +24,13 @@ interface CompositeTabProps {
 }
 
 type CompositeSubTabId =
-  "overview" | "phases" | "wealth" | "networth" | "stress" | "timeline"
+  | "summary"
+  | "overview"
+  | "phases"
+  | "wealth"
+  | "networth"
+  | "stress"
+  | "timeline"
 
 interface CompositeSubTabConfig {
   id: CompositeSubTabId
@@ -31,6 +39,7 @@ interface CompositeSubTabConfig {
 }
 
 const COMPOSITE_SUB_TABS: CompositeSubTabConfig[] = [
+  { id: "summary", label: "Summary", icon: "fa-list-ul" },
   { id: "phases", label: "Phases", icon: "fa-clipboard-list" },
   { id: "networth", label: "Net Worth", icon: "fa-wallet" },
   { id: "overview", label: "FI Overview", icon: "fa-bullseye" },
@@ -54,11 +63,7 @@ function CompositeSubTabNavigation({
 }: CompositeSubTabNavigationProps): React.ReactElement {
   const { projection } = useCompositeProjectionContext()
 
-  const sustainabilityText = projection
-    ? projection.isSustainable
-      ? `Sustainable to age ${projection.yearlyProjections[projection.yearlyProjections.length - 1]?.age ?? "?"}`
-      : `Savings deplete at age ${projection.depletionAge ?? "?"}`
-    : null
+  const sustainabilityText = compositeOutlook(projection)?.badge ?? null
 
   return (
     <div className="border-b border-gray-200 mb-4">
@@ -128,6 +133,8 @@ export default function CompositeTab({
   settings,
 }: CompositeTabProps): React.ReactElement {
   const projectionState = useCompositeProjection(plans, settings)
+  // Summary sits first in the bar but Phases stays the landing tab — that's
+  // where the user configures, and an explicit test asserts it.
   const [activeTab, setActiveTab] = useState<CompositeSubTabId>("phases")
 
   const contextValue: CompositeProjectionValue = {
@@ -142,6 +149,7 @@ export default function CompositeTab({
           activeTab={activeTab}
           onTabChange={setActiveTab}
         />
+        {activeTab === "summary" && <SummaryTab />}
         {activeTab === "overview" && <FiOverviewTab />}
         {activeTab === "phases" && <PhasesTab />}
         {activeTab === "wealth" && <WealthJourneyTab />}

--- a/src/components/features/independence/DetailsTabContent.tsx
+++ b/src/components/features/independence/DetailsTabContent.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import InfoTooltip from "@components/ui/Tooltip"
 import KpiCard from "@components/ui/KpiCard"
 import { RetirementPlan, RetirementProjection } from "types/independence"
@@ -9,6 +9,11 @@ import {
   PlanFindingsCard,
 } from "@components/features/independence"
 import VerdictBanner from "./VerdictBanner"
+import LifestyleSummary from "./LifestyleSummary"
+import { usePlanExpenses } from "./usePlanExpenses"
+import { useExpenseCategories } from "./useExpenseCategories"
+import { useLifestyleCatalog } from "./useLifestyleCatalog"
+import { buildLifestyleSummary } from "@lib/independence/lifestyleSummary"
 import { applyRealReturn } from "@components/features/independence/scenario/scenarioToPayload"
 import { isStreamInflationIndexed } from "@lib/independence/valueBasis"
 import type { ScenarioState } from "@components/features/independence/scenario/types"
@@ -50,6 +55,19 @@ export default function DetailsTabContent({
   includedPensionFvDifferential,
 }: DetailsTabContentProps): React.ReactElement {
   const { hideValues } = usePrivacyMode()
+  const { expenses, isLoading: expensesLoading } = usePlanExpenses(plan.id)
+  const { labels } = useExpenseCategories()
+  const { catalog } = useLifestyleCatalog(planCurrency)
+  const lifestyle = useMemo(
+    () =>
+      buildLifestyleSummary({
+        expenses,
+        projection,
+        labels,
+        catalog,
+      }),
+    [expenses, projection, labels, catalog],
+  )
 
   // Pull effective values from the unified scenario state. realReturn is
   // distributed across cash + equity rates via applyRealReturn.
@@ -188,6 +206,18 @@ export default function DetailsTabContent({
             />
           </div>
         </div>
+      )}
+
+      {/* The "Sustainable spending" tile above says how much. This says what
+          it buys — the same backend figure, spread across the categories the
+          user actually described. */}
+      {(lifestyle || expensesLoading) && (
+        <LifestyleSummary
+          model={lifestyle}
+          currencySymbol={effectiveCurrency}
+          hideValues={hideValues}
+          isLoading={expensesLoading && !lifestyle}
+        />
       )}
 
       {/* Two-column: inputs-only Plan Details | Plan Insights (findings) */}

--- a/src/components/features/independence/LifestyleSummary.tsx
+++ b/src/components/features/independence/LifestyleSummary.tsx
@@ -1,0 +1,455 @@
+import React, { useId } from "react"
+import { formatCurrency } from "@lib/independence/formatters"
+import {
+  COMFORT_SCALE_MAX,
+  headroomPhrase,
+  type LifestyleSummaryModel,
+  type LifestyleCategory,
+} from "@lib/independence/lifestyleSummary"
+
+/**
+ * The lifestyle mood board: what a plan supports, read as a life rather than a
+ * lump sum. A comfort band up top, then a tile per category — icon, name,
+ * amount — tinted by its share of the spend, so the shape of the life lands
+ * before any of the numbers are read.
+ *
+ * Two variants, one component. `payoff` is the end-of-onboarding moment —
+ * saturated, animated, the one place this product raises its voice. `panel`
+ * is the same board sitting quietly inside the plan view, where the user is
+ * working rather than being told something.
+ */
+
+const HIDDEN_VALUE = "****"
+const STAGGER_MS = 45
+
+export interface LifestyleSummaryProps {
+  model: LifestyleSummaryModel | null
+  currencySymbol?: string
+  /** Privacy mode. Masks amounts; the board stays, since a proportion is not a figure. */
+  hideValues?: boolean
+  variant?: "payoff" | "panel"
+  isLoading?: boolean
+  /** Overrides the heading. Used where the caller names the surface itself
+   *  (a composite phase, say) rather than the plan as a whole. */
+  title?: string
+  /** Shown in place of the board when there is no model. */
+  emptyMessage?: string
+}
+
+export default function LifestyleSummary({
+  model,
+  currencySymbol = "$",
+  hideValues = false,
+  variant = "panel",
+  isLoading = false,
+  title,
+  emptyMessage = "Add what you expect to spend and we'll show the lifestyle your plan supports.",
+}: LifestyleSummaryProps): React.ReactElement {
+  const isPayoff = variant === "payoff"
+  const headingId = useId()
+  // Rounded to whole units: the tile amounts are already whole (allocate()
+  // rounds them), and the Summary tab's "Sustainable spending" tile shows the
+  // same figure rounded. Cents made the headline disagree with both.
+  const money = (v: number): string =>
+    hideValues ? HIDDEN_VALUE : formatCurrency(Math.round(v), currencySymbol)
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className={
+        isPayoff
+          ? "rounded-2xl bg-independence-700 px-6 py-6 text-white sm:px-8 sm:py-7"
+          : "rounded-xl border border-gray-100 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+      }
+    >
+      <Heading
+        id={headingId}
+        isPayoff={isPayoff}
+        text={headingText(model, title)}
+      />
+
+      {isLoading ? (
+        <Skeleton isPayoff={isPayoff} />
+      ) : !model ? (
+        <p
+          className={`mt-3 text-sm ${
+            isPayoff ? "text-white/80" : "text-gray-600 dark:text-gray-300"
+          }`}
+        >
+          {emptyMessage}
+        </p>
+      ) : (
+        <>
+          <Headline model={model} isPayoff={isPayoff} money={money} />
+          {model.comfort && <Comfort model={model} isPayoff={isPayoff} />}
+          {/* auto-fit rather than fixed columns: the same board has to work in
+              a narrow onboarding step and a full-width plan card. */}
+          <ol className="mt-4 grid grid-cols-[repeat(auto-fit,minmax(10rem,1fr))] gap-2.5">
+            {model.categories.map((category, index) => (
+              <Tile
+                key={category.categoryName}
+                category={category}
+                index={index}
+                isPayoff={isPayoff}
+                money={money}
+              />
+            ))}
+          </ol>
+          <Footnotes model={model} isPayoff={isPayoff} money={money} />
+        </>
+      )}
+    </section>
+  )
+}
+
+/**
+ * A described-basis model makes no affordability claim, so it must not be
+ * headed as though it did — "what your plan supports" would be asserting
+ * exactly the thing the backend didn't tell us.
+ */
+export function headingText(
+  model: LifestyleSummaryModel | null,
+  title?: string,
+): string {
+  if (title) return title
+  return model?.basis === "described"
+    ? "What this costs"
+    : "What your plan supports"
+}
+
+/**
+ * The payoff screen owns its page, so it heads at h2. The panel sits among
+ * the plan view's h3 section headings — matching them keeps the document
+ * outline intact rather than punching a hole in it for styling's sake.
+ */
+function Heading({
+  id,
+  isPayoff,
+  text,
+}: {
+  id: string
+  isPayoff: boolean
+  text: string
+}): React.ReactElement {
+  return isPayoff ? (
+    <h2 id={id} className="text-base font-semibold text-white/90">
+      {text}
+    </h2>
+  ) : (
+    <h3
+      id={id}
+      className="text-sm font-semibold text-gray-900 dark:text-gray-100"
+    >
+      {text}
+    </h3>
+  )
+}
+
+interface ValueProps {
+  model: LifestyleSummaryModel
+  isPayoff: boolean
+  money: (v: number) => string
+}
+
+function Headline({ model, isPayoff, money }: ValueProps): React.ReactElement {
+  return (
+    <div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+      <p
+        className={`tabular-nums font-bold ${
+          isPayoff
+            ? "text-4xl text-white sm:text-5xl"
+            : "text-2xl text-gray-900 dark:text-gray-50"
+        }`}
+      >
+        {money(model.monthlyTotal)}
+        <span
+          className={`ml-1.5 font-normal ${
+            isPayoff
+              ? "text-base text-white/70"
+              : "text-sm text-gray-500 dark:text-gray-400"
+          }`}
+        >
+          / month
+        </span>
+      </p>
+      <Adjustment model={model} isPayoff={isPayoff} />
+    </div>
+  )
+}
+
+/**
+ * The comfort read: a word, a filled scale, and — crucially — what the gap is
+ * worth in the user's own categories.
+ *
+ * "Generous" alone would be claiming an absolute standard of living, which
+ * nothing in the data supports. "Generous — everything you planned for, plus
+ * two-thirds of your Entertainment budget spare" says the same thing in
+ * language people use, and every word of it is arithmetic on figures the user
+ * supplied. The sentence is what earns the label.
+ */
+function Comfort({
+  model,
+  isPayoff,
+}: {
+  model: LifestyleSummaryModel
+  isPayoff: boolean
+}): React.ReactElement | null {
+  const comfort = model.comfort
+  if (!comfort) return null
+  // On the described basis the total IS the described total, so the phrase
+  // would always be "just about exactly the life you described" — true,
+  // vacuous, and it makes the comfort band look like it's about headroom when
+  // it's a summary of the breakdown.
+  const phrase = model.basis === "supported" ? headroomPhrase(model) : null
+
+  return (
+    <div className="mt-3">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span
+          className={`text-sm font-semibold ${
+            isPayoff ? "text-white" : "text-gray-900 dark:text-gray-100"
+          }`}
+        >
+          {/* "lifestyle" is doing real work: the band rates the standard of
+              living the breakdown describes, while the sentence below rates
+              whether the plan can pay for it. Without the noun, "Generous"
+              sitting above "the plan falls short" reads as a contradiction
+              rather than as two different facts. */}
+          {comfort.label} lifestyle
+        </span>
+        <span
+          className="flex items-center gap-[3px]"
+          role="img"
+          aria-label={`${comfort.label}: ${comfort.score} out of ${COMFORT_SCALE_MAX}`}
+        >
+          {Array.from({ length: COMFORT_SCALE_MAX }, (_, index) => {
+            const reached = index < comfort.score
+            return (
+              <span
+                key={index}
+                className={`h-1.5 w-3 rounded-full ${
+                  isPayoff
+                    ? reached
+                      ? "bg-white"
+                      : "bg-white/25"
+                    : reached
+                      ? "bg-independence-500"
+                      : "bg-gray-200 dark:bg-gray-700"
+                }`}
+              />
+            )
+          })}
+        </span>
+        <span
+          className={`tabular-nums text-xs font-medium ${
+            isPayoff ? "text-white/80" : "text-gray-500 dark:text-gray-400"
+          }`}
+        >
+          {comfort.score}/{COMFORT_SCALE_MAX}
+        </span>
+      </div>
+      {phrase && (
+        <p
+          className={`mt-1 text-sm ${
+            isPayoff ? "text-white/80" : "text-gray-600 dark:text-gray-300"
+          }`}
+        >
+          {capitalise(phrase)}.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function capitalise(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1)
+}
+
+function Adjustment({
+  model,
+  isPayoff,
+}: {
+  model: LifestyleSummaryModel
+  isPayoff: boolean
+}): React.ReactElement | null {
+  if (model.adjustmentPercent == null || model.direction === "level")
+    return null
+  const magnitude = Math.abs(Math.round(model.adjustmentPercent))
+  if (magnitude === 0) return null
+  const label =
+    model.direction === "headroom"
+      ? `${magnitude}% more than you described`
+      : `${magnitude}% less than you described`
+
+  const tone = isPayoff
+    ? "bg-white/15 text-white"
+    : model.direction === "headroom"
+      ? "bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+      : "bg-amber-50 text-amber-800 dark:bg-amber-950 dark:text-amber-200"
+
+  return (
+    <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${tone}`}>
+      {label}
+    </span>
+  )
+}
+
+/**
+ * Tint carries the category's share of the spend. Deliberately not a bar:
+ * strength of colour reads as "how much of this life is this" at a glance,
+ * which is the mood board's job, while the amount underneath stays exact.
+ */
+function tintFor(share: number, isPayoff: boolean): string {
+  const weight = Math.max(0, Math.min(1, share))
+  return isPayoff
+    ? `rgba(255, 255, 255, ${(0.1 + weight * 0.16).toFixed(3)})`
+    : `rgba(249, 115, 22, ${(0.05 + weight * 0.15).toFixed(3)})`
+}
+
+function Tile({
+  category,
+  index,
+  isPayoff,
+  money,
+}: {
+  category: LifestyleCategory
+  index: number
+  isPayoff: boolean
+  money: (v: number) => string
+}): React.ReactElement {
+  // A rounding-sized difference isn't worth a second line.
+  const rescaled = Math.abs(category.amount - category.described) >= 1
+  return (
+    <li
+      className={`flex flex-col gap-1 rounded-xl px-3 py-3 ${
+        isPayoff ? "animate-tile-in" : ""
+      }`}
+      style={{
+        backgroundColor: tintFor(category.share, isPayoff),
+        ...(isPayoff ? { animationDelay: `${index * STAGGER_MS}ms` } : {}),
+      }}
+    >
+      {/* The catalog carries the emoji, so the board and these tiles mark a
+          category the same way. The rollup spans categories and has none. */}
+      <span aria-hidden="true" className="text-base leading-none">
+        {category.emoji ??
+          (category.isRollup ? "\u00b7\u00b7\u00b7" : "\u2022")}
+      </span>
+      <span
+        className={`truncate text-xs font-medium ${
+          isPayoff
+            ? category.isRollup
+              ? "text-white/70"
+              : "text-white/90"
+            : category.isRollup
+              ? "text-gray-500 dark:text-gray-400"
+              : "text-gray-700 dark:text-gray-200"
+        }`}
+        title={category.categoryName}
+      >
+        {category.categoryName}
+      </span>
+      {/* What this level of spend actually buys. The benchmark is the point —
+          "health insurance + gym" says more than SGD400 ever will. Where no
+          band is authored we fall back to the category's own description, so
+          the tile still says something. */}
+      {(category.benchmark ?? category.description) && (
+        <span
+          className={`text-[0.6875rem] leading-snug ${
+            isPayoff ? "text-white/60" : "text-gray-500 dark:text-gray-400"
+          }`}
+        >
+          {category.benchmark ?? category.description}
+        </span>
+      )}
+      <span
+        className={`mt-auto pt-1 tabular-nums text-sm font-semibold ${
+          isPayoff ? "text-white" : "text-gray-900 dark:text-gray-100"
+        }`}
+      >
+        {money(category.amount)}
+      </span>
+      {/* These figures are the described mix scaled to what the plan actually
+          supports, so they don't match what was typed in. Without saying so,
+          "Housing S$2,278" against a S$2,500 budget just looks like a bug. */}
+      {rescaled && (
+        <span
+          className={`tabular-nums text-[0.6875rem] ${
+            isPayoff ? "text-white/60" : "text-gray-500 dark:text-gray-400"
+          }`}
+        >
+          of {money(category.described)} planned
+        </span>
+      )}
+    </li>
+  )
+}
+
+function Footnotes({ model, isPayoff, money }: ValueProps): React.ReactElement {
+  const muted = isPayoff ? "text-white/75" : "text-gray-600 dark:text-gray-300"
+  return (
+    <div className={`mt-4 space-y-1.5 text-sm ${muted}`}>
+      {readSentence(model) && <p>{readSentence(model)}</p>}
+      {model.liquidation && (
+        <p
+          className={
+            isPayoff ? "text-white/60" : "text-gray-500 dark:text-gray-400"
+          }
+        >
+          Selling illiquid assets lifts this to{" "}
+          <span className="tabular-nums">
+            {money(model.liquidation.supportedMonthly)}
+          </span>
+          /month
+          {model.liquidation.fromAge != null
+            ? ` from age ${model.liquidation.fromAge}`
+            : ""}
+          .
+        </p>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Describes the shape of the user's own mix and how it sits against the plan.
+ * Says nothing about how many holidays the money buys — the backend supplies
+ * no lifestyle benchmarks, and inventing them here would be fiction.
+ */
+export function readSentence(model: LifestyleSummaryModel): string | null {
+  const mix = model.mixDescriptor
+  // A described-basis model was built without a projection, so every phrasing
+  // about what "the plan supports" is unearned. Name the mix and stop.
+  // Same when the comfort read is present: it already states the headroom in
+  // plainer words, and saying it twice makes neither land.
+  if (model.basis === "described" || model.comfort)
+    return mix ? `${mix}.` : null
+  switch (model.direction) {
+    case "headroom":
+      return mix
+        ? `${mix}, with room to spare.`
+        : "Your plan supports more than you described."
+    case "shortfall":
+      return mix
+        ? `${mix}, and running ahead of what the plan supports.`
+        : "Your plan supports less than you described."
+    default:
+      return mix
+        ? `${mix}, and the plan supports it.`
+        : "Your plan supports the lifestyle you described."
+  }
+}
+
+function Skeleton({ isPayoff }: { isPayoff: boolean }): React.ReactElement {
+  const block = isPayoff ? "bg-white/20" : "bg-gray-100 dark:bg-gray-800"
+  return (
+    <div className="mt-4 space-y-3" aria-hidden="true">
+      <div className={`h-8 w-40 animate-pulse rounded ${block}`} />
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(8rem,1fr))] gap-2.5">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className={`h-20 animate-pulse rounded-xl ${block}`} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/independence/PlanFiOverviewTab.tsx
+++ b/src/components/features/independence/PlanFiOverviewTab.tsx
@@ -21,34 +21,20 @@ import type { RentalIncomeData } from "./useUnifiedProjection"
 import { useMonteCarloSimulation } from "./useMonteCarloSimulation"
 import KpiCard from "@components/ui/KpiCard"
 import CollapsibleSection from "@components/ui/CollapsibleSection"
+import { currencySymbolFor } from "@lib/formatters"
 
 const HIDDEN_VALUE = "****"
 const MC_ITERATION_OPTIONS = [500, 1000, 2000, 5000]
 
 function fmtShort(v: number, currency: string): string {
-  const sym =
-    currency === "USD"
-      ? "$"
-      : currency === "NZD"
-        ? "NZ$"
-        : currency === "SGD"
-          ? "S$"
-          : "$"
+  const sym = currencySymbolFor(currency)
   if (v >= 1_000_000) return `${sym}${(v / 1_000_000).toFixed(2)}M`
   if (v >= 1_000) return `${sym}${(v / 1_000).toFixed(0)}K`
   return `${sym}${v.toLocaleString()}`
 }
 
 function fmtFull(v: number, currency: string): string {
-  const sym =
-    currency === "USD"
-      ? "$"
-      : currency === "NZD"
-        ? "NZ$"
-        : currency === "SGD"
-          ? "S$"
-          : "$"
-  return `${sym}${Math.round(v).toLocaleString()}`
+  return `${currencySymbolFor(currency)}${Math.round(v).toLocaleString()}`
 }
 
 function fmtAxis(v: number): string {
@@ -135,7 +121,6 @@ export default function PlanFiOverviewTab({
   onOpenStressTest,
 }: PlanFiOverviewTabProps): React.ReactElement | null {
   const [mcIterations, setMcIterations] = useState(1000)
-
   const {
     result: mcResult,
     isRunning,

--- a/src/components/features/independence/__tests__/LifestyleSummary.test.tsx
+++ b/src/components/features/independence/__tests__/LifestyleSummary.test.tsx
@@ -1,0 +1,388 @@
+import React from "react"
+import { render, screen, within } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import LifestyleSummary from "../LifestyleSummary"
+import type { LifestyleSummaryModel } from "@lib/independence/lifestyleSummary"
+
+const model = (
+  overrides: Partial<LifestyleSummaryModel> = {},
+): LifestyleSummaryModel => ({
+  basis: "supported",
+  monthlyTotal: 5100,
+  describedMonthly: 4600,
+  adjustmentPercent: 11,
+  direction: "headroom",
+  categories: [
+    {
+      categoryName: "Housing",
+      categoryLabelId: "cat-Housing",
+      emoji: "\u{1F3E0}",
+      description: "Rates, management fees, insurance, maintenance",
+      described: 2000,
+      amount: 2200,
+      share: 1,
+      isRollup: false,
+    },
+    {
+      categoryName: "Travel",
+      categoryLabelId: "cat-Travel",
+      emoji: "\u2708\uFE0F",
+      described: 1000,
+      amount: 1100,
+      share: 0.5,
+      isRollup: false,
+    },
+    {
+      categoryName: "Everything else",
+      categoryLabelId: "",
+      described: 1600,
+      amount: 1800,
+      share: 0.82,
+      isRollup: true,
+    },
+  ],
+  mixDescriptor: "Housing-heavy",
+  liquidation: null,
+  comfort: {
+    key: "comfortable",
+    label: "Comfortable",
+    step: 3,
+    score: 6,
+    basedOn: 3,
+  },
+  ...overrides,
+})
+
+describe("LifestyleSummary", () => {
+  it("leads with the monthly figure the plan supports", () => {
+    render(<LifestyleSummary model={model()} />)
+    expect(screen.getByText("$5,100")).toBeInTheDocument()
+    expect(screen.getByText("/ month")).toBeInTheDocument()
+  })
+
+  it("lists every category with its supported amount", () => {
+    render(<LifestyleSummary model={model()} />)
+    expect(screen.getByText("Housing")).toBeInTheDocument()
+    expect(screen.getByText("$2,200")).toBeInTheDocument()
+    expect(screen.getByText("Everything else")).toBeInTheDocument()
+    expect(screen.getAllByRole("listitem")).toHaveLength(3)
+  })
+
+  it("uses the caller's currency symbol", () => {
+    render(<LifestyleSummary model={model()} currencySymbol="NZ$" />)
+    expect(screen.getByText("NZ$5,100")).toBeInTheDocument()
+  })
+
+  it("states how the figure compares to what was described", () => {
+    render(<LifestyleSummary model={model()} />)
+    expect(screen.getByText("11% more than you described")).toBeInTheDocument()
+  })
+
+  it("phrases a shortfall without scolding", () => {
+    render(
+      <LifestyleSummary
+        model={model({
+          direction: "shortfall",
+          adjustmentPercent: -18,
+          comfort: null,
+        })}
+      />,
+    )
+    expect(screen.getByText("18% less than you described")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Housing-heavy, and running ahead of what the plan supports.",
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("does not state the headroom twice when the comfort read is shown", () => {
+    render(<LifestyleSummary model={model()} />)
+    expect(screen.getByText("Housing-heavy.")).toBeInTheDocument()
+    expect(screen.queryByText(/with room to spare/)).not.toBeInTheDocument()
+  })
+
+  it("says nothing about the comparison when it is level", () => {
+    render(<LifestyleSummary model={model({ direction: "level" })} />)
+    expect(screen.queryByText(/than you described/)).not.toBeInTheDocument()
+  })
+
+  it("surfaces the with-liquidation figure when there is one", () => {
+    render(
+      <LifestyleSummary
+        model={model({
+          liquidation: { supportedMonthly: 6300, fromAge: 71 },
+        })}
+      />,
+    )
+    expect(
+      screen.getByText(/Selling illiquid assets lifts this to/),
+    ).toBeInTheDocument()
+    expect(screen.getByText("$6,300")).toBeInTheDocument()
+    expect(screen.getByText(/from age 71/)).toBeInTheDocument()
+  })
+
+  describe("privacy mode", () => {
+    it("masks every figure but keeps the board", () => {
+      render(<LifestyleSummary model={model()} hideValues />)
+      expect(screen.queryByText("$5,100")).not.toBeInTheDocument()
+      expect(screen.queryByText("$2,200")).not.toBeInTheDocument()
+      expect(screen.getAllByText("****").length).toBeGreaterThan(1)
+      // Categories and their weighting are shape, not figures, and the board
+      // is useless without them.
+      expect(screen.getAllByRole("listitem")).toHaveLength(3)
+      expect(screen.getByText("Housing")).toBeInTheDocument()
+    })
+  })
+
+  describe("the comfort read", () => {
+    it("names the band and marks its place on the scale", () => {
+      render(<LifestyleSummary model={model()} />)
+      expect(screen.getByText("Comfortable lifestyle")).toBeInTheDocument()
+      expect(
+        screen.getByRole("img", { name: /Comfortable: 6 out of 10/ }),
+      ).toBeInTheDocument()
+      expect(screen.getByText("6/10")).toBeInTheDocument()
+    })
+
+    it("says what the gap is worth in the user's own categories", () => {
+      // The label alone would claim an absolute standard of living. This
+      // sentence is what earns it — and it's arithmetic on the user's figures.
+      render(<LifestyleSummary model={model()} />)
+      expect(
+        screen.getByText(/and about .* Travel budget spare/),
+      ).toBeInTheDocument()
+    })
+
+    it("rates the lifestyle, not the affordability", () => {
+      // A generous lifestyle the plan can't quite fund is two facts, not a
+      // contradiction — but only if the band says what it is rating.
+      render(
+        <LifestyleSummary
+          model={model({
+            direction: "shortfall",
+            adjustmentPercent: -9,
+            monthlyTotal: 4100,
+            describedMonthly: 4600,
+          })}
+        />,
+      )
+      expect(screen.getByText("Comfortable lifestyle")).toBeInTheDocument()
+      expect(screen.getByText(/falls short/)).toBeInTheDocument()
+    })
+
+    it("drops the headroom line on the described basis", () => {
+      // Total and described total are the same number there, so the phrase
+      // could only ever say "just about exactly the life you described".
+      render(<LifestyleSummary model={model({ basis: "described" })} />)
+      expect(screen.getByText("Comfortable lifestyle")).toBeInTheDocument()
+      expect(
+        screen.queryByText(/exactly the life you described/),
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText(/budget spare/)).not.toBeInTheDocument()
+    })
+
+    it("stays silent when there is no comfort to report", () => {
+      render(<LifestyleSummary model={model({ comfort: null })} />)
+      expect(
+        screen.queryByText(/Comfortable lifestyle/),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe("the mood board", () => {
+    it("says what the spend buys, in preference to what the bucket covers", () => {
+      render(
+        <LifestyleSummary
+          model={model({
+            categories: [
+              {
+                categoryName: "Healthcare",
+                categoryLabelId: "cat-Healthcare",
+                benchmark: "health insurance + gym",
+                description: "Medical, dental, vision, insurance",
+                described: 400,
+                amount: 400,
+                share: 1,
+                isRollup: false,
+              },
+            ],
+          })}
+        />,
+      )
+      expect(screen.getByText("health insurance + gym")).toBeInTheDocument()
+      expect(
+        screen.queryByText("Medical, dental, vision, insurance"),
+      ).not.toBeInTheDocument()
+    })
+
+    it("falls back to the description where no band is authored", () => {
+      render(<LifestyleSummary model={model()} />)
+      expect(
+        screen.getByText("Rates, management fees, insurance, maintenance"),
+      ).toBeInTheDocument()
+    })
+
+    it("shows what was planned whenever the figure has been rescaled", () => {
+      // The tiles are the described mix scaled to what the plan supports, so
+      // "Housing S$2,278" against a S$2,500 budget reads as a bug unless the
+      // rescaling is stated.
+      render(<LifestyleSummary model={model()} />)
+      expect(screen.getByText("of $2,000 planned")).toBeInTheDocument()
+    })
+
+    it("stays quiet when the figure is the one that was planned", () => {
+      render(
+        <LifestyleSummary
+          model={model({
+            basis: "described",
+            categories: [
+              {
+                categoryName: "Housing",
+                categoryLabelId: "cat-Housing",
+                described: 2000,
+                amount: 2000,
+                share: 1,
+                isRollup: false,
+              },
+            ],
+          })}
+        />,
+      )
+      expect(screen.queryByText(/planned/)).not.toBeInTheDocument()
+    })
+
+    it("marks each category with the catalog's emoji", () => {
+      // The catalog owns these, so the board and these tiles agree.
+      render(<LifestyleSummary model={model()} />)
+      expect(screen.getByText("\u{1F3E0}")).toBeInTheDocument()
+      expect(screen.getByText("\u2708\uFE0F")).toBeInTheDocument()
+      // The rollup spans categories, so it has no emoji of its own.
+      expect(screen.getByText("\u00b7\u00b7\u00b7")).toBeInTheDocument()
+    })
+
+    it("weights each tile's tint by its share of the spend", () => {
+      const { container } = render(<LifestyleSummary model={model()} />)
+      const tiles = container.querySelectorAll<HTMLElement>("li")
+      // Housing (share 1) sits stronger than Travel (share 0.5).
+      const alpha = (el: HTMLElement): number =>
+        Number(el.style.backgroundColor.match(/[\d.]+\)$/)?.[0].slice(0, -1))
+      expect(alpha(tiles[0])).toBeGreaterThan(alpha(tiles[1]))
+    })
+  })
+
+  describe("heading", () => {
+    it("claims support only on the supported basis", () => {
+      render(<LifestyleSummary model={model()} />)
+      expect(
+        screen.getByRole("heading", { name: "What your plan supports" }),
+      ).toBeInTheDocument()
+    })
+
+    it("drops the affordability claim on the described basis", () => {
+      // The composite projection gives no sustainable figure — heading the
+      // panel "what your plan supports" would assert what wasn't measured.
+      render(
+        <LifestyleSummary
+          model={model({ basis: "described", adjustmentPercent: null })}
+        />,
+      )
+      expect(
+        screen.queryByRole("heading", { name: "What your plan supports" }),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole("heading", { name: "What this costs" }),
+      ).toBeInTheDocument()
+    })
+
+    it("never claims support in the read-out on the described basis", () => {
+      render(<LifestyleSummary model={model({ basis: "described" })} />)
+      expect(screen.getByText("Housing-heavy.")).toBeInTheDocument()
+      expect(screen.queryByText(/plan supports/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/room to spare/i)).not.toBeInTheDocument()
+    })
+
+    it("lets the caller name the surface", () => {
+      render(
+        <LifestyleSummary
+          model={model({ basis: "described" })}
+          title="Slow-go · age 70–80"
+        />,
+      )
+      expect(
+        screen.getByRole("heading", { name: "Slow-go · age 70–80" }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe("variants", () => {
+    it("heads the payoff at h2 — it owns the screen", () => {
+      render(<LifestyleSummary model={model()} variant="payoff" />)
+      expect(
+        screen.getByRole("heading", {
+          level: 2,
+          name: /what your plan supports/i,
+        }),
+      ).toBeInTheDocument()
+    })
+
+    it("heads the panel at h3 to sit among the plan view's sections", () => {
+      render(<LifestyleSummary model={model()} variant="panel" />)
+      expect(
+        screen.getByRole("heading", {
+          level: 3,
+          name: /what your plan supports/i,
+        }),
+      ).toBeInTheDocument()
+    })
+
+    it("animates tiles on the payoff only", () => {
+      const { container: payoff } = render(
+        <LifestyleSummary model={model()} variant="payoff" />,
+      )
+      expect(payoff.querySelectorAll(".animate-tile-in")).toHaveLength(3)
+
+      const { container: panel } = render(
+        <LifestyleSummary model={model()} variant="panel" />,
+      )
+      expect(panel.querySelectorAll(".animate-tile-in")).toHaveLength(0)
+    })
+
+    it("staggers the payoff reveal", () => {
+      const { container } = render(
+        <LifestyleSummary model={model()} variant="payoff" />,
+      )
+      const tiles = container.querySelectorAll<HTMLElement>(".animate-tile-in")
+      expect(tiles[0].style.animationDelay).toBe("0ms")
+      expect(tiles[1].style.animationDelay).not.toBe("0ms")
+    })
+  })
+
+  describe("without a model", () => {
+    it("teaches the user what to do instead of showing nothing", () => {
+      render(<LifestyleSummary model={null} />)
+      expect(
+        screen.getByText(/Add what you expect to spend/i),
+      ).toBeInTheDocument()
+    })
+
+    it("accepts a caller-supplied message", () => {
+      render(<LifestyleSummary model={null} emptyMessage="Nothing yet." />)
+      expect(screen.getByText("Nothing yet.")).toBeInTheDocument()
+    })
+
+    it("shows skeleton bars while loading, not a spinner", () => {
+      render(<LifestyleSummary model={null} isLoading />)
+      expect(screen.queryByText(/Add what you expect/i)).not.toBeInTheDocument()
+      expect(screen.queryByRole("listitem")).not.toBeInTheDocument()
+    })
+  })
+
+  it("keeps the heading available to assistive tech", () => {
+    render(<LifestyleSummary model={model()} />)
+    const region = screen.getByRole("region", {
+      name: /what your plan supports/i,
+    })
+    expect(within(region).getByText("Housing")).toBeInTheDocument()
+  })
+})

--- a/src/components/features/independence/composite/tabs/SummaryTab.tsx
+++ b/src/components/features/independence/composite/tabs/SummaryTab.tsx
@@ -1,0 +1,110 @@
+import React from "react"
+import LifestyleSummary from "@components/features/independence/LifestyleSummary"
+import { usePlanExpenses } from "@components/features/independence/usePlanExpenses"
+import { useExpenseCategories } from "@components/features/independence/useExpenseCategories"
+import { useLifestyleCatalog } from "@components/features/independence/useLifestyleCatalog"
+import { buildExpenseMix } from "@lib/independence/lifestyleSummary"
+import { currencySymbolFor } from "@lib/formatters"
+import { usePrivacyMode } from "@hooks/usePrivacyMode"
+import Spinner from "@components/ui/Spinner"
+import { useCompositeProjectionContext } from "../CompositeProjectionContext"
+import { compositeOutlook } from "@lib/independence/compositeOutlook"
+import type { CompositePhaseInfo } from "types/independence"
+
+/**
+ * The shape of spending through each phase of a composite plan.
+ *
+ * Deliberately shows what each phase COSTS, not what it supports. A composite
+ * projection returns no sustainable-spend figure, and the obvious shortcut —
+ * borrowing one phase's single-plan sustainable number — answers a different
+ * question ("if this phase were your whole retirement…") and would read as an
+ * affordability claim the backend never made. Whether the composite as a whole
+ * holds up is already answered by the sustainability badge in the tab bar.
+ */
+export default function SummaryTab(): React.ReactElement {
+  const { projection, isLoading } = useCompositeProjectionContext()
+  const phases = projection?.phases ?? []
+
+  if (isLoading && phases.length === 0) {
+    return (
+      <div className="py-12 flex justify-center">
+        <Spinner label="Building your phases…" size="lg" />
+      </div>
+    )
+  }
+
+  if (phases.length === 0) {
+    return (
+      <div className="rounded-xl border border-gray-100 bg-white p-6 text-sm text-gray-600 shadow-sm">
+        No phases yet. Create one and this will show how your spending changes
+        across each stage of your independence.
+      </div>
+    )
+  }
+
+  const outlook = compositeOutlook(projection)
+
+  return (
+    <div className="space-y-4">
+      {/* The only affordability claim a composite can honestly make: the
+          projection returns no sustainable-spend figure to scale the phase
+          breakdowns against, but it does know whether the money lasts. */}
+      {outlook && (
+        <div className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm">
+          <h3 className="text-sm font-semibold text-gray-900">
+            Your phases, together
+          </h3>
+          <p
+            className={`mt-1 flex items-center gap-2 text-sm ${
+              outlook.sustainable ? "text-green-700" : "text-amber-800"
+            }`}
+          >
+            <i
+              aria-hidden="true"
+              className={`fas ${
+                outlook.sustainable
+                  ? "fa-check-circle"
+                  : "fa-exclamation-triangle"
+              }`}
+            />
+            {outlook.statement}
+          </p>
+        </div>
+      )}
+      <p className="text-sm text-gray-600">
+        How your spending changes shape across each phase.
+      </p>
+      {phases.map((phase) => (
+        <PhaseSpend key={`${phase.planId}-${phase.fromAge}`} phase={phase} />
+      ))}
+    </div>
+  )
+}
+
+function PhaseSpend({
+  phase,
+}: {
+  phase: CompositePhaseInfo
+}): React.ReactElement | null {
+  const { hideValues } = usePrivacyMode()
+  const { expenses, isLoading } = usePlanExpenses(phase.planId)
+  const { labels } = useExpenseCategories()
+  const { catalog } = useLifestyleCatalog(phase.expensesCurrency)
+  const mix = buildExpenseMix({
+    expenses,
+    labels,
+    catalog,
+  })
+
+  if (!mix && !isLoading) return null
+
+  return (
+    <LifestyleSummary
+      model={mix}
+      title={`${phase.planName} · age ${phase.fromAge}–${phase.toAge}`}
+      currencySymbol={currencySymbolFor(phase.expensesCurrency)}
+      hideValues={hideValues}
+      isLoading={isLoading && !mix}
+    />
+  )
+}

--- a/src/components/features/independence/useExpenseCategories.ts
+++ b/src/components/features/independence/useExpenseCategories.ts
@@ -1,0 +1,22 @@
+import useSwr from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+import type { CategoryLabel, CategoryLabelsResponse } from "types/independence"
+
+const categoriesKey = "/api/independence/categories"
+
+/**
+ * The category definitions, for their descriptions — "Medical, dental, vision,
+ * insurance" says what a bucket actually covers in a way the name alone can't.
+ * A plan's expenses only carry the category id and name, so the descriptions
+ * have to be fetched alongside.
+ */
+export function useExpenseCategories(): {
+  labels: CategoryLabel[] | undefined
+  isLoading: boolean
+} {
+  const { data, isLoading } = useSwr<CategoryLabelsResponse>(
+    categoriesKey,
+    simpleFetcher(categoriesKey),
+  )
+  return { labels: data?.data, isLoading }
+}

--- a/src/components/features/independence/useLifestyleCatalog.ts
+++ b/src/components/features/independence/useLifestyleCatalog.ts
@@ -1,0 +1,25 @@
+import useSwr from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+import type { LifestyleCatalogResponse } from "types/independence"
+
+/**
+ * The lifestyle catalog: per-category tiers, each with an amount, an emoji and
+ * a description of what that level of spend buys.
+ *
+ * svc-retire owns this, converts it to the plan's currency and caches it — so
+ * the summary surfaces describe a life using the same tiers the mood board
+ * offers, rather than a second set of numbers maintained in the frontend.
+ */
+export function useLifestyleCatalog(currency: string | undefined): {
+  catalog: LifestyleCatalogResponse | undefined
+  isLoading: boolean
+} {
+  const key = currency
+    ? `/api/independence/lifestyle-catalog?currency=${encodeURIComponent(currency)}`
+    : "/api/independence/lifestyle-catalog"
+  const { data, isLoading } = useSwr<LifestyleCatalogResponse>(
+    key,
+    simpleFetcher(key),
+  )
+  return { catalog: data, isLoading }
+}

--- a/src/components/features/independence/usePlanExpenses.ts
+++ b/src/components/features/independence/usePlanExpenses.ts
@@ -1,0 +1,20 @@
+import useSwr from "swr"
+import { simpleFetcher } from "@utils/api/fetchHelper"
+import type { PlanExpense, PlanExpensesResponse } from "types/independence"
+
+/**
+ * The plan's expense mix by category. The plan record itself only carries the
+ * monthly total, so anything that needs the breakdown — the lifestyle
+ * summary — has to ask for it separately.
+ */
+export function usePlanExpenses(planId: string | undefined): {
+  expenses: PlanExpense[] | undefined
+  isLoading: boolean
+} {
+  const key = planId ? `/api/independence/plans/${planId}/expenses` : null
+  const { data, isLoading } = useSwr<PlanExpensesResponse>(
+    key,
+    key ? simpleFetcher(key) : null,
+  )
+  return { expenses: data?.data, isLoading }
+}

--- a/src/components/features/onboarding/OnboardingWizard.tsx
+++ b/src/components/features/onboarding/OnboardingWizard.tsx
@@ -156,6 +156,10 @@ const OnboardingWizard: React.FC = () => {
     useState(0)
   const [independenceTargetAge, setIndependenceTargetAge] = useState(65)
   const [independencePlanCreated, setIndependencePlanCreated] = useState(false)
+  // Kept so the final step can project the plan and show what it supports.
+  const [independencePlanId, setIndependencePlanId] = useState<string | null>(
+    null,
+  )
 
   // Work plan state (collected in the Independence step)
   const [workingIncomeMonthly, setWorkingIncomeMonthly] = useState(0)
@@ -751,6 +755,7 @@ const OnboardingWizard: React.FC = () => {
               const planBody = await planResponse.json()
               const planId = planBody?.data?.id
               if (planId) {
+                setIndependencePlanId(planId)
                 await saveOnboardingExpenses(
                   planId,
                   independenceMonthlyExpenses,
@@ -988,6 +993,8 @@ const OnboardingWizard: React.FC = () => {
             insuranceCount={insurances.length}
             portfolioId={createdPortfolioId}
             independencePlanCreated={independencePlanCreated}
+            independencePlanId={independencePlanId}
+            independenceCurrency={baseCurrency}
             brokerageCreated={brokerageCreated}
           />
         )

--- a/src/components/features/onboarding/steps/CompleteStep.tsx
+++ b/src/components/features/onboarding/steps/CompleteStep.tsx
@@ -1,5 +1,9 @@
 import React from "react"
 import Link from "next/link"
+import LifestyleSummary from "@components/features/independence/LifestyleSummary"
+import { useLifestyleOutlook } from "../useLifestyleOutlook"
+import { currencySymbolFor } from "@lib/formatters"
+
 interface CompleteStepProps {
   portfolioName: string
   bankAccountCount: number
@@ -8,6 +12,9 @@ interface CompleteStepProps {
   insuranceCount: number
   portfolioId: string | null
   independencePlanCreated?: boolean
+  /** Set when a plan was created — lets this step show what it supports. */
+  independencePlanId?: string | null
+  independenceCurrency?: string
   brokerageCreated?: boolean
 }
 
@@ -20,8 +27,16 @@ const CompleteStep: React.FC<CompleteStepProps> = ({
   pensionCount,
   insuranceCount,
   independencePlanCreated,
+  independencePlanId,
+  independenceCurrency = "USD",
   brokerageCreated,
 }) => {
+  // The payoff: everything above is a receipt for work done, this is the one
+  // thing the user actually came for.
+  const { model: lifestyle, isLoading: lifestyleLoading } = useLifestyleOutlook(
+    independencePlanId,
+    independenceCurrency,
+  )
   const chips: Array<{ icon: string; color: string; label: string }> = [
     { icon: "fa-folder", color: "text-blue-500", label: portfolioName },
     ...(bankAccountCount > 0
@@ -101,6 +116,18 @@ const CompleteStep: React.FC<CompleteStepProps> = ({
           </Link>
         )}
       </div>
+
+      {/* The payoff — what all of that data entry was actually for. */}
+      {independencePlanId && (lifestyle || lifestyleLoading) && (
+        <div className="mb-5">
+          <LifestyleSummary
+            variant="payoff"
+            model={lifestyle}
+            isLoading={lifestyleLoading && !lifestyle}
+            currencySymbol={currencySymbolFor(independenceCurrency)}
+          />
+        </div>
+      )}
 
       {/* Next-step pointers — side-by-side, compact */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/src/components/features/onboarding/useLifestyleOutlook.ts
+++ b/src/components/features/onboarding/useLifestyleOutlook.ts
@@ -1,0 +1,56 @@
+import { useMemo } from "react"
+import useSwr from "swr"
+import { usePlanExpenses } from "@components/features/independence/usePlanExpenses"
+import { useExpenseCategories } from "@components/features/independence/useExpenseCategories"
+import { useLifestyleCatalog } from "@components/features/independence/useLifestyleCatalog"
+import {
+  buildLifestyleSummary,
+  type LifestyleSummaryModel,
+} from "@lib/independence/lifestyleSummary"
+import type { ProjectionResponse } from "types/independence"
+
+/**
+ * The lifestyle read for the end of onboarding.
+ *
+ * Assets are deliberately omitted from the projection request: svc-retire
+ * resolves them from the plan's linked portfolios, which the user has just
+ * finished populating. Sending our own totals here would mean two places
+ * deciding what the user owns.
+ */
+export function useLifestyleOutlook(
+  planId: string | null | undefined,
+  currency: string,
+): { model: LifestyleSummaryModel | null; isLoading: boolean } {
+  const { expenses, isLoading: expensesLoading } = usePlanExpenses(
+    planId ?? undefined,
+  )
+  const { labels } = useExpenseCategories()
+  const { catalog } = useLifestyleCatalog(currency)
+
+  const url = planId ? `/api/independence/projection/${planId}` : null
+  const { data, isLoading: projectionLoading } = useSwr<ProjectionResponse>(
+    url ? [url, currency] : null,
+    async () => {
+      const res = await fetch(url!, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currency }),
+      })
+      if (!res.ok) throw new Error("Failed to fetch projection")
+      return res.json()
+    },
+  )
+
+  const model = useMemo(
+    () =>
+      buildLifestyleSummary({
+        expenses,
+        projection: data?.data,
+        labels,
+        catalog,
+      }),
+    [expenses, data, labels, catalog],
+  )
+
+  return { model, isLoading: expensesLoading || projectionLoading }
+}

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -86,6 +86,19 @@ export const formatCurrencySymbol = (value: number, symbol = "$"): string =>
   `${symbol}${value.toLocaleString()}`
 
 /**
+ * Display symbol for a currency code. Disambiguates the dollar currencies the
+ * product actually plans in; anything else falls back to a bare "$" rather
+ * than pretending to be a full currency table.
+ * @param currency - ISO currency code (e.g. "NZD")
+ * @returns Symbol prefix (e.g. "NZ$")
+ */
+export const currencySymbolFor = (currency: string | undefined): string => {
+  if (currency === "NZD") return "NZ$"
+  if (currency === "SGD") return "S$"
+  return "$"
+}
+
+/**
  * Format a number with sign prefix for display.
  * @param value - Numeric value
  * @param fractionDigits - Number of decimal places (default: 2)

--- a/src/lib/utils/independence/compositeOutlook.test.ts
+++ b/src/lib/utils/independence/compositeOutlook.test.ts
@@ -1,0 +1,69 @@
+import { compositeOutlook } from "@lib/independence/compositeOutlook"
+import type { CompositeProjectionResult } from "types/independence"
+
+const projection = (
+  overrides: Partial<CompositeProjectionResult> = {},
+): CompositeProjectionResult =>
+  ({
+    asOfDate: "2026-07-28",
+    displayCurrency: "SGD",
+    phases: [],
+    totalAssets: 0,
+    liquidAssets: 0,
+    runwayYears: 30,
+    isSustainable: true,
+    yearlyProjections: [{ age: 88 }, { age: 89 }, { age: 90 }],
+    warnings: [],
+    ...overrides,
+  }) as CompositeProjectionResult
+
+describe("compositeOutlook", () => {
+  it("reads the end age off the last projected year", () => {
+    const outlook = compositeOutlook(projection())!
+    expect(outlook.sustainable).toBe(true)
+    expect(outlook.age).toBe(90)
+    expect(outlook.badge).toBe("Sustainable to age 90")
+    expect(outlook.statement).toBe(
+      "Your phases hold together — the money lasts to age 90.",
+    )
+  })
+
+  it("names the age the money runs out", () => {
+    const outlook = compositeOutlook(
+      projection({ isSustainable: false, depletionAge: 78 }),
+    )!
+    expect(outlook.sustainable).toBe(false)
+    expect(outlook.age).toBe(78)
+    expect(outlook.badge).toBe("Savings deplete at age 78")
+    expect(outlook.statement).toBe("These phases run out of money at age 78.")
+  })
+
+  it("still says something useful without an age", () => {
+    const sustainable = compositeOutlook(projection({ yearlyProjections: [] }))!
+    expect(sustainable.badge).toBe("Sustainable to age ?")
+    expect(sustainable.statement).toBe("Your phases hold together.")
+
+    const depleting = compositeOutlook(
+      projection({ isSustainable: false, depletionAge: undefined }),
+    )!
+    expect(depleting.statement).toBe(
+      "These phases run out of money before the end of the plan.",
+    )
+  })
+
+  it("says nothing without a projection", () => {
+    expect(compositeOutlook(undefined)).toBeNull()
+  })
+
+  it("keeps the badge and the statement agreeing", () => {
+    // They render in two places — the tab bar and the Summary header — and a
+    // second copy of this logic would eventually contradict the first.
+    for (const sustainable of [true, false]) {
+      const outlook = compositeOutlook(
+        projection({ isSustainable: sustainable, depletionAge: 78 }),
+      )!
+      expect(outlook.sustainable).toBe(sustainable)
+      expect(outlook.badge.includes("Sustainable")).toBe(sustainable)
+    }
+  })
+})

--- a/src/lib/utils/independence/compositeOutlook.ts
+++ b/src/lib/utils/independence/compositeOutlook.ts
@@ -1,0 +1,54 @@
+import type { CompositeProjectionResult } from "types/independence"
+
+/**
+ * Whether a phased plan holds together, in the two forms the UI needs.
+ *
+ * Extracted so the tab-bar badge and the Summary header can't drift apart:
+ * they are the same claim about the same projection, and two copies of
+ * "sustainable to age N" would eventually disagree.
+ *
+ * This is the only affordability statement a composite can honestly make.
+ * `CompositeProjectionResult` returns no sustainable-spend figure, so there is
+ * nothing to scale the phase breakdowns against — what it does know is whether
+ * the money lasts, and until when.
+ */
+export interface CompositeOutlook {
+  sustainable: boolean
+  /** Age the money lasts to, or the age it runs out. Null when unknowable. */
+  age: number | null
+  /** Terse, for the tab bar. */
+  badge: string
+  /** A sentence, for the Summary header. */
+  statement: string
+}
+
+export function compositeOutlook(
+  projection: CompositeProjectionResult | undefined,
+): CompositeOutlook | null {
+  if (!projection) return null
+
+  if (projection.isSustainable) {
+    const rows = projection.yearlyProjections
+    const age = rows?.[rows.length - 1]?.age ?? null
+    return {
+      sustainable: true,
+      age,
+      badge: `Sustainable to age ${age ?? "?"}`,
+      statement:
+        age != null
+          ? `Your phases hold together — the money lasts to age ${age}.`
+          : "Your phases hold together.",
+    }
+  }
+
+  const age = projection.depletionAge ?? null
+  return {
+    sustainable: false,
+    age,
+    badge: `Savings deplete at age ${age ?? "?"}`,
+    statement:
+      age != null
+        ? `These phases run out of money at age ${age}.`
+        : "These phases run out of money before the end of the plan.",
+  }
+}

--- a/src/lib/utils/independence/lifestyleSummary.test.ts
+++ b/src/lib/utils/independence/lifestyleSummary.test.ts
@@ -1,0 +1,757 @@
+import {
+  buildExpenseMix,
+  buildLifestyleSummary,
+  headroomPhrase,
+  ROLLUP_LABEL,
+  type ComfortBand,
+  type LifestyleSummaryModel,
+} from "@lib/independence/lifestyleSummary"
+import type {
+  LifestyleCatalogResponse,
+  PlanExpense,
+  RetirementProjection,
+} from "types/independence"
+
+/** Two ladders, four rungs each — enough to exercise the scoring. */
+const catalog = {
+  householdSize: 2,
+  currency: "SGD",
+  categories: [
+    {
+      key: "housing",
+      displayName: "Housing",
+      emoji: "\u{1F3E0}",
+      categoryLabelId: "cat-Housing",
+      sortOrder: 1,
+      tiers: [
+        {
+          label: "Lean",
+          emoji: "\u{1F3E0}",
+          monthlyAmount: 500,
+          description: "owned outright",
+          reserve: false,
+        },
+        {
+          label: "Simple",
+          emoji: "\u{1F3E0}",
+          monthlyAmount: 1500,
+          description: "a modest rental",
+          reserve: false,
+        },
+        {
+          label: "Comfortable",
+          emoji: "\u{1F3E0}",
+          monthlyAmount: 2500,
+          description: "a condo rental",
+          reserve: false,
+        },
+        {
+          label: "Premium",
+          emoji: "\u{1F3E0}",
+          monthlyAmount: 4000,
+          description: "prime housing",
+          reserve: false,
+        },
+      ],
+    },
+    {
+      key: "food",
+      displayName: "Food",
+      emoji: "\u{1F37D}",
+      categoryLabelId: "cat-Food",
+      sortOrder: 2,
+      tiers: [
+        {
+          label: "Lean",
+          emoji: "\u{1F37D}",
+          monthlyAmount: 400,
+          description: "cooking at home",
+          reserve: false,
+        },
+        {
+          label: "Simple",
+          emoji: "\u{1F37D}",
+          monthlyAmount: 900,
+          description: "the odd meal out",
+          reserve: false,
+        },
+        {
+          label: "Comfortable",
+          emoji: "\u{1F37D}",
+          monthlyAmount: 1500,
+          description: "restaurants most weeks",
+          reserve: false,
+        },
+        {
+          label: "Premium",
+          emoji: "\u{1F37D}",
+          monthlyAmount: 2500,
+          description: "eating out by default",
+          reserve: false,
+        },
+      ],
+    },
+  ],
+} as LifestyleCatalogResponse
+
+const expense = (categoryName: string, monthlyAmount: number): PlanExpense => ({
+  id: `id-${categoryName}`,
+  planId: "plan-1",
+  categoryLabelId: `cat-${categoryName}`,
+  categoryName,
+  monthlyAmount,
+  currency: "NZD",
+  sortOrder: 0,
+})
+
+const projection = (
+  overrides: Partial<RetirementProjection> = {},
+): RetirementProjection =>
+  ({
+    currency: "NZD",
+    yearlyProjections: [],
+    nonSpendableAtRetirement: 0,
+    housingReturnRate: 0,
+    sustainableMonthlyExpense: 5100,
+    expenseAdjustmentPercent: 11,
+    ...overrides,
+  }) as RetirementProjection
+
+const mix = [
+  expense("Housing", 2000),
+  expense("Travel", 1200),
+  expense("Food", 800),
+  expense("Health", 600),
+]
+
+describe("comfort, as a summary of the breakdown", () => {
+  const bandFor = (entries: Array<[string, number]>): ComfortBand | null =>
+    buildExpenseMix({
+      expenses: entries.map(([name, amount]) => expense(name, amount)),
+      catalog,
+    })!.comfort
+
+  it("reads a frugal breakdown as challenging", () => {
+    // Bottom rung of every ladder.
+    const band = bandFor([
+      ["Housing", 500],
+      ["Food", 400],
+    ])!
+    expect(band.key).toBe("challenging")
+    expect(band.score).toBeLessThanOrEqual(2)
+  })
+
+  it("reads a top-rung breakdown as luxury", () => {
+    const band = bandFor([
+      ["Housing", 4000],
+      ["Food", 2500],
+    ])!
+    expect(band.key).toBe("luxury")
+    expect(band.score).toBe(10)
+  })
+
+  it("weights by spend rather than averaging the rungs", () => {
+    // Housing sits on the top rung, Food on the bottom. A plain average of the
+    // two would land mid-scale; weighting by what each actually costs puts it
+    // near the top, because the money is overwhelmingly in the housing.
+    const band = bandFor([
+      ["Housing", 4000],
+      ["Food", 400],
+    ])!
+    expect(band.score).toBeGreaterThanOrEqual(8)
+    expect(band.basedOn).toBe(2)
+  })
+
+  it("lets a big frugal category pull the read down", () => {
+    const lavishHousingOnly = bandFor([["Housing", 4000]])!
+    const sameHousingPlusFrugalFood = bandFor([
+      ["Housing", 4000],
+      ["Food", 400],
+    ])!
+    expect(sameHousingPlusFrugalFood.score).toBeLessThan(
+      lavishHousingOnly.score,
+    )
+  })
+
+  it("ignores categories with no ladder rather than scoring them zero", () => {
+    // "Ruby" has no bands. Counting it as the bottom rung would drag every
+    // plan down for the crime of having a category we haven't described.
+    const withCustom = bandFor([
+      ["Housing", 2500],
+      ["Ruby", 5000],
+    ])!
+    const without = bandFor([["Housing", 2500]])!
+    expect(withCustom.score).toBe(without.score)
+    expect(withCustom.basedOn).toBe(1)
+  })
+
+  it("says nothing when no category has a ladder", () => {
+    expect(bandFor([["Ruby", 500]])).toBeNull()
+    // No catalog loaded yet — nothing to place anyone on.
+    expect(
+      buildExpenseMix({ expenses: [expense("Housing", 2500)] })!.comfort,
+    ).toBeNull()
+  })
+
+  it("never lets the number disagree with the word", () => {
+    const ranges: Record<string, [number, number]> = {
+      challenging: [1, 2],
+      tight: [3, 4],
+      comfortable: [5, 6],
+      generous: [7, 8],
+      luxury: [9, 10],
+    }
+    for (let amount = 200; amount <= 6_000; amount += 100) {
+      const band = bandFor([["Housing", amount]])!
+      const [lo, hi] = ranges[band.key]
+      expect(band.score).toBeGreaterThanOrEqual(lo)
+      expect(band.score).toBeLessThanOrEqual(hi)
+    }
+  })
+
+  it("never goes backwards as a budget grows", () => {
+    let previous = 0
+    for (let amount = 200; amount <= 6_000; amount += 100) {
+      const score = bandFor([["Housing", amount]])!.score
+      expect(score).toBeGreaterThanOrEqual(previous)
+      previous = score
+    }
+    expect(previous).toBe(10)
+  })
+})
+
+describe("headroomPhrase", () => {
+  const cats = (
+    entries: Array<[string, number]>,
+    isRollup = false,
+  ): LifestyleSummaryModel["categories"] =>
+    entries.map(([categoryName, described]) => ({
+      categoryName,
+      categoryLabelId: `cat-${categoryName}`,
+      described,
+      amount: described,
+      share: 1,
+      isRollup,
+    }))
+
+  it("measures a surplus against whichever budget it most resembles", () => {
+    // +$500 against Entertainment $500 — a whole one.
+    const phrase = headroomPhrase({
+      monthlyTotal: 4500,
+      describedMonthly: 4000,
+      categories: cats([
+        ["Housing", 2500],
+        ["Food", 1000],
+        ["Entertainment", 500],
+      ]),
+    })
+    expect(phrase).toBe(
+      "everything you planned for, and about a whole Entertainment budget spare",
+    )
+  })
+
+  it("uses a coarse fraction, not a decimal", () => {
+    const phrase = headroomPhrase({
+      monthlyTotal: 4250,
+      describedMonthly: 4000,
+      categories: cats([
+        ["Housing", 3000],
+        ["Entertainment", 500],
+      ]),
+    })
+    // 250 / 500 — half, not "0.5 of".
+    expect(phrase).toBe(
+      "everything you planned for, and about half an Entertainment budget spare",
+    )
+  })
+
+  it("frames a shortfall as what would have to give", () => {
+    const phrase = headroomPhrase({
+      monthlyTotal: 3500,
+      describedMonthly: 4000,
+      categories: cats([
+        ["Housing", 3000],
+        ["Travel", 500],
+      ]),
+    })
+    expect(phrase).toBe("the plan falls short by about a whole Travel budget")
+  })
+
+  it("calls a negligible gap the same life", () => {
+    const phrase = headroomPhrase({
+      monthlyTotal: 4020,
+      describedMonthly: 4000,
+      categories: cats([["Housing", 4000]]),
+    })
+    expect(phrase).toBe("just about exactly the life you described")
+  })
+
+  it("reads as a sentence when the category is a person's name", () => {
+    // "Your whole Ruby budget more than the plan can cover." stated a
+    // comparison without ever making it, and "your ... Ruby" reads oddly.
+    const phrase = headroomPhrase({
+      monthlyTotal: 3500,
+      describedMonthly: 4000,
+      categories: cats([
+        ["Housing", 3000],
+        ["Ruby", 500],
+      ]),
+    })
+    expect(phrase).toBe("the plan falls short by about a whole Ruby budget")
+  })
+
+  it.each([
+    ["Entertainment", "an Entertainment"],
+    ["Other", "an Other"],
+    // "u" is a vowel whose sound usually isn't — Utilities takes "a".
+    ["Utilities", "a Utilities"],
+    ["Housing", "a Housing"],
+  ])("gets the article right for %s", (category, expected) => {
+    const phrase = headroomPhrase({
+      monthlyTotal: 4250,
+      describedMonthly: 4000,
+      categories: cats([
+        ["Housing", 3000],
+        [category, 500],
+      ]),
+    })
+    expect(phrase).toContain(`half ${expected} budget`)
+  })
+
+  it("pluralises a quantity over one", () => {
+    const phrase = headroomPhrase({
+      monthlyTotal: 5000,
+      describedMonthly: 4000,
+      categories: cats([
+        ["Housing", 3500],
+        ["Travel", 500],
+      ]),
+    })
+    expect(phrase).toBe(
+      "everything you planned for, and about two Travel budgets spare",
+    )
+  })
+
+  it("won't measure against the rolled-up remainder", () => {
+    // "Half your Everything else budget" means nothing to anyone.
+    const phrase = headroomPhrase({
+      monthlyTotal: 4500,
+      describedMonthly: 4000,
+      categories: cats([["Everything else", 4000]], true),
+    })
+    expect(phrase).toBeNull()
+  })
+})
+
+describe("buildExpenseMix", () => {
+  it("still gets a comfort read — it needs no projection", () => {
+    // The band summarises the category ladders, so a composite phase can have
+    // one even though the composite projection has no sustainable figure.
+    expect(buildExpenseMix({ expenses: mix, catalog })!.comfort).not.toBeNull()
+  })
+
+  it("reports what was described, making no affordability claim", () => {
+    const model = buildExpenseMix({ expenses: mix })!
+
+    expect(model.basis).toBe("described")
+    expect(model.monthlyTotal).toBe(4600)
+    expect(model.categories.map((c) => c.amount)).toEqual([
+      2000, 1200, 800, 600,
+    ])
+  })
+
+  it("never carries an adjustment or a liquidation figure", () => {
+    // Both come off a projection this basis deliberately never consults.
+    const model = buildExpenseMix({ expenses: mix })!
+
+    expect(model.adjustmentPercent).toBeNull()
+    expect(model.direction).toBe("level")
+    expect(model.liquidation).toBeNull()
+  })
+
+  it("sizes bars against the largest category", () => {
+    const model = buildExpenseMix({
+      expenses: [expense("Housing", 2000), expense("Food", 500)],
+    })!
+
+    expect(model.categories[0].share).toBe(1)
+    expect(model.categories[1].share).toBeCloseTo(0.25)
+  })
+
+  it("rolls the tail up like the supported basis does", () => {
+    const model = buildExpenseMix({
+      expenses: [
+        expense("A", 100),
+        expense("B", 90),
+        expense("C", 80),
+        expense("D", 70),
+        expense("E", 60),
+        expense("F", 50),
+        expense("G", 40),
+      ],
+      maxCategories: 5,
+    })!
+
+    expect(model.categories).toHaveLength(6)
+    expect(model.categories[5].categoryName).toBe(ROLLUP_LABEL)
+    expect(model.categories[5].amount).toBe(90)
+  })
+
+  it("still describes the mix", () => {
+    const model = buildExpenseMix({
+      expenses: [expense("Housing", 3000), expense("Food", 500)],
+    })!
+    expect(model.mixDescriptor).toBe("Housing-dominant")
+  })
+
+  it("returns null when nothing was described", () => {
+    expect(buildExpenseMix({ expenses: [] })).toBeNull()
+    expect(buildExpenseMix({ expenses: [expense("Housing", 0)] })).toBeNull()
+  })
+})
+
+describe("category descriptions", () => {
+  const labels = [
+    {
+      id: "cat-Healthcare",
+      ownerId: "SYSTEM",
+      name: "Healthcare",
+      description: "Medical, dental, vision, insurance",
+      sortOrder: 1,
+    },
+    {
+      id: "cat-Housing",
+      ownerId: "SYSTEM",
+      name: "Housing",
+      description: "Rates, management fees, insurance, maintenance",
+      sortOrder: 2,
+    },
+  ]
+
+  it("attaches the backend's own words for each bucket", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("Housing", 2000), expense("Healthcare", 600)],
+      projection: projection(),
+      labels,
+    })!
+    expect(model.categories[0].description).toBe(
+      "Rates, management fees, insurance, maintenance",
+    )
+    expect(model.categories[1].description).toBe(
+      "Medical, dental, vision, insurance",
+    )
+  })
+
+  it("leaves a user's own category undescribed rather than inventing one", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("Housing", 2000), expense("Ruby", 500)],
+      projection: projection(),
+      labels,
+    })!
+    expect(model.categories[1].description).toBeUndefined()
+  })
+
+  it("has the remainder describe itself by what it swallowed", () => {
+    const model = buildLifestyleSummary({
+      expenses: [
+        expense("Housing", 600),
+        expense("Food", 500),
+        expense("Travel", 400),
+        expense("Health", 300),
+        expense("Pets", 200),
+        expense("Golf", 100),
+        expense("Books", 50),
+      ],
+      projection: projection(),
+      labels,
+      maxCategories: 5,
+    })!
+    expect(model.categories[5].description).toBe("Golf, Books")
+  })
+
+  it("works without labels at all", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("Housing", 2000)],
+      projection: projection(),
+    })!
+    expect(model.categories[0].description).toBeUndefined()
+  })
+
+  it("prefers the catalog tier over the category's own description", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("Housing", 2500)],
+      projection: projection({ sustainableMonthlyExpense: 2500 }),
+      labels,
+      catalog,
+    })!
+    expect(model.categories[0].benchmark).toBe("a condo rental")
+    expect(model.categories[0].emoji).toBe("\u{1F3E0}")
+    // The description is still carried; the component decides which to show.
+    expect(model.categories[0].description).toBe(
+      "Rates, management fees, insurance, maintenance",
+    )
+  })
+
+  it("places the supported amount on the ladder, not the described one", () => {
+    // Labelling the life the user typed rather than the one the plan pays for
+    // would describe a standard of living they can't actually reach.
+    const model = buildLifestyleSummary({
+      expenses: [expense("Housing", 4000)],
+      projection: projection({ sustainableMonthlyExpense: 500 }),
+      labels,
+      catalog,
+    })!
+    expect(model.categories[0].amount).toBe(500)
+    expect(model.categories[0].benchmark).toBe("owned outright")
+  })
+
+  it("carries no tier until the catalog has loaded", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("Housing", 2500)],
+      projection: projection(),
+      labels,
+    })!
+    expect(model.categories[0].benchmark).toBeUndefined()
+    expect(model.categories[0].emoji).toBeUndefined()
+  })
+
+  it("carries descriptions on the described basis too", () => {
+    const model = buildExpenseMix({
+      expenses: [expense("Healthcare", 600)],
+      labels,
+    })!
+    expect(model.categories[0].description).toBe(
+      "Medical, dental, vision, insurance",
+    )
+  })
+})
+
+describe("buildLifestyleSummary", () => {
+  it("is flagged as making an affordability claim", () => {
+    expect(
+      buildLifestyleSummary({ expenses: mix, projection: projection() })!.basis,
+    ).toBe("supported")
+  })
+
+  it("scales each described category to what the plan supports", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("Housing", 2000), expense("Travel", 2000)],
+      projection: projection({ sustainableMonthlyExpense: 3000 }),
+    })!
+
+    expect(model.categories.map((c) => c.amount)).toEqual([1500, 1500])
+  })
+
+  it("makes the rows add up to the headline despite rounding", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("A", 333), expense("B", 333), expense("C", 334)],
+      projection: projection({ sustainableMonthlyExpense: 1001 }),
+    })!
+
+    const total = model.categories.reduce((sum, c) => sum + c.amount, 0)
+    expect(total).toBe(1001)
+  })
+
+  it("rolls the tail into a single remainder row", () => {
+    const model = buildLifestyleSummary({
+      expenses: [
+        expense("Housing", 2000),
+        expense("Travel", 1000),
+        expense("Food", 500),
+        expense("Health", 100),
+        expense("Pets", 50),
+        expense("Golf", 40),
+        expense("Books", 10),
+      ],
+      projection: projection({ sustainableMonthlyExpense: 3700 }),
+      maxCategories: 5,
+    })!
+
+    expect(model.categories).toHaveLength(6)
+    const rollup = model.categories[5]
+    expect(rollup.categoryName).toBe(ROLLUP_LABEL)
+    expect(rollup.isRollup).toBe(true)
+    // Pets makes the top 5; only Golf + Books fall into the remainder
+    expect(rollup.described).toBe(50)
+  })
+
+  it("ranks categories by amount, largest first", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("Food", 800), expense("Housing", 2000)],
+      projection: projection(),
+    })!
+
+    expect(model.categories.map((c) => c.categoryName)).toEqual([
+      "Housing",
+      "Food",
+    ])
+  })
+
+  it("sizes bars against the largest category, not the total", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("Housing", 2000), expense("Food", 1000)],
+      projection: projection({ sustainableMonthlyExpense: 3000 }),
+    })!
+
+    expect(model.categories[0].share).toBe(1)
+    expect(model.categories[1].share).toBeCloseTo(0.5)
+  })
+
+  it("ignores categories the user left at zero", () => {
+    const model = buildLifestyleSummary({
+      expenses: [expense("Housing", 2000), expense("Yacht", 0)],
+      projection: projection(),
+    })!
+
+    expect(model.categories.map((c) => c.categoryName)).toEqual(["Housing"])
+  })
+
+  describe("direction", () => {
+    it("reads headroom from the backend adjustment", () => {
+      const model = buildLifestyleSummary({
+        expenses: mix,
+        projection: projection({ expenseAdjustmentPercent: 11 }),
+      })!
+      expect(model.direction).toBe("headroom")
+      expect(model.adjustmentPercent).toBe(11)
+    })
+
+    it("reads shortfall from the backend adjustment", () => {
+      const model = buildLifestyleSummary({
+        expenses: mix,
+        projection: projection({ expenseAdjustmentPercent: -20 }),
+      })!
+      expect(model.direction).toBe("shortfall")
+    })
+
+    it("treats a sub-1% adjustment as level", () => {
+      const model = buildLifestyleSummary({
+        expenses: mix,
+        projection: projection({ expenseAdjustmentPercent: 0.4 }),
+      })!
+      expect(model.direction).toBe("level")
+    })
+
+    it("is level when the backend sends no adjustment", () => {
+      const model = buildLifestyleSummary({
+        expenses: mix,
+        projection: projection({ expenseAdjustmentPercent: undefined }),
+      })!
+      expect(model.direction).toBe("level")
+      expect(model.adjustmentPercent).toBeNull()
+    })
+  })
+
+  describe("mix descriptor", () => {
+    it("names a category that dominates the mix", () => {
+      const model = buildLifestyleSummary({
+        expenses: [expense("Housing", 3000), expense("Food", 500)],
+        projection: projection(),
+      })!
+      expect(model.mixDescriptor).toBe("Housing-dominant")
+    })
+
+    it("names a category that merely leans heavy", () => {
+      const model = buildLifestyleSummary({
+        expenses: [
+          expense("Travel", 300),
+          expense("Food", 250),
+          expense("Housing", 250),
+          expense("Health", 200),
+        ],
+        projection: projection(),
+      })!
+      expect(model.mixDescriptor).toBe("Travel-heavy")
+    })
+
+    it("calls an even spread balanced", () => {
+      const model = buildLifestyleSummary({
+        expenses: [
+          expense("A", 100),
+          expense("B", 100),
+          expense("C", 100),
+          expense("D", 100),
+          expense("E", 100),
+          expense("F", 100),
+        ],
+        projection: projection(),
+      })!
+      expect(model.mixDescriptor).toBe("Balanced")
+    })
+  })
+
+  describe("liquidation", () => {
+    it("surfaces the with-liquidation figure when it is better", () => {
+      const model = buildLifestyleSummary({
+        expenses: mix,
+        projection: projection({
+          sustainableMonthlyExpense: 5100,
+          sustainableWithLiquidation: 6300,
+          liquidationAge: 71,
+        }),
+      })!
+      expect(model.liquidation).toEqual({
+        supportedMonthly: 6300,
+        fromAge: 71,
+      })
+    })
+
+    it("stays quiet when selling up buys nothing", () => {
+      const model = buildLifestyleSummary({
+        expenses: mix,
+        projection: projection({
+          sustainableMonthlyExpense: 5100,
+          sustainableWithLiquidation: 5100,
+        }),
+      })!
+      expect(model.liquidation).toBeNull()
+    })
+  })
+
+  describe("nothing honest to say", () => {
+    it("returns null when no expenses were described", () => {
+      expect(
+        buildLifestyleSummary({ expenses: [], projection: projection() }),
+      ).toBeNull()
+    })
+
+    it("returns null when every category is zero", () => {
+      expect(
+        buildLifestyleSummary({
+          expenses: [expense("Housing", 0)],
+          projection: projection(),
+        }),
+      ).toBeNull()
+    })
+
+    it("returns null when the backend has no sustainable figure", () => {
+      expect(
+        buildLifestyleSummary({
+          expenses: mix,
+          projection: projection({ sustainableMonthlyExpense: undefined }),
+        }),
+      ).toBeNull()
+    })
+
+    it("returns null without a projection at all", () => {
+      expect(
+        buildLifestyleSummary({ expenses: mix, projection: null }),
+      ).toBeNull()
+    })
+  })
+
+  it("survives a plan the projection cannot sustain at all", () => {
+    const model = buildLifestyleSummary({
+      expenses: mix,
+      projection: projection({
+        sustainableMonthlyExpense: 0,
+        expenseAdjustmentPercent: -100,
+      }),
+    })!
+
+    expect(model.monthlyTotal).toBe(0)
+    expect(model.categories.every((c) => c.amount === 0)).toBe(true)
+    expect(model.categories.every((c) => c.share === 0)).toBe(true)
+    expect(model.direction).toBe("shortfall")
+  })
+})

--- a/src/lib/utils/independence/lifestyleSummary.ts
+++ b/src/lib/utils/independence/lifestyleSummary.ts
@@ -1,0 +1,489 @@
+import type {
+  CategoryLabel,
+  LifestyleCatalogResponse,
+  PlanExpense,
+  RetirementProjection,
+} from "types/independence"
+import { tierLevelFor, type TierLevel } from "@lib/independence/lifestyleTiers"
+
+/**
+ * Turns a plan's expense mix plus the backend's sustainable-spend figures into
+ * the "what your plan supports" read.
+ *
+ * The totals are NEVER derived here — `sustainableMonthlyExpense` and
+ * `expenseAdjustmentPercent` come off the projection exactly as svc-retire
+ * calculated them. All this module does is distribute that total across the
+ * categories the user described, so the number becomes a lifestyle rather than
+ * a lump sum.
+ */
+
+/** Below this the adjustment is noise, not a message worth showing. */
+const LEVEL_THRESHOLD_PERCENT = 1
+
+/** Share of described spend at which one category defines the whole mix. */
+const DOMINANT_SHARE = 0.45
+/** Share at which a category is worth naming, but isn't the whole story. */
+const HEAVY_SHARE = 0.2
+
+export const ROLLUP_LABEL = "Everything else"
+
+/**
+ * How the plan feels to live on, from challenging to luxury.
+ *
+ * This is a SUMMARY OF THE BREAKDOWN, not a restatement of the headroom. Each
+ * category sits on its own ladder — S$750 of healthcare is rung 3 of 4 — and
+ * the overall read is those rungs averaged, weighted by what each category
+ * costs. So a plan whose housing and food are near the top of their ladders
+ * reads as generous even if it happens to spend exactly what was described,
+ * and a plan with headroom over a frugal life still reads as tight.
+ *
+ * Anchored, therefore, to svc-retire's lifestyle catalog rather than to the
+ * user's own expectations. Categories with no ladder — a custom
+ * category, an unsupported currency — are left out of the average entirely,
+ * because scoring them as zero would drag every plan down for the crime of
+ * having a category we haven't described.
+ */
+export const COMFORT_STEPS = [
+  "challenging",
+  "tight",
+  "comfortable",
+  "generous",
+  "luxury",
+] as const
+
+export type ComfortKey = (typeof COMFORT_STEPS)[number]
+
+export const COMFORT_SCALE_MAX = 10
+
+export interface ComfortBand {
+  key: ComfortKey
+  label: string
+  /** 1-based position among the five named bands. */
+  step: number
+  /** 1–10. Finer than the band, so movement inside one is still visible. */
+  score: number
+  /** How many categories the average is over — the read is thin below ~3. */
+  basedOn: number
+}
+
+const COMFORT_LABELS: Record<ComfortKey, string> = {
+  challenging: "Challenging",
+  tight: "Tight",
+  comfortable: "Comfortable",
+  generous: "Generous",
+  luxury: "Luxury",
+}
+
+/** Two score points per band, so the number and the word can never disagree. */
+function keyForScore(score: number): ComfortKey {
+  return COMFORT_STEPS[Math.min(4, Math.floor((score - 1) / 2))]
+}
+
+interface Weighted {
+  amount: number
+  level: TierLevel | null
+}
+
+/**
+ * Weighted by spend: what a plan mostly pays for should mostly decide how it
+ * reads. An extravagant pet budget shouldn't outvote modest housing.
+ */
+export function comfortFromBreakdown(entries: Weighted[]): ComfortBand | null {
+  const scored = entries.filter((e) => e.level && e.amount > 0)
+  const weight = scored.reduce((sum, e) => sum + e.amount, 0)
+  if (scored.length === 0 || weight <= 0) return null
+
+  const position =
+    scored.reduce((sum, e) => {
+      const { index, of } = e.level!
+      // Rung 1 of 4 → 0, rung 4 of 4 → 1.
+      return sum + e.amount * ((index - 1) / Math.max(1, of - 1))
+    }, 0) / weight
+
+  const score = Math.min(
+    COMFORT_SCALE_MAX,
+    Math.max(1, Math.round(1 + position * (COMFORT_SCALE_MAX - 1))),
+  )
+  const key = keyForScore(score)
+  return {
+    key,
+    label: COMFORT_LABELS[key],
+    step: COMFORT_STEPS.indexOf(key) + 1,
+    score,
+    basedOn: scored.length,
+  }
+}
+
+/**
+ * Coarse quantities, because "0.63 of your Entertainment budget" is a number
+ * and "two-thirds of an Entertainment budget" is a thought.
+ *
+ * Each entry is a complete quantity phrase, plural included. Composing them
+ * from parts is what produced "your whole your Ruby budget" — and "a" rather
+ * than "your" keeps it readable when the category is a person's name: "a whole
+ * Ruby budget" works, "your whole Ruby budget" reads like an accusation.
+ */
+const QUANTITIES: Array<[ratio: number, phrase: (category: string) => string]> =
+  [
+    [0.25, (c) => `a quarter of ${aOrAn(c)} budget`],
+    [0.33, (c) => `a third of ${aOrAn(c)} budget`],
+    [0.5, (c) => `half ${aOrAn(c)} budget`],
+    [0.67, (c) => `two-thirds of ${aOrAn(c)} budget`],
+    [0.75, (c) => `three-quarters of ${aOrAn(c)} budget`],
+    [1, (c) => `a whole ${c} budget`],
+    [1.5, (c) => `one and a half ${c} budgets`],
+    [2, (c) => `two ${c} budgets`],
+    [3, (c) => `three ${c} budgets`],
+  ]
+
+/**
+ * "an Entertainment budget", "a Utilities budget". Deliberately excludes "u":
+ * the letter is a vowel but the sound usually isn't, and category names that
+ * start with one — Utilities — take "a".
+ */
+function aOrAn(word: string): string {
+  return /^[aeio]/i.test(word.trim()) ? `an ${word}` : `a ${word}`
+}
+
+/** Below this the gap isn't worth a sentence — it's the same life. */
+const NEGLIGIBLE_SHARE = 0.02
+
+function nearestQuantity(ratio: number, category: string): string {
+  const [, phrase] = QUANTITIES.reduce((best, entry) =>
+    Math.abs(entry[0] - ratio) < Math.abs(best[0] - ratio) ? entry : best,
+  )
+  return phrase(category)
+}
+
+/**
+ * Says what the gap between supported and described spend is *worth*, in terms
+ * of something the user named themselves.
+ *
+ * This is what makes the comfort band mean anything without inventing external
+ * benchmarks: "two-thirds of your Entertainment budget spare" is arithmetic on
+ * the user's own figures, and it lands as a lifestyle statement rather than a
+ * financial one. Returns null when there's no named category to measure
+ * against — the rolled-up remainder is not a thing anyone recognises as theirs.
+ */
+export function headroomPhrase(
+  model: Pick<
+    LifestyleSummaryModel,
+    "monthlyTotal" | "describedMonthly" | "categories"
+  >,
+): string | null {
+  const surplus = model.monthlyTotal - model.describedMonthly
+  if (model.describedMonthly <= 0) return null
+  if (Math.abs(surplus) / model.describedMonthly < NEGLIGIBLE_SHARE) {
+    return "just about exactly the life you described"
+  }
+
+  const named = model.categories.filter((c) => !c.isRollup && c.described > 0)
+  if (named.length === 0) return null
+
+  // The category whose own budget is closest in size to the gap — that's the
+  // one that makes the comparison land.
+  const magnitude = Math.abs(surplus)
+  const reference = named.reduce((best, c) =>
+    Math.abs(c.described - magnitude) < Math.abs(best.described - magnitude)
+      ? c
+      : best,
+  )
+  const quantity = nearestQuantity(
+    magnitude / reference.described,
+    reference.categoryName,
+  )
+
+  // Both read as complete sentences once capitalised by the caller. The
+  // shortfall used to be a bare noun phrase — "Your whole Ruby budget more than
+  // the plan can cover." — which stated a comparison without ever making it.
+  return surplus > 0
+    ? `everything you planned for, and about ${quantity} spare`
+    : `the plan falls short by about ${quantity}`
+}
+
+export interface LifestyleCategory {
+  categoryName: string
+  /** Catalog id, for looking the category's tiers up. */
+  categoryLabelId: string
+  /** Catalog emoji for the tile. Absent for a user's own category. */
+  emoji?: string
+  /** What this level of spend buys, in this market — "health insurance + gym".
+   *  Absent where no band is authored; see lifestyleBenchmarks. */
+  benchmark?: string
+  /** The backend's own words for what the bucket covers — "Medical, dental,
+   *  vision, insurance". Shown only when there's no benchmark to show instead. */
+  description?: string
+  /** Monthly amount the user entered. */
+  described: number
+  /** The amount rendered: scaled to what the plan supports, or the
+   *  described amount itself when `basis` is "described". */
+  amount: number
+  /** 0–1, relative to the largest category — the bar's width. */
+  share: number
+  /** True for the rolled-up remainder row. */
+  isRollup: boolean
+}
+
+export type LifestyleDirection = "headroom" | "shortfall" | "level"
+
+/**
+ * What the figures mean.
+ *
+ * - `supported` — the backend's sustainable spend, spread across categories.
+ *   Makes an affordability claim.
+ * - `described` — only what the user said they'd spend. Makes NO claim about
+ *   whether the plan can afford it. Used where the backend has no sustainable
+ *   figure to give (composite/phased projections), so that the absence of an
+ *   answer never gets rendered as one.
+ */
+export type LifestyleBasis = "supported" | "described"
+
+export interface LifestyleSummaryModel {
+  basis: LifestyleBasis
+  /** The headline: sustainable monthly spend, or the described total. */
+  monthlyTotal: number
+  /** Sum of what the user entered. */
+  describedMonthly: number
+  /** Backend's adjustment: positive = room to spend more. Null when absent. */
+  adjustmentPercent: number | null
+  direction: LifestyleDirection
+  categories: LifestyleCategory[]
+  /** e.g. "Travel-heavy", "Housing-dominant", "Balanced". Null when unknowable. */
+  mixDescriptor: string | null
+  /** Present only when selling illiquid assets lifts the sustainable figure. */
+  liquidation: { supportedMonthly: number; fromAge: number | null } | null
+  /** Comfort relative to the described life. Null on the described basis,
+   *  where there is no projection to compare against. */
+  comfort: ComfortBand | null
+}
+
+interface BuildArgs {
+  expenses: PlanExpense[] | undefined
+  projection: RetirementProjection | null | undefined
+  /** Category definitions, for their descriptions. Optional: without them the
+   *  board still works, it just says less. */
+  labels?: CategoryLabel[]
+  /** svc-retire's tier catalog, already converted to the plan's currency. */
+  catalog?: LifestyleCatalogResponse
+  /** Categories shown before the rest roll up. */
+  maxCategories?: number
+}
+
+/**
+ * Returns null when there's nothing honest to say — no expenses described, or
+ * no sustainable figure from the backend. Callers render the mirror or empty
+ * variant in that case rather than inventing a number.
+ */
+export function buildLifestyleSummary({
+  expenses,
+  projection,
+  labels,
+  catalog,
+  maxCategories = 5,
+}: BuildArgs): LifestyleSummaryModel | null {
+  const described = (expenses ?? []).filter((e) => (e.monthlyAmount || 0) > 0)
+  const describedMonthly = described.reduce(
+    (sum, e) => sum + e.monthlyAmount,
+    0,
+  )
+  const supportedMonthly = projection?.sustainableMonthlyExpense
+
+  if (described.length === 0 || describedMonthly <= 0) return null
+  if (supportedMonthly == null || supportedMonthly < 0) return null
+
+  const ranked = [...described].sort(
+    (a, b) => b.monthlyAmount - a.monthlyAmount,
+  )
+  const grouped = rollUp(ranked, maxCategories, labels)
+  const categories = allocate(grouped, describedMonthly, supportedMonthly)
+  const largest = Math.max(...categories.map((c) => c.amount), 0)
+  // Banded on the SUPPORTED amount: describing the figure the user typed
+  // would label a life their plan may not actually pay for.
+  const withBenchmarks = categories.map((c) => {
+    const level = tierLevelFor(c.categoryLabelId, c.amount, catalog)
+    return { ...c, level, benchmark: level?.descriptor, emoji: level?.emoji }
+  })
+
+  return {
+    basis: "supported",
+    monthlyTotal: supportedMonthly,
+    describedMonthly,
+    adjustmentPercent: projection?.expenseAdjustmentPercent ?? null,
+    direction: toDirection(projection?.expenseAdjustmentPercent),
+    categories: withBenchmarks.map((c) => ({
+      ...c,
+      share: largest > 0 ? c.amount / largest : 0,
+    })),
+    mixDescriptor: describeMix(ranked, describedMonthly),
+    liquidation: toLiquidation(projection, supportedMonthly),
+    comfort: comfortFromBreakdown(withBenchmarks),
+  }
+}
+
+/**
+ * The spending shape alone, with no affordability claim attached.
+ *
+ * For surfaces where the backend has no sustainable figure to give — a
+ * composite/phased projection returns none — this shows what the user
+ * described and stops there. The alternative would be deriving a sustainable
+ * number from one phase and presenting it as the whole plan's, which is
+ * exactly the invention this codebase forbids.
+ */
+export function buildExpenseMix({
+  expenses,
+  labels,
+  catalog,
+  maxCategories = 5,
+}: {
+  expenses: PlanExpense[] | undefined
+  labels?: CategoryLabel[]
+  catalog?: LifestyleCatalogResponse
+  maxCategories?: number
+}): LifestyleSummaryModel | null {
+  const described = (expenses ?? []).filter((e) => (e.monthlyAmount || 0) > 0)
+  const describedMonthly = described.reduce(
+    (sum, e) => sum + e.monthlyAmount,
+    0,
+  )
+  if (described.length === 0 || describedMonthly <= 0) return null
+
+  const ranked = [...described].sort(
+    (a, b) => b.monthlyAmount - a.monthlyAmount,
+  )
+  const grouped = rollUp(ranked, maxCategories, labels)
+  const largest = Math.max(...grouped.map((g) => g.described), 0)
+  const mixWithBenchmarks = grouped.map((g) => {
+    const level = tierLevelFor(g.categoryLabelId, g.described, catalog)
+    return {
+      ...g,
+      amount: g.described,
+      level,
+      benchmark: level?.descriptor,
+      emoji: level?.emoji,
+    }
+  })
+
+  return {
+    basis: "described",
+    monthlyTotal: describedMonthly,
+    describedMonthly,
+    adjustmentPercent: null,
+    direction: "level",
+    categories: mixWithBenchmarks.map((g) => ({
+      ...g,
+      share: largest > 0 ? g.amount / largest : 0,
+    })),
+    mixDescriptor: describeMix(ranked, describedMonthly),
+    liquidation: null,
+    // A lifestyle read, not an affordability one — it needs no projection, so
+    // composite phases get it too.
+    comfort: comfortFromBreakdown(mixWithBenchmarks),
+  }
+}
+
+interface Grouped {
+  categoryName: string
+  categoryLabelId: string
+  description?: string
+  described: number
+  isRollup: boolean
+}
+
+/** Top N by amount, with the tail collapsed into a single row. */
+function rollUp(
+  ranked: PlanExpense[],
+  maxCategories: number,
+  labels: CategoryLabel[] | undefined,
+): Grouped[] {
+  const describe = new Map(
+    (labels ?? []).map((l) => [l.id, l.description?.trim() || undefined]),
+  )
+  const head: Grouped[] = ranked.slice(0, maxCategories).map((e) => ({
+    categoryName: e.categoryName,
+    categoryLabelId: e.categoryLabelId,
+    description: describe.get(e.categoryLabelId),
+    described: e.monthlyAmount,
+    isRollup: false,
+  }))
+  const tail = ranked.slice(maxCategories)
+  if (tail.length === 0) return head
+  return [
+    ...head,
+    {
+      categoryName: ROLLUP_LABEL,
+      // The remainder spans categories, so it matches no single tier ladder.
+      categoryLabelId: "",
+      // It describes itself best by naming what it swallowed.
+      description: tail.map((e) => e.categoryName).join(", "),
+      described: tail.reduce((sum, e) => sum + e.monthlyAmount, 0),
+      isRollup: true,
+    },
+  ]
+}
+
+/**
+ * Scales each category by supported/described. The last row absorbs the
+ * rounding drift so the rows always add up to the supported total — a
+ * breakdown that doesn't sum to its own headline destroys trust faster than
+ * any amount of imprecision.
+ */
+function allocate(
+  groups: Grouped[],
+  describedMonthly: number,
+  supportedMonthly: number,
+): Omit<LifestyleCategory, "share">[] {
+  const ratio = describedMonthly > 0 ? supportedMonthly / describedMonthly : 0
+  const scaled = groups.map((g) => ({
+    ...g,
+    amount: Math.round(g.described * ratio),
+  }))
+  const drift = Math.round(supportedMonthly) - sum(scaled.map((s) => s.amount))
+  const last = scaled[scaled.length - 1]
+  if (last) last.amount = Math.max(0, last.amount + drift)
+  return scaled
+}
+
+function toDirection(
+  adjustmentPercent: number | undefined,
+): LifestyleDirection {
+  if (adjustmentPercent == null) return "level"
+  if (adjustmentPercent > LEVEL_THRESHOLD_PERCENT) return "headroom"
+  if (adjustmentPercent < -LEVEL_THRESHOLD_PERCENT) return "shortfall"
+  return "level"
+}
+
+/**
+ * Names the shape of the user's OWN mix. Deliberately says nothing about how
+ * many holidays the money buys: the backend supplies no lifestyle benchmarks,
+ * and inventing them here would be fiction dressed as advice.
+ */
+function describeMix(
+  ranked: PlanExpense[],
+  describedMonthly: number,
+): string | null {
+  const top = ranked[0]
+  if (!top || describedMonthly <= 0) return null
+  const share = top.monthlyAmount / describedMonthly
+  const name = top.categoryName.trim()
+  if (!name) return null
+  if (share >= DOMINANT_SHARE) return `${name}-dominant`
+  if (share >= HEAVY_SHARE) return `${name}-heavy`
+  return "Balanced"
+}
+
+function toLiquidation(
+  projection: RetirementProjection | null | undefined,
+  supportedMonthly: number,
+): LifestyleSummaryModel["liquidation"] {
+  const withLiquidation = projection?.sustainableWithLiquidation
+  if (withLiquidation == null || withLiquidation <= supportedMonthly)
+    return null
+  return {
+    supportedMonthly: withLiquidation,
+    fromAge: projection?.liquidationAge ?? null,
+  }
+}
+
+function sum(values: number[]): number {
+  return values.reduce((total, v) => total + v, 0)
+}

--- a/src/lib/utils/independence/lifestyleTiers.test.ts
+++ b/src/lib/utils/independence/lifestyleTiers.test.ts
@@ -1,0 +1,75 @@
+import { tierLevelFor } from "@lib/independence/lifestyleTiers"
+import type { LifestyleCatalogResponse } from "types/independence"
+
+const catalog = {
+  householdSize: 2,
+  currency: "SGD",
+  categories: [
+    {
+      key: "housing",
+      displayName: "Housing",
+      emoji: "🏠",
+      categoryLabelId: "cat-Housing",
+      sortOrder: 1,
+      tiers: [
+        {
+          label: "Lean",
+          emoji: "🏠",
+          monthlyAmount: 500,
+          description: "owned outright",
+          reserve: false,
+        },
+        {
+          label: "Comfortable",
+          emoji: "🏡",
+          monthlyAmount: 2500,
+          description: "a condo rental",
+          reserve: false,
+        },
+        {
+          label: "Premium",
+          emoji: "🏘️",
+          monthlyAmount: 4000,
+          description: "prime housing",
+          reserve: false,
+        },
+      ],
+    },
+  ],
+} as LifestyleCatalogResponse
+
+describe("tierLevelFor", () => {
+  it("places a spend on the nearest tier", () => {
+    expect(tierLevelFor("cat-Housing", 2400, catalog)).toEqual({
+      descriptor: "a condo rental",
+      emoji: "🏡",
+      index: 2,
+      of: 3,
+    })
+  })
+
+  it("matches on the catalog's own id, never the category name", () => {
+    // The catalog and the plan's expenses share categoryLabelId, so nothing
+    // here has to guess from a display name — which is how "Healthcare"
+    // previously matched a rule meant for "car".
+    expect(tierLevelFor("Housing", 2400, catalog)).toBeNull()
+  })
+
+  it("clamps to the ends rather than falling off them", () => {
+    expect(tierLevelFor("cat-Housing", 10, catalog)?.index).toBe(1)
+    expect(tierLevelFor("cat-Housing", 99_999, catalog)?.index).toBe(3)
+  })
+
+  it("says nothing for a category the catalog doesn't cover", () => {
+    expect(tierLevelFor("cat-Ruby", 500, catalog)).toBeNull()
+  })
+
+  it("says nothing before the catalog loads", () => {
+    expect(tierLevelFor("cat-Housing", 2500, undefined)).toBeNull()
+  })
+
+  it("says nothing about a zero or negative amount", () => {
+    expect(tierLevelFor("cat-Housing", 0, catalog)).toBeNull()
+    expect(tierLevelFor("cat-Housing", -100, catalog)).toBeNull()
+  })
+})

--- a/src/lib/utils/independence/lifestyleTiers.ts
+++ b/src/lib/utils/independence/lifestyleTiers.ts
@@ -1,0 +1,64 @@
+import type {
+  LifestyleCatalogResponse,
+  LifestyleTier,
+} from "types/independence"
+
+/**
+ * Where a spend sits on its category's tier ladder, per the svc-retire
+ * catalog.
+ *
+ * This replaces a hard-coded band table that used to live in the frontend.
+ * The catalog is the single source: svc-retire owns the amounts, converts
+ * them to the plan's currency and caches them, so the summary surfaces and
+ * the mood board describe the same life with the same words.
+ */
+export interface TierLevel {
+  /** What this level of spend buys — "health insurance + gym". */
+  descriptor: string
+  /** Category emoji, for the mood board tile. */
+  emoji: string
+  /** 1-based rung. */
+  index: number
+  /** Rungs on this ladder, so callers can normalise. */
+  of: number
+}
+
+/** Nearest tier by amount — the catalog's own matching rule. */
+function nearestTierIndex(amount: number, tiers: LifestyleTier[]): number {
+  let best = 0
+  let bestDistance = Infinity
+  tiers.forEach((tier, index) => {
+    const distance = Math.abs(tier.monthlyAmount - amount)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      best = index
+    }
+  })
+  return best
+}
+
+/**
+ * Looks up by `categoryLabelId` — the catalog carries the same id the plan's
+ * expenses do, so this never has to guess from a category's name. Returns null
+ * for anything the catalog doesn't cover: a user's own category, or a catalog
+ * that hasn't loaded.
+ */
+export function tierLevelFor(
+  categoryLabelId: string,
+  amount: number,
+  catalog: LifestyleCatalogResponse | undefined,
+): TierLevel | null {
+  if (!catalog || amount <= 0) return null
+  const category = catalog.categories.find(
+    (c) => c.categoryLabelId === categoryLabelId,
+  )
+  if (!category?.tiers.length) return null
+  const index = nearestTierIndex(amount, category.tiers)
+  const tier = category.tiers[index]
+  return {
+    descriptor: tier.description,
+    emoji: tier.emoji || category.emoji,
+    index: index + 1,
+    of: category.tiers.length,
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -80,6 +80,45 @@
   }
 }
 
+/* Lifestyle summary bars grow out from the axis on first paint.
+   scaleX rather than width: if the animation never runs — headless render,
+   background tab, animations disabled — the bar still sits at its true
+   length. The reveal enhances a correct default instead of gating it. */
+.animate-bar-grow {
+  animation: bar-grow 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: left center;
+}
+
+@keyframes bar-grow {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+/* Mood-board tiles settle in on the payoff screen. Like the bars, the
+   animation only ever enhances a correct default: no fill-mode holding them
+   invisible if it never runs. */
+.animate-tile-in {
+  animation: tile-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes tile-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem) scale(0.96);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-bar-grow,
+  .animate-tile-in {
+    animation: none;
+  }
+}
+
 html,
 body {
   padding: 0;

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -45,7 +45,11 @@ export interface WorkScenariosResponse {
 // ============ Manual Asset Categories ============
 // Asset categories for users without portfolios
 export type ManualAssetCategory =
-  "CASH" | "EQUITY" | "ETF" | "MUTUAL_FUND" | "RE"
+  | "CASH"
+  | "EQUITY"
+  | "ETF"
+  | "MUTUAL_FUND"
+  | "RE"
 
 export type ManualAssets = Record<ManualAssetCategory, number>
 


### PR DESCRIPTION
One commit. Includes bc-view's `fantail.yaml` service definition (was #1123).

**Does not touch `ExpensesStep.tsx`** — the mood board in the expenses step is
 #1121's, and an earlier revision of this PR restructured that same file. It's
reverted, so the only remaining overlap between the two PRs is two files taken
from #1121 verbatim (`lifestyle-catalog.ts` and the catalog types), which
resolve as identical content rather than a conflict.

The expenses step was using an evocative, category-tinted treatment to do data
entry. This moves that idea to where it earns its keep and leaves the entry
step to be a fast way to type eight numbers.

### New: `LifestyleSummary`

Reads a projection back as a life rather than a lump sum — the monthly spend
the plan supports, distributed across the categories the user described.

```
What your plan supports

  $5,100 / month          11% more than you described
  Generous  ▬▬▬▬░
  Everything you planned for, plus two-thirds of your
  Healthcare budget spare.

  ┌──────────────────┐ ┌──────────────────┐
  │  ♥               │ │  ⌂               │
  │  Healthcare      │ │  Housing         │
  │  health          │ │  Rates, fees,    │
  │  insurance + gym │ │  maintenance     │
  │  S$400           │ │  S$2,500         │
  └──────────────────┘ └──────────────────┘
      ▲ tint strength = share of the spend

  Housing-heavy, with room to spare.
  Selling illiquid assets lifts this to $6,300/month from age 71.
```

### Challenging → Luxury, earned by the sentence under it

`Challenging · Tight · Comfortable · Generous · Luxury`, off
`expenseAdjustmentPercent`.

A bare label would be claiming an absolute standard of living, which nothing in
the data supports — "$6,000/month is luxury" needs cost-of-living benchmarks per
country and currency that svc-retire doesn't return, and this plan alone spans
SGD and NZD phases. What makes the word safe to state plainly is the line
beneath it: the gap expressed as a multiple of a budget the user named
themselves.

> Everything you planned for, plus two-thirds of your Healthcare budget spare.

That's pure arithmetic on their own figures — no benchmarks, no invention — and
it lands as a statement about their life rather than their finances. The
category chosen is whichever budget is closest in size to the gap, so the
comparison is one that means something; fractions are coarse ("two-thirds", not
"0.63") because the second is a number and the first is a thought. The rolled-up
remainder is never used as the reference: "half your Everything else budget"
means nothing to anyone.

The old mix line drops its headroom clause when this is shown — stating the same
fact twice makes neither land.

### Tiers come from svc-retire's catalog

Each tile says what that level of spend buys — **S$2,500 housing is "a condo
rental"** — read from `GET /lifestyle/catalog` (svc-retire #167, merged), which
svc-retire converts to the plan's currency and caches.

An earlier revision of this PR hard-coded those bands in the frontend, with my
own SGD/NZD figures researched off SingStat and Stats NZ. That's deleted:
`lifestyleBenchmarks.ts` and `categoryIcons.ts` are gone, along with ~60 tests
pinning numbers the backend already owns. The catalog carries the amounts, the
descriptions **and** the emoji, so these tiles and the mood board in #1121 mark
a category the same way and describe it in the same words.

Matching is on `categoryLabelId`, which the catalog and a plan's expenses share
— so nothing guesses from a display name. The deleted icon map had to guess,
and a test in its history records "Health**care**" matching a rule meant for
"car" and rendering a medical budget as a motoring one.

Tiers are read from the **supported** amount, not the described one: labelling
the life someone typed rather than the one their plan pays for would name a
standard of living they can't reach.

The proxy route (`/api/independence/lifestyle-catalog`) and the catalog types
are taken verbatim from #1121 so that if both land, the overlap is an identical
file rather than a conflict.

### The composite view: a Summary sub-tab, on a different basis

It also carries the one affordability claim a composite can honestly make —
`Your phases hold together — the money lasts to age 90.` — read from
`isSustainable` / `depletionAge`. `compositeOutlook` is extracted so the tab-bar
badge and this header can't drift into disagreeing about the same projection.


`/independence` gets a **Summary** sub-tab, first in the bar, showing how
spending changes shape across each phase — one panel per phase, in that
phase's own currency and age range.

It shows what each phase **costs**, not what it supports, and the model carries
an explicit `basis: "supported" | "described"` to keep that distinction
structural rather than a matter of remembering. `CompositeProjectionResult`
returns no `sustainableMonthlyExpense`, `expenseAdjustmentPercent` or
`sustainableWithLiquidation`, and the obvious shortcut — borrowing one phase's
single-plan sustainable figure — answers a different question ("if this phase
were your whole retirement…") while reading as an affordability claim the
backend never made.

On the described basis the component drops the adjustment chip, the liquidation
line, and any read-out phrased around what "the plan supports"; the heading
becomes the phase name. Upgrading it to a real affordability claim is a
svc-retire change: add those three fields to the composite contract.

Phases stays the landing tab — Summary sits to its left but doesn't steal the
default, since that's where configuration happens and a test asserts it.

### Verification

`yarn test` 2289 pass · `yarn lint` clean · `yarn typecheck` clean.
37 new tests across the derivation and the component, including the
zero-sustainable, no-projection, shortfall, privacy and reduced-motion paths.

Driven live against a real plan, which caught two defects now fixed:

- The headline rendered cents (`6,506.52`) while its own rows and the tile
  above were whole units. Rounded.
- On a full-width card a single column of bars became wall-to-wall slabs with
  nothing to compare against. Rows go two-column from `sm` up.

The onboarding payoff is still unverified in a browser — reaching it means
running a fresh signup through to completion.
