### PR TITLE
feat(independence): rebuild the composite Phases tab around a timeline

### DIFF
--- a/src/components/features/independence/CompositeTab.tsx
+++ b/src/components/features/independence/CompositeTab.tsx
@@ -133,9 +133,10 @@ export default function CompositeTab({
   settings,
 }: CompositeTabProps): React.ReactElement {
   const projectionState = useCompositeProjection(plans, settings)
-  // Summary sits first in the bar but Phases stays the landing tab — that's
-  // where the user configures, and an explicit test asserts it.
-  const [activeTab, setActiveTab] = useState<CompositeSubTabId>("phases")
+  // Summary is the landing tab: it answers "does this hold together, and what
+  // does each phase cost" without the user touching a control. Phases is one
+  // click away for when they want to change the shape.
+  const [activeTab, setActiveTab] = useState<CompositeSubTabId>("summary")
 
   const contextValue: CompositeProjectionValue = {
     plans,

--- a/src/components/features/independence/PhaseConfigList.tsx
+++ b/src/components/features/independence/PhaseConfigList.tsx
@@ -1,6 +1,11 @@
-import React from "react"
+import React, { useState } from "react"
+import Link from "next/link"
 import type { RetirementPlan, CompositePhase } from "types/independence"
 import MathInput from "@components/ui/MathInput"
+import {
+  phaseTone,
+  resolvePhases,
+} from "@components/features/independence/composite/PhaseTimeline"
 
 interface PhaseConfigListProps {
   plans: RetirementPlan[]
@@ -8,19 +13,106 @@ interface PhaseConfigListProps {
   onPhaseChange: (phases: CompositePhase[]) => void
   onExclude: (planId: string) => void
   excludedPlanIds: Set<string>
+  /** Resolved horizon for the open-ended last phase (from the projection). */
+  horizonAge?: number
+  /** Phase highlighted on the timeline band, kept in sync both ways. */
+  activeIndex?: number | null
+  onActiveChange?: (index: number | null) => void
 }
+
+const AGE_INPUT_CLASS =
+  "w-16 rounded-md border border-gray-300 px-2 py-1 text-center font-mono text-sm tabular-nums text-gray-900 focus:border-independence-500 focus:outline-none focus:ring-1 focus:ring-independence-500"
+
+const ORDER_BUTTON_CLASS =
+  "rounded p-1.5 text-gray-400 transition-colors duration-150 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-1 focus:ring-independence-500 disabled:pointer-events-none disabled:opacity-30 motion-reduce:transition-none"
 
 function getPlanName(plans: RetirementPlan[], planId: string): string {
   return plans.find((p) => p.id === planId)?.name ?? "Unknown Plan"
 }
 
+function getPlanNarrative(
+  plans: RetirementPlan[],
+  planId: string,
+): string | undefined {
+  return plans.find((p) => p.id === planId)?.narrative?.trim() || undefined
+}
+
+/**
+ * Read-only context for one phase, sourced from that phase's own plan. The
+ * composite carries no narrative of its own — the story of a composite plan
+ * is the phases it runs through, so each phase shows its plan's narrative and
+ * links to where that narrative is edited.
+ */
+function PhaseNarrative({
+  planId,
+  narrative,
+}: {
+  planId: string
+  narrative: string | undefined
+}): React.ReactElement {
+  const [expanded, setExpanded] = useState(false)
+
+  if (!narrative) {
+    return (
+      <p className="mt-1 text-sm text-gray-500">
+        No context yet —{" "}
+        <Link
+          href={`/independence/wizard/${planId}`}
+          className="font-medium text-independence-700 underline-offset-2 hover:underline"
+        >
+          describe this phase
+        </Link>
+        .
+      </p>
+    )
+  }
+
+  return (
+    <div className="mt-1">
+      <p
+        className={`max-w-[70ch] text-sm text-gray-600 ${
+          expanded ? "" : "line-clamp-2"
+        }`}
+      >
+        {narrative}
+      </p>
+      <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="font-medium text-gray-500 underline-offset-2 hover:text-gray-700 hover:underline focus:outline-none focus:ring-1 focus:ring-independence-500"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+        <Link
+          href={`/independence/wizard/${planId}`}
+          className="font-medium text-independence-700 underline-offset-2 hover:underline"
+        >
+          Edit phase
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The editable half of the Phases tab: one row per phase carrying its age
+ * window, length, order controls, and the plan narrative that says what the
+ * phase is for. Pairs with the timeline band above it — the band shows the
+ * shape, these rows change it.
+ */
 export default function PhaseConfigList({
   plans,
   phases,
   onPhaseChange,
   onExclude,
   excludedPlanIds,
+  horizonAge,
+  activeIndex = null,
+  onActiveChange,
 }: PhaseConfigListProps): React.ReactElement {
+  const resolved = resolvePhases(phases, plans, horizonAge)
+
   const handleFromAgeChange = (index: number, value: number): void => {
     const updated = [...phases]
     updated[index] = { ...updated[index], fromAge: value }
@@ -69,109 +161,139 @@ export default function PhaseConfigList({
   }
 
   return (
-    <div className="space-y-2">
-      <h3 className="text-sm font-medium text-gray-700 mb-2">
-        Phase Configuration
-      </h3>
-
-      {/* Excluded plans toggle */}
+    <div>
       {plans.length > 1 && (
-        <div className="flex flex-wrap gap-2 mb-3">
-          {plans.map((plan) => (
-            <label
-              key={plan.id}
-              className="inline-flex items-center text-xs cursor-pointer"
-            >
-              <input
-                type="checkbox"
-                checked={!excludedPlanIds.has(plan.id)}
-                onChange={() => onExclude(plan.id)}
-                className="rounded border-gray-300 text-independence-600 focus:ring-independence-500 mr-1"
-              />
-              <span
-                className={
-                  excludedPlanIds.has(plan.id)
-                    ? "text-gray-400 line-through"
-                    : "text-gray-700"
-                }
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-medium text-gray-500">
+            Plans in this timeline
+          </span>
+          {plans.map((plan) => {
+            const included = !excludedPlanIds.has(plan.id)
+            return (
+              // A button carrying the checkbox role, not a label wrapping an
+              // input — the wrapped-input form double-fires when the whole
+              // chip is the tap target.
+              <button
+                key={plan.id}
+                type="button"
+                role="checkbox"
+                aria-checked={included}
+                onClick={() => onExclude(plan.id)}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors duration-150 focus:outline-none focus:ring-1 focus:ring-independence-500 motion-reduce:transition-none ${
+                  included
+                    ? "border-independence-200 bg-independence-50 text-independence-700"
+                    : "border-gray-200 bg-white text-gray-400 line-through hover:text-gray-600"
+                }`}
               >
                 {plan.name}
-              </span>
-            </label>
-          ))}
-        </div>
-      )}
-
-      {/* Phase rows */}
-      {phases.length === 0 ? (
-        <p className="text-sm text-gray-500">
-          Select at least one plan to configure phases.
-        </p>
-      ) : (
-        <div className="border border-gray-200 rounded-lg divide-y divide-gray-100">
-          {phases.map((phase, index) => {
-            const isLast = index === phases.length - 1
-            const toAge = phase.toAge ?? "end"
-            const duration =
-              typeof toAge === "number" ? toAge - phase.fromAge : "..."
-            return (
-              <div
-                key={phase.planId}
-                // flex-wrap + min-w-0 let rows reflow on narrow (mobile flip
-                // card) widths; a no-op on desktop where the row fits one line.
-                className="flex flex-wrap items-center gap-2 px-3 py-2 text-sm min-w-0"
-              >
-                <span className="font-medium text-gray-700 shrink-0 truncate max-w-[8rem]">
-                  {getPlanName(plans, phase.planId)}:
-                </span>
-                <MathInput
-                  value={phase.fromAge}
-                  onChange={(v) => handleFromAgeChange(index, Math.round(v))}
-                  className="w-14 px-1 py-0.5 border border-gray-300 rounded text-center text-sm focus:ring-1 focus:ring-independence-500 focus:border-independence-500"
-                  min={18}
-                  max={120}
-                  aria-label={`${getPlanName(plans, phase.planId)} from age`}
-                />
-                <span className="text-gray-400">→</span>
-                {isLast ? (
-                  <span className="w-14 text-center text-gray-500">end</span>
-                ) : (
-                  <MathInput
-                    value={phase.toAge ?? 0}
-                    onChange={(v) => handleToAgeChange(index, Math.round(v))}
-                    className="w-14 px-1 py-0.5 border border-gray-300 rounded text-center text-sm focus:ring-1 focus:ring-independence-500 focus:border-independence-500"
-                    min={18}
-                    max={120}
-                    aria-label={`${getPlanName(plans, phase.planId)} to age`}
-                  />
-                )}
-                <span className="text-xs text-gray-400 w-16 text-right">
-                  ({typeof duration === "number" ? `${duration} yr` : duration})
-                </span>
-                <div className="flex gap-0.5">
-                  <button
-                    onClick={() => handleMoveUp(index)}
-                    disabled={index === 0}
-                    className="p-1 text-gray-400 hover:text-gray-600 disabled:opacity-30"
-                    title="Move up"
-                    aria-label={`Move phase ${index + 1} up`}
-                  >
-                    <i className="fas fa-chevron-up text-xs"></i>
-                  </button>
-                  <button
-                    onClick={() => handleMoveDown(index)}
-                    disabled={isLast}
-                    className="p-1 text-gray-400 hover:text-gray-600 disabled:opacity-30"
-                    title="Move down"
-                    aria-label={`Move phase ${index + 1} down`}
-                  >
-                    <i className="fas fa-chevron-down text-xs"></i>
-                  </button>
-                </div>
-              </div>
+              </button>
             )
           })}
         </div>
+      )}
+
+      {phases.length === 0 ? (
+        <div className="py-12 text-center">
+          <i
+            aria-hidden="true"
+            className="fas fa-clipboard-list text-4xl text-gray-300"
+          ></i>
+          <p className="mt-3 text-lg text-gray-500">No phases yet</p>
+          <p className="mt-1 text-sm text-gray-500">
+            Include at least one plan above to lay out the years it covers.
+          </p>
+        </div>
+      ) : (
+        <ol className="mt-4 divide-y divide-gray-100 border-t border-gray-100">
+          {phases.map((phase, index) => {
+            const isLast = index === phases.length - 1
+            const name = getPlanName(plans, phase.planId)
+            const isActive = activeIndex === index
+            return (
+              <li
+                key={phase.planId}
+                onMouseEnter={() => onActiveChange?.(index)}
+                onMouseLeave={() => onActiveChange?.(null)}
+                className={`grid gap-x-6 gap-y-2 px-1 py-3 transition-colors duration-150 motion-reduce:transition-none sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start ${
+                  isActive ? "bg-independence-50" : ""
+                }`}
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-3">
+                    <span
+                      aria-hidden="true"
+                      className={`h-2.5 w-2.5 shrink-0 rounded-full ${phaseTone(
+                        index,
+                      )}`}
+                    />
+                    <span className="min-w-0 truncate text-sm font-medium text-gray-900">
+                      {name}
+                    </span>
+                  </div>
+                  <div className="pl-[1.375rem]">
+                    <PhaseNarrative
+                      planId={phase.planId}
+                      narrative={getPlanNarrative(plans, phase.planId)}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2 pl-[1.375rem] sm:pl-0">
+                  <MathInput
+                    value={phase.fromAge}
+                    onChange={(v) => handleFromAgeChange(index, Math.round(v))}
+                    className={AGE_INPUT_CLASS}
+                    min={18}
+                    max={120}
+                    aria-label={`${name} from age`}
+                  />
+                  <span aria-hidden="true" className="text-gray-400">
+                    →
+                  </span>
+                  {isLast ? (
+                    <span className="w-16 text-center font-mono text-sm text-gray-500">
+                      end
+                    </span>
+                  ) : (
+                    <MathInput
+                      value={phase.toAge ?? 0}
+                      onChange={(v) => handleToAgeChange(index, Math.round(v))}
+                      className={AGE_INPUT_CLASS}
+                      min={18}
+                      max={120}
+                      aria-label={`${name} to age`}
+                    />
+                  )}
+                  <span className="w-14 text-right font-mono text-sm tabular-nums text-gray-500">
+                    {resolved[index].years} yr
+                  </span>
+                  <div className="flex">
+                    <button
+                      type="button"
+                      onClick={() => handleMoveUp(index)}
+                      disabled={index === 0}
+                      className={ORDER_BUTTON_CLASS}
+                      title="Move up"
+                      aria-label={`Move phase ${index + 1} up`}
+                    >
+                      <i className="fas fa-chevron-up text-xs"></i>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleMoveDown(index)}
+                      disabled={isLast}
+                      className={ORDER_BUTTON_CLASS}
+                      title="Move down"
+                      aria-label={`Move phase ${index + 1} down`}
+                    >
+                      <i className="fas fa-chevron-down text-xs"></i>
+                    </button>
+                  </div>
+                </div>
+              </li>
+            )
+          })}
+        </ol>
       )}
     </div>
   )

--- a/src/components/features/independence/__tests__/CompositeTab.test.tsx
+++ b/src/components/features/independence/__tests__/CompositeTab.test.tsx
@@ -181,12 +181,11 @@ describe("CompositeTab", () => {
     })
   })
 
-  it("renders narrative field in Phases tab", () => {
+  it("carries no composite narrative field", () => {
     render(<CompositeTab plans={plans} settings={settings} />)
-    // Narrative textarea is inside PhasesTab (default tab).
-    // PhasesTab renders desktop + mobile copies so there are two labels.
-    const narrativeLabels = screen.getAllByText(/Plan narrative/)
-    expect(narrativeLabels.length).toBeGreaterThanOrEqual(1)
+    // Narrative belongs to each phase's own plan, not the composite.
+    expect(screen.queryByText(/Plan narrative/)).not.toBeInTheDocument()
+    expect(document.querySelector("textarea")).toBeNull()
   })
 
   it("renders all sub-tabs in the navigation", () => {
@@ -202,10 +201,16 @@ describe("CompositeTab", () => {
     ).toBeInTheDocument()
   })
 
-  it("defaults to the Phases tab", () => {
+  it("defaults to the Summary tab", () => {
     render(<CompositeTab plans={plans} settings={settings} />)
-    const phasesTab = screen.getByRole("tab", { name: /Phases/ })
-    expect(phasesTab).toHaveAttribute("aria-selected", "true")
+    expect(screen.getByRole("tab", { name: /Summary/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    )
+    expect(screen.getByRole("tab", { name: /Phases/ })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    )
   })
 
   it("switches to the Wealth Journey tab when clicked", async () => {
@@ -266,11 +271,12 @@ describe("CompositeTab", () => {
     expect(screen.getByText(/Savings deplete at age 70/)).toBeInTheDocument()
   })
 
-  it("renders error inside Phases tab when present", () => {
+  it("renders error inside Phases tab when present", async () => {
     const { useCompositeProjection } = jest.requireMock(
       "@hooks/useCompositeProjection",
     )
-    useCompositeProjection.mockReturnValueOnce({
+    // Not `...Once`: the tab switch re-renders, and the error must survive it.
+    useCompositeProjection.mockReturnValue({
       phases: [],
       setPhases: jest.fn(),
       displayCurrency: "SGD",
@@ -284,6 +290,8 @@ describe("CompositeTab", () => {
     })
 
     render(<CompositeTab plans={plans} settings={settings} />)
+    // Phases is no longer the landing tab — switch to it to read its error.
+    await userEvent.click(screen.getByRole("tab", { name: /Phases/ }))
     expect(screen.getByText("Something went wrong")).toBeInTheDocument()
   })
 

--- a/src/components/features/independence/__tests__/PhaseConfigList.test.tsx
+++ b/src/components/features/independence/__tests__/PhaseConfigList.test.tsx
@@ -61,19 +61,15 @@ describe("PhaseConfigList", () => {
   it("renders phase rows with plan names", () => {
     render(<PhaseConfigList {...defaultProps} />)
 
-    // Plan name appears in checkbox and as row label (with colon)
-    expect(screen.getByText("Asia Plan")).toBeInTheDocument()
-    expect(screen.getByText("Asia Plan:")).toBeInTheDocument()
-    expect(screen.getByText("Europe Plan")).toBeInTheDocument()
-    expect(screen.getByText("Europe Plan:")).toBeInTheDocument()
+    // Plan name appears on the inclusion chip and as the row label.
+    expect(screen.getAllByText("Asia Plan")).toHaveLength(2)
+    expect(screen.getAllByText("Europe Plan")).toHaveLength(2)
   })
 
   it("uses plan names as row labels instead of generic phase numbers", () => {
     render(<PhaseConfigList {...defaultProps} />)
 
-    expect(screen.getByText("Asia Plan:")).toBeInTheDocument()
-    expect(screen.getByText("Europe Plan:")).toBeInTheDocument()
-    expect(screen.queryByText("Phase 1:")).not.toBeInTheDocument()
+    expect(screen.queryByText("Phase 1")).not.toBeInTheDocument()
   })
 
   it("renders age inputs for each phase", () => {
@@ -165,14 +161,15 @@ describe("PhaseConfigList", () => {
   it("shows message when no phases", () => {
     render(<PhaseConfigList {...defaultProps} phases={[]} />)
 
+    expect(screen.getByText("No phases yet")).toBeInTheDocument()
     expect(
-      screen.getByText("Select at least one plan to configure phases."),
+      screen.getByText(/Include at least one plan above/),
     ).toBeInTheDocument()
   })
 
   it("renders duration for non-last phases", () => {
     render(<PhaseConfigList {...defaultProps} />)
 
-    expect(screen.getByText("(15 yr)")).toBeInTheDocument()
+    expect(screen.getByText("15 yr")).toBeInTheDocument()
   })
 })

--- a/src/components/features/independence/composite/BenefitsStartPhasePicker.tsx
+++ b/src/components/features/independence/composite/BenefitsStartPhasePicker.tsx
@@ -3,6 +3,7 @@ import { mutate } from "swr"
 import type { RetirementPlan } from "types/independence"
 import { toPlanRequestPayload } from "@utils/independence/planHelpers"
 import { useCompositeProjectionContext } from "./CompositeProjectionContext"
+import LeverRow, { LEVER_SELECT_CLASS } from "./LeverRow"
 
 /** Same SWR key the Independence page uses to list plans (src/pages/independence/index.tsx). */
 const PLANS_KEY = "/api/independence/plans"
@@ -48,8 +49,8 @@ async function updateBenefitsStartAge(
 export default function BenefitsStartPhasePicker(): React.ReactElement | null {
   const { plans, phases } = useCompositeProjectionContext()
   const [saving, setSaving] = useState(false)
-  // Rendered twice per page (desktop + mobile FlipCard) — a static id would
-  // duplicate in the DOM, so derive a unique one per instance.
+  // Derived per instance so the label/select association stays unique even if
+  // the picker is ever rendered more than once on a page.
   const selectId = useId()
 
   if (phases.length === 0) {
@@ -106,34 +107,34 @@ export default function BenefitsStartPhasePicker(): React.ReactElement | null {
   }
 
   return (
-    <div className="space-y-2">
-      <label
-        htmlFor={selectId}
-        className="block text-sm font-medium text-gray-700"
-      >
-        NZ Super / benefits start
-      </label>
-      <select
-        id={selectId}
-        aria-label="NZ Super / benefits start"
-        value={selectedValue}
-        disabled={saving}
-        onChange={(e) => {
-          void handleChange(e.target.value)
-        }}
-        className="px-2 py-1 border border-gray-300 rounded text-sm focus:ring-1 focus:ring-independence-500 focus:border-independence-500 disabled:opacity-50"
-      >
-        {disabledOptionValue && (
-          <option value={disabledOptionValue} disabled>
-            {disabledOptionLabel}
-          </option>
-        )}
-        {phases.map((phase) => (
-          <option key={phase.planId} value={String(phase.fromAge)}>
-            {getPlanName(plans, phase.planId)} — from age {phase.fromAge}
-          </option>
-        ))}
-      </select>
-    </div>
+    <LeverRow
+      label={
+        <label htmlFor={selectId}>NZ Super / government benefits start</label>
+      }
+      hint="Applied to every plan in the timeline, so the projection gates them the same way."
+      control={
+        <select
+          id={selectId}
+          aria-label="NZ Super / benefits start"
+          value={selectedValue}
+          disabled={saving}
+          onChange={(e) => {
+            void handleChange(e.target.value)
+          }}
+          className={LEVER_SELECT_CLASS}
+        >
+          {disabledOptionValue && (
+            <option value={disabledOptionValue} disabled>
+              {disabledOptionLabel}
+            </option>
+          )}
+          {phases.map((phase) => (
+            <option key={phase.planId} value={String(phase.fromAge)}>
+              {getPlanName(plans, phase.planId)} — from age {phase.fromAge}
+            </option>
+          ))}
+        </select>
+      }
+    />
   )
 }

--- a/src/components/features/independence/composite/CompositeProjectionContext.tsx
+++ b/src/components/features/independence/composite/CompositeProjectionContext.tsx
@@ -24,9 +24,6 @@ export interface CompositeProjectionValue {
   setDisplayCurrency: (currency: string) => void
   excludedPlanIds: Set<string>
   toggleExclusion: (planId: string) => void
-  /** Overarching composite-plan narrative (shared across all phases). */
-  compositeNarrative: string
-  setCompositeNarrative: (narrative: string) => void
   /** Work scenario ID selected for composite projections. */
   compositeWorkScenarioId: string | undefined
   setCompositeWorkScenarioId: (id: string | undefined) => void

--- a/src/components/features/independence/composite/LeverRow.tsx
+++ b/src/components/features/independence/composite/LeverRow.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode } from "react"
+
+/**
+ * One phase-boundary lever: a labelled decision on the left, its control on
+ * the right. Residence and benefits-start both answer the same shape of
+ * question ("which phase does this start in?"), so they share one row
+ * vocabulary and one control width instead of each inventing their own.
+ */
+export default function LeverRow({
+  label,
+  hint,
+  control,
+}: {
+  label: ReactNode
+  hint?: ReactNode
+  control: ReactNode
+}): React.ReactElement {
+  return (
+    <div className="grid gap-2 py-3 sm:grid-cols-[1fr_16rem] sm:items-center sm:gap-4">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-gray-900">{label}</p>
+        {hint && <p className="mt-0.5 text-xs text-gray-500">{hint}</p>}
+      </div>
+      {control}
+    </div>
+  )
+}
+
+/** Shared select styling so every lever control reads as the same affordance. */
+export const LEVER_SELECT_CLASS =
+  "w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-independence-500 focus:outline-none focus:ring-1 focus:ring-independence-500 disabled:opacity-50"

--- a/src/components/features/independence/composite/PhaseTimeline.tsx
+++ b/src/components/features/independence/composite/PhaseTimeline.tsx
@@ -1,0 +1,132 @@
+import React from "react"
+import type { CompositePhase, RetirementPlan } from "types/independence"
+
+/**
+ * Tonal ramp for phase segments — steps of the Independence capability hue,
+ * so a phase reads as one series rather than four unrelated colours. Cycles
+ * for users with more phases than steps.
+ */
+const PHASE_TONES = [
+  "bg-independence-700",
+  "bg-independence-500",
+  "bg-independence-200",
+  "bg-independence-600",
+  "bg-independence-100",
+]
+
+/** Tone class for a phase at `index`. Shared with the phase row markers so a
+ *  row and its segment are visibly the same phase. */
+export function phaseTone(index: number): string {
+  return PHASE_TONES[index % PHASE_TONES.length]
+}
+
+export interface ResolvedPhase {
+  planId: string
+  planName: string
+  fromAge: number
+  /** Resolved end age — the open-ended last phase borrows the projection's. */
+  toAge: number
+  years: number
+}
+
+function planName(plans: RetirementPlan[], planId: string): string {
+  return plans.find((p) => p.id === planId)?.name?.trim() || "Unnamed plan"
+}
+
+/**
+ * Resolve display ages for a phase list. The last phase carries no `toAge`
+ * ("end"), so it borrows the horizon the projection resolved; without a
+ * projection yet it falls back to a nominal span so the band still renders
+ * proportionally on first paint.
+ */
+export function resolvePhases(
+  phases: CompositePhase[],
+  plans: RetirementPlan[],
+  horizonAge: number | undefined,
+): ResolvedPhase[] {
+  const FALLBACK_LAST_PHASE_YEARS = 10
+  return phases.map((phase, index) => {
+    const isLast = index === phases.length - 1
+    const explicit = phase.toAge ?? (isLast ? horizonAge : undefined)
+    const toAge = explicit ?? phase.fromAge + FALLBACK_LAST_PHASE_YEARS
+    return {
+      planId: phase.planId,
+      planName: planName(plans, phase.planId),
+      fromAge: phase.fromAge,
+      toAge,
+      years: Math.max(toAge - phase.fromAge, 0),
+    }
+  })
+}
+
+interface PhaseTimelineProps {
+  resolved: ResolvedPhase[]
+  /** Index of the phase currently highlighted elsewhere on the tab. */
+  activeIndex: number | null
+  onActiveChange: (index: number | null) => void
+}
+
+/**
+ * The composite plan drawn as what it actually is: one contiguous band of
+ * years, split into phases. Segment width is proportional to the phase's
+ * length, so a long Slow-Go stretch reads as long without reading a number.
+ *
+ * Presentation only — every value here is editable in the phase rows below,
+ * and hovering either surface highlights the other.
+ */
+export default function PhaseTimeline({
+  resolved,
+  activeIndex,
+  onActiveChange,
+}: PhaseTimelineProps): React.ReactElement | null {
+  if (resolved.length === 0) return null
+
+  const start = resolved[0].fromAge
+  const end = resolved[resolved.length - 1].toAge
+  const span = Math.max(end - start, 0)
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <h3 className="text-sm font-medium text-gray-700">Timeline</h3>
+        <p className="font-mono text-xs tabular-nums text-gray-500">
+          age {start} → {end} · {span} years
+        </p>
+      </div>
+
+      <ol className="mt-3 flex items-stretch gap-1">
+        {resolved.map((phase, index) => {
+          const isActive = activeIndex === index
+          return (
+            <li
+              key={`${phase.planId}-${phase.fromAge}`}
+              // Proportional width, floored so a one-year phase stays readable.
+              style={{ flexGrow: Math.max(phase.years, 1) }}
+              className="min-w-[3.5rem] basis-0"
+              onMouseEnter={() => onActiveChange(index)}
+              onMouseLeave={() => onActiveChange(null)}
+            >
+              <p
+                className={`truncate text-xs font-medium ${
+                  isActive ? "text-independence-700" : "text-gray-900"
+                }`}
+                title={phase.planName}
+              >
+                {phase.planName}
+              </p>
+              <div
+                aria-hidden="true"
+                className={`mt-1.5 h-3 origin-bottom rounded-sm transition-transform duration-150 ease-out motion-reduce:transition-none ${phaseTone(
+                  index,
+                )} ${isActive ? "scale-y-150" : ""}`}
+              />
+              <p className="mt-1.5 truncate font-mono text-[11px] tabular-nums text-gray-500">
+                {phase.fromAge}–{phase.toAge} · {phase.years} yr
+              </p>
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/src/components/features/independence/composite/ResidencePhasePicker.tsx
+++ b/src/components/features/independence/composite/ResidencePhasePicker.tsx
@@ -3,6 +3,7 @@ import type { PropertyIncomeRequest, RetirementPlan } from "types/independence"
 import { usePropertyIncomes } from "@utils/independence/usePropertyIncomes"
 import { usePrivateAssetConfigs } from "@utils/assets/usePrivateAssetConfigs"
 import { useCompositeProjectionContext } from "./CompositeProjectionContext"
+import LeverRow, { LEVER_SELECT_CLASS } from "./LeverRow"
 
 /** `<select>` value representing "no owner-occupy phase selected". */
 const RENTED_THROUGHOUT = ""
@@ -101,46 +102,39 @@ export default function ResidencePhasePicker(): React.ReactElement | null {
   const isLoading = configsLoading || incomesLoading
 
   return (
-    <div className="space-y-2">
-      <h3 className="text-sm font-medium text-gray-700 mb-2">
-        Residence Phase
-      </h3>
-      <p className="text-xs text-gray-500 mb-2">
-        Choose the phase in which you move into each rental property, or leave
-        it rented throughout.
-      </p>
-      <div className="border border-gray-200 rounded-lg divide-y divide-gray-100">
-        {rentalProperties.map((config) => {
-          const row = getPropertyIncomeForAsset(config.assetId)
-          const occupiedFromAge = row?.occupiedFromAge
-          const hasOccupiedFromAge =
-            occupiedFromAge !== undefined && occupiedFromAge !== null
-          const matchedPhase = hasOccupiedFromAge
-            ? phases.find((p) => p.fromAge === occupiedFromAge)
-            : undefined
-          const selectedValue = !hasOccupiedFromAge
-            ? RENTED_THROUGHOUT
-            : matchedPhase
-              ? String(occupiedFromAge)
-              : `custom-${occupiedFromAge}`
+    <>
+      {rentalProperties.map((config) => {
+        const row = getPropertyIncomeForAsset(config.assetId)
+        const occupiedFromAge = row?.occupiedFromAge
+        const hasOccupiedFromAge =
+          occupiedFromAge !== undefined && occupiedFromAge !== null
+        const matchedPhase = hasOccupiedFromAge
+          ? phases.find((p) => p.fromAge === occupiedFromAge)
+          : undefined
+        const selectedValue = !hasOccupiedFromAge
+          ? RENTED_THROUGHOUT
+          : matchedPhase
+            ? String(occupiedFromAge)
+            : `custom-${occupiedFromAge}`
 
-          const assetLabel = assetNames[config.assetId] || config.assetId
-          const saving = savingAssetIds.has(config.assetId)
+        const assetLabel = assetNames[config.assetId] || config.assetId
+        const saving = savingAssetIds.has(config.assetId)
 
-          return (
-            <div
-              key={config.assetId}
-              className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-sm min-w-0"
-            >
-              <div className="min-w-0">
-                <span className="font-medium text-gray-700 truncate">
-                  {assetLabel}
-                </span>
-                <span className="ml-2 text-xs text-gray-500">
+        return (
+          <LeverRow
+            key={config.assetId}
+            label={`Move into ${assetLabel}`}
+            hint={
+              <>
+                Earning{" "}
+                <span className="font-mono tabular-nums">
                   {config.rentalCurrency}{" "}
-                  {config.monthlyRentalIncome.toLocaleString()}/mo
+                  {config.monthlyRentalIncome.toLocaleString()}
                 </span>
-              </div>
+                /mo until you do
+              </>
+            }
+            control={
               <select
                 aria-label={`${assetLabel} residence phase`}
                 value={selectedValue}
@@ -148,7 +142,7 @@ export default function ResidencePhasePicker(): React.ReactElement | null {
                 onChange={(e) => {
                   void handleChange(config.assetId, e.target.value)
                 }}
-                className="px-2 py-1 border border-gray-300 rounded text-sm focus:ring-1 focus:ring-independence-500 focus:border-independence-500 disabled:opacity-50"
+                className={LEVER_SELECT_CLASS}
               >
                 <option value={RENTED_THROUGHOUT}>Rented throughout</option>
                 {phases.map((phase) => (
@@ -163,10 +157,10 @@ export default function ResidencePhasePicker(): React.ReactElement | null {
                   </option>
                 )}
               </select>
-            </div>
-          )
-        })}
-      </div>
-    </div>
+            }
+          />
+        )
+      })}
+    </>
   )
 }

--- a/src/components/features/independence/composite/__tests__/BenefitsStartPhasePicker.test.tsx
+++ b/src/components/features/independence/composite/__tests__/BenefitsStartPhasePicker.test.tsx
@@ -64,8 +64,6 @@ function makeCtx(
     setDisplayCurrency: jest.fn(),
     excludedPlanIds: new Set<string>(),
     toggleExclusion: jest.fn(),
-    compositeNarrative: "",
-    setCompositeNarrative: jest.fn(),
     compositeWorkScenarioId: undefined,
     setCompositeWorkScenarioId: jest.fn(),
     projection: undefined,

--- a/src/components/features/independence/composite/__tests__/FiOverviewTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/FiOverviewTab.test.tsx
@@ -128,8 +128,6 @@ function makeCtx(
     setDisplayCurrency: jest.fn(),
     excludedPlanIds: new Set<string>(),
     toggleExclusion: jest.fn(),
-    compositeNarrative: "",
-    setCompositeNarrative: jest.fn(),
     compositeWorkScenarioId: undefined,
     setCompositeWorkScenarioId: jest.fn(),
     projection: undefined,

--- a/src/components/features/independence/composite/__tests__/PhasesTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/PhasesTab.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
-import type { CompositePhase } from "types/independence"
+import type { CompositePhase, RetirementPlan } from "types/independence"
 import {
   CompositeProjectionProvider,
   type CompositeProjectionValue,
@@ -55,22 +55,26 @@ jest.mock("../BenefitsStartPhasePicker", () => ({
 import PhasesTab from "../tabs/PhasesTab"
 
 const defaultPhases: CompositePhase[] = [
-  { planId: "p1", fromAge: 65, toAge: 90 },
+  { planId: "p1", fromAge: 65, toAge: 75 },
+  { planId: "p2", fromAge: 75 },
 ]
+
+const defaultPlans = [
+  { id: "p1", name: "Go-Go" },
+  { id: "p2", name: "Slow Go" },
+] as RetirementPlan[]
 
 function makeCtx(
   overrides: Partial<CompositeProjectionValue> = {},
 ): CompositeProjectionValue {
   return {
-    plans: [],
+    plans: defaultPlans,
     phases: defaultPhases,
     setPhases: jest.fn(),
     displayCurrency: "USD",
     setDisplayCurrency: jest.fn(),
     excludedPlanIds: new Set<string>(),
     toggleExclusion: jest.fn(),
-    compositeNarrative: "My plan narrative",
-    setCompositeNarrative: jest.fn(),
     compositeWorkScenarioId: undefined,
     setCompositeWorkScenarioId: jest.fn(),
     projection: undefined,
@@ -93,96 +97,69 @@ function renderWithCtx(
 }
 
 describe("PhasesTab", () => {
-  it("renders the desktop layout container", () => {
+  it("renders one responsive layout, not duplicated desktop/mobile copies", () => {
     renderWithCtx()
-    expect(screen.getByTestId("phases-desktop-layout")).toBeInTheDocument()
+    expect(screen.getAllByTestId("phases-layout")).toHaveLength(1)
+    expect(screen.getAllByTestId("phase-config-list")).toHaveLength(1)
   })
 
-  it("desktop layout contains the narrative textarea with id=composite-narrative", () => {
+  it("carries no composite narrative field — narrative lives on each phase plan", () => {
     renderWithCtx()
-    const desktopLayout = screen.getByTestId("phases-desktop-layout")
-    // The desktop textarea sits inside the desktop layout div.
-    const desktopTextarea = desktopLayout.querySelector(
-      "textarea#composite-narrative",
-    )
-    expect(desktopTextarea).toBeInTheDocument()
+    expect(document.querySelector("textarea")).toBeNull()
+    expect(screen.queryByText(/Plan narrative/i)).not.toBeInTheDocument()
   })
 
-  it("renders the mobile layout container", () => {
+  it("renders the timeline band with each phase's span", () => {
     renderWithCtx()
-    expect(screen.getByTestId("phases-mobile-layout")).toBeInTheDocument()
+    expect(screen.getByText("Timeline")).toBeInTheDocument()
+    expect(screen.getByText(/65–75 · 10 yr/)).toBeInTheDocument()
   })
 
-  it("mobile layout contains its own narrative textarea with unique id", () => {
-    renderWithCtx()
-    const mobileLayout = screen.getByTestId("phases-mobile-layout")
-    const mobileTextarea = mobileLayout.querySelector(
-      "textarea#composite-narrative-mobile",
-    )
-    expect(mobileTextarea).toBeInTheDocument()
-  })
-
-  it("both textarea ids are present in the document and are different", () => {
-    renderWithCtx()
-    const desktopTextarea = document.getElementById("composite-narrative")
-    const mobileTextarea = document.getElementById("composite-narrative-mobile")
-
-    expect(desktopTextarea).toBeInTheDocument()
-    expect(mobileTextarea).toBeInTheDocument()
-    expect(desktopTextarea?.id).not.toBe(mobileTextarea?.id)
-  })
-
-  it("both textareas reflect the compositeNarrative value from context", () => {
-    renderWithCtx({ compositeNarrative: "Phase narrative text" })
-
-    const allTextareas = screen.getAllByPlaceholderText(
-      /Overarching goal across all phases/i,
-    )
-    // One from desktop layout, one from mobile flip card
-    expect(allTextareas).toHaveLength(2)
-    allTextareas.forEach((ta) => {
-      expect(ta).toHaveValue("Phase narrative text")
+  it("resolves the open-ended last phase from the projection horizon", () => {
+    renderWithCtx({
+      projection: {
+        phases: [
+          {
+            planId: "p1",
+            planName: "Go-Go",
+            fromAge: 65,
+            toAge: 75,
+            expensesCurrency: "USD",
+          },
+          {
+            planId: "p2",
+            planName: "Slow Go",
+            fromAge: 75,
+            toAge: 90,
+            expensesCurrency: "USD",
+          },
+        ],
+      } as CompositeProjectionValue["projection"],
     })
+    expect(screen.getByText(/age 65 → 90 · 25 years/)).toBeInTheDocument()
   })
 
-  it("renders PhaseConfigList in both desktop and mobile layouts", () => {
+  it("groups both phase levers in a single panel", () => {
     renderWithCtx()
-    const stubs = screen.getAllByTestId("phase-config-list")
-    // desktop layout + mobile flip card (front face)
-    expect(stubs.length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByTestId("phase-levers")).toBeInTheDocument()
+    expect(screen.getAllByTestId("residence-phase-picker")).toHaveLength(1)
+    expect(screen.getAllByTestId("benefits-start-phase-picker")).toHaveLength(1)
   })
 
-  it("renders ResidencePhasePicker below the phase list in both layouts", () => {
-    renderWithCtx()
-    const stubs = screen.getAllByTestId("residence-phase-picker")
-    // desktop layout + mobile flip card (front face)
-    expect(stubs.length).toBeGreaterThanOrEqual(2)
+  it("hides the levers panel when there are no phases to hang them off", () => {
+    renderWithCtx({ phases: [] })
+    expect(screen.queryByTestId("phase-levers")).not.toBeInTheDocument()
   })
 
-  it("renders BenefitsStartPhasePicker below ResidencePhasePicker in both layouts", () => {
-    renderWithCtx()
-    const stubs = screen.getAllByTestId("benefits-start-phase-picker")
-    // desktop layout + mobile flip card (front face)
-    expect(stubs.length).toBeGreaterThanOrEqual(2)
-  })
-
-  it("mobile layout contains a FlipCard flip-card-inner element", () => {
-    renderWithCtx()
-    const mobileLayout = screen.getByTestId("phases-mobile-layout")
-    const inner = mobileLayout.querySelector("[data-testid='flip-card-inner']")
-    expect(inner).toBeInTheDocument()
+  it("shows a spinner while the projection is calculating", () => {
+    renderWithCtx({ isLoading: true })
+    expect(
+      screen.getByText(/Calculating composite projection/i),
+    ).toBeInTheDocument()
   })
 
   it("shows an error alert when error is set", () => {
     renderWithCtx({ error: "Something went wrong" })
     expect(screen.getByText("Something went wrong")).toBeInTheDocument()
-  })
-
-  it("shows a spinner when isLoading is true", () => {
-    renderWithCtx({ isLoading: true })
-    // Spinner renders a visually-hidden label; check for it
-    expect(
-      screen.getByText(/Calculating composite projection/i),
-    ).toBeInTheDocument()
   })
 })

--- a/src/components/features/independence/composite/__tests__/ResidencePhasePicker.test.tsx
+++ b/src/components/features/independence/composite/__tests__/ResidencePhasePicker.test.tsx
@@ -96,8 +96,6 @@ function makeCtx(
     setDisplayCurrency: jest.fn(),
     excludedPlanIds: new Set<string>(),
     toggleExclusion: jest.fn(),
-    compositeNarrative: "",
-    setCompositeNarrative: jest.fn(),
     compositeWorkScenarioId: undefined,
     setCompositeWorkScenarioId: jest.fn(),
     projection: undefined,
@@ -154,8 +152,8 @@ describe("ResidencePhasePicker", () => {
     renderWithCtx()
 
     expect(screen.getAllByRole("combobox")).toHaveLength(1)
-    expect(screen.getByText("Rental Condo")).toBeInTheDocument()
-    expect(screen.queryByText("Home")).not.toBeInTheDocument()
+    expect(screen.getByText("Move into Rental Condo")).toBeInTheDocument()
+    expect(screen.queryByText(/Move into Home/)).not.toBeInTheDocument()
   })
 
   it("excludes pension configs and zero-rent properties", () => {
@@ -176,9 +174,11 @@ describe("ResidencePhasePicker", () => {
     renderWithCtx()
 
     expect(screen.getAllByRole("combobox")).toHaveLength(1)
-    expect(screen.getByText("Rental Condo")).toBeInTheDocument()
-    expect(screen.queryByText("CPF")).not.toBeInTheDocument()
-    expect(screen.queryByText("Empty Section")).not.toBeInTheDocument()
+    expect(screen.getByText("Move into Rental Condo")).toBeInTheDocument()
+    expect(screen.queryByText(/Move into CPF/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Move into Empty Section/),
+    ).not.toBeInTheDocument()
   })
 
   it("renders null when there are no phases", () => {

--- a/src/components/features/independence/composite/__tests__/StressTestTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/StressTestTab.test.tsx
@@ -113,8 +113,6 @@ function makeCtx(
     setDisplayCurrency: jest.fn(),
     excludedPlanIds: new Set<string>(),
     toggleExclusion: jest.fn(),
-    compositeNarrative: "",
-    setCompositeNarrative: jest.fn(),
     compositeWorkScenarioId: undefined,
     setCompositeWorkScenarioId: jest.fn(),
     projection: undefined,

--- a/src/components/features/independence/composite/tabs/PhasesTab.tsx
+++ b/src/components/features/independence/composite/tabs/PhasesTab.tsx
@@ -1,8 +1,8 @@
-import React from "react"
+import React, { useState } from "react"
 import PhaseConfigList from "../../PhaseConfigList"
+import PhaseTimeline, { resolvePhases } from "../PhaseTimeline"
 import ResidencePhasePicker from "../ResidencePhasePicker"
 import BenefitsStartPhasePicker from "../BenefitsStartPhasePicker"
-import FlipCard from "@components/ui/FlipCard"
 import Spinner from "@components/ui/Spinner"
 import Alert from "@components/ui/Alert"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
@@ -10,46 +10,19 @@ import { useCompositeProjectionContext } from "../CompositeProjectionContext"
 
 const HIDDEN_VALUE = "****"
 
-/** Shared narrative textarea content — accepts an `id` so desktop and mobile
- *  copies can each have a unique DOM id while staying controlled from the same
- *  context value. */
-function NarrativeField({
-  id,
-  value,
-  onChange,
-}: {
-  id: string
-  value: string
-  onChange: (v: string) => void
-}): React.ReactElement {
-  return (
-    <>
-      <label
-        htmlFor={id}
-        className="block text-sm font-medium text-gray-700 mb-1"
-      >
-        Plan narrative
-        <span className="ml-1 text-xs font-normal text-gray-500">
-          (optional)
-        </span>
-      </label>
-      <textarea
-        id={id}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        rows={7}
-        placeholder="Overarching goal across all phases. Used as context by AI tools."
-        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-independence-500 focus:border-independence-500"
-      />
-    </>
-  )
-}
+const PANEL_CLASS = "rounded-lg border border-gray-200 bg-white p-4"
 
 /**
- * Phases tab — phase configuration (left) + narrative (right).
+ * Phases tab — where a composite plan's shape is laid out.
  *
- * Desktop (`lg+`): unchanged two-column layout — config flex-1, narrative w-72.
- * Mobile (below `lg`): a flip card — front = PhaseConfigList, back = narrative.
+ * Reads top-down as one idea: the timeline band shows the years each phase
+ * covers, the rows beneath it edit those years and carry each phase's own
+ * narrative, and the levers panel holds the two decisions that land on a
+ * phase boundary rather than a single age. Hovering a row lifts its timeline
+ * segment and vice versa, so the map and the editor stay tied together.
+ *
+ * There is no composite-level narrative: the story of a composite plan is the
+ * phases it runs through, each described on its own plan.
  */
 export default function PhasesTab(): React.ReactElement {
   const { hideValues } = usePrivacyMode()
@@ -59,125 +32,107 @@ export default function PhasesTab(): React.ReactElement {
     setPhases,
     excludedPlanIds,
     toggleExclusion,
+    projection,
     scenarios,
     isLoading,
     error,
-    compositeNarrative,
-    setCompositeNarrative,
   } = useCompositeProjectionContext()
 
-  const narrativeValue = compositeNarrative ?? ""
+  const [activeIndex, setActiveIndex] = useState<number | null>(null)
+
+  // The last phase is open-ended ("end"); the projection is what resolves it
+  // to a real horizon age, so borrow that once it has landed.
+  const horizonAge = projection?.phases?.[projection.phases.length - 1]?.toAge
+  const resolved = resolvePhases(phases, plans, horizonAge)
+  const hasPhases = phases.length > 0
 
   return (
-    <div className="space-y-6">
-      {/* Phase Configuration + Narrative */}
-      <div className="bg-white rounded-xl shadow-md p-4">
-        {/* ── Desktop: two-column side-by-side (lg+) ── */}
-        <div
-          className="hidden lg:flex gap-6"
-          data-testid="phases-desktop-layout"
-        >
-          <div className="flex-1 min-w-0 space-y-4">
-            <PhaseConfigList
-              plans={plans}
-              phases={phases}
-              onPhaseChange={setPhases}
-              onExclude={toggleExclusion}
-              excludedPlanIds={excludedPlanIds}
-            />
+    <div className="space-y-4">
+      <section className={PANEL_CLASS} data-testid="phases-layout">
+        <PhaseTimeline
+          resolved={resolved}
+          activeIndex={activeIndex}
+          onActiveChange={setActiveIndex}
+        />
+        <div className={hasPhases ? "mt-5" : ""}>
+          <PhaseConfigList
+            plans={plans}
+            phases={phases}
+            onPhaseChange={setPhases}
+            onExclude={toggleExclusion}
+            excludedPlanIds={excludedPlanIds}
+            horizonAge={horizonAge}
+            activeIndex={activeIndex}
+            onActiveChange={setActiveIndex}
+          />
+        </div>
+      </section>
+
+      {hasPhases && (
+        <section className={PANEL_CLASS} data-testid="phase-levers">
+          <h3 className="text-sm font-medium text-gray-700">Phase levers</h3>
+          <p className="mt-1 text-xs text-gray-500">
+            Decisions that land on a phase boundary rather than a single age.
+          </p>
+          <div className="mt-2 divide-y divide-gray-100">
             <ResidencePhasePicker />
             <BenefitsStartPhasePicker />
           </div>
-          <div className="w-72 shrink-0">
-            <NarrativeField
-              id="composite-narrative"
-              value={narrativeValue}
-              onChange={setCompositeNarrative}
-            />
-          </div>
-        </div>
+        </section>
+      )}
 
-        {/* ── Mobile: flip card (below lg) ── */}
-        <div className="lg:hidden" data-testid="phases-mobile-layout">
-          <FlipCard
-            frontLabel="Phases"
-            backLabel="Narrative"
-            front={
-              <div className="space-y-4">
-                <PhaseConfigList
-                  plans={plans}
-                  phases={phases}
-                  onPhaseChange={setPhases}
-                  onExclude={toggleExclusion}
-                  excludedPlanIds={excludedPlanIds}
-                />
-                <ResidencePhasePicker />
-                <BenefitsStartPhasePicker />
-              </div>
-            }
-            back={
-              <NarrativeField
-                id="composite-narrative-mobile"
-                value={narrativeValue}
-                onChange={setCompositeNarrative}
-              />
-            }
-          />
-        </div>
-      </div>
-
-      {/* Loading / Error */}
       {isLoading && (
-        <div className="text-center py-8">
+        <div className="py-8 text-center">
           <Spinner label="Calculating composite projection..." size="lg" />
         </div>
       )}
 
       {error && <Alert>{error}</Alert>}
 
-      {/* Scenario Comparison */}
       {!isLoading && scenarios && scenarios.scenarios.length > 0 && (
-        <div className="bg-white rounded-xl shadow-md p-4">
-          <h3 className="text-sm font-medium text-gray-700 mb-3">
-            Scenario Comparison
+        <section className={PANEL_CLASS}>
+          <h3 className="text-sm font-medium text-gray-700">
+            Scenario comparison
           </h3>
-          <div className="overflow-x-auto">
+          <div className="mt-3 overflow-x-auto">
             <table className="min-w-full text-sm">
               <thead>
-                <tr className="border-b border-gray-200 text-left text-xs text-gray-500 uppercase">
-                  <th className="py-2 px-2">Scenario</th>
-                  <th className="py-2 px-2 text-right">Runway (years)</th>
-                  <th className="py-2 px-2 text-right">Depletion Age</th>
-                  <th className="py-2 px-2 text-center">Sustainable</th>
+                <tr className="border-b border-gray-200 text-left text-xs font-medium text-gray-500">
+                  <th className="px-2 py-2">Scenario</th>
+                  <th className="px-2 py-2 text-right">Runway (years)</th>
+                  <th className="px-2 py-2 text-right">Depletion age</th>
+                  <th className="px-2 py-2 text-center">Sustainable</th>
                 </tr>
               </thead>
               <tbody>
                 {scenarios.scenarios.map((s) => (
-                  <tr key={s.name} className="border-b border-gray-50">
-                    <td className="py-1.5 px-2">
-                      <div className="font-medium text-gray-800">{s.name}</div>
+                  <tr key={s.name} className="border-b border-gray-100">
+                    <td className="px-2 py-2">
+                      <div className="font-medium text-gray-900">{s.name}</div>
                       <div className="text-xs text-gray-500">
                         {s.description}
                       </div>
                     </td>
-                    <td className="py-1.5 px-2 text-right text-gray-700">
+                    <td className="px-2 py-2 text-right font-mono tabular-nums text-gray-700">
                       {hideValues
                         ? HIDDEN_VALUE
                         : s.projection.runwayYears.toFixed(1)}
                     </td>
-                    <td className="py-1.5 px-2 text-right text-gray-700">
+                    <td className="px-2 py-2 text-right font-mono tabular-nums text-gray-700">
                       {hideValues
                         ? HIDDEN_VALUE
                         : (s.projection.depletionAge ?? "Never")}
                     </td>
-                    <td className="py-1.5 px-2 text-center">
+                    <td className="px-2 py-2 text-center">
                       {s.projection.isSustainable ? (
-                        <span className="text-green-600">
-                          <i className="fas fa-check"></i>
+                        <span className="font-medium text-gain">
+                          <i aria-hidden="true" className="fas fa-check mr-1" />
+                          Yes
                         </span>
                       ) : (
-                        <span className="text-red-600">
-                          <i className="fas fa-times"></i>
+                        <span className="font-medium text-loss">
+                          <i aria-hidden="true" className="fas fa-times mr-1" />
+                          No
                         </span>
                       )}
                     </td>
@@ -186,7 +141,7 @@ export default function PhasesTab(): React.ReactElement {
               </tbody>
             </table>
           </div>
-        </div>
+        </section>
       )}
     </div>
   )

--- a/src/hooks/useCompositeProjection.ts
+++ b/src/hooks/useCompositeProjection.ts
@@ -22,9 +22,6 @@ export interface UseCompositeProjectionResult {
   setDisplayCurrency: (currency: string) => void
   excludedPlanIds: Set<string>
   toggleExclusion: (planId: string) => void
-  /** Free-form narrative describing the overarching composite-plan goal. */
-  compositeNarrative: string
-  setCompositeNarrative: (narrative: string) => void
   /** Work scenario ID to use for composite projections. */
   compositeWorkScenarioId: string | undefined
   setCompositeWorkScenarioId: (id: string | undefined) => void
@@ -103,7 +100,6 @@ export function useCompositeProjection(
   const [excludedPlanIds, setExcludedPlanIds] = useState<Set<string>>(new Set())
   const [phases, setPhases] = useState<CompositePhase[]>([])
   const [displayCurrency, setDisplayCurrency] = useState(defaultCurrency)
-  const [compositeNarrative, setCompositeNarrative] = useState<string>("")
   const [compositeWorkScenarioId, setCompositeWorkScenarioId] = useState<
     string | undefined
   >(undefined)
@@ -130,12 +126,10 @@ export function useCompositeProjection(
     )
     const savedPhases = parseSavedPhases(settings.compositePhases)
     const savedCurrency = settings.compositeDisplayCurrency
-    const savedNarrative = settings.compositeNarrative
     const savedWorkScenarioId = settings.compositeWorkScenarioId
 
     if (savedExclusions) setExcludedPlanIds(savedExclusions)
     if (savedCurrency) setDisplayCurrency(savedCurrency)
-    if (savedNarrative != null) setCompositeNarrative(savedNarrative)
     if (savedWorkScenarioId != null)
       setCompositeWorkScenarioId(savedWorkScenarioId)
 
@@ -171,7 +165,6 @@ export function useCompositeProjection(
         compositeDisplayCurrency: displayCurrency,
         compositePhases: JSON.stringify(phases),
         compositeExcludedPlanIds: JSON.stringify(Array.from(excludedPlanIds)),
-        compositeNarrative: compositeNarrative,
         compositeWorkScenarioId: compositeWorkScenarioId,
       }).catch(() => {
         // Silent save failure — not critical
@@ -185,7 +178,6 @@ export function useCompositeProjection(
     phases,
     displayCurrency,
     excludedPlanIds,
-    compositeNarrative,
     compositeWorkScenarioId,
     initialized,
     updateSettings,
@@ -302,8 +294,6 @@ export function useCompositeProjection(
     setDisplayCurrency,
     excludedPlanIds,
     toggleExclusion,
-    compositeNarrative,
-    setCompositeNarrative,
     compositeWorkScenarioId,
     setCompositeWorkScenarioId,
     projection,

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -45,11 +45,7 @@ export interface WorkScenariosResponse {
 // ============ Manual Asset Categories ============
 // Asset categories for users without portfolios
 export type ManualAssetCategory =
-  | "CASH"
-  | "EQUITY"
-  | "ETF"
-  | "MUTUAL_FUND"
-  | "RE"
+  "CASH" | "EQUITY" | "ETF" | "MUTUAL_FUND" | "RE"
 
 export type ManualAssets = Record<ManualAssetCategory, number>
 
@@ -1190,12 +1186,6 @@ export interface UserIndependenceSettings {
   compositeDisplayCurrency?: string
   compositePhases?: string
   compositeExcludedPlanIds?: string
-  /**
-   * Free-form narrative describing the overarching goal of the composite
-   * plan — applies across ALL phases. Surfaced to svc-agent as shared
-   * cross-plan context.
-   */
-  compositeNarrative?: string
   compositeWorkScenarioId?: string
   /**
    * JSON-serialised string[] of portfolio IDs to exclude from wealth
@@ -1222,8 +1212,6 @@ export interface UpdateSettingsRequest {
   compositeDisplayCurrency?: string
   compositePhases?: string
   compositeExcludedPlanIds?: string
-  /** Free-form composite-level narrative. Empty string clears it. */
-  compositeNarrative?: string
   compositeWorkScenarioId?: string
   /**
    * JSON-serialised string[] of portfolio IDs to exclude from wealth


### PR DESCRIPTION
The Phases tab hid what a composite plan actually is — a contiguous band of years split into stages — behind a cramped list of age inputs, a narrative textarea pinned to a 288px column, and two mismatched pickers stacked underneath. Desktop and mobile rendered as duplicated DOM (a flip card), doubling every id and control.

**Now**

- **Timeline band** leads the tab: segment width tracks phase length, tonal steps of the Independence hue keep it one chart series, ages/durations in the mono tabular face. `PhaseTimeline.tsx` also owns `resolvePhases` (the open-ended last phase borrows the projection's horizon).
- **One responsive row list**, no duplicated mobile copy: age window, length, order controls, plus that phase's own plan narrative clamped to two lines with show-more and an edit link into the wizard.
- **Hover/focus sync** both ways between a row and its segment (transform-only, `motion-reduce` guarded).
- **Phase levers panel**: residence + benefits-start behind a shared `LeverRow` with matched control widths, instead of a full-width row next to a narrow select.
- Teaching empty state; plan-inclusion chips as `button[role=checkbox]` (the label-wrapped input double-fired); flat bordered panels per DESIGN.md.
- **Summary is the landing tab** — it answers "does this hold together, what does each phase cost" with no controls touched.

**Composite narrative removed.** A composite has no story of its own; carrying one alongside each plan's narrative left two sources of truth. Requires monowai/svc-retire#174 (drops the field + column) — merge/deploy that first.

Gates: `yarn test` (240 suites / 2418 tests), `prettier`, `lint`, `typecheck` all green. Verified in-browser at desktop width against live kauri data; the harness could not resize the Chrome window, so narrow-width behaviour is by construction (grid collapses below `sm`, chips wrap, segments floor at 3.5rem) rather than screenshotted.