### PR TITLE
feat(independence): edit each phase from the Summary tab

### DIFF
--- a/src/components/features/independence/LifestyleSummary.tsx
+++ b/src/components/features/independence/LifestyleSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from "react"
+import React, { ReactNode, useId } from "react"
 import { formatCurrency } from "@lib/independence/formatters"
 import {
   COMFORT_SCALE_MAX,
@@ -34,6 +34,10 @@ export interface LifestyleSummaryProps {
   title?: string
   /** Shown in place of the board when there is no model. */
   emptyMessage?: string
+  /** Optional control rendered beside the heading — e.g. an edit link for the
+   *  plan this board describes. Kept out of the heading text so the accessible
+   *  name stays the phase, not the phase plus a verb. */
+  action?: ReactNode
 }
 
 export default function LifestyleSummary({
@@ -44,6 +48,7 @@ export default function LifestyleSummary({
   isLoading = false,
   title,
   emptyMessage = "Add what you expect to spend and we'll show the lifestyle your plan supports.",
+  action,
 }: LifestyleSummaryProps): React.ReactElement {
   const isPayoff = variant === "payoff"
   const headingId = useId()
@@ -62,11 +67,14 @@ export default function LifestyleSummary({
           : "rounded-xl border border-gray-100 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
       }
     >
-      <Heading
-        id={headingId}
-        isPayoff={isPayoff}
-        text={headingText(model, title)}
-      />
+      <div className="flex items-start justify-between gap-3">
+        <Heading
+          id={headingId}
+          isPayoff={isPayoff}
+          text={headingText(model, title)}
+        />
+        {action}
+      </div>
 
       {isLoading ? (
         <Skeleton isPayoff={isPayoff} />

--- a/src/components/features/independence/composite/__tests__/SummaryTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/SummaryTab.test.tsx
@@ -1,0 +1,120 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import {
+  CompositeProjectionProvider,
+  type CompositeProjectionValue,
+} from "../CompositeProjectionContext"
+
+jest.mock("@hooks/usePrivacyMode", () => ({
+  usePrivacyMode: () => ({ hideValues: false }),
+}))
+
+jest.mock("@components/features/independence/usePlanExpenses", () => ({
+  usePlanExpenses: () => ({ expenses: [], isLoading: false }),
+}))
+
+jest.mock("@components/features/independence/useExpenseCategories", () => ({
+  useExpenseCategories: () => ({ labels: {} }),
+}))
+
+jest.mock("@components/features/independence/useLifestyleCatalog", () => ({
+  useLifestyleCatalog: () => ({ catalog: null }),
+}))
+
+// The board itself is covered by LifestyleSummary.test.tsx. Here we only care
+// that each phase gets a title and its own action slot.
+jest.mock("@components/features/independence/LifestyleSummary", () => ({
+  __esModule: true,
+  default: ({
+    title,
+    action,
+  }: {
+    title?: string
+    action?: React.ReactNode
+  }): React.ReactElement => (
+    <div data-testid="lifestyle-summary">
+      <span>{title}</span>
+      {action}
+    </div>
+  ),
+}))
+
+import SummaryTab from "../tabs/SummaryTab"
+
+const projection = {
+  phases: [
+    {
+      planId: "p1",
+      planName: "Go-Go",
+      fromAge: 61,
+      toAge: 70,
+      expensesCurrency: "SGD",
+    },
+    {
+      planId: "p2",
+      planName: "Slow Go",
+      fromAge: 70,
+      toAge: 80,
+      expensesCurrency: "SGD",
+    },
+  ],
+} as unknown as CompositeProjectionValue["projection"]
+
+function renderWithCtx(
+  overrides: Partial<CompositeProjectionValue> = {},
+): void {
+  const ctx = {
+    plans: [],
+    phases: [],
+    setPhases: jest.fn(),
+    displayCurrency: "SGD",
+    setDisplayCurrency: jest.fn(),
+    excludedPlanIds: new Set<string>(),
+    toggleExclusion: jest.fn(),
+    compositeWorkScenarioId: undefined,
+    setCompositeWorkScenarioId: jest.fn(),
+    projection,
+    scenarios: undefined,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  } as CompositeProjectionValue
+  render(
+    <CompositeProjectionProvider value={ctx}>
+      <SummaryTab />
+    </CompositeProjectionProvider>,
+  )
+}
+
+describe("SummaryTab", () => {
+  it("gives each phase an edit link to that phase's plan", () => {
+    renderWithCtx()
+
+    const goGo = screen.getByRole("link", { name: /Edit Go-Go/i })
+    expect(goGo).toHaveAttribute("href", "/independence/wizard/p1")
+
+    const slowGo = screen.getByRole("link", { name: /Edit Slow Go/i })
+    expect(slowGo).toHaveAttribute("href", "/independence/wizard/p2")
+  })
+
+  it("renders one board per phase, titled with its age window", () => {
+    renderWithCtx()
+
+    expect(screen.getAllByTestId("lifestyle-summary")).toHaveLength(2)
+    expect(screen.getByText("Go-Go · age 61–70")).toBeInTheDocument()
+    expect(screen.getByText("Slow Go · age 70–80")).toBeInTheDocument()
+  })
+
+  it("shows no edit links when there are no phases", () => {
+    renderWithCtx({
+      projection: {
+        phases: [],
+      } as unknown as CompositeProjectionValue["projection"],
+    })
+
+    expect(
+      screen.queryByRole("link", { name: /Edit/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/features/independence/composite/tabs/SummaryTab.tsx
+++ b/src/components/features/independence/composite/tabs/SummaryTab.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import Link from "next/link"
 import LifestyleSummary from "@components/features/independence/LifestyleSummary"
 import { usePlanExpenses } from "@components/features/independence/usePlanExpenses"
 import { useExpenseCategories } from "@components/features/independence/useExpenseCategories"
@@ -85,7 +86,7 @@ function PhaseSpend({
   phase,
 }: {
   phase: CompositePhaseInfo
-}): React.ReactElement | null {
+}): React.ReactElement {
   const { hideValues } = usePrivacyMode()
   const { expenses, isLoading } = usePlanExpenses(phase.planId)
   const { labels } = useExpenseCategories()
@@ -96,8 +97,9 @@ function PhaseSpend({
     catalog,
   })
 
-  if (!mix && !isLoading) return null
-
+  // A phase with no expenses still renders: it's in the timeline, so it belongs
+  // in the summary, and its empty board is exactly where the edit link needs to
+  // be reachable. LifestyleSummary carries the teaching empty message.
   return (
     <LifestyleSummary
       model={mix}
@@ -105,6 +107,17 @@ function PhaseSpend({
       currencySymbol={currencySymbolFor(phase.expensesCurrency)}
       hideValues={hideValues}
       isLoading={isLoading && !mix}
+      emptyMessage={`Add what you expect to spend from age ${phase.fromAge} and we'll show the life this phase supports.`}
+      action={
+        <Link
+          href={`/independence/wizard/${phase.planId}`}
+          aria-label={`Edit ${phase.planName}`}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-700 transition-colors duration-150 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-1 focus:ring-independence-500 motion-reduce:transition-none dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          <i aria-hidden="true" className="fas fa-pen text-[10px]" />
+          Edit
+        </Link>
+      }
     />
   )
 }


### PR DESCRIPTION
Summary showed what every phase costs with no way to act on it — changing a phase meant leaving for the plan list and finding it by name.

**Edit per phase**
- Each phase board gets an **Edit** link (ghost button, `fa-pen`) beside its heading
- `LifestyleSummary` gains an optional `action` slot rather than baking the link in, so the payoff variant and the ExpensesStep board are untouched
- Accessible name is `Edit <phase>` so three edit links on one page stay distinguishable
- **Behaviour change:** a phase with no expense rows used to render nothing at all on Summary, which would have hidden the edit link exactly where it's most needed. It now renders the board's empty state with a phase-specific message.

**Wizard step deep-links**
- `WIZARD_STEPS` entries carry a stable `slug` (`personal`, `wealth`, `assumptions`, `income`, `expenses`, `life-events`) and `stepIdForSlug()` resolves it
- `/independence/wizard/{id}?step=expenses` opens on Expenses; the phase board links there, since that board is about what the phase spends
- Slugs are deliberately separate from step `name`: names are user-facing copy, and one rewording shouldn't break links already in the wild
- Unknown / repeated / malformed tokens resolve to `undefined` → step 1, same as today. Edit mode only — a new plan must start at step 1 because later steps validate against fields step 1 collects.

Tests: new `SummaryTab.test.tsx` (per-phase hrefs, one board per phase, no-phases case) plus `stepIdForSlug` coverage (round-trip, case/whitespace, unknown, `string[]`, slug uniqueness + url-safety). Full suite 241 files / 2426 tests, prettier, lint, typecheck green.

Verified in-browser against live kauri data: three edit links resolve to the right plan ids, and clicking one lands on the wizard's Expenses step with the phase's S$6,640 loaded.
