### PR TITLE
feat(independence): deep-link the wizard to a step

### DIFF
--- a/src/components/features/independence/WizardContainer.tsx
+++ b/src/components/features/independence/WizardContainer.tsx
@@ -40,6 +40,14 @@ interface WizardContainerProps {
    * /plans/{id} consumes a full PlanRequest — see {@link buildWizardPlanRequest}.
    */
   plan?: RetirementPlan | null
+  /**
+   * Step to open on, 1-indexed. Lets a caller deep-link straight to the part
+   * of the plan it was talking about (the Summary tab's spend board links to
+   * Expenses). Edit mode only — a new plan has to start at step 1, since the
+   * later steps validate against fields step 1 collects. Out-of-range values
+   * fall back to 1.
+   */
+  initialStep?: number
 }
 
 /**
@@ -116,10 +124,15 @@ export default function WizardContainer({
   planId,
   initialData,
   plan,
+  initialStep,
 }: WizardContainerProps): React.ReactElement {
   const isEditMode = Boolean(planId)
   const router = useRouter()
-  const [currentStep, setCurrentStep] = useState(1)
+  const [currentStep, setCurrentStep] = useState(() =>
+    isEditMode && initialStep && initialStep >= 1 && initialStep <= TOTAL_STEPS
+      ? initialStep
+      : 1,
+  )
   const [clientId, setClientId] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/src/components/features/independence/composite/__tests__/SummaryTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/SummaryTab.test.tsx
@@ -92,10 +92,16 @@ describe("SummaryTab", () => {
     renderWithCtx()
 
     const goGo = screen.getByRole("link", { name: /Edit Go-Go/i })
-    expect(goGo).toHaveAttribute("href", "/independence/wizard/p1")
+    expect(goGo).toHaveAttribute(
+      "href",
+      "/independence/wizard/p1?step=expenses",
+    )
 
     const slowGo = screen.getByRole("link", { name: /Edit Slow Go/i })
-    expect(slowGo).toHaveAttribute("href", "/independence/wizard/p2")
+    expect(slowGo).toHaveAttribute(
+      "href",
+      "/independence/wizard/p2?step=expenses",
+    )
   })
 
   it("renders one board per phase, titled with its age window", () => {

--- a/src/components/features/independence/composite/tabs/SummaryTab.tsx
+++ b/src/components/features/independence/composite/tabs/SummaryTab.tsx
@@ -110,7 +110,9 @@ function PhaseSpend({
       emptyMessage={`Add what you expect to spend from age ${phase.fromAge} and we'll show the life this phase supports.`}
       action={
         <Link
-          href={`/independence/wizard/${phase.planId}`}
+          // Straight to Expenses: this board is about what the phase spends,
+          // so that's the part of the wizard the user came to change.
+          href={`/independence/wizard/${phase.planId}?step=expenses`}
           aria-label={`Edit ${phase.planName}`}
           className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-700 transition-colors duration-150 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-1 focus:ring-independence-500 motion-reduce:transition-none dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
         >

--- a/src/lib/utils/independence/stepConfig.test.ts
+++ b/src/lib/utils/independence/stepConfig.test.ts
@@ -1,4 +1,9 @@
-import { WIZARD_STEPS, TOTAL_STEPS, getStepFields } from "./stepConfig"
+import {
+  WIZARD_STEPS,
+  TOTAL_STEPS,
+  getStepFields,
+  stepIdForSlug,
+} from "./stepConfig"
 
 describe("WIZARD_STEPS", () => {
   it("should have 6 steps", () => {
@@ -121,5 +126,35 @@ describe("getStepFields", () => {
     expect(getStepFields(4)).toHaveLength(3) // Income
     expect(getStepFields(5)).toHaveLength(1) // Expenses
     expect(getStepFields(6)).toHaveLength(1) // Life Events
+  })
+})
+
+describe("stepIdForSlug", () => {
+  it("maps every step's slug back to its id", () => {
+    WIZARD_STEPS.forEach((step) => {
+      expect(stepIdForSlug(step.slug)).toBe(step.id)
+    })
+  })
+
+  it("deep-links the expenses step, which is what a spend board links to", () => {
+    expect(stepIdForSlug("expenses")).toBe(5)
+  })
+
+  it("is case-insensitive and tolerates surrounding whitespace", () => {
+    expect(stepIdForSlug(" Expenses ")).toBe(5)
+  })
+
+  it("returns undefined for anything it doesn't recognise", () => {
+    expect(stepIdForSlug("nope")).toBeUndefined()
+    expect(stepIdForSlug("")).toBeUndefined()
+    expect(stepIdForSlug(undefined)).toBeUndefined()
+    // A query param can arrive as string[] when repeated; not a slug.
+    expect(stepIdForSlug(["expenses"] as unknown as string)).toBeUndefined()
+  })
+
+  it("gives every step a unique, url-safe slug", () => {
+    const slugs = WIZARD_STEPS.map((s) => s.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+    slugs.forEach((slug) => expect(slug).toMatch(/^[a-z][a-z-]*$/))
   })
 })

--- a/src/lib/utils/independence/stepConfig.ts
+++ b/src/lib/utils/independence/stepConfig.ts
@@ -10,6 +10,12 @@ export interface WizardStep {
   id: number
   name: string
   /**
+   * Stable url token for `?step=` deep links. Independent of `name`, which is
+   * user-facing copy and translatable — a link in the wild must not break
+   * because a label was reworded.
+   */
+  slug: string
+  /**
    * Font Awesome icon class (without the leading `fas`) used by
    * WizardProgress so the step indicator stays recognisable on narrow
    * mobile widths where the digit-and-label combination collapsed to an
@@ -22,18 +28,21 @@ export interface WizardStep {
 export const WIZARD_STEPS: WizardStep[] = [
   {
     id: 1,
+    slug: "personal",
     name: wizardMessages.steps.personalInfo.name,
     icon: "fa-user",
     fields: ["planName", "expensesCurrency", "country", "narrative"],
   },
   {
     id: 2,
+    slug: "wealth",
     name: wizardMessages.steps.assets.name,
     icon: "fa-piggy-bank",
     fields: ["selectedPortfolioIds", "manualAssets"],
   },
   {
     id: 3,
+    slug: "assumptions",
     name: wizardMessages.steps.assumptions.name,
     icon: "fa-sliders-h",
     fields: [
@@ -49,18 +58,21 @@ export const WIZARD_STEPS: WizardStep[] = [
   },
   {
     id: 4,
+    slug: "income",
     name: wizardMessages.steps.income.name,
     icon: "fa-hand-holding-usd",
     fields: ["pensionMonthly", "socialSecurityMonthly", "otherIncomeMonthly"],
   },
   {
     id: 5,
+    slug: "expenses",
     name: wizardMessages.steps.expenses.name,
     icon: "fa-receipt",
     fields: ["expenses"],
   },
   {
     id: 6,
+    slug: "life-events",
     name: wizardMessages.steps.lifeEvents.name,
     icon: "fa-calendar-day",
     fields: ["lifeEvents"],
@@ -75,4 +87,14 @@ export const TOTAL_STEPS = WIZARD_STEPS.length
 export const getStepFields = (stepNumber: number): (keyof WizardFormData)[] => {
   const step = WIZARD_STEPS.find((s) => s.id === stepNumber)
   return step?.fields ?? []
+}
+
+/**
+ * Resolve a `?step=` token to its step id. Returns undefined for anything
+ * unrecognised so callers fall back to step 1 rather than landing nowhere.
+ */
+export const stepIdForSlug = (slug: string | undefined): number | undefined => {
+  if (typeof slug !== "string") return undefined
+  const normalised = slug.trim().toLowerCase()
+  return WIZARD_STEPS.find((step) => step.slug === normalised)?.id
 }

--- a/src/pages/independence/wizard/[planId].tsx
+++ b/src/pages/independence/wizard/[planId].tsx
@@ -19,10 +19,15 @@ import {
   parseExcludedPortfolioIds,
   parseExcludedRentalAssetIds,
 } from "@lib/independence/planHelpers"
+import { stepIdForSlug } from "@lib/independence/stepConfig"
 
 function EditPlanWizard(): React.ReactElement {
   const router = useRouter()
-  const { planId } = router.query
+  const { planId, step } = router.query
+  // `?step=expenses` opens the wizard where the caller was looking — the
+  // Summary tab's per-phase spend board links straight to Expenses. Unknown
+  // tokens resolve to undefined and the wizard opens at step 1 as before.
+  const initialStep = stepIdForSlug(typeof step === "string" ? step : undefined)
 
   // Fetch plan with retirement expenses
   const { data, error, isLoading } = useSwr<PlanWithExpensesResponse>(
@@ -166,6 +171,7 @@ function EditPlanWizard(): React.ReactElement {
             planId={planId as string}
             initialData={initialData}
             plan={plan}
+            initialStep={initialStep}
           />
         </div>
       </div>


### PR DESCRIPTION
Follow-on to #1126, which squash-merged before this commit landed on the branch — main has the per-phase **Edit** button but it still opens the wizard at Personal Info, three clicks from the spend figures the user was looking at.

- `WIZARD_STEPS` entries carry a stable `slug` (`personal`, `wealth`, `assumptions`, `income`, `expenses`, `life-events`); `stepIdForSlug()` resolves it
- `/independence/wizard/{id}?step=expenses` opens on Expenses, and the phase spend board links there — that board is about what the phase spends
- Slugs are deliberately separate from step `name`: names are user-facing copy, and one rewording shouldn't break links already in the wild
- Unknown / repeated / malformed tokens resolve to `undefined` → step 1, unchanged behaviour
- Edit mode only: a new plan must start at step 1, because later steps validate against fields step 1 collects

Tests cover the slug round-trip over every step, case/whitespace tolerance, unknown tokens, the `string[]` repeated-param case, and slug uniqueness + url-safety; `SummaryTab.test.tsx` asserts the new hrefs.

Rebased on current main (post auth0 6 / babel 8 bumps, deps reinstalled): 241 suites / 2426 tests, typecheck, lint, prettier green. Verified in-browser earlier against live kauri data — the link lands on Expenses with the phase's S$6,640 loaded.