### PR TITLE
style: prettier sweep on holdings page and rebalance types

### DIFF
--- a/src/pages/brokers/[brokerId]/holdings.tsx
+++ b/src/pages/brokers/[brokerId]/holdings.tsx
@@ -128,8 +128,8 @@ export default withPageAuthRequired(
 
     const brokers: Broker[] = brokersData.data || []
     const holdings:
-      | (BrokerHoldingsResponse & { totalHoldings: number })
-      | null = mergedHoldings
+      (BrokerHoldingsResponse & { totalHoldings: number }) | null =
+      mergedHoldings
     // Sell proposes SELL trns against a real broker; NO_BROKER is a UI
     // sentinel grouping unassigned transactions, not a real broker id.
     const canSell = brokerId !== "NO_BROKER"

--- a/types/rebalance.d.ts
+++ b/types/rebalance.d.ts
@@ -190,10 +190,7 @@ export interface RebalanceCalculationResponse {
 // === Execution Types (persisted rebalance configurations) ===
 
 export type ExecutionPlanStatus =
-  | "DRAFT"
-  | "IN_PROGRESS"
-  | "COMPLETED"
-  | "CANCELLED"
+  "DRAFT" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED"
 
 export type ExecutionMode = "REBALANCE" | "INVEST_CASH" | "AD_HOC"
 


### PR DESCRIPTION
Two files drifted from prettier 3.9.6 output on main. No behaviour change.