### PR TITLE
fix(build): trace meriyah ESM entry into standalone output

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,6 +26,15 @@ const nextConfig = {
     includePaths: [path.join(__dirname, "styles")],
   },
   output: "standalone",
+  // @sentry/nextjs is loaded as a server external, and its transitive dep
+  // @sentry/server-utils -> meriyah resolves through the ESM "default"
+  // condition (dist/meriyah.mjs) at runtime. Standalone file tracing only
+  // follows the CJS "require" condition, so it copies dist/meriyah.cjs alone
+  // and every SSR page + API route 500s in the image with
+  // "Cannot find module .../meriyah/dist/meriyah.mjs". Ship the whole dist.
+  outputFileTracingIncludes: {
+    "/**/*": ["./node_modules/meriyah/dist/**"],
+  },
   // Turbopack configuration (for dev mode with --turbopack)
   turbopack: {
     rules: {


### PR DESCRIPTION
@sentry/nextjs is a server external; its transitive dep @sentry/server-utils
resolves meriyah through the ESM "default" condition (dist/meriyah.mjs).
Next.js standalone file tracing only follows the CJS "require" condition, so
the image shipped dist/meriyah.cjs alone. Every SSR page and API route then
threw "Cannot find module /app/node_modules/meriyah/dist/meriyah.mjs" and
returned 500 — portfolios and independence plans could not load on kauri.

outputFileTracingIncludes pulls the whole meriyah dist into standalone.
Verified: .next/standalone/node_modules/meriyah/dist now contains meriyah.mjs,
and a standalone server run logs zero meriyah module errors.