### PR TITLE
fix(dates): todayIso returns the local calendar date, not UTC

### DIFF
--- a/__tests__/components/features/accounts/SetPriceDialog.test.tsx
+++ b/__tests__/components/features/accounts/SetPriceDialog.test.tsx
@@ -1,0 +1,53 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import SetPriceDialog from "@components/features/accounts/SetPriceDialog"
+import { Asset } from "types/beancounter"
+import { pinClock, unpinClock } from "../../../support/pinClock"
+
+const mockAsset = {
+  id: "asset-2",
+  code: "OWNER:PENSION",
+  name: "Pension Policy",
+  market: { code: "PRIVATE", currency: { code: "SGD" } },
+  assetCategory: { id: "PENSION", name: "Policies" },
+} as unknown as Asset
+
+const dateInput = (): HTMLInputElement =>
+  document.querySelector('input[type="date"]') as HTMLInputElement
+
+describe("accounts/SetPriceDialog price date", () => {
+  afterEach(unpinClock)
+
+  it("seeds the price date with the user's local date, not the UTC date", () => {
+    pinClock("2026-08-02T23:00:00Z", +8)
+
+    render(
+      <SetPriceDialog
+        asset={mockAsset}
+        onClose={jest.fn()}
+        onSave={jest.fn()}
+      />,
+    )
+
+    expect(dateInput().value).toBe("2026-08-03")
+  })
+
+  it("submits the local date it seeded", async () => {
+    pinClock("2026-08-02T23:00:00Z", +8)
+    const onSave = jest.fn().mockResolvedValue(undefined)
+
+    render(
+      <SetPriceDialog asset={mockAsset} onClose={jest.fn()} onSave={onSave} />,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText(/current market value/i), {
+      target: { value: "2500" },
+    })
+    fireEvent.click(screen.getByText("Save"))
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith("asset-2", "2026-08-03", "2500"),
+    )
+  })
+})

--- a/__tests__/components/features/holdings/SetPriceDialog.test.tsx
+++ b/__tests__/components/features/holdings/SetPriceDialog.test.tsx
@@ -1,0 +1,56 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import SetPriceDialog from "@components/features/holdings/SetPriceDialog"
+import { Asset } from "types/beancounter"
+import { pinClock, unpinClock } from "../../../support/pinClock"
+
+const mockAsset = {
+  id: "asset-1",
+  code: "OWNER:HOUSE",
+  name: "Family Home",
+  market: { code: "PRIVATE", currency: { code: "SGD" } },
+  assetCategory: { id: "RE", name: "Real Estate" },
+} as unknown as Asset
+
+const dateInput = (): HTMLInputElement =>
+  document.querySelector('input[type="date"]') as HTMLInputElement
+
+describe("holdings/SetPriceDialog price date", () => {
+  afterEach(unpinClock)
+
+  // 23:00 UTC on 2 Aug is already 07:00 on 3 Aug in Singapore (UTC+8).
+  // The backend resolves "today" in Asia/Singapore, so seeding the UTC date
+  // would write the price against the wrong day.
+  it("seeds the price date with the user's local date, not the UTC date", () => {
+    pinClock("2026-08-02T23:00:00Z", +8)
+
+    render(
+      <SetPriceDialog
+        asset={mockAsset}
+        onClose={jest.fn()}
+        onSave={jest.fn()}
+      />,
+    )
+
+    expect(dateInput().value).toBe("2026-08-03")
+  })
+
+  it("submits the local date it seeded", async () => {
+    pinClock("2026-08-02T23:00:00Z", +8)
+    const onSave = jest.fn().mockResolvedValue(undefined)
+
+    render(
+      <SetPriceDialog asset={mockAsset} onClose={jest.fn()} onSave={onSave} />,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText(/current market value/i), {
+      target: { value: "1500" },
+    })
+    fireEvent.click(screen.getByText("Save"))
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith("asset-1", "2026-08-03", "1500"),
+    )
+  })
+})

--- a/__tests__/lib/utils/formatters.test.ts
+++ b/__tests__/lib/utils/formatters.test.ts
@@ -18,9 +18,37 @@ import {
   formatPercent as independenceFormatPercent,
 } from "@lib/independence/formatters"
 
+import { pinClock, unpinClock } from "../../support/pinClock"
+
 describe("todayIso", () => {
+  afterEach(unpinClock)
+
   it("returns a YYYY-MM-DD string", () => {
     expect(todayIso()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  // Zones ahead of UTC (e.g. Asia/Singapore, UTC+8) roll into the next
+  // calendar day before UTC does. The UTC date here is still 2026-08-02, but
+  // the user's today is 2026-08-03 — and the user's today is what a trade or
+  // price date means.
+  it("returns the local calendar date when local is a day ahead of UTC", () => {
+    pinClock("2026-08-02T23:00:00Z", +8)
+
+    expect(todayIso()).toBe("2026-08-03")
+  })
+
+  // Zones behind UTC (e.g. America/New_York) are still on the previous
+  // calendar day after UTC midnight.
+  it("returns the local calendar date when local is a day behind UTC", () => {
+    pinClock("2026-08-03T02:00:00Z", -4)
+
+    expect(todayIso()).toBe("2026-08-02")
+  })
+
+  it("zero-pads single-digit months and days", () => {
+    pinClock("2026-01-04T16:00:00Z", +8)
+
+    expect(todayIso()).toBe("2026-01-05")
   })
 })
 

--- a/__tests__/support/pinClock.ts
+++ b/__tests__/support/pinClock.ts
@@ -1,0 +1,29 @@
+/**
+ * Test helper: pin the clock to a fixed instant AND a fixed local UTC offset.
+ *
+ * `process.env.TZ` cannot be mutated reliably part-way through a jest run, so
+ * the local calendar accessors are stubbed instead. That makes local-vs-UTC
+ * date divergence deterministic regardless of the machine's real timezone —
+ * a developer in Asia/Singapore and CI in UTC both see the same result.
+ *
+ * Call `jest.restoreAllMocks()` and `jest.useRealTimers()` when done.
+ *
+ * @param instantIso  The absolute instant, e.g. "2026-08-02T23:00:00Z".
+ * @param utcOffsetHours  The local zone's offset from UTC, e.g. +8 for SGT.
+ */
+export const pinClock = (instantIso: string, utcOffsetHours: number): void => {
+  const instant = new Date(instantIso)
+  const local = new Date(instant.getTime() + utcOffsetHours * 3_600_000)
+
+  jest.useFakeTimers().setSystemTime(instant)
+  jest
+    .spyOn(Date.prototype, "getFullYear")
+    .mockReturnValue(local.getUTCFullYear())
+  jest.spyOn(Date.prototype, "getMonth").mockReturnValue(local.getUTCMonth())
+  jest.spyOn(Date.prototype, "getDate").mockReturnValue(local.getUTCDate())
+}
+
+export const unpinClock = (): void => {
+  jest.restoreAllMocks()
+  jest.useRealTimers()
+}

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -113,9 +113,21 @@ export const formatSignedNumber = (
 }
 
 /**
- * Returns today's date as a YYYY-MM-DD string (ISO 8601 date part).
+ * Returns today's date as a YYYY-MM-DD string (ISO 8601 date part), in the
+ * *local* calendar, not UTC.
+ *
+ * `toISOString()` would yield the UTC calendar date, which is a day behind for
+ * zones ahead of UTC (Asia/Singapore, UTC+8, between 00:00 and 08:00 local) and
+ * a day ahead for zones behind it. Callers use this to seed trade/price dates,
+ * which the backend resolves against its own configured zone — so an off-by-one
+ * lands the row on the wrong day.
  */
-export const todayIso = (): string => new Date().toISOString().split("T")[0]
+export const todayIso = (): string => {
+  const now = new Date()
+  const month = String(now.getMonth() + 1).padStart(2, "0")
+  const day = String(now.getDate()).padStart(2, "0")
+  return `${now.getFullYear()}-${month}-${day}`
+}
 
 /**
  * Extracts a readable message from an unknown error value.


### PR DESCRIPTION
## Problem

`todayIso()` was `new Date().toISOString().split("T")[0]`, which yields the **UTC** calendar date. It seeds the date field in the Set Price and Set Balance dialogs, trade-date fields, the onboarding wizard and the date-picker "today" shortcut.

The backend resolves dates in its own configured zone (`beancounter.zone`, `Asia/Singapore` on the deployment). Between 00:00 and 08:00 Singapore time the browser sends the previous calendar day, so a price or trade lands on the wrong date — and the read that values it asks for the right one. The dialog also displays a date one day behind.

## Change

`todayIso()` now composes the date from local parts (`getFullYear` / `getMonth`+1 / `getDate`, zero-padded).

All 20 call sites were audited: every one means "today for the user", so fixing the helper is correct and avoids leaving the same off-by-one on every other date-seeding surface. One caller, `pages/api/holdings/weights.ts`, is server-side, where "local" is the container zone — that is UTC in the cluster, so no behaviour change there.

## Tests

`__tests__/lib/utils/formatters.test.ts` — three cases covering a zone 8 hours ahead of UTC, a zone 4 hours behind, and zero-padding. `__tests__/support/pinClock.ts` pins both the instant and the local UTC offset so the divergence is deterministic regardless of the machine's real timezone; an earlier attempt using `process.env.TZ` passed for the wrong reason on a machine already set to Asia/Singapore.

First tests for both `SetPriceDialog` components, asserting the seeded date and the date handed to `onSave`.

`yarn test` (2442 passing), `prettier`, `lint`, `typecheck`, `check-imports` all clean. `ocr review` no comments — though it reported reviewing only the source file, so the tests were not AI-reviewed.

## Related

#1135 — the same class of bug in `DateInput`'s `+`/`-` shortcuts, which mix local getters with a `toISOString()` round-trip. Only misbehaves in zones behind UTC; left out to keep this diff reviewable.
