### PR TITLE
fix(news): ask agent to skip the coverage-availability preamble

### DIFF
--- a/src/components/features/holdings/NewsSentimentPopup.tsx
+++ b/src/components/features/holdings/NewsSentimentPopup.tsx
@@ -40,7 +40,11 @@ async function performFetch(
     `If live news coverage is unavailable for this ticker/exchange, ` +
     `provide a concise general-knowledge summary of the company, its sector, ` +
     `recent themes, and qualitative sentiment — clearly labelled as general ` +
-    `knowledge, not live news.`
+    `knowledge, not live news. ` +
+    `Start the response directly with the markdown heading — no preamble, ` +
+    `no lead-in sentence about coverage availability or what you are about ` +
+    `to do. State the general-knowledge caveat only as a short line directly ` +
+    `under the heading.`
 
   const res = await fetch("/api/agent/query", {
     method: "POST",


### PR DESCRIPTION
The News & Sentiment popup renders the agent reply raw. For tickers with
no live coverage the model opened with a lead-in sentence, pushing the
actual summary below the fold. The query now asks it to start at the
heading and carry the caveat as a short line beneath.