### PR TITLE
dev: hooks that reach every clone — secret scan, and stop ignoring .husky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,8 +77,10 @@ test-results/
 # Claude Code & AI tools
 .claude/
 
-# Husky git hooks
-.husky/
+# NOT .husky/ — hooks are meant to be shared, that is what husky is for.
+# Its generated plumbing ignores itself (.husky/_/.gitignore is `*`), so
+# there is nothing here to exclude. Ignoring the directory left pre-push
+# untracked and this machine the only one that ran tests before a push.
 
 # Code quality tools
 codacy-coverage-reporter

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,37 @@
+#!/usr/bin/env bash
+# >>> beancounter secret scan >>>
+# Blocks a commit that stages a literal secret. See bc-claude/security/.
+# Bypass (only when you are certain): git commit --no-verify
+#
+# The config is found at RUN time rather than baked in, because bc-view's copy
+# of this block lives in TRACKED .husky/pre-commit. A path from this machine
+# travels to every other clone, where -c points at nothing, gitleaks errors,
+# and every commit is refused under a message about staged secrets.
+# Order: an explicit override, then bc-claude beside this repo, then the
+# checkout this was installed from (still right for a worktree on this
+# machine). None of them found is a warning, never a blocked commit.
+if command -v gitleaks >/dev/null 2>&1; then
+  bc_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  for bc_cfg in "${BC_GITLEAKS_CONFIG:-}" \
+                "$bc_root/../bc-claude/security/gitleaks.toml" \
+                "/Users/mikeh/IdeaProjects/monowai/bc-claude/security/gitleaks.toml"; do
+    [ -n "$bc_cfg" ] && [ -f "$bc_cfg" ] && break || bc_cfg=""
+  done
+  if [ -z "$bc_cfg" ]; then
+    echo "gitleaks.toml not found — secret scan SKIPPED" >&2
+    echo "  put bc-claude beside this repo, or set BC_GITLEAKS_CONFIG" >&2
+  elif ! gitleaks protect --staged --redact --no-banner -c "$bc_cfg"; then
+    echo ""
+    echo "  A staged change looks like a literal secret."
+    echo "  Use an env var instead:  SOME_SECRET: \${SOME_SECRET}"
+    echo "  False positive? Add an allowlist entry to:"
+    echo "    $bc_cfg"
+    exit 1
+  fi
+else
+  echo "gitleaks not installed — secret scan SKIPPED (brew install gitleaks)" >&2
+fi
+# <<< beancounter secret scan <<<
 echo "🔧 Running pre-commit checks..."
 
 # 1. Import path regression check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+echo "🧪 Running tests before push..."
+
+yarn test || exit 1
+
+echo "✅ All tests passed!"


### PR DESCRIPTION
Two changes, one subject: git hooks that actually reach every checkout.

## 1. Secret scan on pre-commit

Blocks a commit that stages a literal secret, using the shared gitleaks
config in `bc-claude/security/`. The block is generated by that repo's
`install-hooks.sh`.

The config path is resolved at **run time** rather than baked in. bc-view is
the one repo where this block lives in a tracked file — husky owns
`core.hooksPath`, so the hook is `.husky/pre-commit`, not `.git/hooks/`. An
absolute path from one machine would travel to every other clone, where
`-c` points at nothing, gitleaks exits non-zero, and the hook refuses
**every commit** behind a message about staged secrets.

Lookup order: `BC_GITLEAKS_CONFIG` → `bc-claude` beside this repo → the
checkout it was installed from. None found warns and scans nothing, rather
than blocking — a missing scanner must never be a blocked commit, which is
the rule the block already applied to a missing `gitleaks` binary.

Verified against a throwaway repo with a deliberately broken baked-in path:

| Case | Result |
|------|--------|
| clean file, config found via sibling | scan ran, commit passed |
| staged fake secret | commit refused, hint shows the resolved path |
| no config anywhere | warned, commit allowed |

## 2. Stop ignoring `.husky/`

`.gitignore` excluded `.husky/` while `.husky/pre-commit` was already
tracked — the rule landed after that file, so the directory has had two
hooks under opposite treatment ever since.

The casualty was **`.husky/pre-push`**, which runs the test suite before a
push and existed on one machine only. A fresh clone, or any fantail
worktree, pushed with no test gate and nothing said so. It is tracked here.

Nothing is lost by dropping the rule: husky generates
`.husky/_/.gitignore` containing `*`, so its plumbing already excludes
itself — confirmed with `git check-ignore` after the change.

## Not included

`package.json` still has `"prepare": "husky install"`. That form is
deprecated in husky v9 and removed in v10; it wants to be `"prepare":
"husky"`. Left out to keep this PR to one subject.

## Checks

`yarn test` 2442 passed / 244 suites · `yarn typecheck` clean ·
`yarn prettier` no-op · `yarn lint` one pre-existing `useEffect` deps
warning, untouched by this diff. `ocr` skipped it — shell hooks are not a
reviewable file type.
