### PR TITLE
chore(husky): prepare runs husky, not the removed install subcommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deps:update": "yarn upgrade-interactive",
     "check-imports": "node scripts/check-imports.js",
     "precommit": "lint-staged",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^4.26.0",


### PR DESCRIPTION
One word in `package.json`:

```diff
-"prepare": "husky install"
+"prepare": "husky"
```

## Why

We are on husky 9.1.7, where `husky install` is deprecated — it prints
`husky - install command is DEPRECATED` on every `yarn install`. In v10 the
subcommand is **removed**, at which point `yarn prepare` exits non-zero on a
fresh clone and the hooks are silently never wired: no secret scan, no
pre-push test gate.

## Verified after the change

- `yarn prepare` runs clean, no deprecation notice.
- `git config core.hooksPath` is still `.husky/_`.
- `.husky/_` regenerates its plumbing.
- The pre-commit hook fired on this very commit.

## Checks

`yarn test` 2442 passed / 244 suites · `yarn typecheck` clean ·
`yarn prettier` no-op · `yarn lint` one pre-existing `useEffect` deps
warning, untouched by this diff.

Independent of #1138 — different file, no overlap, either order merges.
