### PR TITLE
fix(trade): link Invest tab sizing and label the current holding

### DIFF
--- a/src/components/features/holdings/ActionsMenus.tsx
+++ b/src/components/features/holdings/ActionsMenus.tsx
@@ -145,9 +145,13 @@ export interface ActionsMenuProps {
   tradeCurrency: { code: string; symbol: string; name: string }
   valueIn: string
   held?: Record<string, number>
-  /** Trade-currency -> portfolio base-currency rate for the trade dialog's
-   * weight/target-sizing maths. Omitted for same-currency holdings. */
+  /** Displayed-currency -> portfolio-currency rate for the trade dialog's
+   * target-sizing maths. 1 when the row already shows portfolio currency. */
   fxRate?: number
+  /** The position's weight as svc-position computed it, in percent. Passed
+   * through so the dialog shows the same figure as the row rather than
+   * re-deriving one. */
+  currentWeight?: number
   onTrade?: (data: QuickSellData) => void
   onQuickSell?: (data: QuickSellData) => void
   onCorporateActions?: (data: CorporateActionsData) => void
@@ -175,6 +179,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
   tradeCurrency,
   held,
   fxRate,
+  currentWeight,
   onTrade,
   onQuickSell,
   onCorporateActions,
@@ -200,6 +205,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
     price,
     held,
     fxRate,
+    currentWeight,
   })
 
   const handle =

--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -594,6 +594,9 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
           modalOpen={tradeModalOpen}
           setModalOpen={handleTradeModalClose}
           initialValues={quickSellData}
+          // svc-position already weighed this holding; show its answer rather
+          // than deriving a second one that can disagree with the row.
+          currentWeightOverride={quickSellData?.currentWeight ?? null}
         />
       )}
       {cashModalOpen && (

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -43,7 +43,7 @@ import {
   CorporateActionsData,
   SectorWeightingsData,
 } from "./ActionsMenus"
-import { deriveTradeToBaseFxRate } from "@lib/trns/tradeFormHelpers"
+import { deriveTradeToPortfolioFxRate } from "@lib/trns/tradeFormHelpers"
 import { COPYABLE_HOLDING_COLUMNS } from "./constants"
 
 export type { CorporateActionsData, SectorWeightingsData }
@@ -211,14 +211,22 @@ export default function Rows({
                       fromDate={dateValues?.opened}
                       closedDate={dateValues?.closed}
                       quantity={quantityValues.total}
-                      price={moneyValues[valueIn].priceData?.close || 0}
+                      price={
+                        // A trade is denominated in the asset's own currency,
+                        // so the dialog gets the trade-currency price — not
+                        // the row's display-converted one.
+                        moneyValues["TRADE"]?.priceData?.close ||
+                        moneyValues[valueIn].priceData?.close ||
+                        0
+                      }
                       costBasis={moneyValues["TRADE"]?.costBasis || 0}
                       tradeCurrency={
                         moneyValues["TRADE"]?.currency || portfolio.currency
                       }
                       valueIn={valueIn}
                       held={held}
-                      fxRate={deriveTradeToBaseFxRate(moneyValues)}
+                      fxRate={deriveTradeToPortfolioFxRate(moneyValues)}
+                      currentWeight={moneyValues[valueIn].weight * 100}
                       onTrade={isCashRelated(asset) ? undefined : onTrade}
                       onQuickSell={
                         isCashRelated(asset) ? undefined : onQuickSell

--- a/src/components/features/holdings/__tests__/QuickSell.test.tsx
+++ b/src/components/features/holdings/__tests__/QuickSell.test.tsx
@@ -110,6 +110,9 @@ describe("Quick Sell Feature via Actions Menu", () => {
         price: 150,
         held: undefined,
         fxRate: 1,
+        // svc-position's own weight (0.5), forwarded as a percentage so the
+        // trade dialog shows the figure the row shows.
+        currentWeight: 50,
       })
     })
 
@@ -197,6 +200,9 @@ describe("Quick Sell Feature via Actions Menu", () => {
         price: 150,
         held: undefined,
         fxRate: 1,
+        // svc-position's own weight (0.5), forwarded as a percentage so the
+        // trade dialog shows the figure the row shows.
+        currentWeight: 50,
       })
     })
 

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -11,6 +11,7 @@ import {
   isExpenseType,
   isIncomeType,
   isSimpleAmountType,
+  isSellSide,
   deriveDefaultMarket,
   getTradeColorScheme,
   getQtyPriceTint,
@@ -42,6 +43,7 @@ import { convert } from "@lib/trns/tradeUtils"
 import {
   computeWeightInfo,
   computeCurrentPositionWeight,
+  computeResultingPositionWeight,
   calculateQuantityFromTargetWeight,
   calculateNewPositionQuantityFromTargetWeight,
   calculateQuantityFromTradeValue,
@@ -73,6 +75,9 @@ import {
 } from "@lib/trns/tradeFormConfig"
 import { useUserPreferences } from "@contexts/UserPreferencesContext"
 import { showPortfolioPicker } from "@lib/user/zenMode"
+
+/** Two decimals is the resolution money and weights are quoted at here. */
+const round2 = (value: number): number => Math.round(value * 100) / 100
 
 const TradeInputForm: React.FC<{
   portfolio: Portfolio
@@ -112,8 +117,6 @@ const TradeInputForm: React.FC<{
   const [copyStatus, setCopyStatus] = useState<"idle" | "success" | "error">(
     "idle",
   )
-  const [targetWeight, setTargetWeight] = useState<string>("")
-  const [tradeValue, setTradeValue] = useState<string>("")
   const [isFetchingPrice, setIsFetchingPrice] = useState(false)
   const [activeTab, setActiveTab] = useState<"trade" | "invest" | "settlement">(
     "trade",
@@ -145,6 +148,10 @@ const TradeInputForm: React.FC<{
   // Track whether the user has manually overridden computed trade amount.
   // When set, the auto-recalculation useEffect is skipped.
   const tradeAmountOverriddenRef = useRef(false)
+
+  // Set the first time the Invest tab is opened. From then on the Invest tab
+  // owns the trade size, so the Quick Sell quantity prefills stay out of it.
+  const investSeededRef = useRef(false)
 
   // Fetch portfolios for portfolio selection
   const { data: portfoliosData } = useSwr(
@@ -275,15 +282,13 @@ const TradeInputForm: React.FC<{
       // Edit mode: populate from transaction
       reset(buildEditModeValues(transaction))
       setSelectedPortfolioId(transaction.portfolio.id)
-      setTargetWeight("")
-      setTradeValue("")
+      investSeededRef.current = false
       setSubmitError(null)
       setActiveTab("trade")
     } else if (modalOpen && initialValues) {
       // Quick sell mode: populate from initialValues
       reset(buildQuickSellValues(initialValues, defaultValues))
-      setTargetWeight("")
-      setTradeValue("")
+      investSeededRef.current = false
       setActiveTab("trade")
     } else if (modalOpen && !initialValues && !isEditMode) {
       // Create mode: reset to defaults, using portfolio-appropriate market
@@ -294,8 +299,7 @@ const TradeInputForm: React.FC<{
           portfolio.currency.code,
         ),
       )
-      setTargetWeight("")
-      setTradeValue("")
+      investSeededRef.current = false
       setActiveTab("trade")
     }
   }, [
@@ -382,64 +386,83 @@ const TradeInputForm: React.FC<{
   // effect below), so a picker there would be redundant.
   const hasHeldBrokers = Object.keys(initialValues?.held ?? {}).length > 1
 
-  // Handle target weight change
-  const handleTargetWeightChange = (newTargetWeight: string): void => {
-    setTargetWeight(newTargetWeight)
-    if (currentPositionWeight === null) return
-    const result = calculateQuantityFromTargetWeight(
-      parseFloat(newTargetWeight),
-      currentPositionWeight,
-      price,
-      weightBasis,
-      fxRate,
-    )
-    if (!result) return
-    setValue("quantity", result.quantity)
-    setValue("type", { value: result.tradeType, label: result.tradeType })
-  }
-
-  // A brand-new position (no existing holding) has no current weight, but we
-  // can still size it to a target weight of the resulting, post-trade
-  // portfolio — provided the portfolio already has value to weigh against.
-  const newPositionTargetWeight = useMemo(
+  // A trade can be sized three equivalent ways — cash amount, share count,
+  // target weight. `quantity` is the one truth; the other two are derived from
+  // it, so editing any one of them moves the other two in the same render.
+  // (MathInput ignores incoming values while focused, so the field being typed
+  // into is never overwritten mid-keystroke.)
+  const investAmount = round2(quantity * price)
+  const resultingPositionQuantity = Math.max(
+    positionQty + (isSellSide(type?.value) ? -quantity : quantity),
+    0,
+  )
+  const deltaShares = resultingPositionQuantity - positionQty
+  const resultingPositionWeight = useMemo(
     () =>
+      computeResultingPositionWeight({
+        currentPositionQuantity: positionQty,
+        tradeQuantity: quantity,
+        tradeType: type?.value,
+        price,
+        portfolioMarketValue: weightBasis,
+        fxRate,
+      }),
+    [positionQty, quantity, type?.value, price, weightBasis, fxRate],
+  )
+  // A brand-new position has no current weight, but it can still be sized to a
+  // target weight of the resulting, post-trade portfolio — provided the
+  // portfolio already has value to weigh against.
+  const canTargetNewPositionWeight =
+    currentPositionWeight === null && price > 0 && weightBasis > 0
+  const canSizeByWeight =
+    (currentPositionWeight !== null && price > 0 && weightBasis > 0) ||
+    canTargetNewPositionWeight
+  const targetWeightValue =
+    resultingPositionWeight === null ? 0 : round2(resultingPositionWeight)
+
+  // Target weight is the weight the POSITION lands on. An existing holding is
+  // re-weighed against the same portfolio value; a new one grows it.
+  const handleTargetWeightChange = (newTargetWeight: number): void => {
+    if (newTargetWeight < 0) return
+    const result =
       currentPositionWeight === null
         ? calculateNewPositionQuantityFromTargetWeight(
-            parseFloat(targetWeight),
+            newTargetWeight,
             price,
             weightBasis,
             fxRate,
           )
-        : null,
-    [currentPositionWeight, targetWeight, price, weightBasis, fxRate],
-  )
-  const canTargetNewPositionWeight =
-    currentPositionWeight === null && price > 0 && weightBasis > 0
-
-  // Handle target weight change for a new (not-yet-held) position.
-  const handleNewPositionTargetWeightChange = (
-    newTargetWeight: string,
-  ): void => {
-    setTargetWeight(newTargetWeight)
-    const result = calculateNewPositionQuantityFromTargetWeight(
-      parseFloat(newTargetWeight),
-      price,
-      weightBasis,
-      fxRate,
-    )
+        : calculateQuantityFromTargetWeight(
+            newTargetWeight,
+            currentPositionWeight,
+            price,
+            weightBasis,
+            fxRate,
+          )
     if (!result) return
     setValue("quantity", result.quantity)
     setValue("type", { value: result.tradeType, label: result.tradeType })
   }
 
-  // Handle trade value change
-  const handleTradeValueChange = (newTradeValue: string): void => {
-    setTradeValue(newTradeValue)
-    const qty = calculateQuantityFromTradeValue(
-      parseFloat(newTradeValue),
-      price,
-    )
-    if (qty !== null) setValue("quantity", qty)
+  // Cash amount → the whole shares that amount buys at the current price.
+  const handleInvestAmountChange = (newInvestAmount: number): void => {
+    const qty = calculateQuantityFromTradeValue(newInvestAmount, price)
+    if (qty !== null) setValue("quantity", Math.max(qty, 0))
+  }
+
+  const handleTradeQuantityChange = (newQuantity: number): void => {
+    setValue("quantity", Math.max(newQuantity, 0))
+  }
+
+  // Opened from a holding, `quantity` arrives prefilled with the whole
+  // position — the Quick Sell affordance. On the Invest tab that reads as
+  // "double this holding", so the first visit starts from a clean slate and
+  // the holding is shown as context instead.
+  const openInvestTab = (): void => {
+    setActiveTab("invest")
+    if (investSeededRef.current) return
+    investSeededRef.current = true
+    if (positionQty > 0 && quantity === positionQty) setValue("quantity", 0)
   }
 
   // Fetch price for selected asset
@@ -675,8 +698,11 @@ const TradeInputForm: React.FC<{
   // Quick Sell: choosing a broker sets the quantity to that broker's holding
   // (the intent is to sell out one custodian's split-adjusted position). Only
   // fires when per-broker holdings are known (`held`); leaves the field alone
-  // for brokers that hold none, and is inert in edit mode (no `held`).
+  // for brokers that hold none, and is inert in edit mode (no `held`). Once
+  // the Invest tab owns the sizing, the broker only says where the trade
+  // executes — resizing the trade there would be wrong.
   useEffect(() => {
+    if (investSeededRef.current) return
     const brokerQty = heldQuantityForBroker(
       initialValues?.held,
       brokerId,
@@ -788,20 +814,12 @@ const TradeInputForm: React.FC<{
                   {!isSimpleAmount && !isEditMode && (
                     <button
                       type="button"
-                      disabled={needsPrice}
                       className={`flex-1 py-2 text-xs font-medium transition-colors ${
-                        needsPrice
-                          ? "text-gray-300 cursor-not-allowed"
-                          : activeTab === "invest"
-                            ? "border-b-2 border-purple-500 text-purple-600"
-                            : "text-gray-500 hover:text-gray-700"
+                        activeTab === "invest"
+                          ? "border-b-2 border-blue-500 text-blue-600"
+                          : "text-gray-500 hover:text-gray-700"
                       }`}
-                      onClick={() => {
-                        setActiveTab("invest")
-                        if (!tradeValue && tradeAmount) {
-                          setTradeValue(String(Math.abs(tradeAmount)))
-                        }
-                      }}
+                      onClick={openInvestTab}
                     >
                       {"Invest"}
                     </button>
@@ -1191,132 +1209,267 @@ const TradeInputForm: React.FC<{
               {/* === Invest Tab === */}
               {activeTab === "invest" && !isSimpleAmount && !isEditMode && (
                 <div className="space-y-4">
-                  <div>
-                    <label className={labelClass}>{"Invest Value"}</label>
-                    <p className="text-xs text-gray-500 mb-1">
-                      {"Enter amount to invest, quantity will be calculated"}
-                    </p>
+                  {/* Sizing — cash, shares and weight are three views of one
+                      trade. Editing any one moves the other two. */}
+                  <section className="rounded-lg border border-gray-200 p-3 space-y-3">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <label htmlFor="invest-amount" className={labelClass}>
+                        {isSellSide(type?.value)
+                          ? "Amount to raise"
+                          : "Amount to invest"}
+                      </label>
+                      <span
+                        data-testid="invest-direction"
+                        className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider transition-colors ${getTradeColorScheme(type?.value).bg} ${getTradeColorScheme(type?.value).text}`}
+                      >
+                        {type?.value || "BUY"}
+                      </span>
+                    </div>
                     <div className="relative">
                       <MathInput
-                        value={tradeValue ? parseFloat(tradeValue) : 0}
-                        onChange={(value) =>
-                          handleTradeValueChange(String(value))
-                        }
-                        placeholder={
-                          price > 0
-                            ? "Enter amount to invest"
-                            : "Set price first"
-                        }
+                        id="invest-amount"
+                        value={investAmount}
+                        onChange={handleInvestAmountChange}
+                        placeholder={price > 0 ? "0.00" : "Set a price first"}
                         disabled={!price || price <= 0}
-                        className={`${inputClass} disabled:bg-gray-100`}
+                        className={`${inputClass} pr-16 text-lg font-medium text-gray-900 disabled:bg-gray-100 disabled:text-gray-500`}
                       />
-                      {price > 0 && tradeValue && (
-                        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500">
-                          = {Math.floor(parseFloat(tradeValue) / price)} shares
-                        </span>
-                      )}
+                      <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-gray-500">
+                        {currentTradeCurrency}
+                      </span>
                     </div>
-                  </div>
 
-                  {currentPositionWeight !== null ? (
-                    <div className="bg-purple-50 border border-purple-200 rounded-lg p-3">
-                      <label className="block text-xs font-medium text-purple-800 mb-2">
-                        {"Target Weight"}
-                      </label>
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-xs text-purple-700">
-                          {"Current Weight"}:{" "}
-                          <strong>{currentPositionWeight.toFixed(2)}%</strong>
-                        </span>
-                        <span className="text-purple-400">&rarr;</span>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label htmlFor="invest-shares" className={labelClass}>
+                          {"Shares to trade"}
+                        </label>
                         <MathInput
-                          value={targetWeight ? parseFloat(targetWeight) : 0}
-                          onChange={(value) => {
-                            if (value >= 0) {
-                              handleTargetWeightChange(String(value))
-                            }
-                          }}
-                          placeholder={currentPositionWeight.toFixed(1)}
-                          className="w-20 px-2 py-2 border border-purple-300 rounded text-sm"
-                        />
-                        <span className="text-purple-600 text-sm">%</span>
-                      </div>
-                    </div>
-                  ) : canTargetNewPositionWeight ? (
-                    <div className="bg-purple-50 border border-purple-200 rounded-lg p-3">
-                      <label className="block text-xs font-medium text-purple-800 mb-2">
-                        {"Target Weight"}
-                      </label>
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-xs text-purple-700">
-                          {"New position"}
-                        </span>
-                        <span className="text-purple-400">&rarr;</span>
-                        <MathInput
-                          value={targetWeight ? parseFloat(targetWeight) : 0}
-                          onChange={(value) => {
-                            if (value >= 0) {
-                              handleNewPositionTargetWeightChange(String(value))
-                            }
-                          }}
-                          placeholder={"0.0"}
-                          className="w-20 px-2 py-2 border border-purple-300 rounded text-sm"
-                        />
-                        <span className="text-purple-600 text-sm">
-                          {"% of portfolio"}
-                        </span>
-                      </div>
-                      {newPositionTargetWeight && (
-                        <p className="mt-2 text-xs text-purple-700">
-                          {newPositionTargetWeight.quantity} {"shares · "}
-                          <NumericFormat
-                            value={newPositionTargetWeight.quantity * price}
-                            displayType="text"
-                            thousandSeparator
-                            decimalScale={2}
-                            fixedDecimalScale
-                            prefix="$"
-                          />
-                          {" of a "}
-                          <NumericFormat
-                            value={
-                              newPositionTargetWeight.nominalPortfolioValue
-                            }
-                            displayType="text"
-                            thousandSeparator
-                            decimalScale={2}
-                            fixedDecimalScale
-                            prefix="$"
-                          />
-                          {" portfolio"}
-                        </p>
-                      )}
-                    </div>
-                  ) : (
-                    <div className="bg-gray-50 border border-gray-200 rounded-lg p-3 text-center">
-                      <p className="text-xs text-gray-500">
-                        {
-                          "Target weight needs a price and an existing portfolio value"
-                        }
-                      </p>
-                    </div>
-                  )}
-
-                  {/* Charges */}
-                  <div>
-                    <label className={labelClass}>{"Fees"}</label>
-                    <Controller
-                      name="fees"
-                      control={control as any}
-                      render={({ field }) => (
-                        <MathInput
-                          value={field.value}
-                          onChange={field.onChange}
+                          id="invest-shares"
+                          value={quantity}
+                          onChange={handleTradeQuantityChange}
+                          placeholder="0"
                           className={inputClass}
                         />
-                      )}
-                    />
-                  </div>
+                      </div>
+                      <div>
+                        <label
+                          htmlFor="invest-target-weight"
+                          className={labelClass}
+                        >
+                          {"Target weight"}
+                        </label>
+                        <div className="relative">
+                          <MathInput
+                            id="invest-target-weight"
+                            value={targetWeightValue}
+                            onChange={handleTargetWeightChange}
+                            placeholder={canSizeByWeight ? "0.0" : "—"}
+                            disabled={!canSizeByWeight}
+                            className={`${inputClass} pr-7 disabled:bg-gray-100 disabled:text-gray-500`}
+                          />
+                          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
+                            {"%"}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+
+                    <p className="text-xs text-gray-500">
+                      {canSizeByWeight
+                        ? "Set any one — the other two follow."
+                        : "Target weight needs a price and a portfolio value to weigh against."}
+                    </p>
+
+                    {fees > 0 && price > 0 && (
+                      <div className="flex items-center justify-between border-t border-gray-100 pt-2 text-xs">
+                        <span className="text-gray-500">
+                          {isSellSide(type?.value)
+                            ? "Net proceeds after fees"
+                            : "Cash required including fees"}
+                        </span>
+                        <span className="font-mono tabular-nums text-gray-900">
+                          <NumericFormat
+                            value={Math.abs(tradeAmount)}
+                            displayType="text"
+                            thousandSeparator
+                            decimalScale={2}
+                            fixedDecimalScale
+                          />{" "}
+                          {currentTradeCurrency}
+                        </span>
+                      </div>
+                    )}
+                  </section>
+
+                  {/* What you hold now, and where this trade leaves it. */}
+                  <section className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+                    <div className="flex items-center gap-3">
+                      <div
+                        data-testid="invest-current-position"
+                        className="min-w-0 flex-1"
+                      >
+                        <p className="text-[11px] font-medium text-gray-500">
+                          {"Currently held"}
+                        </p>
+                        {currentPositionWeight === null ? (
+                          <>
+                            <p className="mt-1 font-mono text-base text-gray-400">
+                              {"—"}
+                            </p>
+                            <p className="text-xs text-gray-500">
+                              {"New position"}
+                            </p>
+                          </>
+                        ) : (
+                          <>
+                            <p className="mt-1 font-mono tabular-nums text-base text-gray-900">
+                              {positionQty.toLocaleString()}
+                            </p>
+                            <p className="text-xs text-gray-500">
+                              <NumericFormat
+                                value={positionQty * price}
+                                displayType="text"
+                                thousandSeparator
+                                decimalScale={2}
+                                fixedDecimalScale
+                              />{" "}
+                              {currentTradeCurrency}
+                            </p>
+                            <p className="mt-0.5 font-mono tabular-nums text-sm font-semibold text-gray-700">
+                              {currentPositionWeight.toFixed(2)}%
+                            </p>
+                          </>
+                        )}
+                      </div>
+
+                      <i
+                        className="fas fa-arrow-right shrink-0 text-gray-300"
+                        aria-hidden="true"
+                      ></i>
+
+                      <div
+                        data-testid="invest-resulting-position"
+                        className="min-w-0 flex-1 text-right"
+                      >
+                        <p className="text-[11px] font-medium text-gray-500">
+                          {"After this trade"}
+                        </p>
+                        <p className="mt-1 font-mono tabular-nums text-base text-gray-900">
+                          {resultingPositionQuantity.toLocaleString()}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          <NumericFormat
+                            value={resultingPositionQuantity * price}
+                            displayType="text"
+                            thousandSeparator
+                            decimalScale={2}
+                            fixedDecimalScale
+                          />{" "}
+                          {currentTradeCurrency}
+                        </p>
+                        {resultingPositionWeight !== null && (
+                          <p className="mt-0.5 font-mono tabular-nums text-sm font-semibold text-gray-900">
+                            {resultingPositionWeight.toFixed(2)}%
+                          </p>
+                        )}
+                        {deltaShares !== 0 && (
+                          <p
+                            className={`font-mono tabular-nums text-xs font-medium ${
+                              deltaShares > 0
+                                ? "text-emerald-700"
+                                : "text-red-700"
+                            }`}
+                          >
+                            {deltaShares > 0 ? "+" : "-"}
+                            {Math.abs(deltaShares).toLocaleString()}
+                            {" shares"}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </section>
+
+                  {/* Execution — the price the sizing divides by, what it
+                      costs, and which brokerage it goes through. */}
+                  <section className="space-y-3">
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label htmlFor="invest-price" className={labelClass}>
+                          {isFetchingPrice ? `${"Price"} ...` : "Price"}
+                        </label>
+                        <Controller
+                          name="price"
+                          control={control as any}
+                          render={({ field }) => (
+                            <MathInput
+                              id="invest-price"
+                              value={field.value}
+                              onChange={field.onChange}
+                              step="0.01"
+                              className={inputClass}
+                            />
+                          )}
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="invest-fees" className={labelClass}>
+                          {"Fees"}
+                        </label>
+                        <Controller
+                          name="fees"
+                          control={control as any}
+                          render={({ field }) => (
+                            <MathInput
+                              id="invest-fees"
+                              value={field.value}
+                              onChange={field.onChange}
+                              className={inputClass}
+                            />
+                          )}
+                        />
+                      </div>
+                    </div>
+
+                    {acceptsBroker(type?.value) && (
+                      <div>
+                        <div className="mb-1 flex items-center justify-between">
+                          <label htmlFor="invest-broker" className={labelClass}>
+                            {"Broker"}
+                          </label>
+                          <a
+                            href="/brokers"
+                            target="_blank"
+                            className="text-xs text-blue-500 hover:text-blue-700"
+                          >
+                            {"Manage"}
+                          </a>
+                        </div>
+                        <Controller
+                          name="brokerId"
+                          control={control as any}
+                          render={({ field }) => (
+                            <select
+                              id="invest-broker"
+                              className={inputClass}
+                              value={field.value || ""}
+                              onChange={(e) => field.onChange(e.target.value)}
+                            >
+                              <option value="">{"-- No broker --"}</option>
+                              {brokers.map((broker) => (
+                                <option key={broker.id} value={broker.id}>
+                                  {broker.name}
+                                  {broker.accountNumber
+                                    ? ` (${broker.accountNumber})`
+                                    : ""}
+                                </option>
+                              ))}
+                            </select>
+                          )}
+                        />
+                      </div>
+                    )}
+                  </section>
                 </div>
               )}
 

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -447,10 +447,14 @@ const TradeInputForm: React.FC<{
   // Cash amount → the whole shares that amount buys at the current price.
   const handleInvestAmountChange = (newInvestAmount: number): void => {
     const qty = calculateQuantityFromTradeValue(newInvestAmount, price)
-    if (qty !== null) setValue("quantity", Math.max(qty, 0))
+    if (qty !== null && Number.isFinite(qty))
+      setValue("quantity", Math.max(qty, 0))
   }
 
+  // Guarded: a non-finite quantity would propagate NaN through every derived
+  // figure on the tab (amount, weight, the whole ledger).
   const handleTradeQuantityChange = (newQuantity: number): void => {
+    if (!Number.isFinite(newQuantity)) return
     setValue("quantity", Math.max(newQuantity, 0))
   }
 
@@ -521,7 +525,10 @@ const TradeInputForm: React.FC<{
 
   useEffect(() => {
     if (tradeAmountOverriddenRef.current) return
-    if (quantity && price) {
+    // EXPENSE/INCOME carry a hand-entered amount with no quantity behind it —
+    // never derive over the top of it.
+    if (isSimpleAmountType(type.value)) return
+    if (quantity || price) {
       const tradeAmount = calculateTradeAmount(
         quantity,
         price,
@@ -1702,7 +1709,10 @@ const TradeInputForm: React.FC<{
                   >
                     {type?.value || "BUY"}
                   </span>
-                  <span className="font-semibold text-gray-900 tabular-nums">
+                  <span
+                    data-testid="trade-summary-amount"
+                    className="font-semibold text-gray-900 tabular-nums"
+                  >
                     <NumericFormat
                       value={tradeAmount}
                       displayType="text"

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -396,7 +396,6 @@ const TradeInputForm: React.FC<{
     positionQty + (isSellSide(type?.value) ? -quantity : quantity),
     0,
   )
-  const deltaShares = resultingPositionQuantity - positionQty
   const resultingPositionWeight = useMemo(
     () =>
       computeResultingPositionWeight({
@@ -821,10 +820,13 @@ const TradeInputForm: React.FC<{
                   {!isSimpleAmount && !isEditMode && (
                     <button
                       type="button"
+                      disabled={needsPrice}
                       className={`flex-1 py-2 text-xs font-medium transition-colors ${
-                        activeTab === "invest"
-                          ? "border-b-2 border-blue-500 text-blue-600"
-                          : "text-gray-500 hover:text-gray-700"
+                        needsPrice
+                          ? "text-gray-300 cursor-not-allowed"
+                          : activeTab === "invest"
+                            ? "border-b-2 border-blue-500 text-blue-600"
+                            : "text-gray-500 hover:text-gray-700"
                       }`}
                       onClick={openInvestTab}
                     >
@@ -1075,7 +1077,10 @@ const TradeInputForm: React.FC<{
                     <div
                       className={`rounded-lg p-3 ${getQtyPriceTint(type?.value)}`}
                     >
-                      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                      {/* Three across at every width — wrapping Fees onto its
+                          own row is what pushes Broker below the fold on a
+                          phone. */}
+                      <div className="grid grid-cols-3 gap-2 sm:gap-3">
                         <div>
                           <label className={labelClass}>
                             {actualPositionQuantity > 0 ? (
@@ -1128,7 +1133,7 @@ const TradeInputForm: React.FC<{
                             )}
                           />
                         </div>
-                        <div className="col-span-2 sm:col-span-1">
+                        <div>
                           <label className={labelClass}>{"Fees"}</label>
                           <Controller
                             name="fees"
@@ -1215,232 +1220,156 @@ const TradeInputForm: React.FC<{
 
               {/* === Invest Tab === */}
               {activeTab === "invest" && !isSimpleAmount && !isEditMode && (
-                <div className="space-y-4">
-                  {/* Sizing — cash, shares and weight are three views of one
-                      trade. Editing any one moves the other two. */}
-                  <section className="rounded-lg border border-gray-200 p-3 space-y-3">
-                    <div className="flex items-baseline justify-between gap-2">
+                <div className="space-y-3">
+                  {/* Cash, shares and weight are three views of one trade —
+                      set any one and the other two follow. The summary strip
+                      below the form carries the headline total and direction,
+                      so nothing here restates them. */}
+                  <div className="grid grid-cols-3 gap-2 sm:gap-3">
+                    <div>
                       <label htmlFor="invest-amount" className={labelClass}>
-                        {isSellSide(type?.value)
-                          ? "Amount to raise"
-                          : "Amount to invest"}
+                        {isSellSide(type?.value) ? "Raise" : "Invest"}
                       </label>
-                      <span
-                        data-testid="invest-direction"
-                        className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider transition-colors ${getTradeColorScheme(type?.value).bg} ${getTradeColorScheme(type?.value).text}`}
-                      >
-                        {type?.value || "BUY"}
-                      </span>
-                    </div>
-                    <div className="relative">
-                      <MathInput
-                        id="invest-amount"
-                        value={investAmount}
-                        onChange={handleInvestAmountChange}
-                        placeholder={price > 0 ? "0.00" : "Set a price first"}
-                        disabled={!price || price <= 0}
-                        className={`${inputClass} pr-16 text-lg font-medium text-gray-900 disabled:bg-gray-100 disabled:text-gray-500`}
-                      />
-                      <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-gray-500">
-                        {currentTradeCurrency}
-                      </span>
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-3">
-                      <div>
-                        <label htmlFor="invest-shares" className={labelClass}>
-                          {"Shares to trade"}
-                        </label>
+                      <div className="relative">
                         <MathInput
-                          id="invest-shares"
-                          value={quantity}
-                          onChange={handleTradeQuantityChange}
-                          placeholder="0"
-                          className={inputClass}
+                          id="invest-amount"
+                          value={investAmount}
+                          onChange={handleInvestAmountChange}
+                          placeholder="0.00"
+                          className={`${inputClass} pr-11`}
                         />
-                      </div>
-                      <div>
-                        <label
-                          htmlFor="invest-target-weight"
-                          className={labelClass}
-                        >
-                          {"Target weight"}
-                        </label>
-                        <div className="relative">
-                          <MathInput
-                            id="invest-target-weight"
-                            value={targetWeightValue}
-                            onChange={handleTargetWeightChange}
-                            placeholder={canSizeByWeight ? "0.0" : "—"}
-                            disabled={!canSizeByWeight}
-                            className={`${inputClass} pr-7 disabled:bg-gray-100 disabled:text-gray-500`}
-                          />
-                          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
-                            {"%"}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-
-                    <p className="text-xs text-gray-500">
-                      {canSizeByWeight
-                        ? "Set any one — the other two follow."
-                        : "Target weight needs a price and a portfolio value to weigh against."}
-                    </p>
-
-                    {fees > 0 && price > 0 && (
-                      <div className="flex items-center justify-between border-t border-gray-100 pt-2 text-xs">
-                        <span className="text-gray-500">
-                          {isSellSide(type?.value)
-                            ? "Net proceeds after fees"
-                            : "Cash required including fees"}
-                        </span>
-                        <span className="font-mono tabular-nums text-gray-900">
-                          <NumericFormat
-                            value={Math.abs(tradeAmount)}
-                            displayType="text"
-                            thousandSeparator
-                            decimalScale={2}
-                            fixedDecimalScale
-                          />{" "}
+                        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-medium text-gray-500">
                           {currentTradeCurrency}
                         </span>
                       </div>
-                    )}
-                  </section>
+                    </div>
+                    <div>
+                      <label htmlFor="invest-shares" className={labelClass}>
+                        {"Shares"}
+                      </label>
+                      <MathInput
+                        id="invest-shares"
+                        value={quantity}
+                        onChange={handleTradeQuantityChange}
+                        placeholder="0"
+                        className={inputClass}
+                      />
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="invest-target-weight"
+                        className={labelClass}
+                      >
+                        {"Target"}
+                      </label>
+                      <div className="relative">
+                        <MathInput
+                          id="invest-target-weight"
+                          value={targetWeightValue}
+                          onChange={handleTargetWeightChange}
+                          placeholder={canSizeByWeight ? "0.0" : "—"}
+                          disabled={!canSizeByWeight}
+                          className={`${inputClass} pr-7 disabled:bg-gray-100 disabled:text-gray-500`}
+                        />
+                        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-sm text-gray-500">
+                          {"%"}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
 
                   {/* What you hold now, and where this trade leaves it. */}
-                  <section className="rounded-lg border border-gray-200 bg-gray-50 p-3">
-                    <div className="flex items-center gap-3">
-                      <div
-                        data-testid="invest-current-position"
-                        className="min-w-0 flex-1"
-                      >
-                        <p className="text-[11px] font-medium text-gray-500">
-                          {"Currently held"}
-                        </p>
-                        {currentPositionWeight === null ? (
-                          <>
-                            <p className="mt-1 font-mono text-base text-gray-400">
-                              {"—"}
-                            </p>
-                            <p className="text-xs text-gray-500">
-                              {"New position"}
-                            </p>
-                          </>
-                        ) : (
-                          <>
-                            <p className="mt-1 font-mono tabular-nums text-base text-gray-900">
-                              {positionQty.toLocaleString()}
-                            </p>
-                            <p className="text-xs text-gray-500">
-                              <NumericFormat
-                                value={positionQty * price}
-                                displayType="text"
-                                thousandSeparator
-                                decimalScale={2}
-                                fixedDecimalScale
-                              />{" "}
-                              {currentTradeCurrency}
-                            </p>
-                            <p className="mt-0.5 font-mono tabular-nums text-sm font-semibold text-gray-700">
-                              {currentPositionWeight.toFixed(2)}%
-                            </p>
-                          </>
-                        )}
-                      </div>
+                  <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+                    <div className="grid grid-cols-[1fr_minmax(4.5rem,auto)_minmax(4.5rem,auto)] items-baseline gap-x-3">
+                      <span />
+                      <span className="text-right text-[10px] font-medium uppercase tracking-wide text-gray-500">
+                        {"Current"}
+                      </span>
+                      <span className="text-right text-[10px] font-medium uppercase tracking-wide text-gray-500">
+                        {"After"}
+                      </span>
 
-                      <i
-                        className="fas fa-arrow-right shrink-0 text-gray-300"
-                        aria-hidden="true"
-                      ></i>
-
-                      <div
-                        data-testid="invest-resulting-position"
-                        className="min-w-0 flex-1 text-right"
+                      <span className="text-xs text-gray-500">
+                        {"Value"}
+                        <span className="text-gray-400">
+                          {" "}
+                          {portfolio.currency.code}
+                        </span>
+                      </span>
+                      <span
+                        data-testid="invest-current-value"
+                        className="text-right font-mono text-xs tabular-nums text-gray-600"
                       >
-                        <p className="text-[11px] font-medium text-gray-500">
-                          {"After this trade"}
-                        </p>
-                        <p className="mt-1 font-mono tabular-nums text-base text-gray-900">
-                          {resultingPositionQuantity.toLocaleString()}
-                        </p>
-                        <p className="text-xs text-gray-500">
+                        {positionQty > 0 ? (
                           <NumericFormat
-                            value={resultingPositionQuantity * price}
+                            value={positionQty * price * fxRate}
                             displayType="text"
                             thousandSeparator
                             decimalScale={2}
                             fixedDecimalScale
-                          />{" "}
-                          {currentTradeCurrency}
-                        </p>
-                        {resultingPositionWeight !== null && (
-                          <p className="mt-0.5 font-mono tabular-nums text-sm font-semibold text-gray-900">
-                            {resultingPositionWeight.toFixed(2)}%
-                          </p>
+                          />
+                        ) : (
+                          "—"
                         )}
-                        {deltaShares !== 0 && (
-                          <p
-                            className={`font-mono tabular-nums text-xs font-medium ${
-                              deltaShares > 0
-                                ? "text-emerald-700"
-                                : "text-red-700"
-                            }`}
-                          >
-                            {deltaShares > 0 ? "+" : "-"}
-                            {Math.abs(deltaShares).toLocaleString()}
-                            {" shares"}
-                          </p>
+                      </span>
+                      <span
+                        data-testid="invest-after-value"
+                        className="text-right font-mono text-xs tabular-nums text-gray-900"
+                      >
+                        <NumericFormat
+                          value={resultingPositionQuantity * price * fxRate}
+                          displayType="text"
+                          thousandSeparator
+                          decimalScale={2}
+                          fixedDecimalScale
+                        />
+                      </span>
+
+                      <span className="text-xs text-gray-500">{"Weight"}</span>
+                      <span
+                        data-testid="invest-current-weight"
+                        className="text-right font-mono text-sm tabular-nums text-gray-600"
+                      >
+                        {currentPositionWeight === null
+                          ? "—"
+                          : `${currentPositionWeight.toFixed(2)}%`}
+                      </span>
+                      <span
+                        data-testid="invest-after-weight"
+                        className="text-right font-mono text-sm font-semibold tabular-nums text-gray-900"
+                      >
+                        {resultingPositionWeight === null
+                          ? "—"
+                          : `${resultingPositionWeight.toFixed(2)}%`}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Fees and where the trade executes. Price stays on the
+                      Trade tab — it describes the asset, not the sizing. */}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div
+                      className={acceptsBroker(type?.value) ? "" : "col-span-2"}
+                    >
+                      <label htmlFor="invest-fees" className={labelClass}>
+                        {"Fees"}
+                      </label>
+                      <Controller
+                        name="fees"
+                        control={control as any}
+                        render={({ field }) => (
+                          <MathInput
+                            id="invest-fees"
+                            value={field.value}
+                            onChange={field.onChange}
+                            className={inputClass}
+                          />
                         )}
-                      </div>
+                      />
                     </div>
-                  </section>
-
-                  {/* Execution — the price the sizing divides by, what it
-                      costs, and which brokerage it goes through. */}
-                  <section className="space-y-3">
-                    <div className="grid grid-cols-2 gap-3">
-                      <div>
-                        <label htmlFor="invest-price" className={labelClass}>
-                          {isFetchingPrice ? `${"Price"} ...` : "Price"}
-                        </label>
-                        <Controller
-                          name="price"
-                          control={control as any}
-                          render={({ field }) => (
-                            <MathInput
-                              id="invest-price"
-                              value={field.value}
-                              onChange={field.onChange}
-                              step="0.01"
-                              className={inputClass}
-                            />
-                          )}
-                        />
-                      </div>
-                      <div>
-                        <label htmlFor="invest-fees" className={labelClass}>
-                          {"Fees"}
-                        </label>
-                        <Controller
-                          name="fees"
-                          control={control as any}
-                          render={({ field }) => (
-                            <MathInput
-                              id="invest-fees"
-                              value={field.value}
-                              onChange={field.onChange}
-                              className={inputClass}
-                            />
-                          )}
-                        />
-                      </div>
-                    </div>
-
                     {acceptsBroker(type?.value) && (
                       <div>
-                        <div className="mb-1 flex items-center justify-between">
+                        <div className="flex items-center justify-between">
                           <label htmlFor="invest-broker" className={labelClass}>
                             {"Broker"}
                           </label>
@@ -1476,7 +1405,7 @@ const TradeInputForm: React.FC<{
                         />
                       </div>
                     )}
-                  </section>
+                  </div>
                 </div>
               )}
 
@@ -1705,6 +1634,7 @@ const TradeInputForm: React.FC<{
                   className={`shrink-0 rounded-lg px-3 py-2 flex items-center justify-center gap-3 text-sm ${colors.bg} border ${colors.border}`}
                 >
                   <span
+                    data-testid="trade-summary-type"
                     className={`text-[10px] font-semibold uppercase tracking-wider ${colors.text}`}
                   >
                     {type?.value || "BUY"}

--- a/src/components/features/transactions/__tests__/TradeInputForm.invest.test.tsx
+++ b/src/components/features/transactions/__tests__/TradeInputForm.invest.test.tsx
@@ -1,0 +1,200 @@
+import React from "react"
+import { render, screen, fireEvent, within } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import TradeInputForm from "../TradeInputForm"
+import { makePortfolio, USD } from "@test-fixtures/beancounter"
+
+// The Invest tab sizes a trade three equivalent ways — cash amount, share
+// count, target weight. These tests pin the rule that all three stay in step
+// with the single underlying quantity, whichever one the user edits.
+
+const mockBrokers = {
+  data: [
+    { id: "ib", name: "Interactive Brokers", settlementAccounts: [] },
+    { id: "asb", name: "ASB Securities", settlementAccounts: [] },
+  ],
+}
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (!key) return { data: undefined, error: undefined, isLoading: false }
+    if (key.includes("brokers"))
+      return { data: mockBrokers, error: undefined, isLoading: false }
+    if (key.includes("portfolios"))
+      return {
+        data: { data: [] },
+        error: undefined,
+        isLoading: false,
+      }
+    if (key.includes("markets"))
+      return {
+        data: {
+          data: [{ code: "NASDAQ", name: "NASDAQ", currency: { code: "USD" } }],
+        },
+        error: undefined,
+        isLoading: false,
+      }
+    if (key.includes("currencies"))
+      return {
+        data: { data: [{ code: "USD" }] },
+        error: undefined,
+        isLoading: false,
+      }
+    return { data: { data: [] }, error: undefined, isLoading: false }
+  },
+  mutate: jest.fn(),
+}))
+
+jest.mock("@contexts/UserPreferencesContext", () => ({
+  useUserPreferences: () => ({
+    preferences: { id: "u1" },
+    isLoading: false,
+    refetch: jest.fn(),
+  }),
+}))
+
+// AssetSearch reaches for the asset API on mount; the Invest tab doesn't
+// exercise it, so a stub keeps the test to the sizing behaviour.
+jest.mock("@components/features/assets/AssetSearch", () => ({
+  __esModule: true,
+  default: () => <input aria-label="Asset" readOnly />,
+}))
+
+const portfolio = makePortfolio({
+  marketValue: 10000,
+  currency: USD,
+  base: USD,
+})
+
+// A holding of 100 @ 10 in a 10,000 portfolio: 1,000 held = 10% weight.
+const heldPosition = {
+  asset: "AAPL",
+  assetId: "a-1",
+  market: "NASDAQ",
+  quantity: 100,
+  price: 10,
+  currency: "USD",
+  type: "BUY" as const,
+}
+
+const renderInvestTab = (
+  initialValues: Record<string, unknown> = heldPosition,
+): void => {
+  render(
+    <TradeInputForm
+      portfolio={portfolio}
+      modalOpen={true}
+      setModalOpen={jest.fn()}
+      initialValues={initialValues as never}
+    />,
+  )
+  fireEvent.click(screen.getByRole("button", { name: "Invest" }))
+}
+
+const amountField = (): HTMLInputElement =>
+  screen.getByLabelText("Amount to invest") as HTMLInputElement
+const sharesField = (): HTMLInputElement =>
+  screen.getByLabelText("Shares to trade") as HTMLInputElement
+const weightField = (): HTMLInputElement =>
+  screen.getByLabelText("Target weight") as HTMLInputElement
+
+describe("TradeInputForm — Invest tab", () => {
+  test("labels the current holding rather than leaving its figures unexplained", () => {
+    renderInvestTab()
+
+    const held = screen.getByTestId("invest-current-position")
+    expect(within(held).getByText(/Currently held/i)).toBeInTheDocument()
+    expect(within(held).getByText("100")).toBeInTheDocument()
+    expect(within(held).getByText("10.00%")).toBeInTheDocument()
+  })
+
+  test("a target weight change flows through to the amount and share count", () => {
+    renderInvestTab()
+
+    fireEvent.change(weightField(), { target: { value: "15" } })
+
+    // 15% of 10,000 = 1,500 against 1,000 held → buy 50 shares for 500.
+    expect(sharesField()).toHaveValue("50")
+    expect(amountField()).toHaveValue("500")
+  })
+
+  test("an amount change flows through to the share count and target weight", () => {
+    renderInvestTab()
+
+    fireEvent.change(amountField(), { target: { value: "1000" } })
+
+    // 1,000 buys 100 shares, taking the holding to 2,000 of 10,000 = 20%.
+    expect(sharesField()).toHaveValue("100")
+    expect(weightField()).toHaveValue("20")
+  })
+
+  test("a share-count change flows through to the amount and target weight", () => {
+    renderInvestTab()
+
+    fireEvent.change(sharesField(), { target: { value: "25" } })
+
+    expect(amountField()).toHaveValue("250")
+    expect(weightField()).toHaveValue("12.5")
+  })
+
+  test("a target weight below the current one sizes a SELL", () => {
+    renderInvestTab()
+
+    fireEvent.change(weightField(), { target: { value: "4" } })
+
+    expect(sharesField()).toHaveValue("60")
+    expect(screen.getByTestId("invest-direction")).toHaveTextContent("SELL")
+  })
+
+  test("shows the resulting position beside the current one", () => {
+    renderInvestTab()
+
+    fireEvent.change(weightField(), { target: { value: "15" } })
+
+    const after = screen.getByTestId("invest-resulting-position")
+    expect(within(after).getByText("150")).toBeInTheDocument()
+    expect(within(after).getByText("15.00%")).toBeInTheDocument()
+  })
+
+  test("the broker can be changed without leaving the tab", () => {
+    renderInvestTab()
+
+    const broker = screen.getByLabelText("Broker") as HTMLSelectElement
+    fireEvent.change(broker, { target: { value: "asb" } })
+    expect(broker.value).toBe("asb")
+  })
+
+  test("price is editable on the tab that divides by it", () => {
+    renderInvestTab()
+
+    fireEvent.change(sharesField(), { target: { value: "10" } })
+    expect(amountField()).toHaveValue("100")
+
+    fireEvent.change(screen.getByLabelText("Price"), {
+      target: { value: "20" },
+    })
+    expect(amountField()).toHaveValue("200")
+  })
+
+  test("a brand-new position sizes against the post-trade portfolio", () => {
+    renderInvestTab({
+      asset: "MSFT",
+      assetId: "a-2",
+      market: "NASDAQ",
+      quantity: 0,
+      price: 10,
+      currency: "USD",
+      type: "BUY",
+    })
+
+    expect(screen.getByTestId("invest-current-position")).toHaveTextContent(
+      /New position/i,
+    )
+
+    fireEvent.change(weightField(), { target: { value: "50" } })
+    // V / (10,000 + V) = 50% → V = 10,000 → 1,000 shares.
+    expect(sharesField()).toHaveValue("1000")
+    expect(amountField()).toHaveValue("10000")
+  })
+})

--- a/src/components/features/transactions/__tests__/TradeInputForm.invest.test.tsx
+++ b/src/components/features/transactions/__tests__/TradeInputForm.invest.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen, fireEvent, within } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import TradeInputForm from "../TradeInputForm"
 import { makePortfolio, USD } from "@test-fixtures/beancounter"
@@ -93,20 +93,23 @@ const renderInvestTab = (
 }
 
 const amountField = (): HTMLInputElement =>
-  screen.getByLabelText("Amount to invest") as HTMLInputElement
+  screen.getByLabelText(/^(Invest|Raise)$/) as HTMLInputElement
 const sharesField = (): HTMLInputElement =>
-  screen.getByLabelText("Shares to trade") as HTMLInputElement
+  screen.getByLabelText("Shares") as HTMLInputElement
 const weightField = (): HTMLInputElement =>
-  screen.getByLabelText("Target weight") as HTMLInputElement
+  screen.getByLabelText("Target") as HTMLInputElement
 
 describe("TradeInputForm — Invest tab", () => {
   test("labels the current holding rather than leaving its figures unexplained", () => {
     renderInvestTab()
 
-    const held = screen.getByTestId("invest-current-position")
-    expect(within(held).getByText(/Currently held/i)).toBeInTheDocument()
-    expect(within(held).getByText("100")).toBeInTheDocument()
-    expect(within(held).getByText("10.00%")).toBeInTheDocument()
+    expect(screen.getByText("Current")).toBeInTheDocument()
+    expect(screen.getByTestId("invest-current-value")).toHaveTextContent(
+      "1,000.00",
+    )
+    expect(screen.getByTestId("invest-current-weight")).toHaveTextContent(
+      "10.00%",
+    )
   })
 
   test("the trade summary follows the tab down to nothing-yet-sized", () => {
@@ -152,7 +155,8 @@ describe("TradeInputForm — Invest tab", () => {
     fireEvent.change(weightField(), { target: { value: "4" } })
 
     expect(sharesField()).toHaveValue("60")
-    expect(screen.getByTestId("invest-direction")).toHaveTextContent("SELL")
+    // Direction lives in the summary strip only — the tab does not restate it.
+    expect(screen.getByTestId("trade-summary-type")).toHaveTextContent("SELL")
   })
 
   test("shows the resulting position beside the current one", () => {
@@ -160,9 +164,12 @@ describe("TradeInputForm — Invest tab", () => {
 
     fireEvent.change(weightField(), { target: { value: "15" } })
 
-    const after = screen.getByTestId("invest-resulting-position")
-    expect(within(after).getByText("150")).toBeInTheDocument()
-    expect(within(after).getByText("15.00%")).toBeInTheDocument()
+    expect(screen.getByTestId("invest-after-value")).toHaveTextContent(
+      "1,500.00",
+    )
+    expect(screen.getByTestId("invest-after-weight")).toHaveTextContent(
+      "15.00%",
+    )
   })
 
   test("the broker can be changed without leaving the tab", () => {
@@ -173,16 +180,10 @@ describe("TradeInputForm — Invest tab", () => {
     expect(broker.value).toBe("asb")
   })
 
-  test("price is editable on the tab that divides by it", () => {
+  test("price stays on the Trade tab — it describes the asset, not the sizing", () => {
     renderInvestTab()
 
-    fireEvent.change(sharesField(), { target: { value: "10" } })
-    expect(amountField()).toHaveValue("100")
-
-    fireEvent.change(screen.getByLabelText("Price"), {
-      target: { value: "20" },
-    })
-    expect(amountField()).toHaveValue("200")
+    expect(screen.queryByLabelText("Price")).not.toBeInTheDocument()
   })
 
   test("a brand-new position sizes against the post-trade portfolio", () => {
@@ -196,9 +197,8 @@ describe("TradeInputForm — Invest tab", () => {
       type: "BUY",
     })
 
-    expect(screen.getByTestId("invest-current-position")).toHaveTextContent(
-      /New position/i,
-    )
+    expect(screen.getByTestId("invest-current-weight")).toHaveTextContent("—")
+    expect(screen.getByTestId("invest-current-value")).toHaveTextContent("—")
 
     fireEvent.change(weightField(), { target: { value: "50" } })
     // V / (10,000 + V) = 50% → V = 10,000 → 1,000 shares.

--- a/src/components/features/transactions/__tests__/TradeInputForm.invest.test.tsx
+++ b/src/components/features/transactions/__tests__/TradeInputForm.invest.test.tsx
@@ -109,6 +109,14 @@ describe("TradeInputForm — Invest tab", () => {
     expect(within(held).getByText("10.00%")).toBeInTheDocument()
   })
 
+  test("the trade summary follows the tab down to nothing-yet-sized", () => {
+    // Opened from a holding the quantity arrives prefilled with the whole
+    // position; the Invest tab clears it, and the summary strip has to agree.
+    renderInvestTab()
+
+    expect(screen.getByTestId("trade-summary-amount")).toHaveTextContent("0.00")
+  })
+
   test("a target weight change flows through to the amount and share count", () => {
     renderInvestTab()
 

--- a/src/lib/utils/trns/tradeFormHelpers.test.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.test.ts
@@ -1,6 +1,7 @@
 import {
   computeWeightInfo,
   computeCurrentPositionWeight,
+  computeResultingPositionWeight,
   calculateQuantityFromTargetWeight,
   calculateNewPositionQuantityFromTargetWeight,
   calculateQuantityFromTradeValue,
@@ -1003,6 +1004,134 @@ describe("tradeFormHelpers", () => {
           quantity: 50,
         }),
       ).toBe(25)
+    })
+  })
+
+  describe("computeResultingPositionWeight", () => {
+    test("adds a BUY to an existing holding against a fixed portfolio value", () => {
+      // 100 held @ 10 in a 10,000 portfolio = 10%. Buying 50 more takes the
+      // position to 150 * 10 = 1,500 of the same 10,000 = 15%.
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 100,
+          tradeQuantity: 50,
+          tradeType: "BUY",
+          price: 10,
+          portfolioMarketValue: 10000,
+        }),
+      ).toBeCloseTo(15, 6)
+    })
+
+    test("subtracts a SELL from an existing holding", () => {
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 100,
+          tradeQuantity: 50,
+          tradeType: "SELL",
+          price: 10,
+          portfolioMarketValue: 10000,
+        }),
+      ).toBeCloseTo(5, 6)
+    })
+
+    test("selling the whole holding lands on 0%", () => {
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 100,
+          tradeQuantity: 100,
+          tradeType: "SELL",
+          price: 10,
+          portfolioMarketValue: 10000,
+        }),
+      ).toBe(0)
+    })
+
+    test("a new position grows the portfolio it is weighed against", () => {
+      // No holding yet: the buy is funded from outside, so 1,000 of new value
+      // in a 10,000 portfolio is 1000/11000 — matching the sizing helper.
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 0,
+          tradeQuantity: 100,
+          tradeType: "BUY",
+          price: 10,
+          portfolioMarketValue: 10000,
+        }),
+      ).toBeCloseTo((1000 / 11000) * 100, 6)
+    })
+
+    test("converts the trade-currency price to base via fxRate", () => {
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 100,
+          tradeQuantity: 0,
+          tradeType: "BUY",
+          price: 10,
+          portfolioMarketValue: 10000,
+          fxRate: 2,
+        }),
+      ).toBeCloseTo(20, 6)
+    })
+
+    test("returns null without a price or a portfolio to weigh against", () => {
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 100,
+          tradeQuantity: 10,
+          tradeType: "BUY",
+          price: 0,
+          portfolioMarketValue: 10000,
+        }),
+      ).toBeNull()
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 100,
+          tradeQuantity: 10,
+          tradeType: "BUY",
+          price: 10,
+          portfolioMarketValue: 0,
+        }),
+      ).toBeNull()
+    })
+
+    test("round-trips the existing-holding target weight it was sized from", () => {
+      const sized = calculateQuantityFromTargetWeight(15, 10, 10, 10000)!
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 100,
+          tradeQuantity: sized.quantity,
+          tradeType: sized.tradeType,
+          price: 10,
+          portfolioMarketValue: 10000,
+        }),
+      ).toBeCloseTo(15, 6)
+    })
+
+    test("round-trips a SELL-side target weight", () => {
+      const sized = calculateQuantityFromTargetWeight(4, 10, 10, 10000)!
+      expect(sized.tradeType).toBe("SELL")
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 100,
+          tradeQuantity: sized.quantity,
+          tradeType: sized.tradeType,
+          price: 10,
+          portfolioMarketValue: 10000,
+        }),
+      ).toBeCloseTo(4, 6)
+    })
+
+    test("round-trips the new-position target weight it was sized from", () => {
+      const sized = calculateNewPositionQuantityFromTargetWeight(70, 10, 30000)!
+      expect(
+        computeResultingPositionWeight({
+          currentPositionQuantity: 0,
+          tradeQuantity: sized.quantity,
+          tradeType: sized.tradeType,
+          price: 10,
+          portfolioMarketValue: 30000,
+        }),
+      ).toBeCloseTo(70, 6)
     })
   })
 })

--- a/src/lib/utils/trns/tradeFormHelpers.test.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.test.ts
@@ -18,7 +18,7 @@ import {
   resolveSellableQuantity,
   heldQuantityForBroker,
   singleHeldBrokerId,
-  deriveTradeToBaseFxRate,
+  deriveTradeToPortfolioFxRate,
 } from "./tradeFormHelpers"
 import { Transaction } from "types/beancounter"
 
@@ -179,32 +179,35 @@ describe("tradeFormHelpers", () => {
     })
   })
 
-  describe("deriveTradeToBaseFxRate", () => {
-    test("returns base/trade market value ratio", () => {
-      expect(
-        deriveTradeToBaseFxRate({
-          TRADE: { marketValue: 8860.25 },
-          BASE: { marketValue: 11451.98 },
-        }),
-      ).toBeCloseTo(1.2925, 4)
-    })
+  describe("deriveTradeToPortfolioFxRate", () => {
+    // One holding, two buckets: USD 3,482 == SGD 4,462.53.
+    const voo = {
+      TRADE: { marketValue: 3482 },
+      PORTFOLIO: { marketValue: 4462.53 },
+    }
 
-    test("returns 1 when trade market value is zero or missing", () => {
-      expect(
-        deriveTradeToBaseFxRate({
-          TRADE: { marketValue: 0 },
-          BASE: { marketValue: 100 },
-        }),
-      ).toBe(1)
-      expect(deriveTradeToBaseFxRate({ BASE: { marketValue: 100 } })).toBe(1)
+    test("converts the trade-currency price to the portfolio currency", () => {
+      expect(deriveTradeToPortfolioFxRate(voo)).toBeCloseTo(1.2816, 4)
     })
 
     test("returns 1 for same-currency holdings (equal values)", () => {
       expect(
-        deriveTradeToBaseFxRate({
+        deriveTradeToPortfolioFxRate({
           TRADE: { marketValue: 5000 },
-          BASE: { marketValue: 5000 },
+          PORTFOLIO: { marketValue: 5000 },
         }),
+      ).toBe(1)
+    })
+
+    test("returns 1 when the trade market value is zero or missing", () => {
+      expect(
+        deriveTradeToPortfolioFxRate({
+          TRADE: { marketValue: 0 },
+          PORTFOLIO: { marketValue: 100 },
+        }),
+      ).toBe(1)
+      expect(
+        deriveTradeToPortfolioFxRate({ PORTFOLIO: { marketValue: 100 } }),
       ).toBe(1)
     })
   })

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -9,6 +9,7 @@ import {
   calculateTradeWeight,
   calculateNewPositionWeight,
   getAssetCurrency,
+  isSellSide,
 } from "./tradeUtils"
 import { getDisplayCode, stripOwnerPrefix } from "@lib/assets/assetUtils"
 import { deriveBrokerCode } from "@lib/openBrokerage/brokerCode"
@@ -198,6 +199,58 @@ export const calculateNewPositionQuantityFromTargetWeight = (
     tradeType: "BUY",
     nominalPortfolioValue: portfolioMarketValue + quantity * priceInBase,
   }
+}
+
+/**
+ * The weight the position lands on once this trade settles — the inverse of
+ * the two target-weight sizing helpers above, so a weight typed in comes back
+ * out unchanged.
+ *
+ * Mirrors each helper's basis exactly:
+ * - an existing holding is re-weighed against the SAME portfolio value
+ *   (the trade is funded from inside the portfolio), matching
+ *   `calculateQuantityFromTargetWeight`;
+ * - a brand-new position grows the portfolio it is weighed against
+ *   (funded from outside), matching
+ *   `calculateNewPositionQuantityFromTargetWeight`.
+ *
+ * Returns null when there is no price or no portfolio value to weigh against.
+ */
+export const computeResultingPositionWeight = (params: {
+  currentPositionQuantity: number
+  tradeQuantity: number
+  tradeType: string
+  price: number
+  portfolioMarketValue: number
+  fxRate?: number
+}): number | null => {
+  const {
+    currentPositionQuantity,
+    tradeQuantity,
+    tradeType,
+    price,
+    portfolioMarketValue,
+    fxRate = 1,
+  } = params
+
+  if (!price || price <= 0) return null
+  if (!portfolioMarketValue || portfolioMarketValue <= 0) return null
+
+  // `price` is trade currency; the portfolio value is base currency.
+  const priceInBase = price * fxRate
+  const signedQuantity = isSellSide(tradeType) ? -tradeQuantity : tradeQuantity
+
+  if (currentPositionQuantity > 0) {
+    const resultingQuantity = Math.max(
+      currentPositionQuantity + signedQuantity,
+      0,
+    )
+    return ((resultingQuantity * priceInBase) / portfolioMarketValue) * 100
+  }
+
+  const addedValue = Math.max(signedQuantity, 0) * priceInBase
+  if (addedValue <= 0) return 0
+  return (addedValue / (portfolioMarketValue + addedValue)) * 100
 }
 
 /**

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -99,20 +99,28 @@ export const computeWeightInfo = (
 }
 
 /**
- * Derive the trade-currency -> portfolio base-currency FX rate for a position
- * from its already-valued money buckets: base marketValue / trade marketValue.
- * Both buckets value the same holding, so their ratio is the FX rate. Falls
- * back to 1 (same currency / insufficient data) when either bucket is missing
- * or the trade value is zero.
+ * The FX rate from an asset's trade currency to the portfolio's reporting
+ * currency — the currency the weight basis (`portfolio.marketValue`) is quoted
+ * in. Both buckets value the same holding, so their ratio is the rate.
+ *
+ * A trade is denominated in the asset's own currency, so the dialog is handed
+ * the trade-currency price and converts once, here, to weigh it against the
+ * portfolio. Handing it a price that a holdings row had already converted for
+ * display and then applying this rate would count the FX twice and inflate
+ * every weight by it.
+ *
+ * Falls back to 1 (same currency / insufficient data) when either bucket is
+ * missing or the trade value is zero.
  */
-export const deriveTradeToBaseFxRate = (moneyValues: {
+export const deriveTradeToPortfolioFxRate = (moneyValues: {
   TRADE?: { marketValue?: number }
-  BASE?: { marketValue?: number }
+  PORTFOLIO?: { marketValue?: number }
 }): number => {
   const tradeValue = moneyValues.TRADE?.marketValue
-  const baseValue = moneyValues.BASE?.marketValue
-  if (!tradeValue || baseValue === undefined || baseValue === null) return 1
-  return baseValue / tradeValue
+  const portfolioValue = moneyValues.PORTFOLIO?.marketValue
+  if (!tradeValue || portfolioValue === undefined || portfolioValue === null)
+    return 1
+  return portfolioValue / tradeValue
 }
 
 /**

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -29,10 +29,13 @@ export interface QuickSellData {
   type?: "BUY" | "SELL" | "INCOME" | "EXPENSE"
   currentPositionQuantity?: number // For rebalance: the current position size
   held?: Record<string, number> // Broker name -> quantity for broker selection
-  // Trade-currency -> portfolio base-currency rate, so the trade dialog can
-  // weigh a trade-currency price against the base-currency portfolio value.
-  // Omitted for same-currency holdings (treated as 1).
+  // Displayed-currency -> portfolio-currency rate, so the trade dialog can
+  // weigh the price the row displayed against the portfolio value. Omitted
+  // when the row already displays portfolio currency (treated as 1).
   fxRate?: number
+  // The position's weight in percent, as svc-position computed it. The dialog
+  // displays this rather than re-deriving one, so the two agree.
+  currentWeight?: number
 }
 
 export interface RebalanceData {


### PR DESCRIPTION
Depends on **monowai/beancounter#1066** — svc-position now weighs every position
in one common currency. Merge and deploy that first; the holdings table's weight
column stays wrong until it lands.

## Problem

Changing the target weight on the Invest tab moved nothing you could see. The
weight handler set the form `quantity`, but Invest Value and the share count
lived in their own local state that nothing wrote back to — so the amount stayed
stale until you tabbed over to **Trade** to find the quantity had changed.

Underneath that, the same panel mixed currencies. The row handed the dialog
`moneyValues[valueIn].priceData.close` — a price already converted for display —
and then applied a trade→base FX rate on top, counting the FX twice. VOO in an
SGD portfolio read **2.31%** in the dialog, **1.42%** in the table, against a
true **1.80%**.

And the tab showed the holding's market value and share count with no label
saying so — they came from the Quick Sell prefill (`quantity` = the whole
holding), so the tab silently proposed doubling the position.

## Change

**One truth, three views.** Cash amount, share count and target weight are all
derived from the form `quantity`, so editing any one moves the other two in the
same render. `MathInput` already ignores incoming values while focused, so the
field being typed into is never overwritten mid-keystroke.

**One currency per figure.**

- A trade is denominated in the asset's own currency, so the dialog now gets the
  **trade-currency** price and converts once, to the currency the weight basis is
  quoted in (`deriveTradeToPortfolioFxRate`, replacing `deriveTradeToBaseFxRate`).
- The dialog no longer re-derives a current weight that could disagree with the
  row it was opened from — svc-position already weighed the holding, so its
  answer is passed through and displayed.
- The Current/After ledger states its values in the portfolio currency it weighs
  them against, labelled as such.

**Labelled, and self-contained.** A `Current → After` ledger of value and weight,
plus the broker, so sizing a trade no longer means bouncing between tabs. First
entry to the tab clears the Quick Sell prefill so it starts from a clean slate.

**New helper — `computeResultingPositionWeight`.** The inverse of the two
target-weight sizing helpers, mirroring each one's basis (an existing holding is
re-weighed against the same portfolio value; a new position grows the value it is
weighed against). A weight typed in comes back out unchanged — tested both ways.

**Drive-by fix.** The trade amount was only derived when `quantity` was truthy,
so the summary strip kept a stale figure once the quantity hit zero.

### Layout (review feedback)

- Price returns to the Trade tab — it describes the asset, not the sizing.
- The headline amount and BUY/SELL live only in the summary strip; the tab
  doesn't restate them.
- Current and After are aligned columns of value and weight. The share count is
  the Shares field's job, so it's gone from the ledger.
- Sizing fields, and the Trade tab's qty/price/fees, stay three-across at every
  width — the wrapped row was what pushed Broker below the fold. Neither tab
  needs vertical scrolling on a phone.
- Off-palette purple is gone; the active tab is Action Blue like its neighbours
  and emerald/red stay reserved for trade direction (DESIGN.md's status-only
  colour rule).

## Verification

- 10 Invest-tab behaviour tests + helper tests for the weight inverse and the FX
  rate; full suite 2461 green, typecheck and lint clean.
- Driven live against a real SGD portfolio holding a USD-traded ETF: weight →
  amount/shares update in place, direction flips to SELL below the current
  weight, ledger reads `Value SGD 4,462.53 → 12,495.08` and `1.80% → 5.04%`
  against a `6,267.60 USD` buy, matching the summary strip.
- Checked at 390×760 and 1440×900: the Invest tab fits without scrolling.
- `ocr review` — 5 low findings; took the NaN guard, rejected the rest (already
  handled downstream, or matching the file's existing convention).
