### PR TITLE
fix(trade): weigh against the total svc-position used, show the basis

### DIFF
--- a/src/components/features/holdings/HoldingActions.tsx
+++ b/src/components/features/holdings/HoldingActions.tsx
@@ -597,6 +597,11 @@ const HoldingActions: React.FC<HoldingActionsProps> = ({
           // svc-position already weighed this holding; show its answer rather
           // than deriving a second one that can disagree with the row.
           currentWeightOverride={quickSellData?.currentWeight ?? null}
+          // ...and weigh the resulting position against the SAME total it used.
+          // `portfolio.marketValue` is a different valuation, so pairing the two
+          // put the current and resulting weights on different denominators —
+          // a target typed in came back out as something else.
+          weightBasisMarketValue={holdingResults.totals?.PORTFOLIO?.marketValue}
         />
       )}
       {cashModalOpen && (

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -780,7 +780,7 @@ const TradeInputForm: React.FC<{
             onClick={handleClose}
           ></div>
           <div
-            className="bg-white sm:rounded-xl shadow-2xl w-full sm:max-w-lg sm:mx-4 p-4 sm:p-5 z-50 text-sm flex flex-col max-h-[95vh] sm:max-h-[90vh] rounded-t-xl overflow-hidden"
+            className="bg-white sm:rounded-xl shadow-2xl w-full sm:max-w-lg sm:mx-4 p-3 sm:p-5 z-50 text-sm flex flex-col max-h-[95vh] sm:max-h-[90vh] rounded-t-xl overflow-hidden"
             onClick={(e) => e.stopPropagation()}
           >
             <TradeFormHeader
@@ -899,7 +899,7 @@ const TradeInputForm: React.FC<{
                   })
                 }
               })}
-              className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden py-4 space-y-4"
+              className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden py-3 space-y-4"
             >
               {/* === Trade Tab === */}
               {activeTab === "trade" && (
@@ -1220,7 +1220,7 @@ const TradeInputForm: React.FC<{
 
               {/* === Invest Tab === */}
               {activeTab === "invest" && !isSimpleAmount && !isEditMode && (
-                <div className="space-y-3">
+                <div className="space-y-2.5">
                   {/* Cash, shares and weight are three views of one trade —
                       set any one and the other two follow. The summary strip
                       below the form carries the headline total and direction,
@@ -1279,17 +1279,17 @@ const TradeInputForm: React.FC<{
                   </div>
 
                   {/* What you hold now, and where this trade leaves it. */}
-                  <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
-                    <div className="grid grid-cols-[1fr_minmax(4.5rem,auto)_minmax(4.5rem,auto)] items-baseline gap-x-3">
+                  <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5">
+                    <div className="grid grid-cols-[1fr_minmax(5.5rem,auto)_minmax(5.5rem,auto)] items-baseline gap-x-4 gap-y-1.5">
                       <span />
-                      <span className="text-right text-[10px] font-medium uppercase tracking-wide text-gray-500">
+                      <span className="text-right text-[11px] font-medium uppercase tracking-wide text-gray-500">
                         {"Current"}
                       </span>
-                      <span className="text-right text-[10px] font-medium uppercase tracking-wide text-gray-500">
+                      <span className="text-right text-[11px] font-medium uppercase tracking-wide text-gray-500">
                         {"After"}
                       </span>
 
-                      <span className="text-xs text-gray-500">
+                      <span className="text-sm text-gray-500">
                         {"Value"}
                         <span className="text-gray-400">
                           {" "}
@@ -1298,7 +1298,7 @@ const TradeInputForm: React.FC<{
                       </span>
                       <span
                         data-testid="invest-current-value"
-                        className="text-right font-mono text-xs tabular-nums text-gray-600"
+                        className="text-right font-mono text-sm tabular-nums text-gray-600"
                       >
                         {positionQty > 0 ? (
                           <NumericFormat
@@ -1314,7 +1314,7 @@ const TradeInputForm: React.FC<{
                       </span>
                       <span
                         data-testid="invest-after-value"
-                        className="text-right font-mono text-xs tabular-nums text-gray-900"
+                        className="text-right font-mono text-sm tabular-nums text-gray-900"
                       >
                         <NumericFormat
                           value={resultingPositionQuantity * price * fxRate}
@@ -1325,10 +1325,10 @@ const TradeInputForm: React.FC<{
                         />
                       </span>
 
-                      <span className="text-xs text-gray-500">{"Weight"}</span>
+                      <span className="text-sm text-gray-500">{"Weight"}</span>
                       <span
                         data-testid="invest-current-weight"
-                        className="text-right font-mono text-sm tabular-nums text-gray-600"
+                        className="text-right font-mono text-base tabular-nums text-gray-600"
                       >
                         {currentPositionWeight === null
                           ? "—"
@@ -1336,7 +1336,7 @@ const TradeInputForm: React.FC<{
                       </span>
                       <span
                         data-testid="invest-after-weight"
-                        className="text-right font-mono text-sm font-semibold tabular-nums text-gray-900"
+                        className="text-right font-mono text-base font-semibold tabular-nums text-gray-900"
                       >
                         {resultingPositionWeight === null
                           ? "—"
@@ -1654,14 +1654,37 @@ const TradeInputForm: React.FC<{
                   <span className="text-xs text-gray-500">
                     {tradeCurrency?.value}
                   </span>
+                  {/* How that amount was arrived at — the shares and the price
+                      they were struck at. Reading it back is how you catch a
+                      mis-keyed price before submitting. */}
+                  {!isSimpleAmount && quantity > 0 && price > 0 && (
+                    <span
+                      data-testid="trade-summary-basis"
+                      className="text-xs text-gray-500 tabular-nums"
+                    >
+                      {quantity.toLocaleString()}
+                      {" @ "}
+                      <NumericFormat
+                        value={price}
+                        displayType="text"
+                        thousandSeparator
+                        decimalScale={2}
+                        fixedDecimalScale
+                      />
+                    </span>
+                  )}
                   {!cashImpact && (
                     <span className="text-xs text-gray-400 italic">
                       {"No cash impact"}
                     </span>
                   )}
                   {weightInfo && !isSimpleAmount && (
-                    <span className="text-xs text-blue-600 font-medium">
-                      {weightInfo.value.toFixed(2)}%
+                    <span
+                      data-testid="trade-summary-weight"
+                      className="text-xs text-blue-600 font-medium"
+                    >
+                      {(resultingPositionWeight ?? weightInfo.value).toFixed(2)}
+                      %
                     </span>
                   )}
                 </div>

--- a/src/components/features/transactions/__tests__/TradeInputForm.invest.test.tsx
+++ b/src/components/features/transactions/__tests__/TradeInputForm.invest.test.tsx
@@ -186,6 +186,44 @@ describe("TradeInputForm — Invest tab", () => {
     expect(screen.queryByLabelText("Price")).not.toBeInTheDocument()
   })
 
+  test("the summary strip shows how the amount was arrived at", () => {
+    renderInvestTab()
+
+    fireEvent.change(sharesField(), { target: { value: "51" } })
+
+    expect(screen.getByTestId("trade-summary-basis")).toHaveTextContent(
+      "51 @ 10.00",
+    )
+  })
+
+  test("a target weight lands on target when the weight comes from the backend", () => {
+    // svc-position weighed this 1,000 holding at 5% — against a 20,000 total,
+    // not the portfolio's own 10,000. Sizing against a DIFFERENT total than the
+    // one it used puts the current and resulting weights on different
+    // denominators, so a target typed in comes back out as something else.
+    render(
+      <TradeInputForm
+        portfolio={portfolio}
+        modalOpen={true}
+        setModalOpen={jest.fn()}
+        initialValues={heldPosition as never}
+        currentWeightOverride={5}
+        weightBasisMarketValue={20000}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Invest" }))
+
+    fireEvent.change(weightField(), { target: { value: "10" } })
+
+    expect(screen.getByTestId("invest-after-weight")).toHaveTextContent(
+      "10.00%",
+    )
+    // ...and the strip agrees with the ledger rather than carrying its own maths.
+    expect(screen.getByTestId("trade-summary-weight")).toHaveTextContent(
+      "10.00%",
+    )
+  })
+
   test("a brand-new position sizes against the post-trade portfolio", () => {
     renderInvestTab({
       asset: "MSFT",


### PR DESCRIPTION
Follow-up to #1141, from review of the shipped tab.

## The bug

Type a 10% target, land on 7.98%.

The current weight came from svc-position (weighed against the holdings total).
The resulting weight was derived against `portfolio.marketValue` — a different
valuation of the same portfolio. Two numbers on two denominators, sitting in the
same two-column ledger, and the sizing maths split the difference: it sized the
buy as if the holding were already worth `9.15% × portfolio.marketValue` when it
was actually worth 9,063.

Both now weigh against `totals[PORTFOLIO].marketValue` — the total svc-position
itself used — so a target typed in comes back out. The summary strip reports the
ledger's figure instead of running its own `computeWeightInfo` maths, which was a
third possible answer.

## Layout, per review

- **The strip carries the basis**: `BUY 16,017.20 USD · 23 @ 696.40 · 10.07%`.
  Reading the shares and price back is how a mis-keyed price gets caught before
  submitting.
- **The ledger gets room** — larger figures, wider columns, more space between
  rows. Paid for out of the dialog's own padding on small screens rather than by
  re-squashing anything, so the tab still fits a phone: measured
  `scrollHeight - clientHeight = 0` at a 530px-tall viewport (a real phone has
  ~700px).

## Verification

- New test: a backend-supplied weight of 5% against a 20,000 basis (not the
  portfolio's own 10,000) still lands a 10% target on exactly 10.00%, in both the
  ledger and the strip. Full suite green.
- Live against the SGD portfolio: target 10 → 23 shares, `4,462.53 → 24,990.17
  SGD`, `1.80% → 10.07%` (10.07 not 10.00 because 23 is a whole number of
  shares), strip agreeing throughout.
