### PR TITLE
fix(rebalance): let Invest Cash prices take real decimals

### DIFF
--- a/__tests__/components/features/rebalance/execution/InvestCashDialog.test.tsx
+++ b/__tests__/components/features/rebalance/execution/InvestCashDialog.test.tsx
@@ -1,0 +1,145 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import InvestCashDialog from "@components/features/rebalance/execution/InvestCashDialog"
+import { ExecutionDto } from "types/rebalance"
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}))
+
+const models = [
+  {
+    id: "model-1",
+    name: "Growth",
+    currentPlanId: "plan-1",
+    currentPlanVersion: 1,
+    risk: 3,
+  },
+]
+
+const plan = { id: "plan-1", assets: [], cashWeight: 0 }
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (key === "/api/rebalance/models") return { data: { data: models } }
+    if (key?.startsWith("/api/rebalance/models/"))
+      return { data: { data: plan } }
+    return { data: undefined }
+  },
+}))
+
+const execution: ExecutionDto = {
+  id: "exec-1",
+  planId: "plan-1",
+  planVersion: 1,
+  modelId: "model-1",
+  modelName: "Growth",
+  portfolioIds: ["p1"],
+  snapshotTotalValue: 10000,
+  snapshotCashValue: 5000,
+  totalPortfolioValue: 10000,
+  currency: "USD",
+  status: "DRAFT",
+  mode: "INVEST_CASH",
+  items: [
+    {
+      id: "item-1",
+      assetId: "asset-1",
+      assetCode: "US:IUAA",
+      assetName: "ISHARES US AGG BND",
+      snapshotWeight: 0,
+      snapshotValue: 0,
+      snapshotQuantity: 0,
+      snapshotPrice: 5.6934,
+      priceCurrency: "USD",
+      planTargetWeight: 1,
+      effectiveTarget: 1,
+      hasOverride: false,
+      deltaValue: 5000,
+      deltaQuantity: 100,
+      action: "BUY",
+      excluded: false,
+      locked: false,
+      sortOrder: 0,
+      isCash: false,
+    },
+  ],
+} as unknown as ExecutionDto
+
+const priceInput = (): HTMLInputElement =>
+  screen.getAllByLabelText("Price")[0] as HTMLInputElement
+
+const goToPreview = async (
+  user: ReturnType<typeof userEvent.setup>,
+): Promise<void> => {
+  render(
+    <InvestCashDialog
+      modalOpen={true}
+      portfolioId="p1"
+      onClose={jest.fn()}
+      onSuccess={jest.fn()}
+    />,
+  )
+  await user.type(screen.getByPlaceholderText("10k"), "5000")
+  await user.click(screen.getByText("Growth"))
+  await user.click(screen.getByText("Preview"))
+  await waitFor(() => expect(screen.getAllByLabelText("Price").length).toBe(2))
+}
+
+describe("InvestCashDialog price editing", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: execution }),
+    }) as unknown as typeof fetch
+  })
+
+  it("shows the snapshot price at full precision, not rounded to 2dp", async () => {
+    const user = userEvent.setup()
+    await goToPreview(user)
+
+    expect(priceInput().value).toBe("5.6934")
+  })
+
+  it("keeps every character the user types, decimals included", async () => {
+    const user = userEvent.setup()
+    await goToPreview(user)
+
+    await user.clear(priceInput())
+    await user.type(priceInput(), "12.3456")
+
+    expect(priceInput().value).toBe("12.3456")
+  })
+
+  it("survives a partially typed number without reformatting", async () => {
+    const user = userEvent.setup()
+    await goToPreview(user)
+
+    await user.clear(priceInput())
+    await user.type(priceInput(), "0.")
+
+    expect(priceInput().value).toBe("0.")
+  })
+
+  it("replaces the whole value on select-all + type", async () => {
+    const user = userEvent.setup()
+    await goToPreview(user)
+
+    await user.tripleClick(priceInput())
+    await user.paste("7.5")
+
+    expect(priceInput().value).toBe("7.5")
+  })
+
+  it("ignores non-numeric keystrokes", async () => {
+    const user = userEvent.setup()
+    await goToPreview(user)
+
+    await user.clear(priceInput())
+    await user.type(priceInput(), "1a2")
+
+    expect(priceInput().value).toBe("12")
+  })
+})

--- a/src/components/features/rebalance/execution/InvestCashDialog.tsx
+++ b/src/components/features/rebalance/execution/InvestCashDialog.tsx
@@ -32,10 +32,24 @@ const formatAssetCode = (code?: string): string => {
   return colonIndex >= 0 ? code.substring(colonIndex + 1) : code
 }
 
-// Track user edits to qty/price
+// Track user edits to qty/price. Stored as the raw text the user typed so a
+// half-finished number ("0.", "1.2") survives re-render — reformatting the
+// value on every keystroke makes decimals impossible to enter.
 interface ItemEdits {
-  [assetId: string]: { quantity?: number; price?: number }
+  [assetId: string]: { quantity?: string; price?: string }
 }
+
+// A draft becomes a number for maths/submission. Blank or unparseable text
+// counts as 0 so the preview totals match what is on screen.
+const draftToNumber = (raw?: string): number | undefined => {
+  if (raw === undefined) return undefined
+  const parsed = Number.parseFloat(raw)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+// Text inputs (not type=number, which fights decimal entry) so keystrokes are
+// screened here: digits and a single decimal point, any number of places.
+const DECIMAL_DRAFT = /^\d*\.?\d*$/
 
 const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
   modalOpen,
@@ -129,11 +143,25 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
 
   // Get effective qty/price for an item (user edit or original)
   const getItemValues = useCallback(
-    (item: ExecutionItemDto): { qty: number; price: number; value: number } => {
+    (
+      item: ExecutionItemDto,
+    ): {
+      qty: number
+      price: number
+      value: number
+      qtyText: string
+      priceText: string
+    } => {
       const edits = itemEdits[item.assetId] || {}
-      const qty = edits.quantity ?? item.deltaQuantity
-      const price = edits.price ?? item.snapshotPrice ?? 0
-      return { qty, price, value: qty * price }
+      const qty = draftToNumber(edits.quantity) ?? item.deltaQuantity
+      const price = draftToNumber(edits.price) ?? item.snapshotPrice ?? 0
+      return {
+        qty,
+        price,
+        value: qty * price,
+        qtyText: edits.quantity ?? String(qty),
+        priceText: edits.price ?? String(price),
+      }
     },
     [itemEdits],
   )
@@ -153,18 +181,20 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
   }, [execution?.snapshotCashValue, buyItems, getItemValues])
 
   // Handle quantity change
-  const handleQuantityChange = (assetId: string, newQty: number): void => {
+  const handleQuantityChange = (assetId: string, newQty: string): void => {
+    if (!DECIMAL_DRAFT.test(newQty)) return
     setItemEdits((prev) => ({
       ...prev,
-      [assetId]: { ...prev[assetId], quantity: Math.max(0, newQty) },
+      [assetId]: { ...prev[assetId], quantity: newQty },
     }))
   }
 
   // Handle price change
-  const handlePriceChange = (assetId: string, newPrice: number): void => {
+  const handlePriceChange = (assetId: string, newPrice: string): void => {
+    if (!DECIMAL_DRAFT.test(newPrice)) return
     setItemEdits((prev) => ({
       ...prev,
-      [assetId]: { ...prev[assetId], price: Math.max(0, newPrice) },
+      [assetId]: { ...prev[assetId], price: newPrice },
     }))
   }
 
@@ -232,8 +262,8 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
           .filter((item) => itemEdits[item.assetId])
           .map((item) => ({
             assetId: item.assetId,
-            quantity: itemEdits[item.assetId]?.quantity,
-            price: itemEdits[item.assetId]?.price,
+            quantity: draftToNumber(itemEdits[item.assetId]?.quantity),
+            price: draftToNumber(itemEdits[item.assetId]?.price),
           }))
 
         const updateResponse = await fetch(
@@ -572,7 +602,7 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
           {/* Mobile: card per buy item */}
           <div className="sm:hidden space-y-2">
             {buyItems.map((item) => {
-              const { qty, price, value } = getItemValues(item)
+              const { value, qtyText, priceText } = getItemValues(item)
               const displayCode = formatAssetCode(item.assetCode)
               return (
                 <div
@@ -606,16 +636,12 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
                         {"Qty"}
                       </span>
                       <input
-                        type="number"
-                        min="0"
-                        step="1"
-                        inputMode="numeric"
-                        value={qty}
+                        type="text"
+                        inputMode="decimal"
+                        autoComplete="off"
+                        value={qtyText}
                         onChange={(e) =>
-                          handleQuantityChange(
-                            item.assetId,
-                            parseInt(e.target.value) || 0,
-                          )
+                          handleQuantityChange(item.assetId, e.target.value)
                         }
                         className="w-full px-3 py-2 text-base text-right border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
                       />
@@ -625,16 +651,12 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
                         {"Price"}
                       </span>
                       <input
-                        type="number"
-                        min="0"
-                        step="0.01"
+                        type="text"
                         inputMode="decimal"
-                        value={price.toFixed(2)}
+                        autoComplete="off"
+                        value={priceText}
                         onChange={(e) =>
-                          handlePriceChange(
-                            item.assetId,
-                            parseFloat(e.target.value) || 0,
-                          )
+                          handlePriceChange(item.assetId, e.target.value)
                         }
                         className="w-full px-3 py-2 text-base text-right border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
                       />
@@ -666,7 +688,7 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
                 {buyItems.map((item) => {
-                  const { qty, price, value } = getItemValues(item)
+                  const { value, qtyText, priceText } = getItemValues(item)
                   const displayCode = formatAssetCode(item.assetCode)
                   return (
                     <tr key={item.assetId} className="bg-green-50">
@@ -688,32 +710,26 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
                       </td>
                       <td className="px-3 py-2">
                         <input
-                          type="number"
-                          min="0"
-                          step="1"
-                          inputMode="numeric"
-                          value={qty}
+                          type="text"
+                          inputMode="decimal"
+                          autoComplete="off"
+                          aria-label="Qty"
+                          value={qtyText}
                           onChange={(e) =>
-                            handleQuantityChange(
-                              item.assetId,
-                              parseInt(e.target.value) || 0,
-                            )
+                            handleQuantityChange(item.assetId, e.target.value)
                           }
                           className="w-full px-2 py-1 text-right text-sm border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
                         />
                       </td>
                       <td className="px-3 py-2">
                         <input
-                          type="number"
-                          min="0"
-                          step="0.01"
+                          type="text"
                           inputMode="decimal"
-                          value={price.toFixed(2)}
+                          autoComplete="off"
+                          aria-label="Price"
+                          value={priceText}
                           onChange={(e) =>
-                            handlePriceChange(
-                              item.assetId,
-                              parseFloat(e.target.value) || 0,
-                            )
+                            handlePriceChange(item.assetId, e.target.value)
                           }
                           className="w-full px-2 py-1 text-right text-sm border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
                         />


### PR DESCRIPTION
The preview's qty/price fields reformatted their own value on every
keystroke (toFixed(2) + parseFloat on change), so typing "5.69" snapped
back to "5.00" with the caret at the end and select-all-and-retype was
unusable. Prices were also capped at 2dp.

Edits are now held as the raw text the user typed and parsed to a number
only for the totals and the PUT payload, and the fields are text inputs
with a decimal keypad hint plus a digits-and-one-point screen — type=number
strips a trailing "." mid-entry. Snapshot prices render at full precision,
and the desktop table's inputs get accessible names.