### PR TITLE
fix(holdings): write Set Balance synchronously so failures surface

### DIFF
--- a/src/components/features/holdings/SetCashBalanceDialog.tsx
+++ b/src/components/features/holdings/SetCashBalanceDialog.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useMemo } from "react"
 import { Portfolio } from "types/beancounter"
-import { postData } from "@components/ui/DropZone"
 import {
-  buildCashRow,
   calculateCashAdjustment,
   CashBalanceAdjustment,
 } from "@lib/trns/tradeUtils"
@@ -16,7 +14,7 @@ interface SetCashBalanceDialogProps {
   portfolio: Portfolio
   currency: string
   currentBalance: number
-  market?: string // "CASH" for currencies, "PRIVATE" for bank accounts
+  assetId: string // The cash asset being adjusted; also the settlement account
   assetCode?: string // Asset code for bank accounts
   assetName?: string // Asset name for display
 }
@@ -27,7 +25,7 @@ const SetCashBalanceDialog: React.FC<SetCashBalanceDialogProps> = ({
   portfolio,
   currency,
   currentBalance,
-  market = "CASH",
+  assetId,
   assetCode,
   assetName,
 }) => {
@@ -60,19 +58,48 @@ const SetCashBalanceDialog: React.FC<SetCashBalanceDialogProps> = ({
     return calculateCashAdjustment(currentBalance, target)
   }, [targetBalance, currentBalance])
 
+  /**
+   * Writes the adjustment through the synchronous trn endpoint.
+   *
+   * This used to publish a row to the async CSV import topic, where a server-side
+   * rejection was retried, acked away and never seen — the dialog reported success
+   * and no transaction existed (#1067). The cash asset settles against itself, so
+   * cashAssetId is the asset being adjusted. tradeDate is left to the server, which
+   * resolves "today" in the configured zone rather than the browser's.
+   */
   const handleProceed = async (): Promise<void> => {
     if (calculation.amount === 0) return
     await handleSubmit(async () => {
       const displayName = assetName || assetCode || currency
-      const row = buildCashRow({
-        type: calculation.type,
-        currency,
-        amount: calculation.amount,
-        comments: `Set ${displayName} balance to ${currency} ${calculation.newBalance.toFixed(2)}`,
-        market,
-        assetCode,
+      const response = await fetch("/api/trns", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          portfolioId: portfolio.id,
+          data: [
+            {
+              assetId,
+              cashAssetId: assetId,
+              trnType: calculation.type,
+              quantity: calculation.amount,
+              // The import path set both; cashAmount is what the cash ladder reads,
+              // and the backend signs it from the trn type.
+              cashAmount: calculation.amount,
+              tradeCurrency: currency,
+              cashCurrency: currency,
+              status: "SETTLED",
+              comments: `Set ${displayName} balance to ${currency} ${calculation.newBalance.toFixed(2)}`,
+            },
+          ],
+        }),
       })
-      await postData(portfolio, false, row)
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(
+          errorData.message || errorData.detail || "Failed to set balance",
+        )
+      }
     })
   }
 

--- a/src/components/features/holdings/__tests__/SetCashBalanceDialog.test.tsx
+++ b/src/components/features/holdings/__tests__/SetCashBalanceDialog.test.tsx
@@ -1,0 +1,109 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { enableFetchMocks } from "jest-fetch-mock"
+import SetCashBalanceDialog from "../SetCashBalanceDialog"
+import type { Portfolio } from "types/beancounter"
+
+enableFetchMocks()
+
+const portfolio = {
+  id: "eur-pf",
+  code: "EUR",
+  name: "EUR Portfolio",
+  currency: { code: "EUR", name: "Euro", symbol: "€" },
+} as unknown as Portfolio
+
+function renderOpen(): void {
+  const { rerender } = render(
+    <SetCashBalanceDialog
+      modalOpen={false}
+      onClose={jest.fn()}
+      portfolio={portfolio}
+      currency="EUR"
+      currentBalance={500}
+      assetId="eur-cash-id"
+      assetName="EUR Balance"
+    />,
+  )
+  rerender(
+    <SetCashBalanceDialog
+      modalOpen={true}
+      onClose={jest.fn()}
+      portfolio={portfolio}
+      currency="EUR"
+      currentBalance={500}
+      assetId="eur-cash-id"
+      assetName="EUR Balance"
+    />,
+  )
+}
+
+async function submitTarget(target: string): Promise<void> {
+  renderOpen()
+  await userEvent.type(screen.getByPlaceholderText("500.00"), target)
+  await userEvent.click(screen.getByRole("button", { name: /Proceed/i }))
+}
+
+beforeEach(() => {
+  fetchMock.resetMocks()
+})
+
+/**
+ * Setting a cash balance used to publish a row to the async import topic, so a
+ * server-side rejection was acked away and the dialog reported success (#1067).
+ * The write has to go through the synchronous trn endpoint, where the caller sees
+ * the failure.
+ */
+describe("SetCashBalanceDialog", () => {
+  it("writes the adjustment synchronously, not onto the import topic", async () => {
+    fetchMock.mockResponse(JSON.stringify({ data: { trns: [] } }))
+
+    await submitTarget("1500")
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/trns")
+
+    const body = JSON.parse(String(init?.body))
+    expect(body.portfolioId).toBe(portfolio.id)
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0]).toMatchObject({
+      assetId: "eur-cash-id",
+      trnType: "DEPOSIT",
+      quantity: 1000,
+      cashAmount: 1000,
+      tradeCurrency: "EUR",
+      cashCurrency: "EUR",
+      status: "SETTLED",
+    })
+  })
+
+  it("withdraws when the target is below the current balance", async () => {
+    fetchMock.mockResponse(JSON.stringify({ data: { trns: [] } }))
+
+    await submitTarget("200")
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body))
+    expect(body.data[0]).toMatchObject({
+      trnType: "WITHDRAWAL",
+      quantity: 300,
+      cashAmount: 300,
+    })
+  })
+
+  it("shows the server's rejection instead of reporting success", async () => {
+    fetchMock.mockResponse(
+      JSON.stringify({ message: "Rejecting the forward dated trade date" }),
+      { status: 400 },
+    )
+
+    await submitTarget("1500")
+
+    expect(
+      await screen.findByText(/Rejecting the forward dated trade date/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Success")).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -858,9 +858,9 @@ function HoldingsPage(): React.ReactElement {
           portfolio={holdingResults.portfolio}
           currency={setCashBalanceData.currency}
           currentBalance={setCashBalanceData.currentBalance}
-          market={setCashBalanceData.market}
           assetCode={setCashBalanceData.assetCode}
           assetName={setCashBalanceData.assetName}
+          assetId={setCashBalanceData.assetId}
         />
       )}
       {setPriceData && (

--- a/src/pages/holdings/aggregated.tsx
+++ b/src/pages/holdings/aggregated.tsx
@@ -786,9 +786,9 @@ function AggregatedHoldingsPage(): React.ReactElement {
             portfolio={cashPortfolio}
             currency={cashBalanceData.currency}
             currentBalance={cashBalanceData.currentBalance}
-            market={cashBalanceData.market}
             assetCode={cashBalanceData.assetCode}
             assetName={cashBalanceData.assetName}
+            assetId={cashBalanceData.assetId}
           />
         )}
         {editAsset && (

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -66,10 +66,10 @@ export interface WeightClickData {
 export interface SetCashBalanceData {
   currency: string // Currency code (e.g., "USD", "NZD")
   currentBalance: number // Current cash balance
-  market?: string // Market code: "CASH" for currencies, "PRIVATE" for bank accounts
   assetCode?: string // Asset code for bank accounts (e.g., "WISE", "USD-SAVINGS")
   assetName?: string // Asset name for display
-  assetId?: string // Asset id — lets aggregated holdings resolve the target portfolio
+  market?: string // Market code: "CASH" for currencies, "PRIVATE" for bank accounts
+  assetId: string // Asset id — the write target, and the settlement account for the adjustment
 }
 
 export interface CashTransferData {


### PR DESCRIPTION
## Problem

The user-visible half of beancounter #1067, and the reason a wrong trade date cost a
debugging session instead of showing an error.

"Set Balance" on a cash or bank account published a CSV row to `/api/trns/import`, which
puts it on a RabbitMQ topic and returns `200 "ok"` immediately. When bc-data rejected the
row it retried, exhausted the policy, acked the delivery and dropped the payload. The
dialog showed **Success** and no transaction existed.

The red run reproduced exactly that — server returned 400, dialog rendered "Success":

```
● SetCashBalanceDialog › shows the server's rejection instead of reporting success
  Unable to find an element with the text: /Rejecting the forward dated trade date/i
  ... <span>Success</span>
```

## Change

Write through the synchronous `/api/trns` endpoint, where the caller sees the failure. The
same endpoint the onboarding wizard already uses for cash deposits.

- `cashAssetId` = the asset being adjusted: a cash asset settles against itself, which is
  what the import adapter resolved implicitly.
- `cashAmount` is sent alongside `quantity`, matching what the import row produced — the
  cash ladder reads `cashAmount`, and the backend signs it from the trn type.
- `tradeDate` is deliberately **omitted** so the server resolves "today" in the configured
  zone (`TrnInput.tradeDate` defaults to `DateUtils().date`). Sending the browser's date is
  what started this whole thread.
- `assetId` is now required on `SetCashBalanceData` — the only producer already passed it.

## Verified against the live API

Rather than trust the payload shape, I posted it to kauri. The first attempt persisted with
`cashAmount 0` because omitting `price` leaves `tradeAmount` at zero, so I added
`cashAmount` explicitly; the second attempt gave `cashAmount 1000` and `tradeDate 2026-08-05`
(SGT — confirming the server-side zone default). Both probe transactions were deleted and
the EUR position is back to empty.

## Not browser-verified

Three new unit tests cover the deposit path, the withdrawal path and the error path, and
the full suite is green (249 suites / 2487 tests), but I did not click through the running
app. Worth a human pass on: Set Balance from the holdings page for a **CASH** currency row,
Set Balance for a **PRIVATE** bank account row, and the same from the aggregated holdings
page (a second call site, updated here too).

## Scope note

I initially removed the `market` field, which the sync write makes redundant, but an
existing `CardView` test asserts it in the event payload. Removing it isn't part of #1067
and the standing rule is not to edit tests to suit a refactor, so I reverted that and left
`market` in place. It is now written and not read — a small follow-up if you want it gone.

Gates: `yarn test` + `prettier` + `lint` + `typecheck` green. `ocr review` — 0 findings.

Relates to beancounter #1067 (paired with beancounter #1071, which dead-letters the
remaining async path).
