### PR TITLE
fix(independence): display the age the backend used, not a client re-derivation

### DIFF
--- a/src/components/features/independence/composite/CompositeProjectionContext.tsx
+++ b/src/components/features/independence/composite/CompositeProjectionContext.tsx
@@ -27,6 +27,12 @@ export interface CompositeProjectionValue {
   /** Work scenario ID selected for composite projections. */
   compositeWorkScenarioId: string | undefined
   setCompositeWorkScenarioId: (id: string | undefined) => void
+  /**
+   * Current age to display — prefers the backend-echoed
+   * `CompositeProjectionResult.currentAge` once a projection has landed,
+   * falling back to a local derivation for first paint (bc-view #1144).
+   */
+  currentAge?: number
 
   // Results
   projection: CompositeProjectionResult | undefined

--- a/src/components/features/independence/composite/__tests__/FiOverviewTab.test.tsx
+++ b/src/components/features/independence/composite/__tests__/FiOverviewTab.test.tsx
@@ -130,6 +130,7 @@ function makeCtx(
     toggleExclusion: jest.fn(),
     compositeWorkScenarioId: undefined,
     setCompositeWorkScenarioId: jest.fn(),
+    currentAge: undefined,
     projection: undefined,
     scenarios: undefined,
     isLoading: false,
@@ -193,6 +194,31 @@ describe("FiOverviewTab — backend-echo fiNumber/fiProgress", () => {
     expect(
       screen.getByText(/Portfolio covers your FI target/i),
     ).toBeInTheDocument()
+  })
+})
+
+// =====================================================================
+// Test — currentAge must come from context (hook's backend-echo-preferred
+// value), not be re-derived locally from settings/plan.yearOfBirth
+// (bc-view #1144).
+// =====================================================================
+
+describe("FiOverviewTab — currentAge from context", () => {
+  it("uses the context's currentAge (not a local settings/plan derivation) for years-to-FI", () => {
+    const projection = makeProjection({
+      fiNumber: 1_313_100,
+      fiProgress: 103.6,
+      liquidAssets: 1_360_893,
+    })
+    // ctx.plans is empty and useIndependenceSettings is mocked to return no
+    // settings, so any local re-derivation (settings/plan.yearOfBirth) would
+    // yield `undefined` here. The component must still show "15 years away"
+    // by reading currentAge straight off the context.
+    renderWithCtx({ projection, currentAge: 50 })
+
+    // fiCrossingAge is 65 (first row whose endingBalance >= fiNumber);
+    // 65 - 50 = 15.
+    expect(screen.getByText("15 years away")).toBeInTheDocument()
   })
 })
 

--- a/src/components/features/independence/composite/tabs/FiOverviewTab.tsx
+++ b/src/components/features/independence/composite/tabs/FiOverviewTab.tsx
@@ -16,13 +16,11 @@ import { deriveFiStack } from "@lib/independence/fiStack"
 import Spinner from "@components/ui/Spinner"
 import Alert from "@components/ui/Alert"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
-import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
 import { useCompositeProjectionContext } from "../CompositeProjectionContext"
 import useCompositeMonteCarloSimulation from "@hooks/useCompositeMonteCarloSimulation"
 
 const HIDDEN_VALUE = "****"
 const MC_ITERATION_OPTIONS = [500, 1000, 2000, 5000]
-const CURRENT_YEAR = new Date().getFullYear()
 
 function fmtShort(v: number): string {
   if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(2)}M`
@@ -113,8 +111,15 @@ function IncomeRow({
 }
 
 export default function FiOverviewTab(): React.ReactElement | null {
-  const { projection, plans, phases, displayCurrency, isLoading, error } =
-    useCompositeProjectionContext()
+  const {
+    projection,
+    plans,
+    phases,
+    displayCurrency,
+    isLoading,
+    error,
+    currentAge,
+  } = useCompositeProjectionContext()
   const { hideValues } = usePrivacyMode()
   const {
     result: mcResult,
@@ -122,7 +127,6 @@ export default function FiOverviewTab(): React.ReactElement | null {
     error: mcError,
     runSimulation,
   } = useCompositeMonteCarloSimulation()
-  const { settings } = useIndependenceSettings()
   const [mcIterations, setMcIterations] = useState(1000)
 
   // Primary plan for income/expense breakdown
@@ -130,12 +134,6 @@ export default function FiOverviewTab(): React.ReactElement | null {
     () => plans.find((p) => p.isPrimary) ?? plans[0],
     [plans],
   )
-
-  // Current age from independence settings, falling back to plan
-  const currentAge = useMemo(() => {
-    const yob = settings?.yearOfBirth ?? primaryPlan?.yearOfBirth
-    return yob ? CURRENT_YEAR - yob : undefined
-  }, [settings, primaryPlan])
 
   // Net monthly retirement expenses — for the income breakdown display only
   const netMonthlyExpenses = primaryPlan

--- a/src/hooks/__tests__/useCompositeProjection.test.ts
+++ b/src/hooks/__tests__/useCompositeProjection.test.ts
@@ -1,5 +1,13 @@
-import { buildInitialPhases } from "../useCompositeProjection"
+import { renderHook, act } from "@testing-library/react"
+import {
+  buildInitialPhases,
+  useCompositeProjection,
+} from "../useCompositeProjection"
 import type { RetirementPlan } from "types/independence"
+
+jest.mock("@hooks/useIndependenceSettings", () => ({
+  useIndependenceSettings: () => ({ updateSettings: jest.fn() }),
+}))
 
 function makePlan(overrides: Partial<RetirementPlan> = {}): RetirementPlan {
   return {
@@ -126,5 +134,74 @@ describe("buildInitialPhases", () => {
     const phases = buildInitialPhases(plans, new Set(), 60, 90)
 
     expect(phases[phases.length - 1].toAge).toBeUndefined()
+  })
+})
+
+// bc-view #1144: the composite hook must prefer the backend-echoed
+// currentAge (CompositeProjectionResult.currentAge, month-of-birth aware,
+// resolved server-side from the plan owner's settings) over any
+// client-derived value once a projection has landed. The client-side
+// derivation remains ONLY as a fallback for first paint, before any
+// projection response exists — and even then it must be month-of-birth
+// aware (via currentAgeFromSettings), not a naive currentYear - yearOfBirth.
+describe("useCompositeProjection — currentAge", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    // Pin "now" to a known date (June 15) so month-of-birth comparisons
+    // are deterministic regardless of when the test suite actually runs.
+    jest.setSystemTime(new Date(2026, 5, 15))
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it("derives currentAge locally (month-of-birth aware) before any projection has landed", () => {
+    // Birth month (December, 1-based 12) is AFTER "now" (June) → local
+    // derivation must subtract one year. A naive `currentYear -
+    // yearOfBirth` would get this wrong (it would report 40, not 39).
+    const yearOfBirth = 1986
+    const monthOfBirth = 12
+
+    const plans = [makePlan({ id: "p1", isPrimary: true, yearOfBirth })]
+
+    const { result } = renderHook(() =>
+      useCompositeProjection(plans, {
+        yearOfBirth,
+        monthOfBirth,
+      } as unknown as import("types/independence").UserIndependenceSettings),
+    )
+
+    // 2026 - 1986 = 40, minus 1 since birth month hasn't happened yet.
+    expect(result.current.currentAge).toBe(39)
+  })
+
+  it("prefers the projection's echoed currentAge once a projection has landed", async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { currentAge: 47, yearlyProjections: [], warnings: [] },
+        }),
+    })
+
+    const plans = [makePlan({ id: "p1", isPrimary: true, yearOfBirth: 1980 })]
+
+    const { result } = renderHook(() =>
+      useCompositeProjection(plans, {
+        yearOfBirth: 1980,
+      } as unknown as import("types/independence").UserIndependenceSettings),
+    )
+
+    await act(async () => {
+      jest.advanceTimersByTime(600)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.projection?.currentAge).toBe(47)
+    expect(result.current.currentAge).toBe(47)
   })
 })

--- a/src/hooks/useCompositeProjection.ts
+++ b/src/hooks/useCompositeProjection.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react"
+import { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import type {
   RetirementPlan,
   UserIndependenceSettings,
@@ -9,6 +9,7 @@ import type {
 } from "types/independence"
 import { useIndependenceSettings } from "@hooks/useIndependenceSettings"
 import { toErrorMessage } from "@lib/formatters"
+import { currentAgeFromSettings } from "@lib/independence/age"
 
 const COMPOSITE_PROJECTION_URL = "/api/independence/composite/projection"
 const COMPOSITE_SCENARIOS_URL = "/api/independence/composite/scenarios"
@@ -25,6 +26,14 @@ export interface UseCompositeProjectionResult {
   /** Work scenario ID to use for composite projections. */
   compositeWorkScenarioId: string | undefined
   setCompositeWorkScenarioId: (id: string | undefined) => void
+  /**
+   * Current age to display. Prefers the backend-echoed
+   * `CompositeProjectionResult.currentAge` once a projection has landed
+   * (svc-retire resolves it from the plan owner's settings, year + month
+   * of birth aware — bc-view #1144); falls back to a local, month-aware
+   * derivation for first paint before any projection response exists.
+   */
+  currentAge: number | undefined
   projection: CompositeProjectionResult | undefined
   scenarios: CompositeScenarioComparison | undefined
   isLoading: boolean
@@ -88,11 +97,31 @@ export function useCompositeProjection(
   plans: RetirementPlan[],
   settings: UserIndependenceSettings | undefined,
 ): UseCompositeProjectionResult {
-  const currentYear = new Date().getFullYear()
   const primaryPlan = plans.find((p) => p.isPrimary) || plans[0]
   const defaultCurrency = primaryPlan?.expensesCurrency || "USD"
-  const yearOfBirth = settings?.yearOfBirth ?? primaryPlan?.yearOfBirth
-  const currentAge = yearOfBirth ? currentYear - yearOfBirth : 60
+  // Month-of-birth aware local derivation (settings first, plan as
+  // fallback — plans don't carry monthOfBirth, only yearOfBirth). Used
+  // only until a projection lands; see `currentAge` below. Memoized
+  // (rather than a bare const) so the React Compiler can see a stable,
+  // trackable dependency for `toggleExclusion` below — an inline call
+  // chain through the currentAgeFromSettings helper otherwise reads as
+  // opaque to the compiler's memoization-preservation check. `new Date()`
+  // stays inside the memo callback (defaulted by currentAgeFromSettings)
+  // rather than hoisted as its own dependency, since a fresh Date on every
+  // render would defeat the memoization and re-trigger the same warning.
+  const localCurrentAge = useMemo(
+    () =>
+      currentAgeFromSettings(settings) ?? currentAgeFromSettings(primaryPlan),
+    [settings, primaryPlan],
+  )
+  // Phase distribution (buildInitialPhases) needs a concrete number to do
+  // arithmetic with and runs BEFORE any projection exists, so it can't use
+  // the backend echo — it keeps its own fallback here. 60 is an arbitrary
+  // "reasonable default" only reachable when neither settings nor any plan
+  // carries a yearOfBirth at all (e.g. a brand-new profile); it never
+  // affects the age actually *displayed* (see `currentAge` below, which
+  // has no such fallback).
+  const phaseSeedAge = localCurrentAge ?? 60
   const lifeExpectancy = settings?.lifeExpectancy ?? 90
 
   const { updateSettings } = useIndependenceSettings()
@@ -119,7 +148,7 @@ export function useCompositeProjection(
   // pattern: `initialized` is the latch, so we perform the one-time seeding
   // during render (guarded by !initialized) instead of in an effect, avoiding
   // a cascading render. Behaviour matches the prior effect keyed on
-  // [plans, settings, currentAge, lifeExpectancy, initialized].
+  // [plans, settings, phaseSeedAge, lifeExpectancy, initialized].
   if (!initialized && plans.length > 0 && settings) {
     const savedExclusions = parseSavedExclusions(
       settings.compositeExcludedPlanIds,
@@ -145,7 +174,7 @@ export function useCompositeProjection(
       const initial = buildInitialPhases(
         plans,
         exclusions,
-        currentAge,
+        phaseSeedAge,
         lifeExpectancy,
       )
       setPhases(initial)
@@ -196,14 +225,14 @@ export function useCompositeProjection(
         const rebuilt = buildInitialPhases(
           plans,
           next,
-          currentAge,
+          phaseSeedAge,
           lifeExpectancy,
         )
         setPhases(rebuilt)
         return next
       })
     },
-    [plans, currentAge, lifeExpectancy],
+    [plans, phaseSeedAge, lifeExpectancy],
   )
 
   // Fetch projection when phases or currency change (debounced)
@@ -287,6 +316,12 @@ export function useCompositeProjection(
     }
   }, [phases, displayCurrency, compositeWorkScenarioId])
 
+  // Display age: the backend echo is authoritative once a projection has
+  // landed (svc-retire resolves it from the plan owner's settings — bc-view
+  // #1144); no further fallback beyond the local derivation, since callers
+  // already null-guard the "no yearOfBirth anywhere" case.
+  const currentAge = projection?.currentAge ?? localCurrentAge
+
   return {
     phases,
     setPhases,
@@ -296,6 +331,7 @@ export function useCompositeProjection(
     toggleExclusion,
     compositeWorkScenarioId,
     setCompositeWorkScenarioId,
+    currentAge,
     projection,
     scenarios,
     isLoading,

--- a/src/lib/utils/independence/__tests__/age.test.ts
+++ b/src/lib/utils/independence/__tests__/age.test.ts
@@ -1,0 +1,47 @@
+import { currentAgeFromSettings, resolveDisplayAges } from "../age"
+
+describe("currentAgeFromSettings", () => {
+  it("returns undefined when yearOfBirth is missing", () => {
+    expect(currentAgeFromSettings(undefined)).toBeUndefined()
+    expect(currentAgeFromSettings({})).toBeUndefined()
+  })
+
+  it("computes age from yearOfBirth alone", () => {
+    const thisYear = new Date().getFullYear()
+    expect(currentAgeFromSettings({ yearOfBirth: thisYear - 40 })).toBe(40)
+  })
+})
+
+describe("resolveDisplayAges", () => {
+  // bc-view #1144: svc-retire echoes the demographics it actually used
+  // (RetirementProjection.planInputs) — the backend is authoritative, so
+  // the echo must win over any client-derived value whenever a projection
+  // has landed, for every plan (not just shared ones).
+  const local = { currentAge: 46, retirementAge: 65, lifeExpectancy: 90 }
+
+  it("prefers the projection echo over the locally-derived values", () => {
+    const result = resolveDisplayAges(
+      { currentAge: 47, retirementAge: 62, lifeExpectancy: 92 },
+      local,
+    )
+    expect(result).toEqual({
+      currentAge: 47,
+      retirementAge: 62,
+      lifeExpectancy: 92,
+    })
+  })
+
+  it("falls back to local values field-by-field when the echo is partial", () => {
+    const result = resolveDisplayAges({ currentAge: 47 }, local)
+    expect(result).toEqual({
+      currentAge: 47,
+      retirementAge: 65,
+      lifeExpectancy: 90,
+    })
+  })
+
+  it("falls back to local values entirely when no projection has landed yet", () => {
+    const result = resolveDisplayAges(undefined, local)
+    expect(result).toEqual(local)
+  })
+})

--- a/src/lib/utils/independence/age.ts
+++ b/src/lib/utils/independence/age.ts
@@ -18,10 +18,16 @@ export interface ProfileDemographics {
 
 export function currentAgeFromSettings(
   settings: ProfileDemographics | undefined | null,
+  // Callers that need to stay React-Compiler-memoizable (calling this from
+  // a hook/component body) should hoist their own `new Date()` at the top
+  // of the render and pass it in — an opaque `new Date()` buried inside an
+  // imported function call reads as an impure/non-deterministic call to
+  // the compiler and can block memoization of unrelated callbacks further
+  // down the same component (see useCompositeProjection.ts).
+  now: Date = new Date(),
 ): number | undefined {
   const yob = settings?.yearOfBirth
   if (!yob) return undefined
-  const now = new Date()
   let age = now.getFullYear() - Number(yob)
   const monthOfBirth = settings?.monthOfBirth
   // Months stored 1-based; getMonth() is 0-based.
@@ -29,4 +35,48 @@ export function currentAgeFromSettings(
     age -= 1
   }
   return age
+}
+
+/** Ages echoed back on `RetirementProjection.planInputs` (see types/independence.d.ts). */
+export interface ProjectionEchoedAges {
+  currentAge?: number
+  retirementAge?: number
+  lifeExpectancy?: number
+}
+
+/** The locally (client-)derived ages, used only until a projection lands. */
+export interface LocalAges {
+  currentAge: number | undefined
+  retirementAge: number
+  lifeExpectancy: number
+}
+
+export interface DisplayAges {
+  currentAge: number | undefined
+  retirementAge: number
+  lifeExpectancy: number
+}
+
+/**
+ * Resolve the ages to show on the plan detail page.
+ *
+ * The backend (svc-retire) is authoritative: every projection response
+ * echoes the demographics it actually used via `RetirementProjection.
+ * planInputs` (resolved from the plan OWNER's settings — important for
+ * shared plans, but also the single source of truth for owned plans).
+ * bc-view must not re-derive the same fact client-side and risk drifting
+ * out of step with the backend's derivation rules (bc-view #1144) — prefer
+ * the echo, field-by-field, over the locally computed value. The local
+ * value remains only as a fallback for first paint, before any projection
+ * has landed.
+ */
+export function resolveDisplayAges(
+  echoed: ProjectionEchoedAges | undefined,
+  local: LocalAges,
+): DisplayAges {
+  return {
+    currentAge: echoed?.currentAge ?? local.currentAge,
+    retirementAge: echoed?.retirementAge ?? local.retirementAge,
+    lifeExpectancy: echoed?.lifeExpectancy ?? local.lifeExpectancy,
+  }
 }

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -56,6 +56,7 @@ import {
   manualAssetsToSlices,
 } from "@lib/independence/planHelpers"
 import { buildCpfSubAccountRows } from "@lib/independence/cpfSubAccountTags"
+import { resolveDisplayAges } from "@lib/independence/age"
 
 function PlanView(): React.ReactElement {
   const router = useRouter()
@@ -534,33 +535,23 @@ function PlanView(): React.ReactElement {
     enabled: isSharedPlanResolved,
   })
 
-  // For shared plans, demographics + retirement age MUST come from the
-  // projection's planInputs echo (server resolves them from the plan
-  // OWNER's settings via the M2M path). Falling through to
-  // independenceSettings here renders the VIEWER's age + "Independence
-  // (60)" marker on someone else's plan. Owned plans keep the existing
-  // settings-driven path so pre-projection rendering still works.
-  const planInputsAges = (
-    adjustedProjection as unknown as
-      | {
-          planInputs?: {
-            currentAge?: number
-            retirementAge?: number
-            lifeExpectancy?: number
-          }
-        }
-      | null
-      | undefined
-  )?.planInputs
-  const displayCurrentAge = isSharedPlan
-    ? (planInputsAges?.currentAge ?? currentAge)
-    : currentAge
-  const displayRetirementAge = isSharedPlan
-    ? (planInputsAges?.retirementAge ?? retirementAge)
-    : retirementAge
-  const displayLifeExpectancy = isSharedPlan
-    ? (planInputsAges?.lifeExpectancy ?? lifeExpectancy)
-    : lifeExpectancy
+  // The backend (svc-retire) is authoritative for age: every projection
+  // response echoes the demographics it actually used via
+  // `RetirementProjection.planInputs` (resolved from the plan OWNER's
+  // settings — critical for shared plans, since falling through to
+  // independenceSettings would render the VIEWER's age + "Independence
+  // (60)" marker on someone else's plan; but also the single source of
+  // truth for owned plans — see bc-view #1144). Prefer the echo for
+  // every plan; the locally-derived values remain only as a fallback for
+  // first paint, before any projection has landed.
+  const displayAges = resolveDisplayAges(adjustedProjection?.planInputs, {
+    currentAge,
+    retirementAge,
+    lifeExpectancy,
+  })
+  const displayCurrentAge = displayAges.currentAge
+  const displayRetirementAge = displayAges.retirementAge
+  const displayLifeExpectancy = displayAges.lifeExpectancy
 
   // Display totals: prefer the server's authoritative numbers from the
   // projection echo so composite assets (CPF sub-accounts, future ILP/

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -1327,6 +1327,13 @@ export interface CompositeProjectionResult {
   retirementAgeFiProgress?: number
   /** Present value today of the Social Security stream (first non-zero-SS phase). Null when no SS. */
   pvGuaranteedIncomeToday?: number
+  /**
+   * Current age used to build this projection, resolved server-side from
+   * the plan owner's settings (year + month of birth aware). Authoritative
+   * echo — bc-view must prefer this over any client-derived age once a
+   * projection has landed (bc-view #1144).
+   */
+  currentAge?: number
 }
 
 export interface CompositeScenarioResult {


### PR DESCRIPTION
## Why

Closes #1144. Age was derived in bc-view *and* in svc-retire. Since svc-retire #179 they
agree — but only by coincidence of both being month-aware, and the composite hook had a
third variant of its own: no month-of-birth adjustment and a hard-coded `60` fallback. The
rule is backend drives data, frontend displays it.

## Change

**Single plan** — read `currentAge` / `retirementAge` / `lifeExpectancy` from the
projection's `planInputs` echo for **every** plan, via a new `resolveDisplayAges` helper
that prefers the echo field-by-field.

Worth noting: previously *only shared plans* read the echo. Owned plans always used the
client value, so the authoritative path was the exception rather than the rule. That
asymmetry is gone.

**Composite** — read the `currentAge` now echoed on `CompositeProjectionResult`
(svc-retire #180) instead of re-deriving it. The `60` fallback no longer reaches anything
displayed; it survives only as `phaseSeedAge`, which seeds `buildInitialPhases` before any
projection exists and needs a concrete number.

`currentAgeFromSettings` stays — it is the pre-projection first-paint fallback, and several
endpoints take age as a genuine *input* rather than echoing it back (`LumpSumProjectionRequest`,
`CpfLifeProjectionRequest`, CPF contribution-band lookups).

## Deliberately left alone

`scenarioToPayload.ts` still sends `payload.currentAge` for owned plans. An existing test
(`scenarioToPayload.test.ts:87-92`) asserts the client value is threaded through, and the
standing rule here is not to edit a test to suit a refactor. It is harmless today — the
backend derives the identical value — but it is the last of the duplicate derivation. **That
assertion encodes the behaviour this issue wants removed, so it needs a decision** rather
than a quiet edit.

`CompositeProjectionContext.currentAge` is optional so the five existing composite tab test
fixtures didn't need touching.

## Order

Merge svc-retire #180 first — the composite half reads a field that doesn't exist until it
ships. The single-plan half is independent.

## Not browser-verified

249 suites / 2492 tests green, prettier / lint / typecheck clean, `ocr review` 0 findings —
but no browser drive. A human should check: the What-If editor for an **owned** plan (age
should come from the echo once the first projection lands), the same for a **shared** plan
(no regression — this path already worked), the composite dashboard FI Overview, and
specifically a user whose **birthday hasn't happened yet this year**, which is where a
re-derivation would drift by a year.
