### PR TITLE
chore: drop Graphite Agent reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,8 +151,8 @@ Rules for new code:
 - Never `@lib/utils/...` — double-`utils`; the alias already points
   inside `src/lib/utils/`.
 
-AI reviewers (e.g. Graphite Agent) get this wrong; reject any suggestion that
-rewrites `@utils/api/*` to `@lib/api/*`.
+AI reviewers get this wrong; reject any suggestion that rewrites
+`@utils/api/*` to `@lib/api/*`.
 
 ## API Routes
 


### PR DESCRIPTION
Graphite is no longer used for BC PRs. The import-alias rule named Graphite Agent as the reviewer that gets `@utils/api/*` wrong — the rule itself still holds for any AI reviewer, so only the attribution changes.

Docs-only. Matching changes: `bc-claude@f6b463b`, beancounter#1079.