### PR TITLE
feat(independence): show salary as its own income-breakdown column

### DIFF
--- a/__tests__/components/features/independence/IncomeBreakdownTable.test.tsx
+++ b/__tests__/components/features/independence/IncomeBreakdownTable.test.tsx
@@ -62,3 +62,37 @@ describe("IncomeBreakdownTable value basis", () => {
     expect(pensionHeader).toHaveTextContent("stays same")
   })
 })
+
+// svc-retire #221: salary credited during working years flows into the
+// backend's totalIncome, so it needs a column of its own — otherwise the
+// visible components fall short of the Total Income beside them.
+describe("IncomeBreakdownTable salary column", () => {
+  const workingYear = makeYear({
+    incomeBreakdown: {
+      investmentReturns: 4000,
+      pension: 0,
+      socialSecurity: 0,
+      otherIncome: 0,
+      rentalIncome: 0,
+      workingIncome: 60000,
+      totalIncome: 64000,
+    },
+  })
+
+  it("shows salary earned in a working year", () => {
+    render(<IncomeBreakdownTable projections={[workingYear]} />)
+    expect(screen.getByText("Salary")).toBeInTheDocument()
+    expect(screen.getAllByText("$60,000").length).toBeGreaterThan(0)
+  })
+
+  it("reported components add up to the total income on the row", () => {
+    render(<IncomeBreakdownTable projections={[workingYear]} />)
+    // 4,000 investment + 60,000 salary — nothing unaccounted for.
+    expect(screen.getAllByText("$64,000").length).toBeGreaterThan(0)
+  })
+
+  it("hides the column for a plan with no working years", () => {
+    render(<IncomeBreakdownTable projections={[makeYear()]} />)
+    expect(screen.queryByText("Salary")).not.toBeInTheDocument()
+  })
+})

--- a/src/components/features/independence/IncomeBreakdownTable.tsx
+++ b/src/components/features/independence/IncomeBreakdownTable.tsx
@@ -53,6 +53,7 @@ export default function IncomeBreakdownTable({
   const columnVisibility = useMemo(() => {
     const hasData = {
       investment: false,
+      workingIncome: false,
       pension: false,
       assetPensions: false,
       lumpSum: false,
@@ -67,6 +68,7 @@ export default function IncomeBreakdownTable({
       if (!breakdown) continue
 
       if (breakdown.investmentReturns > 0) hasData.investment = true
+      if ((breakdown.workingIncome ?? 0) > 0) hasData.workingIncome = true
       if (breakdown.pension > 0) hasData.pension = true
       if ((breakdown.assetPensions ?? 0) > 0) hasData.assetPensions = true
       if ((breakdown.lumpSumPayout ?? 0) > 0) hasData.lumpSum = true
@@ -87,6 +89,7 @@ export default function IncomeBreakdownTable({
   const visibleIncomeColumns =
     1 + // Age (always visible)
     (columnVisibility.investment ? 1 : 0) +
+    (columnVisibility.workingIncome ? 1 : 0) +
     (columnVisibility.pension ? 1 : 0) +
     (columnVisibility.assetPensions ? 1 : 0) +
     (columnVisibility.lumpSum ? 1 : 0) +
@@ -166,6 +169,16 @@ export default function IncomeBreakdownTable({
                     title="Net-of-fee return your investment portfolio (cash + equities) earns each year. Compounds every year, including in independence — while you also draw down capital (see Withdrawals). CPF, pensions and property grow separately in their own columns."
                   >
                     Investment Growth
+                  </span>
+                </th>
+              )}
+              {columnVisibility.workingIncome && (
+                <th className="text-right py-2 px-2 font-medium text-gray-600">
+                  <span
+                    className="text-sky-600 cursor-help"
+                    title="Salary you are still earning in this year — credited until the age you stop working."
+                  >
+                    Salary
                   </span>
                 </th>
               )}
@@ -300,6 +313,13 @@ export default function IncomeBreakdownTable({
                     <td className="text-right py-2 px-2 text-green-600">
                       {breakdown
                         ? formatCurrency(breakdown.investmentReturns)
+                        : "-"}
+                    </td>
+                  )}
+                  {columnVisibility.workingIncome && (
+                    <td className="text-right py-2 px-2 text-sky-600">
+                      {breakdown?.workingIncome
+                        ? formatCurrency(breakdown.workingIncome)
                         : "-"}
                     </td>
                   )}

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -502,6 +502,8 @@ export interface IncomeBreakdown {
   otherIncome: number
   /** Property rental income (stops if liquidated) */
   rentalIncome: number
+  /** Salary earned this year, while age is below the working-income age */
+  workingIncome?: number
   /** One-off life event income at this age */
   lifeEventIncome?: number
   /** One-off life event expense at this age */


### PR DESCRIPTION
Companion to svc-retire #230 (issue svc-retire#221).

The backend credits salary into `totalIncome` during working years but had no
component for it, so the Income Breakdown table's visible columns fell short of
the Total Income beside them by exactly the salary. svc-retire#230 adds
`IncomeBreakdown.workingIncome`; this surfaces it as a **Salary** column, shown
only for plans that actually have working years.

The field is optional, so this is safe to merge before or after the backend —
until bc-retire ships the new field the column simply never appears.

Gates: `yarn test` (2498 pass), `yarn prettier`, `yarn lint`, `yarn typecheck`, `ocr review` (0 findings).
