### PR TITLE
fix(independence): allow the current work scenario to be deleted and restored

### DIFF
--- a/src/components/features/independence/scenarios/ScenarioCard.tsx
+++ b/src/components/features/independence/scenarios/ScenarioCard.tsx
@@ -6,7 +6,6 @@ const HIDDEN_VALUE = "****"
 
 interface ScenarioCardProps {
   scenario: WorkScenario
-  currentCount: number
   onEdit: (scenario: WorkScenario) => void
   onDelete: (scenario: WorkScenario) => void
   onSetCurrent: (scenarioId: string) => void
@@ -14,7 +13,6 @@ interface ScenarioCardProps {
 
 export default function ScenarioCard({
   scenario,
-  currentCount,
   onEdit,
   onDelete,
   onSetCurrent,
@@ -58,15 +56,16 @@ export default function ScenarioCard({
           >
             <i className="fas fa-edit text-xs"></i>
           </button>
-          {(!scenario.isCurrent || currentCount > 1) && (
-            <button
-              onClick={() => onDelete(scenario)}
-              className="text-red-600 hover:text-red-900 p-1.5"
-              title="Delete scenario"
-            >
-              <i className="fas fa-trash text-xs"></i>
-            </button>
-          )}
+          {/* svc-retire #229: the current scenario is deletable too — that is the
+              only way back to plan-driven income. The delete is logical, so it
+              can be restored from the recovery list. */}
+          <button
+            onClick={() => onDelete(scenario)}
+            className="text-red-600 hover:text-red-900 p-1.5"
+            title="Delete scenario"
+          >
+            <i className="fas fa-trash text-xs"></i>
+          </button>
           {!scenario.isCurrent && (
             <button
               onClick={() => onSetCurrent(scenario.id)}

--- a/src/components/features/independence/scenarios/ScenarioList.tsx
+++ b/src/components/features/independence/scenarios/ScenarioList.tsx
@@ -29,6 +29,9 @@ export default function ScenarioList({
     null,
   )
   const [deleteTarget, setDeleteTarget] = useState<WorkScenario | null>(null)
+  // Delete and restore both mutate the overlay that drives every projection, so
+  // a failure has to be visible rather than logged to the console.
+  const [actionError, setActionError] = useState<string | null>(null)
 
   const { data, error, isLoading, mutate } = useSwr<WorkScenariosResponse>(
     scenariosKey,
@@ -37,8 +40,11 @@ export default function ScenarioList({
 
   // Logically deleted scenarios, restorable with their expenses and
   // contributions intact (svc-retire #229).
-  const { data: deletedData, mutate: mutateDeleted } =
-    useSwr<WorkScenariosResponse>(deletedKey, simpleFetcher(deletedKey))
+  const {
+    data: deletedData,
+    error: deletedError,
+    mutate: mutateDeleted,
+  } = useSwr<WorkScenariosResponse>(deletedKey, simpleFetcher(deletedKey))
 
   const scenarios = data?.data || []
   const deletedScenarios = deletedData?.data || []
@@ -87,12 +93,23 @@ export default function ScenarioList({
 
   const handleDeleteConfirm = useCallback(async (): Promise<void> => {
     if (!deleteTarget) return
+    setActionError(null)
     try {
-      await fetch(`${scenariosKey}/${deleteTarget.id}`, { method: "DELETE" })
+      const response = await fetch(`${scenariosKey}/${deleteTarget.id}`, {
+        method: "DELETE",
+      })
+      if (!response.ok) {
+        setActionError(
+          `Failed to delete "${deleteTarget.name}". Please try again.`,
+        )
+        return
+      }
       mutate()
       mutateDeleted()
-    } catch (err) {
-      console.error("Failed to delete scenario:", err)
+    } catch {
+      setActionError(
+        `Failed to delete "${deleteTarget.name}". Please try again.`,
+      )
     } finally {
       setDeleteTarget(null)
     }
@@ -100,16 +117,19 @@ export default function ScenarioList({
 
   const handleRestore = useCallback(
     async (scenarioId: string): Promise<void> => {
+      setActionError(null)
       try {
         const response = await fetch(`${scenariosKey}/${scenarioId}/restore`, {
           method: "POST",
         })
-        if (response.ok) {
-          mutate()
-          mutateDeleted()
+        if (!response.ok) {
+          setActionError("Failed to restore scenario. Please try again.")
+          return
         }
-      } catch (err) {
-        console.error("Failed to restore scenario:", err)
+        mutate()
+        mutateDeleted()
+      } catch {
+        setActionError("Failed to restore scenario. Please try again.")
       }
     },
     [mutate, mutateDeleted],
@@ -164,6 +184,8 @@ export default function ScenarioList({
         </button>
       </div>
 
+      {actionError && <Alert>{actionError}</Alert>}
+
       {scenarios.length === 0 ? (
         <EmptyState
           icon="fas fa-briefcase"
@@ -193,7 +215,7 @@ export default function ScenarioList({
         </div>
       )}
 
-      {deletedScenarios.length > 0 && (
+      {(deletedScenarios.length > 0 || deletedError) && (
         <div className="mt-8 border-t border-gray-200 pt-6">
           <h3 className="text-sm font-semibold text-gray-700 mb-1">
             <i className="fas fa-trash-can-arrow-up text-gray-400 mr-2"></i>
@@ -203,6 +225,11 @@ export default function ScenarioList({
             Restoring brings a scenario back with its expenses and
             contributions. It won&apos;t become current until you choose it.
           </p>
+          {deletedError && (
+            <p className="text-xs text-red-600 mb-3">
+              Couldn&apos;t load deleted scenarios. Refresh to try again.
+            </p>
+          )}
           <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
             {deletedScenarios.map((scenario) => (
               <li

--- a/src/components/features/independence/scenarios/ScenarioList.tsx
+++ b/src/components/features/independence/scenarios/ScenarioList.tsx
@@ -14,6 +14,7 @@ import Alert from "@components/ui/Alert"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
 
 const scenariosKey = "/api/independence/work-scenarios"
+const deletedKey = "/api/independence/work-scenarios/deleted"
 
 interface ScenarioListProps {
   /** Plan currency used to default a NEW scenario. */
@@ -34,8 +35,13 @@ export default function ScenarioList({
     simpleFetcher(scenariosKey),
   )
 
+  // Logically deleted scenarios, restorable with their expenses and
+  // contributions intact (svc-retire #229).
+  const { data: deletedData, mutate: mutateDeleted } =
+    useSwr<WorkScenariosResponse>(deletedKey, simpleFetcher(deletedKey))
+
   const scenarios = data?.data || []
-  const currentCount = scenarios.filter((s) => s.isCurrent).length
+  const deletedScenarios = deletedData?.data || []
 
   const handleCreate = useCallback(() => {
     setEditingScenario(null)
@@ -84,12 +90,30 @@ export default function ScenarioList({
     try {
       await fetch(`${scenariosKey}/${deleteTarget.id}`, { method: "DELETE" })
       mutate()
+      mutateDeleted()
     } catch (err) {
       console.error("Failed to delete scenario:", err)
     } finally {
       setDeleteTarget(null)
     }
-  }, [deleteTarget, mutate])
+  }, [deleteTarget, mutate, mutateDeleted])
+
+  const handleRestore = useCallback(
+    async (scenarioId: string): Promise<void> => {
+      try {
+        const response = await fetch(`${scenariosKey}/${scenarioId}/restore`, {
+          method: "POST",
+        })
+        if (response.ok) {
+          mutate()
+          mutateDeleted()
+        }
+      } catch (err) {
+        console.error("Failed to restore scenario:", err)
+      }
+    },
+    [mutate, mutateDeleted],
+  )
 
   const handleSetCurrent = useCallback(
     async (scenarioId: string): Promise<void> => {
@@ -161,12 +185,50 @@ export default function ScenarioList({
             <ScenarioCard
               key={scenario.id}
               scenario={scenario}
-              currentCount={currentCount}
               onEdit={handleEdit}
               onDelete={setDeleteTarget}
               onSetCurrent={handleSetCurrent}
             />
           ))}
+        </div>
+      )}
+
+      {deletedScenarios.length > 0 && (
+        <div className="mt-8 border-t border-gray-200 pt-6">
+          <h3 className="text-sm font-semibold text-gray-700 mb-1">
+            <i className="fas fa-trash-can-arrow-up text-gray-400 mr-2"></i>
+            Recently deleted
+          </h3>
+          <p className="text-xs text-gray-500 mb-3">
+            Restoring brings a scenario back with its expenses and
+            contributions. It won&apos;t become current until you choose it.
+          </p>
+          <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+            {deletedScenarios.map((scenario) => (
+              <li
+                key={scenario.id}
+                className="flex items-center justify-between px-4 py-3"
+              >
+                <div>
+                  <p className="text-sm font-medium text-gray-900">
+                    {scenario.name}
+                  </p>
+                  {scenario.deletedDate && (
+                    <p className="text-xs text-gray-500">
+                      Deleted {scenario.deletedDate}
+                    </p>
+                  )}
+                </div>
+                <button
+                  onClick={() => handleRestore(scenario.id)}
+                  className="text-sm font-medium text-independence-600 hover:text-independence-800"
+                >
+                  <i className="fas fa-rotate-left mr-1.5 text-xs"></i>
+                  Restore
+                </button>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 
@@ -182,7 +244,11 @@ export default function ScenarioList({
       {deleteTarget && (
         <ConfirmDialog
           title="Delete Scenario"
-          message={`Are you sure you want to delete "${deleteTarget.name}"?`}
+          message={
+            deleteTarget.isCurrent
+              ? `Delete "${deleteTarget.name}"? It is your current scenario, so projections will go back to plan-driven income. You can restore it from Recently deleted.`
+              : `Delete "${deleteTarget.name}"? You can restore it from Recently deleted.`
+          }
           confirmLabel="Delete"
           cancelLabel="Cancel"
           variant="red"

--- a/src/components/features/independence/scenarios/__tests__/ScenarioList.delete.test.tsx
+++ b/src/components/features/independence/scenarios/__tests__/ScenarioList.delete.test.tsx
@@ -1,0 +1,140 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import ScenarioList from "../ScenarioList"
+import { WorkScenario } from "types/independence"
+
+// svc-retire #229: deleting the CURRENT scenario used to be refused with an
+// HTTP 500 and there was no clear/deactivate route, so once a user created a
+// scenario, some scenario overrode their plan income forever. Delete is now a
+// logical delete that clears the current flag, and deleted scenarios can be
+// restored.
+
+const mutate = jest.fn()
+let swrData: { data: WorkScenario[] } | undefined
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string) => {
+    if (key === "/api/independence/work-scenarios/deleted") {
+      return {
+        data: { data: deletedScenarios },
+        error: undefined,
+        isLoading: false,
+        mutate: jest.fn(),
+      }
+    }
+    return { data: swrData, error: undefined, isLoading: false, mutate }
+  },
+}))
+
+jest.mock("@hooks/usePrivacyMode", () => ({
+  usePrivacyMode: () => ({ hideValues: false }),
+}))
+
+function makeScenario(overrides: Partial<WorkScenario> = {}): WorkScenario {
+  return {
+    id: "ws1",
+    ownerId: "u1",
+    name: "Day Job",
+    isCurrent: true,
+    workingIncomeMonthly: 7500,
+    workingExpensesMonthly: 5100,
+    taxesMonthly: 700,
+    bonusMonthly: 0,
+    investmentAllocationPercent: 0.8,
+    currency: "SGD",
+    createdDate: "2026-01-01",
+    updatedDate: "2026-01-01",
+    computedMonthlyContribution: 1360,
+    ...overrides,
+  }
+}
+
+let deletedScenarios: WorkScenario[] = []
+
+describe("ScenarioList delete + restore", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    deletedScenarios = []
+    swrData = { data: [makeScenario()] }
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof fetch
+  })
+
+  it("offers delete on the sole current scenario", () => {
+    render(<ScenarioList />)
+
+    expect(screen.getByTitle("Delete scenario")).toBeInTheDocument()
+  })
+
+  it("warns that deleting the current scenario returns to plan-driven income", async () => {
+    const user = userEvent.setup()
+    render(<ScenarioList />)
+
+    await user.click(screen.getByTitle("Delete scenario"))
+
+    expect(screen.getByText(/plan-driven income/i)).toBeInTheDocument()
+    expect(screen.getByText(/restore/i)).toBeInTheDocument()
+  })
+
+  it("DELETEs the scenario on confirm", async () => {
+    const user = userEvent.setup()
+    render(<ScenarioList />)
+
+    await user.click(screen.getByTitle("Delete scenario"))
+    await user.click(screen.getByRole("button", { name: "Delete" }))
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/independence/work-scenarios/ws1",
+        { method: "DELETE" },
+      )
+    })
+  })
+
+  it("lists deleted scenarios with a restore action", () => {
+    deletedScenarios = [
+      makeScenario({
+        id: "ws-old",
+        name: "Old Contract",
+        isCurrent: false,
+        deletedDate: "2026-01-01",
+      }),
+    ]
+    render(<ScenarioList />)
+
+    expect(screen.getByText("Old Contract")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /restore/i })).toBeInTheDocument()
+  })
+
+  it("POSTs to restore when the restore action is used", async () => {
+    deletedScenarios = [
+      makeScenario({
+        id: "ws-old",
+        name: "Old Contract",
+        isCurrent: false,
+        deletedDate: "2026-01-01",
+      }),
+    ]
+    const user = userEvent.setup()
+    render(<ScenarioList />)
+
+    await user.click(screen.getByRole("button", { name: /restore/i }))
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/independence/work-scenarios/ws-old/restore",
+        { method: "POST" },
+      )
+    })
+  })
+
+  it("hides the recovery section when nothing is deleted", () => {
+    render(<ScenarioList />)
+
+    expect(screen.queryByText(/recently deleted/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/features/independence/scenarios/__tests__/ScenarioList.delete.test.tsx
+++ b/src/components/features/independence/scenarios/__tests__/ScenarioList.delete.test.tsx
@@ -132,6 +132,43 @@ describe("ScenarioList delete + restore", () => {
     })
   })
 
+  it("surfaces a failed restore instead of doing nothing", async () => {
+    deletedScenarios = [
+      makeScenario({
+        id: "ws-old",
+        name: "Old Contract",
+        isCurrent: false,
+        deletedDate: "2026-01-01",
+      }),
+    ]
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof fetch
+    const user = userEvent.setup()
+    render(<ScenarioList />)
+
+    await user.click(screen.getByRole("button", { name: /restore/i }))
+
+    expect(await screen.findByText(/failed to restore/i)).toBeInTheDocument()
+  })
+
+  it("surfaces a failed delete instead of doing nothing", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof fetch
+    const user = userEvent.setup()
+    render(<ScenarioList />)
+
+    await user.click(screen.getByTitle("Delete scenario"))
+    await user.click(screen.getByRole("button", { name: "Delete" }))
+
+    expect(await screen.findByText(/failed to delete/i)).toBeInTheDocument()
+  })
+
   it("hides the recovery section when nothing is deleted", () => {
     render(<ScenarioList />)
 

--- a/src/pages/api/independence/work-scenarios/[scenarioId]/restore.ts
+++ b/src/pages/api/independence/work-scenarios/[scenarioId]/restore.ts
@@ -1,0 +1,9 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getRetireUrl } from "@utils/api/bcConfig"
+
+// Undo a logical delete (svc-retire #229). The scenario comes back with its
+// expenses and contributions, but NOT current.
+export default createApiHandler({
+  url: (req) => getRetireUrl(`/scenarios/${req.query.scenarioId}/restore`),
+  methods: ["POST"],
+})

--- a/src/pages/api/independence/work-scenarios/deleted.ts
+++ b/src/pages/api/independence/work-scenarios/deleted.ts
@@ -1,0 +1,9 @@
+import { createApiHandler } from "@utils/api/createApiHandler"
+import { getRetireUrl } from "@utils/api/bcConfig"
+
+// Logically deleted scenarios that can still be restored (svc-retire #229).
+// Static segment, so it takes precedence over [scenarioId]/index.ts.
+export default createApiHandler({
+  url: getRetireUrl("/scenarios/deleted"),
+  methods: ["GET"],
+})

--- a/types/independence.d.ts
+++ b/types/independence.d.ts
@@ -13,6 +13,13 @@ export interface WorkScenario {
   createdDate: string
   updatedDate: string
   computedMonthlyContribution: number
+  /**
+   * Logical-delete stamp (svc-retire #229). Absent/null on live scenarios.
+   * Deleted scenarios are excluded from /scenarios and appear only under
+   * /scenarios/deleted, where they can be restored with their expenses and
+   * contributions intact.
+   */
+  deletedDate?: string | null
 }
 
 export interface WorkScenarioRequest {


### PR DESCRIPTION
Frontend half of svc-retire#229 (backend: monowai/svc-retire#234 — **deploy that
first**).

## The trap

Deleting the current work scenario was refused by the backend with an HTTP 500,
and `ScenarioCard` hid the delete button entirely whenever a scenario was the
only current one. Between them there was no way out: once a user created their
first scenario, some scenario overrode their plan income in **every** projection
forever. The e2e account still carries a scenario from 2026-01 with
`workingIncomeMonthly=0` that forced full-expense draws through every
accumulation projection.

## What changes

- **Delete is always offered.** The `currentCount > 1` gate is gone (and with it
  the now-unused `currentCount` prop) — deleting the current scenario is the
  supported route back to plan-driven income.
- **The confirm dialog says what actually happens.** For the current scenario:
  projections go back to plan-driven income. Either way: it can be restored.
- **"Recently deleted"** lists what is recoverable with a Restore action.
  Restoring brings the scenario back with its expenses and contributions, and
  deliberately does **not** make it current — that stays an explicit choice.
- **Failures are visible.** Delete and restore both used to `console.error` and
  return, so a failed request looked exactly like a no-op. Both now render an
  `Alert`, and a failed load of the recovery list says so inline instead of
  rendering nothing.

Adds the two proxy routes (`GET /scenarios/deleted`,
`POST /scenarios/{id}/restore`) and `deletedDate` on the `WorkScenario` type.
`deleted.ts` is a static segment so it wins over `[scenarioId]/index.ts`.

## Gates

`yarn test` (251 suites / 2506 tests), `yarn prettier`, `yarn lint`,
`yarn typecheck` — all green. `ocr review --from main --to HEAD` raised 2
findings, both about silent failure; both applied (the Alert work above).

New tests in `ScenarioList.delete.test.tsx` cover: delete offered on the sole
current scenario, the plan-driven-income warning copy, the DELETE call, the
recovery list and its Restore POST, the hidden-when-empty case, and both failure
paths.
