### PR TITLE
fix(independence): feature the plan's headline metric in the projection header

### DIFF
--- a/src/components/features/independence/ScenarioBar.tsx
+++ b/src/components/features/independence/ScenarioBar.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react"
-import type { FiMetrics, PathToHorizon } from "types/independence"
+import type {
+  FiMetrics,
+  HeadlineMetric,
+  PathToHorizon,
+} from "types/independence"
 import InfoTooltip from "@components/ui/Tooltip"
 import type { ScenarioState } from "./scenario/types"
 import StrategyGaugesStrip from "./StrategyGaugesStrip"
@@ -23,6 +27,13 @@ export interface ScenarioBarProps {
   /** Active strategy view — drives the headline gauge + FiMetrics sections. */
   view: StrategyView
   onViewChange: (next: StrategyView) => void
+  /**
+   * The plan's effective headline metric. Features the same gauge the
+   * plans-list card and the Wealth tab feature, so one plan can't report two
+   * different progress percentages. The page drops it once the user picks a
+   * view explicitly — their lens choice then owns the headline slot.
+   */
+  headlineMetric?: HeadlineMetric
   /**
    * Live derived liquid assets from holdings. Acts as the slider default
    * (when `scenario.liquidAssets` is null) and as the upper anchor for the
@@ -67,6 +78,7 @@ export default function ScenarioBar({
   fiMetrics,
   view,
   onViewChange,
+  headlineMetric,
   derivedLiquidAssets,
   planInflation,
   planCashRate,
@@ -119,6 +131,7 @@ export default function ScenarioBar({
               compact
               view={view}
               singleHeadline
+              headlineMetric={headlineMetric}
               offTrack={offTrack}
             />
           </div>

--- a/src/components/features/independence/StrategyGaugesStrip.tsx
+++ b/src/components/features/independence/StrategyGaugesStrip.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import type { FiMetrics } from "types/independence"
+import type { FiMetrics, HeadlineMetric } from "types/independence"
 import { usePrivacyMode } from "@hooks/usePrivacyMode"
 import PensionGauge, { type PensionGaugeProps } from "./PensionGauge"
 import type { StrategyView } from "./strategyView"
@@ -28,6 +28,14 @@ export interface StrategyGaugesStripProps {
    */
   singleHeadline?: boolean
   /**
+   * The plan's effective headline metric from the projection. When its gauge
+   * has data it wins the headline slot, so this strip reports the same
+   * percentage as the plans-list card and the Wealth tab (both of which pick
+   * via `pickHeadlineGauge`). Omit it to let `view` alone drive the headline —
+   * the page does that once the user picks a view explicitly.
+   */
+  headlineMetric?: HeadlineMetric
+  /**
    * Backend says the plan depletes before life expectancy. When set, the
    * Retirement-Age FI gauge is caveated ("based on the 4% rule") so a high %
    * can't read as success while the off-track header carries the real
@@ -48,12 +56,14 @@ export default function StrategyGaugesStrip({
   compact = false,
   view = "ALL",
   singleHeadline = false,
+  headlineMetric,
   offTrack = false,
 }: StrategyGaugesStripProps): React.ReactElement {
   const { hideValues } = usePrivacyMode()
   const ordered = orderGauges(
     buildGauges(fiMetrics, hideValues, offTrack, view),
     view,
+    headlineMetric,
   )
   const gauges = singleHeadline ? ordered.slice(0, 1) : ordered
 
@@ -86,18 +96,32 @@ const VIEW_HEADLINE_KEYS: Record<StrategyView, string[]> = {
   ALL: ["coast-fi", "fire"],
 }
 
+/** Gauge that carries each backend headline metric. */
+const METRIC_GAUGE_KEYS: Record<HeadlineMetric, string> = {
+  EARLY_RETIREMENT_PROGRESS: "fire",
+  RETIREMENT_AGE_FI: "retirement-age-fi",
+  INCOME_COVERAGE: "income-coverage",
+  BRIDGE_PROGRESS: "bridge",
+}
+
 /**
- * Promotes the view-matching gauge to position 0 so it stays visible if
- * the strip is truncated. When view = ALL, returns gauges in their
- * natural order.
+ * Promotes the headline gauge to position 0 so it stays visible if the strip
+ * is truncated. The plan's own headline metric wins when its gauge has data —
+ * that keeps this strip agreeing with the plans-list card and the Wealth tab.
+ * Otherwise the view's priority list decides; with view = ALL and no metric,
+ * gauges keep their natural order.
  */
 function orderGauges(
   gauges: PensionGaugeProps[],
   view: StrategyView,
+  headlineMetric?: HeadlineMetric,
 ): PensionGaugeProps[] {
-  const headline = VIEW_HEADLINE_KEYS[view]
-    .map((key) => gauges.find((g) => g.key === key))
-    .find((g): g is PensionGaugeProps => g != null)
+  const pinnedKey = headlineMetric ? METRIC_GAUGE_KEYS[headlineMetric] : null
+  const headline =
+    (pinnedKey ? gauges.find((g) => g.key === pinnedKey) : undefined) ??
+    VIEW_HEADLINE_KEYS[view]
+      .map((key) => gauges.find((g) => g.key === key))
+      .find((g): g is PensionGaugeProps => g != null)
   if (!headline) return gauges
   const rest = gauges.filter((g) => g.key !== headline.key)
   return [headline, ...rest]

--- a/src/components/features/independence/__tests__/ScenarioBar.test.tsx
+++ b/src/components/features/independence/__tests__/ScenarioBar.test.tsx
@@ -235,6 +235,21 @@ describe("ScenarioBar", () => {
     })
   })
 
+  describe("headline metric", () => {
+    it("features the plan's headline metric instead of Coast FI", () => {
+      render(
+        <ScenarioBar
+          {...baseProps}
+          view="FIRE"
+          fiMetrics={{ fiProgress: 82.3, coastFiProgress: 102.5 } as never}
+          headlineMetric="EARLY_RETIREMENT_PROGRESS"
+        />,
+      )
+      expect(screen.getByText("82.3%")).toBeInTheDocument()
+      expect(screen.queryByText("Coast FI Progress")).not.toBeInTheDocument()
+    })
+  })
+
   describe("Cash → Investments education line", () => {
     it("shows blended return at 0% shift (motivates moving cash to investments)", () => {
       render(<ScenarioBar {...baseProps} />)

--- a/src/components/features/independence/__tests__/StrategyGaugesStrip.test.tsx
+++ b/src/components/features/independence/__tests__/StrategyGaugesStrip.test.tsx
@@ -29,6 +29,56 @@ describe("StrategyGaugesStrip headline", () => {
   })
 })
 
+describe("StrategyGaugesStrip plan headline metric", () => {
+  // The plans-list card and the Wealth tab both feature the plan's
+  // effectiveHeadlineMetric. The projection header has to agree with them,
+  // otherwise the same plan reports two different progress percentages.
+  it("features the pinned Early Retirement gauge ahead of Coast FI", () => {
+    render(
+      <StrategyGaugesStrip
+        fiMetrics={baseFi}
+        view="FIRE"
+        headlineMetric="EARLY_RETIREMENT_PROGRESS"
+        singleHeadline
+      />,
+    )
+    expect(screen.getByText("FIRE Progress")).toBeInTheDocument()
+    expect(screen.getByText("106.3%")).toBeInTheDocument()
+    expect(screen.queryByText("Coast FI Progress")).not.toBeInTheDocument()
+  })
+
+  it("features the pinned Retirement-Age gauge in the FIRE view", () => {
+    render(
+      <StrategyGaugesStrip
+        fiMetrics={
+          {
+            fiProgress: 106.3,
+            coastFiProgress: 84.2,
+            retirementAgeFiProgress: 71.4,
+          } as unknown as FiMetrics
+        }
+        view="FIRE"
+        headlineMetric="RETIREMENT_AGE_FI"
+        singleHeadline
+      />,
+    )
+    expect(screen.getByText("Retirement-Age Progress")).toBeInTheDocument()
+    expect(screen.getByText("71.4%")).toBeInTheDocument()
+  })
+
+  it("falls back to the view ordering when the pinned metric has no data", () => {
+    render(
+      <StrategyGaugesStrip
+        fiMetrics={baseFi}
+        view="FIRE"
+        headlineMetric="BRIDGE_PROGRESS"
+        singleHeadline
+      />,
+    )
+    expect(screen.getByText("Coast FI Progress")).toBeInTheDocument()
+  })
+})
+
 describe("StrategyGaugesStrip Pension headline", () => {
   const pensionFi = {
     fiProgress: 80,

--- a/src/lib/utils/independence/headlineGauge.ts
+++ b/src/lib/utils/independence/headlineGauge.ts
@@ -15,8 +15,11 @@ export interface HeadlineGauge {
 /**
  * Picks which metric to feature based on the plan's effective headline metric.
  * Falls back to Early Retirement Progress when the selected metric has no data.
- * Shared by the projection header (FiSummaryBar) and the Wealth tab card
- * (IndependenceMetrics) so both stay in sync.
+ * Shared by the plans-list card and the Wealth tab card (IndependenceMetrics).
+ *
+ * The projection header renders gauges through StrategyGaugesStrip instead —
+ * it takes the same `effectiveHeadlineMetric` and features the matching gauge,
+ * so one plan reports one headline percentage everywhere.
  */
 export function pickHeadlineGauge(
   metric: HeadlineMetric | undefined,

--- a/src/pages/independence/plans/[id].tsx
+++ b/src/pages/independence/plans/[id].tsx
@@ -948,6 +948,11 @@ function PlanView(): React.ReactElement {
                 defaultStrategyView(adjustedProjection?.effectiveStrategy)
               }
               onViewChange={setStrategyView}
+              headlineMetric={
+                strategyView === null
+                  ? adjustedProjection?.effectiveHeadlineMetric
+                  : undefined
+              }
               derivedLiquidAssets={liquidAssets}
               planInflation={plan.inflationRate}
               planCashRate={plan.cashReturnRate}


### PR DESCRIPTION
## Problem

The same plan reported two different headline percentages: the plans-list card showed **Early Retirement Progress**, while the projection page header showed **Coast FI Progress**. Both numbers were individually correct — they measure against different denominators:

- `fiProgress` = liquid ÷ FI Number (today's 25× expenses)
- `coastFiProgress` = liquid ÷ (FI Number × inflationFactor ÷ growthFactor) — `svc-retire` `FireService.kt:133-146`

Growth outruns inflation, so the coast denominator is smaller and the percentage reads higher. Nothing was wrong with either figure; the surfaces just featured different metrics without saying so.

## Cause

Two headline pickers had drifted apart:

- `headlineGauge.ts` honours the projection's `effectiveHeadlineMetric` — used by the plans-list card and the Wealth tab.
- `StrategyGaugesStrip.tsx` ignored it entirely, promoting `coast-fi` ahead of everything for the `FIRE` and `ALL` views — used by `ScenarioBar`, the projection header.

`headlineGauge.ts` still claimed to be shared with "the projection header (FiSummaryBar)"; that component no longer exists, which is how the two drifted unnoticed.

## Fix

Backend drives display. `StrategyGaugesStrip` takes the effective headline metric and promotes the gauge carrying it, keeping the `VIEW_HEADLINE_KEYS` ordering as the fallback when that gauge has no data. The page supplies the metric only while the user hasn't touched the View dropdown — an explicit lens choice still owns the headline slot.

## Verification

Local stack, both paths exercised in the browser on a plan whose Coast FI gauge is present and reads a different percentage:

- View untouched → header features the plan's headline metric, matching the plans-list card exactly.
- View switched to All → headline hands over to the view priority list and Coast FI takes the slot, as before.

Tests: 4 new (3 in `StrategyGaugesStrip.test.tsx` covering pinned metric, pinned metric in a non-matching view, and fallback when the pinned gauge has no data; 1 in `ScenarioBar.test.tsx` for pass-through). Full suite 2510 passing, typecheck and lint clean. `ocr review` raised one low style finding, applied.

Closes #1150
