### PR TITLE
feat(rebalance): rework model and plan screen layout

### DIFF
--- a/src/components/features/rebalance/common/AssetWeightInput.tsx
+++ b/src/components/features/rebalance/common/AssetWeightInput.tsx
@@ -40,10 +40,13 @@ const AssetWeightInput: React.FC<AssetWeightInputProps> = ({
   showPrice = false,
 }) => {
   const isResolved = UUID_RE.test(assetId)
-  const [showRationale, setShowRationale] = useState(!!rationale)
+  // Collapsed by default even when a rationale exists — the filled comment
+  // icon signals presence; auto-expanding every row turns an imported plan
+  // into a wall of textareas.
+  const [showRationale, setShowRationale] = useState(false)
 
   return (
-    <div className="p-3 bg-gray-50 rounded-lg">
+    <div className="px-3 py-2.5 hover:bg-gray-50 transition-colors">
       {/* Mobile: stack vertically, Desktop: horizontal */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
         {/* Asset info - always visible */}
@@ -86,7 +89,7 @@ const AssetWeightInput: React.FC<AssetWeightInputProps> = ({
                   onPriceChange?.(value > 0 ? value : undefined)
                 }}
                 disabled={readOnly}
-                className="w-20 sm:w-24 px-2 py-1 text-right border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100"
+                className="w-20 sm:w-24 px-2 py-1 text-right font-mono tabular-nums border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100"
               />
               <span className="text-gray-400 text-xs w-8">
                 {priceCurrency || ""}
@@ -101,7 +104,7 @@ const AssetWeightInput: React.FC<AssetWeightInputProps> = ({
               onChange(Math.round(clamped * 100) / 100)
             }}
             disabled={readOnly}
-            className="w-20 sm:w-24 px-2 py-1 text-right border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100"
+            className="w-20 sm:w-24 px-2 py-1 text-right font-mono tabular-nums border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100"
           />
           <span className="text-gray-500">%</span>
           {onRationaleChange && !readOnly && (

--- a/src/components/features/rebalance/common/WeightsSummary.tsx
+++ b/src/components/features/rebalance/common/WeightsSummary.tsx
@@ -2,11 +2,14 @@ import React from "react"
 interface WeightsSummaryProps {
   totalWeight: number
   assetCount: number
+  /** When set and the total is off 100%, the bar offers the fix in place. */
+  onNormalize?: () => void
 }
 
 const WeightsSummary: React.FC<WeightsSummaryProps> = ({
   totalWeight,
   assetCount,
+  onNormalize,
 }) => {
   const isValid = Math.abs(totalWeight - 100) < 0.01
 
@@ -24,10 +27,19 @@ const WeightsSummary: React.FC<WeightsSummaryProps> = ({
         ></i>
         <span className="text-sm">{`${assetCount} assets`}</span>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-3">
+        {!isValid && onNormalize && (
+          <button
+            type="button"
+            onClick={onNormalize}
+            className="text-sm font-medium text-red-700 underline hover:no-underline"
+          >
+            {"Normalize to 100%"}
+          </button>
+        )}
         <span className="text-sm font-medium">{"Total Weight"}:</span>
         <span
-          className={`font-bold ${isValid ? "text-green-700" : "text-red-700"}`}
+          className={`font-mono tabular-nums font-semibold ${isValid ? "text-green-700" : "text-red-700"}`}
         >
           {totalWeight.toFixed(2)}%
         </span>

--- a/src/components/features/rebalance/models/ModelPlans.tsx
+++ b/src/components/features/rebalance/models/ModelPlans.tsx
@@ -7,7 +7,13 @@ import { PlanDto } from "types/rebalance"
 import StatusBadge from "../common/StatusBadge"
 import { formatDate } from "@utils/formatters"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
-import { tableBase, theadBase, thBase, tbodyBase } from "@utils/tableStyles"
+import {
+  tableBase,
+  theadBase,
+  thBase,
+  thRight,
+  tbodyBase,
+} from "@utils/tableStyles"
 
 interface ModelPlansProps {
   modelId: string
@@ -39,13 +45,21 @@ const ModelPlans: React.FC<ModelPlansProps> = ({ modelId }) => {
     }
   }
 
+  // Seed new plans from the latest approved version — iterating on the
+  // current allocations is the normal flow; an empty plan is the fallback.
+  const latestApproved = plans
+    .filter((p) => p.status === "APPROVED")
+    .sort((a, b) => b.version - a.version)[0]
+
   const handleCreatePlan = async (): Promise<void> => {
     setCreating(true)
     try {
       const response = await fetch(`/api/rebalance/models/${modelId}/plans`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        body: JSON.stringify(
+          latestApproved ? { sourcePlanId: latestApproved.id } : {},
+        ),
       })
       if (response.ok) {
         const result = await response.json()
@@ -74,28 +88,35 @@ const ModelPlans: React.FC<ModelPlansProps> = ({ modelId }) => {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-medium text-gray-900">
+        <h2 className="text-lg font-semibold text-gray-900">
           {"Rebalance Plans"}
         </h2>
         <button
           onClick={handleCreatePlan}
           disabled={creating}
-          className="bg-violet-600 text-white px-3 py-1.5 rounded text-sm hover:bg-violet-700 transition-colors flex items-center disabled:opacity-50"
+          title={
+            latestApproved
+              ? `Copies allocations from v${latestApproved.version}`
+              : "Start with an empty plan"
+          }
+          className="bg-invest-600 text-white px-3 py-1.5 rounded-lg text-sm hover:bg-invest-700 transition-colors flex items-center disabled:opacity-50"
         >
           {creating ? (
             <Spinner className="mr-2" />
           ) : (
             <i className="fas fa-plus mr-2"></i>
           )}
-          {"Create Plan"}
+          {latestApproved
+            ? `New Plan from v${latestApproved.version}`
+            : "Create Plan"}
         </button>
       </div>
 
       {plans.length === 0 ? (
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-6 text-center">
-          <i className="fas fa-clipboard-list text-gray-300 text-3xl mb-3"></i>
-          <p className="text-gray-600 mb-4">{"No rebalance plans yet"}</p>
-          <p className="text-sm text-gray-500">
+        <div className="border border-gray-200 rounded-lg py-10 text-center">
+          <i className="fas fa-clipboard-list text-gray-300 text-4xl mb-3"></i>
+          <p className="text-gray-600">{"No rebalance plans yet"}</p>
+          <p className="text-sm text-gray-400 mt-1">
             {"Create a plan to define target allocations for rebalancing."}
           </p>
         </div>
@@ -108,7 +129,7 @@ const ModelPlans: React.FC<ModelPlansProps> = ({ modelId }) => {
                 <th className={thBase}>{"Status"}</th>
                 <th className={thBase}>{"Created"}</th>
                 <th className={thBase}>{"Approved"}</th>
-                <th className={thBase}>{"Assets"}</th>
+                <th className={thRight}>{"Assets"}</th>
                 <th className="px-4 py-3"></th>
               </tr>
             </thead>
@@ -143,7 +164,7 @@ const ModelPlans: React.FC<ModelPlansProps> = ({ modelId }) => {
                   <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
                     {plan.approvedAt ? formatDate(plan.approvedAt) : "-"}
                   </td>
-                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-right font-mono tabular-nums text-gray-500">
                     {plan.assets.length}
                   </td>
                   <td className="px-4 py-3 whitespace-nowrap text-right">

--- a/src/components/features/rebalance/models/ModelPortfolioList.tsx
+++ b/src/components/features/rebalance/models/ModelPortfolioList.tsx
@@ -5,7 +5,13 @@ import { ModelDto } from "types/rebalance"
 import { useModels } from "../hooks/useModels"
 import { TableSkeletonLoader } from "@components/ui/SkeletonLoader"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
-import { tbodyBase, hiddenSm } from "@utils/tableStyles"
+import {
+  tbodyBase,
+  theadBase,
+  thBase,
+  thCenter,
+  hiddenSm,
+} from "@utils/tableStyles"
 
 interface ModelListProps {
   onSelect?: (model: ModelDto) => void
@@ -92,33 +98,17 @@ const ModelPortfolioList: React.FC<ModelListProps> = ({
   }
 
   return (
-    <div className="bg-white shadow-sm border border-gray-200 rounded-lg overflow-hidden">
+    <div className="bg-white shadow-sm border border-gray-200 rounded-lg overflow-x-auto">
       <table className="min-w-full">
-        <thead className="bg-gray-50">
+        <thead className={theadBase}>
           <tr className="border-b border-gray-200">
             {selectable && <th className="px-4 py-3 w-10"></th>}
-            <th className="px-4 py-3 text-left text-sm font-medium text-gray-700">
-              {"Model Name"}
-            </th>
-            <th
-              className={`px-4 py-3 text-left text-sm font-medium text-gray-700 ${hiddenSm}`}
-            >
-              {"Objective"}
-            </th>
-            <th className="px-4 py-3 text-center text-sm font-medium text-gray-700">
-              {"Risk"}
-            </th>
-            <th className="px-4 py-3 text-center text-sm font-medium text-gray-700">
-              {"Current Plan"}
-            </th>
-            <th className="px-4 py-3 text-center text-sm font-medium text-gray-700">
-              {"Base Currency"}
-            </th>
-            {!selectable && (
-              <th className="px-4 py-3 text-center text-sm font-medium text-gray-700">
-                {"Actions"}
-              </th>
-            )}
+            <th className={thBase}>{"Model Name"}</th>
+            <th className={`${thBase} ${hiddenSm}`}>{"Objective"}</th>
+            <th className={thCenter}>{"Risk"}</th>
+            <th className={thCenter}>{"Plan"}</th>
+            <th className={thCenter}>{"Currency"}</th>
+            {!selectable && <th className={thCenter}>{"Actions"}</th>}
           </tr>
         </thead>
         <tbody className={tbodyBase}>

--- a/src/components/features/rebalance/models/ModelWeightsEditor.tsx
+++ b/src/components/features/rebalance/models/ModelWeightsEditor.tsx
@@ -13,6 +13,11 @@ interface ModelWeightsEditorProps {
   showPrice?: boolean
   onShowPriceChart?: (weight: AssetWeightWithDetails) => void
   onShowAssetInsight?: (weight: AssetWeightWithDetails) => void
+  /** Section heading rendered in the toolbar row, so title and every
+   *  action share one line instead of stacking two right-aligned rows. */
+  title?: string
+  /** Host-page actions (e.g. Copy/Export/Import) merged into the toolbar. */
+  extraActions?: React.ReactNode
 }
 
 const ModelWeightsEditor: React.FC<ModelWeightsEditorProps> = ({
@@ -24,6 +29,8 @@ const ModelWeightsEditor: React.FC<ModelWeightsEditorProps> = ({
   showPrice = false,
   onShowPriceChart,
   onShowAssetInsight,
+  title,
+  extraActions,
 }) => {
   const [addAssetModalOpen, setAddAssetModalOpen] = useState(false)
 
@@ -71,63 +78,73 @@ const ModelWeightsEditor: React.FC<ModelWeightsEditorProps> = ({
     onChange(updated)
   }
 
+  const showRowTools = !readOnly && weights.length > 0
+
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <label className="block text-sm font-medium text-gray-700">
-          {"Target Weights"}
-        </label>
-        <div className="flex items-center gap-3">
-          {!readOnly &&
-            weights.length > 0 &&
-            Math.abs(totalWeight - 100) > 0.01 && (
+    <div className="space-y-3">
+      {/* One toolbar row: title left, every action right. Row tools hide
+          while empty — the empty state below carries the Add action. */}
+      {(title || extraActions || showRowTools) && (
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
+          {title && (
+            <h2 className="text-lg font-semibold text-gray-900 whitespace-nowrap mr-4">
+              {title}
+            </h2>
+          )}
+          <div className="flex flex-wrap items-center gap-2 ml-auto">
+            {extraActions}
+            {showRowTools && showPrice && onFetchPrices && (
               <button
                 type="button"
-                onClick={handleNormalize}
-                className="text-sm text-blue-600 hover:text-blue-800"
+                // Wrap so the React SyntheticEvent isn't forwarded as the
+                // first arg — handleFetchPrices treats arg[0] as
+                // `weightsOverride?: AssetWeightWithDetails[]` and would
+                // call .filter() on the event, throw TypeError, and the
+                // caller's try/catch would swallow it (no network fired).
+                onClick={() => onFetchPrices()}
+                disabled={fetchingPrices}
+                className="text-sm text-gray-700 bg-gray-100 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center disabled:opacity-50"
               >
-                {"Normalize to 100%"}
+                <i
+                  className={`fas ${fetchingPrices ? "fa-spinner fa-spin" : "fa-sync-alt"} mr-1.5`}
+                ></i>
+                {"Fetch Prices"}
               </button>
             )}
-          {!readOnly && (
-            <>
-              {showPrice && onFetchPrices && weights.length > 0 && (
-                <button
-                  type="button"
-                  // Wrap so the React SyntheticEvent isn't forwarded as the
-                  // first arg — handleFetchPrices treats arg[0] as
-                  // `weightsOverride?: AssetWeightWithDetails[]` and would
-                  // call .filter() on the event, throw TypeError, and the
-                  // caller's try/catch would swallow it (no network fired).
-                  onClick={() => onFetchPrices()}
-                  disabled={fetchingPrices}
-                  className="text-sm text-gray-700 bg-gray-100 px-3 py-1.5 rounded hover:bg-gray-200 transition-colors flex items-center disabled:opacity-50"
-                >
-                  <i
-                    className={`fas ${fetchingPrices ? "fa-spinner fa-spin" : "fa-sync-alt"} mr-1.5`}
-                  ></i>
-                  {"Fetch Prices"}
-                </button>
-              )}
+            {showRowTools && (
               <button
                 type="button"
                 onClick={() => setAddAssetModalOpen(true)}
-                className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded hover:bg-gray-200 transition-colors flex items-center"
+                className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
               >
                 <i className="fas fa-plus mr-1.5"></i>
                 {"Add Asset"}
               </button>
-            </>
-          )}
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {weights.length === 0 ? (
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-6 text-center text-gray-500">
-          {"No assets added yet"}
+        <div className="border border-gray-200 rounded-lg py-10 text-center">
+          <i className="fas fa-balance-scale text-4xl text-gray-300 mb-3"></i>
+          <p className="text-gray-600">{"No assets in this plan yet"}</p>
+          <p className="text-sm text-gray-400 mt-1">
+            {"Add assets or import holdings to define target allocations."}
+          </p>
+          {!readOnly && (
+            <button
+              type="button"
+              onClick={() => setAddAssetModalOpen(true)}
+              className="mt-4 text-sm bg-invest-600 text-white px-4 py-2 rounded-lg hover:bg-invest-700 transition-colors inline-flex items-center"
+            >
+              <i className="fas fa-plus mr-2"></i>
+              {"Add Asset"}
+            </button>
+          )}
         </div>
       ) : (
-        <div className="space-y-2">
+        <div className="border border-gray-200 rounded-lg divide-y divide-gray-100">
           {weights.map((weight, index) => (
             <AssetWeightInput
               key={weight.assetId}
@@ -160,7 +177,11 @@ const ModelWeightsEditor: React.FC<ModelWeightsEditorProps> = ({
       )}
 
       {weights.length > 0 && (
-        <WeightsSummary totalWeight={totalWeight} assetCount={weights.length} />
+        <WeightsSummary
+          totalWeight={totalWeight}
+          assetCount={weights.length}
+          onNormalize={readOnly ? undefined : handleNormalize}
+        />
       )}
 
       <AddAssetToModelDialog

--- a/src/pages/rebalance/models/[modelId].tsx
+++ b/src/pages/rebalance/models/[modelId].tsx
@@ -56,100 +56,105 @@ function ModelDetailPage(): React.ReactElement {
 
   return (
     <div className="w-full py-4">
-      {/* Breadcrumb */}
-      <nav className="text-sm text-gray-500 mb-4 max-w-4xl mx-auto">
-        <Link href="/rebalance/models" className="hover:text-invest-600">
-          {"Model Portfolios"}
-        </Link>
-        <span className="mx-2">/</span>
-        <span className="text-gray-900">
-          {isNew ? "Create Model" : model?.name || "..."}
-        </span>
-      </nav>
+      <div className="max-w-5xl mx-auto">
+        {/* Breadcrumb */}
+        <nav className="text-sm text-gray-500 mb-4">
+          <Link href="/rebalance/models" className="hover:text-invest-600">
+            {"Model Portfolios"}
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-gray-900">
+            {isNew ? "Create Model" : model?.name || "..."}
+          </span>
+        </nav>
 
-      {/* Model Summary/Edit Section */}
-      <div className="bg-white shadow-sm border border-gray-200 rounded-lg max-w-4xl mx-auto mb-6">
-        {isNew ? (
-          /* New Model - Show full form */
-          <div className="p-6">
-            <h1 className="text-xl font-bold text-gray-900 mb-4">
-              {"Create Model"}
-            </h1>
-            <ModelPortfolioForm
-              onSuccess={() => router.push("/rebalance/models")}
-            />
-          </div>
-        ) : isEditing ? (
-          /* Editing Existing Model */
-          <div className="p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-medium text-gray-900">
-                {"Edit Model Details"}
-              </h2>
-              <button
-                onClick={() => setIsEditing(false)}
-                className="text-sm text-gray-500 hover:text-gray-700"
-              >
-                <i className="fas fa-times mr-1"></i>
-                {"Cancel"}
-              </button>
+        {/* Model Summary/Edit Section */}
+        <div className="bg-white shadow-sm border border-gray-200 rounded-lg mb-6">
+          {isNew ? (
+            /* New Model - Show full form */
+            <div className="p-6">
+              <h1 className="text-2xl font-bold text-gray-900 mb-4">
+                {"Create Model"}
+              </h1>
+              <ModelPortfolioForm
+                onSuccess={() => router.push("/rebalance/models")}
+              />
             </div>
-            <ModelPortfolioForm
-              model={model}
-              onSuccess={() => {
-                mutate()
-                setIsEditing(false)
-              }}
-            />
-          </div>
-        ) : (
-          /* Collapsed Summary View */
-          <div className="p-4">
-            <div className="flex items-start justify-between">
-              <div className="flex-1 min-w-0">
-                <h1 className="text-xl font-bold text-gray-900 truncate">
-                  {model?.name}
-                </h1>
-                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 text-sm text-gray-600">
-                  {model?.objective && (
-                    <span className="truncate max-w-xs" title={model.objective}>
-                      {model.objective}
+          ) : isEditing ? (
+            /* Editing Existing Model */
+            <div className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-semibold text-gray-900">
+                  {"Edit Model Details"}
+                </h2>
+                <button
+                  onClick={() => setIsEditing(false)}
+                  className="text-sm text-gray-500 hover:text-gray-700"
+                >
+                  <i className="fas fa-times mr-1"></i>
+                  {"Cancel"}
+                </button>
+              </div>
+              <ModelPortfolioForm
+                model={model}
+                onSuccess={() => {
+                  mutate()
+                  setIsEditing(false)
+                }}
+              />
+            </div>
+          ) : (
+            /* Collapsed Summary View */
+            <div className="p-6">
+              <div className="flex items-start justify-between">
+                <div className="flex-1 min-w-0">
+                  <h1 className="text-2xl font-bold text-gray-900 truncate">
+                    {model?.name}
+                  </h1>
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-sm text-gray-600">
+                    {model?.objective && (
+                      <span
+                        className="truncate max-w-xs"
+                        title={model.objective}
+                      >
+                        {model.objective}
+                      </span>
+                    )}
+                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700">
+                      {model?.baseCurrency}
                     </span>
-                  )}
-                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700">
-                    {model?.baseCurrency}
-                  </span>
-                  {model?.currentPlanVersion && (
-                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
-                      <i className="fas fa-check-circle mr-1"></i>v
-                      {model.currentPlanVersion}
-                    </span>
+                    {model?.currentPlanVersion && (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
+                        <i className="fas fa-check-circle mr-1"></i>v
+                        {model.currentPlanVersion}
+                      </span>
+                    )}
+                  </div>
+                  {model?.description && (
+                    <p className="mt-2 text-sm text-gray-500 line-clamp-2">
+                      {model.description}
+                    </p>
                   )}
                 </div>
-                {model?.description && (
-                  <p className="mt-2 text-sm text-gray-500 line-clamp-2">
-                    {model.description}
-                  </p>
-                )}
+                <button
+                  onClick={() => setIsEditing(true)}
+                  className="ml-4 text-sm text-invest-600 hover:text-invest-700 flex items-center"
+                >
+                  <i className="fas fa-edit mr-1"></i>
+                  {"Edit"}
+                </button>
               </div>
-              <button
-                onClick={() => setIsEditing(true)}
-                className="ml-4 text-sm text-invest-600 hover:text-invest-700 flex items-center"
-              >
-                <i className="fas fa-edit mr-1"></i>
-                {"Edit"}
-              </button>
             </div>
+          )}
+        </div>
+
+        {/* Plans Section (for existing models) */}
+        {!isNew && model && (
+          <div className="bg-white shadow-sm border border-gray-200 rounded-lg p-6">
+            <ModelPlans modelId={model.id} />
           </div>
         )}
       </div>
-
-      {/* Plans Section (for existing models) */}
-      {!isNew && model && (
-        <div className="bg-white shadow-sm border border-gray-200 rounded-lg p-6 max-w-4xl mx-auto">
-          <ModelPlans modelId={model.id} />
-        </div>
-      )}
     </div>
   )
 }

--- a/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
+++ b/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
@@ -15,6 +15,7 @@ import CopyFieldsDialog, {
   DEFAULT_COPY_FIELDS,
 } from "@components/features/rebalance/models/CopyFieldsDialog"
 import PriceChartPopup from "@components/features/holdings/PriceChartPopup"
+import StatusBadge from "@components/features/rebalance/common/StatusBadge"
 import { PlanAssetDto, AssetWeightWithDetails } from "types/rebalance"
 import { Asset, Market } from "types/beancounter"
 import { escapeCSV, downloadCsv } from "@lib/csvExport"
@@ -573,7 +574,9 @@ function PlanDetailPage(): React.ReactElement {
   if (!router.isReady || isLoading) {
     return (
       <div className="w-full py-4">
-        <TableSkeletonLoader rows={5} />
+        <div className="max-w-5xl mx-auto">
+          <TableSkeletonLoader rows={5} />
+        </div>
       </div>
     )
   }
@@ -592,408 +595,428 @@ function PlanDetailPage(): React.ReactElement {
 
   return (
     <div className="w-full py-4">
-      {/* Breadcrumb */}
-      <nav className="text-sm text-gray-500 mb-4 max-w-5xl mx-auto">
-        <Link href="/rebalance/models" className="hover:text-invest-600">
-          {"Model Portfolios"}
-        </Link>
-        <span className="mx-2">/</span>
-        <Link
-          href={`/rebalance/models/${modelId}`}
-          className="hover:text-invest-600"
-        >
-          {model?.name || "..."}
-        </Link>
-        <span className="mx-2">/</span>
-        <span className="text-gray-900">
-          {"Plan"} v{plan.version}
-        </span>
-      </nav>
-
-      {/* Action error banner */}
-      {actionError && (
-        <Alert
-          variant="error"
-          className="mb-4 max-w-5xl mx-auto flex items-center justify-between"
-        >
-          <span>
-            <i className="fas fa-exclamation-circle mr-2"></i>
-            {actionError}
-          </span>
-          <button
-            onClick={() => setActionError(null)}
-            className="ml-4 text-red-500 hover:text-red-700"
+      <div className="max-w-5xl mx-auto">
+        {/* Breadcrumb */}
+        <nav className="text-sm text-gray-500 mb-4">
+          <Link href="/rebalance/models" className="hover:text-invest-600">
+            {"Model Portfolios"}
+          </Link>
+          <span className="mx-2">/</span>
+          <Link
+            href={`/rebalance/models/${modelId}`}
+            className="hover:text-invest-600"
           >
-            <i className="fas fa-times"></i>
-          </button>
-        </Alert>
-      )}
+            {model?.name || "..."}
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-gray-900">
+            {"Plan"} v{plan.version}
+          </span>
+        </nav>
 
-      {/* Header */}
-      <div className="bg-white shadow-sm border border-gray-200 rounded-lg p-6 max-w-5xl mx-auto mb-6">
-        <div className="flex items-start justify-between mb-4">
-          <div>
+        {/* Action error banner */}
+        {actionError && (
+          <Alert
+            variant="error"
+            className="mb-4 flex items-center justify-between"
+          >
+            <span>
+              <i className="fas fa-exclamation-circle mr-2"></i>
+              {actionError}
+            </span>
+            <button
+              onClick={() => setActionError(null)}
+              className="ml-4 text-red-500 hover:text-red-700"
+            >
+              <i className="fas fa-times"></i>
+            </button>
+          </Alert>
+        )}
+
+        {/* Header */}
+        <div className="bg-white shadow-sm border border-gray-200 rounded-lg p-6 mb-6">
+          <div className="min-w-0">
             <div className="flex items-center gap-3 flex-wrap">
               <h1 className="text-2xl font-bold text-gray-900">
                 {"Plan"} v{plan.version}
               </h1>
-              <span
-                className={`px-2.5 py-1 text-xs font-semibold rounded-full ${
-                  plan.status === "APPROVED"
-                    ? "bg-green-100 text-green-800"
-                    : "bg-yellow-100 text-yellow-800"
-                }`}
-              >
-                {plan.status}
-              </span>
+              <StatusBadge
+                status={plan.status}
+                i18nPrefix="rebalance.plans.status"
+              />
             </div>
             {plan.description && (
               <p className="text-sm text-gray-600 mt-1">{plan.description}</p>
             )}
-          </div>
-          <button
-            onClick={handleCreateNewVersion}
-            disabled={creatingVersion}
-            className="ml-4 text-sm text-invest-600 hover:text-invest-700 transition-colors flex items-center disabled:opacity-50 shrink-0"
-          >
-            {creatingVersion ? (
-              <Spinner className="mr-2" />
-            ) : (
-              <i className="fas fa-code-branch mr-2"></i>
-            )}
-            {"New Version"}
-          </button>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4 text-sm">
-          <div>
-            <span className="text-gray-500">{"Created"}:</span>
-            <span className="ml-2 text-gray-900">
-              {formatDate(plan.createdAt)}
-            </span>
-          </div>
-          {plan.approvedAt && (
-            <div>
-              <span className="text-gray-500">{"Approved"}:</span>
-              <span className="ml-2 text-gray-900">
-                {formatDate(plan.approvedAt)}
+            <p className="text-sm text-gray-500 mt-2">
+              <span>
+                {"Created"} {formatDate(plan.createdAt)}
               </span>
+              {plan.approvedAt && (
+                <>
+                  <span className="mx-2 text-gray-300">{"·"}</span>
+                  <span>
+                    {"Approved"} {formatDate(plan.approvedAt)}
+                  </span>
+                </>
+              )}
+            </p>
+          </div>
+
+          {/* Actions — one filled CTA that tracks intent: Save while dirty,
+              Approve once clean. Delete stays a ghost, pushed to the far edge. */}
+          {isDraft && (
+            <div className="flex items-center gap-3 flex-wrap mt-6 pt-4 border-t border-gray-200">
+              {hasChanges && (
+                <button
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="bg-invest-600 text-white px-4 py-2 rounded-lg hover:bg-invest-700 transition-colors flex items-center disabled:opacity-50"
+                >
+                  {saving ? (
+                    <Spinner className="mr-2" />
+                  ) : (
+                    <i className="fas fa-save mr-2"></i>
+                  )}
+                  {"Save"}
+                </button>
+              )}
+              <button
+                onClick={() => setShowApproveConfirm(true)}
+                disabled={approving || weights.length === 0}
+                className={`px-4 py-2 rounded-lg transition-colors flex items-center disabled:opacity-50 ${
+                  hasChanges
+                    ? "border border-gray-300 text-gray-700 hover:bg-gray-50"
+                    : "bg-invest-600 text-white hover:bg-invest-700"
+                }`}
+              >
+                {approving ? (
+                  <Spinner className="mr-2" />
+                ) : (
+                  <i className="fas fa-check mr-2"></i>
+                )}
+                {"Approve Plan"}
+              </button>
+              <button
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={deleting}
+                className="ml-auto text-sm text-red-600 px-3 py-2 rounded-lg hover:bg-red-50 hover:text-red-700 transition-colors flex items-center disabled:opacity-50"
+              >
+                {deleting ? (
+                  <Spinner className="mr-2" />
+                ) : (
+                  <i className="fas fa-trash mr-2"></i>
+                )}
+                {"Delete"}
+              </button>
+            </div>
+          )}
+
+          {/* An approved plan is locked; the one forward action is drafting
+              the next version, so it gets the region's single filled CTA. */}
+          {!isDraft && (
+            <div className="flex items-center gap-3 mt-6 pt-4 border-t border-gray-200">
+              <button
+                onClick={handleCreateNewVersion}
+                disabled={creatingVersion}
+                className="bg-invest-600 text-white px-4 py-2 rounded-lg hover:bg-invest-700 transition-colors flex items-center disabled:opacity-50"
+              >
+                {creatingVersion ? (
+                  <Spinner className="mr-2" />
+                ) : (
+                  <i className="fas fa-code-branch mr-2"></i>
+                )}
+                {`New Draft from v${plan.version}`}
+              </button>
             </div>
           )}
         </div>
 
-        {/* Actions */}
-        {isDraft && (
-          <div className="flex gap-3 mt-6 pt-4 border-t">
-            {hasChanges && (
-              <button
-                onClick={handleSave}
-                disabled={saving}
-                className="bg-invest-600 text-white px-4 py-2 rounded-lg hover:bg-invest-700 transition-colors flex items-center disabled:opacity-50"
-              >
-                {saving ? (
-                  <Spinner className="mr-2" />
-                ) : (
-                  <i className="fas fa-save mr-2"></i>
-                )}
-                {"Save"}
-              </button>
-            )}
-            <button
-              onClick={() => setShowApproveConfirm(true)}
-              disabled={approving || weights.length === 0}
-              className="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors flex items-center disabled:opacity-50"
-            >
-              {approving ? (
-                <Spinner className="mr-2" />
-              ) : (
-                <i className="fas fa-check mr-2"></i>
-              )}
-              {"Approve Plan"}
-            </button>
-            <button
-              onClick={() => setShowDeleteConfirm(true)}
-              disabled={deleting}
-              className="bg-red-100 text-red-700 px-4 py-2 rounded-lg hover:bg-red-200 transition-colors flex items-center disabled:opacity-50"
-            >
-              {deleting ? (
-                <Spinner className="mr-2" />
-              ) : (
-                <i className="fas fa-trash mr-2"></i>
-              )}
-              {"Delete"}
-            </button>
-          </div>
-        )}
-      </div>
-
-      {/* Assets Editor/Table */}
-      <div className="bg-white shadow-sm border border-gray-200 rounded-lg p-6 max-w-5xl mx-auto">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-medium text-gray-900">
-            {"Target Allocations"}
-          </h2>
-          <div className="flex gap-2">
-            {/* Export / Copy buttons - available for both draft and approved plans */}
-            {weights.length > 0 && (
-              <>
-                <button
-                  onClick={handleCopyCSV}
-                  aria-label="Copy target allocations"
-                  className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
-                >
-                  <i
-                    className={`fas ${copied ? "fa-check text-green-600" : "fa-clipboard"} mr-1.5`}
-                  ></i>
-                  {copied ? "Copied!" : "Copy"}
-                </button>
-                <button
-                  onClick={handleExportCSV}
-                  className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
-                >
-                  <i className="fas fa-download mr-1.5"></i>
-                  {"Export"}
-                </button>
-              </>
-            )}
-            {/* Import dropdown - only for draft plans */}
-            {isDraft && (
-              <>
-                <div className="relative" ref={importDropdownRef}>
-                  <button
-                    onClick={() => setShowImportDropdown(!showImportDropdown)}
-                    className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
-                  >
-                    <i className="fas fa-upload mr-1.5"></i>
-                    {"Import"}
-                    <i className="fas fa-chevron-down ml-1.5 text-xs"></i>
-                  </button>
-                  {showImportDropdown && (
-                    <div className="absolute right-0 mt-1 w-48 bg-white rounded-md shadow-lg border border-gray-200 z-10">
-                      <div className="py-1">
-                        <button
-                          onClick={() => {
-                            setShowImportDropdown(false)
-                            setShowImportHoldingsDialog(true)
-                          }}
-                          className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center"
-                        >
-                          <i className="fas fa-chart-pie mr-3 text-gray-400 w-4"></i>
-                          {"Holdings"}
-                        </button>
-                        <button
-                          onClick={() => {
-                            setShowImportDropdown(false)
-                            csvInputRef.current?.click()
-                          }}
-                          className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center"
-                        >
-                          <i className="fas fa-file-csv mr-3 text-gray-400 w-4"></i>
-                          {"CSV"}
-                        </button>
-                        {previousPlan && (
+        {/* Assets Editor/Table */}
+        <div className="bg-white shadow-sm border border-gray-200 rounded-lg p-6">
+          {isDraft ? (
+            <ModelWeightsEditor
+              title={"Target Allocations"}
+              weights={weights}
+              onChange={handleWeightsChange}
+              onFetchPrices={handleFetchPrices}
+              fetchingPrices={fetchingPrices}
+              showPrice={true}
+              onShowPriceChart={handleShowPriceChart}
+              onShowAssetInsight={(w) => setInsightAsset(w)}
+              extraActions={
+                <>
+                  {weights.length > 0 && (
+                    <>
+                      <button
+                        onClick={handleCopyCSV}
+                        aria-label="Copy target allocations"
+                        className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
+                      >
+                        <i
+                          className={`fas ${copied ? "fa-check text-green-600" : "fa-clipboard"} mr-1.5`}
+                        ></i>
+                        {copied ? "Copied!" : "Copy"}
+                      </button>
+                      <button
+                        onClick={handleExportCSV}
+                        className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
+                      >
+                        <i className="fas fa-download mr-1.5"></i>
+                        {"Export"}
+                      </button>
+                    </>
+                  )}
+                  <div className="relative" ref={importDropdownRef}>
+                    <button
+                      onClick={() => setShowImportDropdown(!showImportDropdown)}
+                      className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
+                    >
+                      <i className="fas fa-upload mr-1.5"></i>
+                      {"Import"}
+                      <i className="fas fa-chevron-down ml-1.5 text-xs"></i>
+                    </button>
+                    {showImportDropdown && (
+                      <div className="absolute right-0 mt-1 w-48 bg-white rounded-md shadow-lg border border-gray-200 z-10">
+                        <div className="py-1">
                           <button
-                            onClick={() =>
-                              handleImportFromPlan(previousPlan.id)
-                            }
+                            onClick={() => {
+                              setShowImportDropdown(false)
+                              setShowImportHoldingsDialog(true)
+                            }}
                             className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center"
                           >
-                            <i className="fas fa-copy mr-3 text-gray-400 w-4"></i>
-                            {`Plan v${previousPlan.version}`}
+                            <i className="fas fa-chart-pie mr-3 text-gray-400 w-4"></i>
+                            {"Holdings"}
                           </button>
-                        )}
+                          <button
+                            onClick={() => {
+                              setShowImportDropdown(false)
+                              csvInputRef.current?.click()
+                            }}
+                            className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center"
+                          >
+                            <i className="fas fa-file-csv mr-3 text-gray-400 w-4"></i>
+                            {"CSV"}
+                          </button>
+                          {previousPlan && (
+                            <button
+                              onClick={() =>
+                                handleImportFromPlan(previousPlan.id)
+                              }
+                              className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center"
+                            >
+                              <i className="fas fa-copy mr-3 text-gray-400 w-4"></i>
+                              {`Plan v${previousPlan.version}`}
+                            </button>
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    )}
+                  </div>
+                  <input
+                    ref={csvInputRef}
+                    type="file"
+                    accept=".csv,.txt"
+                    onChange={handleImportCSV}
+                    className="hidden"
+                  />
+                </>
+              }
+            />
+          ) : (
+            <>
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
+                <h2 className="text-lg font-semibold text-gray-900 whitespace-nowrap mr-4">
+                  {"Target Allocations"}
+                </h2>
+                {weights.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      onClick={handleCopyCSV}
+                      aria-label="Copy target allocations"
+                      className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
+                    >
+                      <i
+                        className={`fas ${copied ? "fa-check text-green-600" : "fa-clipboard"} mr-1.5`}
+                      ></i>
+                      {copied ? "Copied!" : "Copy"}
+                    </button>
+                    <button
+                      onClick={handleExportCSV}
+                      className="text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 transition-colors flex items-center"
+                    >
+                      <i className="fas fa-download mr-1.5"></i>
+                      {"Export"}
+                    </button>
+                  </div>
+                )}
+              </div>
+              {plan.assets.length === 0 ? (
+                <div className="bg-gray-50 border border-gray-200 rounded-lg p-6 text-center text-gray-500">
+                  {"No assets in this plan"}
                 </div>
-                <input
-                  ref={csvInputRef}
-                  type="file"
-                  accept=".csv,.txt"
-                  onChange={handleImportCSV}
-                  className="hidden"
-                />
-              </>
-            )}
-          </div>
+              ) : (
+                <div className="border border-gray-200 rounded-lg overflow-hidden">
+                  <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th className="px-3 sm:px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          {"Asset"}
+                        </th>
+                        <th className="px-3 sm:px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          {"Weight"}
+                        </th>
+                        <th className="hidden sm:table-cell px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          {"Price"}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="bg-white divide-y divide-gray-200">
+                      {plan.assets.map((asset: PlanAssetDto) => (
+                        <tr key={asset.id}>
+                          <td className="px-3 sm:px-4 py-3">
+                            <div>
+                              <div className="flex items-center gap-2">
+                                <span className="font-medium text-gray-900">
+                                  {asset.assetCode || asset.assetId}
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    handleShowPriceChart({
+                                      assetId: asset.assetId,
+                                      assetCode: asset.assetCode,
+                                      assetName: asset.assetName,
+                                      weight: Number(asset.weight) * 100,
+                                    })
+                                  }
+                                  className="p-0.5 text-gray-400 hover:text-gray-600 transition-colors"
+                                  title={"Price history chart"}
+                                >
+                                  <i className="fas fa-chart-line text-xs"></i>
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setInsightAsset({
+                                      assetId: asset.assetId,
+                                      assetCode: asset.assetCode,
+                                      assetName: asset.assetName,
+                                      weight: Number(asset.weight) * 100,
+                                    })
+                                  }
+                                  className="p-0.5 text-gray-400 hover:text-blue-500 transition-colors"
+                                  title={"AI asset insight"}
+                                >
+                                  <i className="fas fa-robot text-xs"></i>
+                                </button>
+                              </div>
+                              {asset.assetName && (
+                                <div className="text-xs text-gray-500">
+                                  {asset.assetName}
+                                </div>
+                              )}
+                              {/* Show price on mobile below asset name */}
+                              {asset.capturedPrice && (
+                                <div className="text-xs text-gray-400 font-mono tabular-nums sm:hidden">
+                                  {asset.capturedPrice.toFixed(2)}{" "}
+                                  {asset.priceCurrency || ""}
+                                </div>
+                              )}
+                              {asset.rationale && (
+                                <div className="text-xs text-invest-600 italic mt-1">
+                                  <i className="fas fa-comment-alt mr-1"></i>
+                                  {asset.rationale}
+                                </div>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-3 sm:px-4 py-3 text-right text-sm text-gray-900 font-mono tabular-nums whitespace-nowrap">
+                            {formatWeight(asset.weight)}
+                          </td>
+                          <td className="hidden sm:table-cell px-4 py-3 text-right text-sm text-gray-500 font-mono tabular-nums whitespace-nowrap">
+                            {asset.capturedPrice
+                              ? `${asset.capturedPrice.toFixed(2)} ${asset.priceCurrency || ""}`
+                              : "-"}
+                          </td>
+                        </tr>
+                      ))}
+                      {/* Cash row */}
+                      {plan.cashWeight > 0 && (
+                        <tr className="bg-gray-50">
+                          <td className="px-3 sm:px-4 py-3">
+                            <span className="font-medium text-gray-700">
+                              <i className="fas fa-coins mr-2 text-gray-400"></i>
+                              {"Cash"}
+                            </span>
+                          </td>
+                          <td className="px-3 sm:px-4 py-3 text-right text-sm text-gray-700 font-mono tabular-nums">
+                            {formatWeight(plan.cashWeight)}
+                          </td>
+                          <td className="hidden sm:table-cell px-4 py-3 text-right text-sm text-gray-500">
+                            -
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
+          )}
         </div>
 
-        {isDraft ? (
-          <ModelWeightsEditor
-            weights={weights}
-            onChange={handleWeightsChange}
-            onFetchPrices={handleFetchPrices}
-            fetchingPrices={fetchingPrices}
-            showPrice={true}
-            onShowPriceChart={handleShowPriceChart}
-            onShowAssetInsight={(w) => setInsightAsset(w)}
+        {/* Import from Holdings Dialog */}
+        <ImportHoldingsDialog
+          modalOpen={showImportHoldingsDialog}
+          modelId={modelId as string}
+          onClose={() => setShowImportHoldingsDialog(false)}
+          onImport={handleImportHoldings}
+        />
+        {showCopyFieldsDialog && (
+          <CopyFieldsDialog
+            initialFields={copyFields}
+            onCopy={handleConfirmCopy}
+            onCancel={() => setShowCopyFieldsDialog(false)}
           />
-        ) : (
-          <>
-            {plan.assets.length === 0 ? (
-              <div className="bg-gray-50 border border-gray-200 rounded-lg p-6 text-center text-gray-500">
-                {"No assets in this plan"}
-              </div>
-            ) : (
-              <div className="border border-gray-200 rounded-lg overflow-hidden">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-3 sm:px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        {"Asset"}
-                      </th>
-                      <th className="px-3 sm:px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        {"Weight"}
-                      </th>
-                      <th className="hidden sm:table-cell px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        {"Price"}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
-                    {plan.assets.map((asset: PlanAssetDto) => (
-                      <tr key={asset.id}>
-                        <td className="px-3 sm:px-4 py-3">
-                          <div>
-                            <div className="flex items-center gap-2">
-                              <span className="font-medium text-gray-900">
-                                {asset.assetCode || asset.assetId}
-                              </span>
-                              <button
-                                type="button"
-                                onClick={() =>
-                                  handleShowPriceChart({
-                                    assetId: asset.assetId,
-                                    assetCode: asset.assetCode,
-                                    assetName: asset.assetName,
-                                    weight: Number(asset.weight) * 100,
-                                  })
-                                }
-                                className="p-0.5 text-gray-400 hover:text-gray-600 transition-colors"
-                                title={"Price history chart"}
-                              >
-                                <i className="fas fa-chart-line text-xs"></i>
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() =>
-                                  setInsightAsset({
-                                    assetId: asset.assetId,
-                                    assetCode: asset.assetCode,
-                                    assetName: asset.assetName,
-                                    weight: Number(asset.weight) * 100,
-                                  })
-                                }
-                                className="p-0.5 text-gray-400 hover:text-blue-500 transition-colors"
-                                title={"AI asset insight"}
-                              >
-                                <i className="fas fa-robot text-xs"></i>
-                              </button>
-                            </div>
-                            {asset.assetName && (
-                              <div className="text-xs text-gray-500">
-                                {asset.assetName}
-                              </div>
-                            )}
-                            {/* Show price on mobile below asset name */}
-                            {asset.capturedPrice && (
-                              <div className="text-xs text-gray-400 sm:hidden">
-                                {asset.capturedPrice.toFixed(2)}{" "}
-                                {asset.priceCurrency || ""}
-                              </div>
-                            )}
-                            {asset.rationale && (
-                              <div className="text-xs text-invest-600 italic mt-1">
-                                <i className="fas fa-comment-alt mr-1"></i>
-                                {asset.rationale}
-                              </div>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-3 sm:px-4 py-3 text-right text-gray-900 whitespace-nowrap">
-                          {formatWeight(asset.weight)}
-                        </td>
-                        <td className="hidden sm:table-cell px-4 py-3 text-right text-gray-500">
-                          {asset.capturedPrice
-                            ? `${asset.capturedPrice.toFixed(2)} ${asset.priceCurrency || ""}`
-                            : "-"}
-                        </td>
-                      </tr>
-                    ))}
-                    {/* Cash row */}
-                    {plan.cashWeight > 0 && (
-                      <tr className="bg-gray-50">
-                        <td className="px-3 sm:px-4 py-3">
-                          <span className="font-medium text-gray-700">
-                            <i className="fas fa-coins mr-2 text-gray-400"></i>
-                            {"Cash"}
-                          </span>
-                        </td>
-                        <td className="px-3 sm:px-4 py-3 text-right text-gray-700">
-                          {formatWeight(plan.cashWeight)}
-                        </td>
-                        <td className="hidden sm:table-cell px-4 py-3 text-right text-gray-500">
-                          -
-                        </td>
-                      </tr>
-                    )}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </>
+        )}
+        {showApproveConfirm && (
+          <ConfirmDialog
+            title={"Approve Plan"}
+            message={"Approve this plan? This will lock the allocations."}
+            confirmLabel={"Approve"}
+            cancelLabel={"Cancel"}
+            variant="blue"
+            onConfirm={handleApprove}
+            onCancel={() => setShowApproveConfirm(false)}
+          />
+        )}
+        {showDeleteConfirm && (
+          <ConfirmDialog
+            title={"Delete Plan"}
+            message={"Delete this draft plan?"}
+            confirmLabel={"Delete"}
+            cancelLabel={"Cancel"}
+            variant="red"
+            onConfirm={handleDelete}
+            onCancel={() => setShowDeleteConfirm(false)}
+          />
+        )}
+        {chartAsset && (
+          <PriceChartPopup
+            asset={chartAsset}
+            onClose={() => setChartAsset(null)}
+          />
+        )}
+        {insightAsset && (
+          <AssetInsightPopup
+            asset={insightAsset}
+            modelName={model?.name || ""}
+            onClose={() => setInsightAsset(null)}
+          />
         )}
       </div>
-
-      {/* Import from Holdings Dialog */}
-      <ImportHoldingsDialog
-        modalOpen={showImportHoldingsDialog}
-        modelId={modelId as string}
-        onClose={() => setShowImportHoldingsDialog(false)}
-        onImport={handleImportHoldings}
-      />
-      {showCopyFieldsDialog && (
-        <CopyFieldsDialog
-          initialFields={copyFields}
-          onCopy={handleConfirmCopy}
-          onCancel={() => setShowCopyFieldsDialog(false)}
-        />
-      )}
-      {showApproveConfirm && (
-        <ConfirmDialog
-          title={"Approve Plan"}
-          message={"Approve this plan? This will lock the allocations."}
-          confirmLabel={"Approve"}
-          cancelLabel={"Cancel"}
-          variant="blue"
-          onConfirm={handleApprove}
-          onCancel={() => setShowApproveConfirm(false)}
-        />
-      )}
-      {showDeleteConfirm && (
-        <ConfirmDialog
-          title={"Delete Plan"}
-          message={"Delete this draft plan?"}
-          confirmLabel={"Delete"}
-          cancelLabel={"Cancel"}
-          variant="red"
-          onConfirm={handleDelete}
-          onCancel={() => setShowDeleteConfirm(false)}
-        />
-      )}
-      {chartAsset && (
-        <PriceChartPopup
-          asset={chartAsset}
-          onClose={() => setChartAsset(null)}
-        />
-      )}
-      {insightAsset && (
-        <AssetInsightPopup
-          asset={insightAsset}
-          modelName={model?.name || ""}
-          onClose={() => setInsightAsset(null)}
-        />
-      )}
     </div>
   )
 }

--- a/src/pages/rebalance/models/index.tsx
+++ b/src/pages/rebalance/models/index.tsx
@@ -8,32 +8,30 @@ function ModelsPage(): React.ReactElement {
 
   return (
     <div className="w-full py-4">
-      {/* Breadcrumb - Model Portfolios is the entry point of the rebalancing flow */}
-      <nav className="text-sm text-gray-500 mb-4">
-        <span className="text-gray-900 font-medium">{"Model Portfolios"}</span>
-      </nav>
-
-      {/* Header */}
-      <div className="flex justify-between items-center mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">
-            {"Model Portfolios"}
-          </h1>
-          <p className="text-sm text-gray-600 mt-1">
-            {"Define target allocations for rebalancing"}
-          </p>
+      <div className="max-w-6xl mx-auto">
+        {/* No breadcrumb: this is the flow's entry point, the h1 carries it */}
+        {/* Header */}
+        <div className="flex justify-between items-center mb-6">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">
+              {"Model Portfolios"}
+            </h1>
+            <p className="text-sm text-gray-600 mt-1">
+              {"Define target allocations for rebalancing"}
+            </p>
+          </div>
+          <button
+            onClick={() => router.push("/rebalance/models/__NEW__")}
+            className="bg-invest-600 text-white px-4 py-2 rounded-lg hover:bg-invest-700 transition-colors flex items-center"
+          >
+            <i className="fas fa-plus mr-2"></i>
+            {"Create Model"}
+          </button>
         </div>
-        <button
-          onClick={() => router.push("/rebalance/models/__NEW__")}
-          className="bg-invest-600 text-white px-4 py-2 rounded-lg hover:bg-invest-700 transition-colors flex items-center"
-        >
-          <i className="fas fa-plus mr-2"></i>
-          {"Create Model"}
-        </button>
-      </div>
 
-      {/* Models List */}
-      <ModelPortfolioList />
+        {/* Models List */}
+        <ModelPortfolioList />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Layout + flow rework of the Invest model/plan screens. Verified live (desktop + 390px mobile) against the local stack with real data.

### Flow: new plan from the last approved version
- **Model page**: `Create Plan` now seeds from the latest approved plan (`sourcePlanId`) and reads **New Plan from vN**; empty plan is the fallback when nothing is approved.
- **Approved plan page**: filled **New Draft from vN** CTA in an actions row — replaces the tiny top-right "New Version" ghost link.
- The ghost link is gone from draft pages too: branching an unfinished draft duplicated drafts; new versions now start from approved plans (ocr flagged this as an intentional behavior change — confirmed).

### Page scaffold
- One wrapper per page: `max-w-5xl` on detail pages, `max-w-6xl` on the models list (table needs the width; `overflow-x-auto` fallback). Previously: full-bleed / 4xl / 5xl mix.
- Detail page titles raised to `text-2xl` — they no longer rank below the list page's title.
- Models index breadcrumb removed (duplicated the h1 directly beneath it).

### Plan detail
- Draft actions: one filled CTA that tracks intent — **Save** while dirty, otherwise **Approve**; Delete demoted to a ghost pushed to the far edge.
- Allocations card: single toolbar row (title + Copy / Export / Import / Fetch Prices / Add Asset) instead of two stacked right-aligned button rows; empty state carries the Add Asset action.
- **Normalize to 100%** moved into the total-weight bar, next to the number it fixes.
- Editor rows: bordered, divided list (mirrors the approved table) instead of stacked gray boxes; rationale collapsed by default — the filled comment icon signals presence.
- Shared `StatusBadge` replaces the hand-rolled status pill (DRAFT now consistent with the list).

### The Almanac compliance
- Tabular numerals: weights, prices and totals in mono `tabular-nums`.
- Off-palette `violet-600` Create Plan button replaced with the Invest domain color.
- Shared table header styles (`thBase`/`thCenter`/`thRight`) on both tables.

## Testing
- 2510/2510 jest, lint 0 errors, typecheck clean, prettier applied.
- `ocr review`: 1 low finding (the intentional New Version removal above).
- Live click-through: models list → model → approved v4 → seeded draft (created + deleted), Add Asset dialog, mobile 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kWgaWpybSCajCzVQZdiPk
