### PR TITLE
test(rebalance): mixed-currency characterization fixtures and API route tests

### DIFF
--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -1446,3 +1446,245 @@ describe("useRebalanceExecution", () => {
     expect(byId("fallback-1")).toBe(true)
   })
 })
+
+// --- Characterization: mixed-currency client math ---
+//
+// `makeItem`/`makeExecution` already default `priceCurrency`/`currency` to
+// "USD" but accept overrides, so no fixture-factory changes were needed for
+// this block — see the top-level fixtures above.
+describe("characterization: mixed-currency client math (#1154/#1156)", () => {
+  // These tests document what the CURRENT client math in
+  // useRebalanceExecution.ts actually produces when an execution's items
+  // carry a `priceCurrency` that differs from the execution/portfolio's own
+  // reporting currency. The hook's computed memo (useRebalanceExecution.ts
+  // ~lines 642-788) never reads `priceCurrency` at all: `totalPortfolioValue`,
+  // `snapshotValue`, `snapshotCashValue` and `snapshotPrice` are all treated
+  // as plain numbers in one implicit unit. In particular `deltaQuantity`
+  // (line ~699-703) divides a delta expressed in the execution's reporting
+  // currency by `snapshotPrice`, which may be quoted in a different currency
+  // entirely — silently mixing currencies to produce a share count. These
+  // tests pin that behavior for future refactors; they do NOT bless it as
+  // correct. The fix belongs on the backend (#1154) per the
+  // backend-drives-data hard rule.
+
+  it("a) an asset priced in USD inside an SGD-reporting execution: deltaValue/deltaQuantity mix the two currencies without conversion", async () => {
+    const exec = makeExecution({
+      currency: "SGD",
+      totalPortfolioValue: 10000,
+      snapshotCashValue: 1000,
+      items: [
+        makeItem({
+          id: "usd-item",
+          assetId: "usd-asset",
+          assetCode: "AAPL",
+          priceCurrency: "USD",
+          snapshotWeight: 0.5,
+          snapshotValue: 5000,
+          snapshotPrice: 100,
+          planTargetWeight: 0.6,
+          isCash: false,
+        }),
+        makeCashItem({
+          assetId: "cash",
+          priceCurrency: "SGD",
+          snapshotWeight: 0.1,
+          snapshotValue: 1000,
+          planTargetWeight: 0.1,
+        }),
+      ],
+    })
+
+    const { result } = await renderWithExecution(exec)
+
+    const usdItem = result.current.displayItems.find(
+      (i) => i.assetId === "usd-asset",
+    )
+    // No override, no other non-cash items: proportional scaling collapses
+    // to (planTargetWeight / totalPlanTargetWeights) * availableForAssets
+    // = (0.6 / 0.6) * (1 - 0.1) = 0.9.
+    expect(usdItem?.effectiveTarget).toBeCloseTo(0.9, 10)
+    // targetValue = 10000 (SGD) * 0.9 = 9000 (SGD); deltaValue = 9000 - 5000
+    // (the item's own snapshotValue, also nominally SGD per the DTO) = 4000.
+    expect(usdItem?.deltaValue).toBeCloseTo(4000, 6)
+    // deltaQuantity = round(deltaValue / snapshotPrice) = round(4000 / 100)
+    // = 40 -- a "4000 SGD" delta divided by a "100 USD" price, treated as
+    // the same unit. priceCurrency is never consulted.
+    expect(usdItem?.deltaQuantity).toBe(40)
+
+    // Cash summary: the 4000 buy has to be funded from somewhere. Nothing
+    // was sold, cashPositionChange is 0 (cash target == current), so the
+    // hook reports a deposit requirement of exactly the mismatched delta.
+    expect(result.current.cashSummary.cashForPurchases).toBeCloseTo(4000, 6)
+    expect(result.current.cashSummary.cashFromSales).toBe(0)
+    expect(result.current.cashSummary.netImpact).toBeCloseTo(-4000, 6)
+    // projectedCash is unclamped and goes negative -- "needs a deposit".
+    expect(result.current.cashSummary.projectedCash).toBeCloseTo(-3000, 6)
+
+    // projectedWeight: excluded rows aside, projectedTotal only ever sums
+    // snapshotValue + deltaValue across items -- again currency-blind. Cash
+    // is clamped to 0 (can't fund the deposit from itself), so the USD item
+    // ends up owning 100% of the projected total.
+    expect(usdItem?.projectedWeight).toBeCloseTo(1, 6)
+    const cash = result.current.displayItems.find((i) => i.isCash)
+    expect(cash?.projectedValue).toBe(0)
+    expect(cash?.projectedWeight).toBe(0)
+  })
+
+  it("b) a plan-only asset (no held position) quoted in EUR inside an SGD-reporting execution gets a full target allocation and a currency-blind share count", async () => {
+    const exec = makeExecution({
+      currency: "SGD",
+      totalPortfolioValue: 10000,
+      snapshotCashValue: 1000,
+      items: [
+        makeItem({
+          id: "held",
+          assetId: "held-asset",
+          assetCode: "MSFT",
+          priceCurrency: "USD",
+          snapshotWeight: 0.9,
+          snapshotValue: 9000,
+          snapshotPrice: 100,
+          planTargetWeight: 0.5,
+          isCash: false,
+        }),
+        makeItem({
+          id: "plan-only",
+          assetId: "eur-planonly-asset",
+          assetCode: "SAP",
+          priceCurrency: "EUR",
+          // Not currently held: zero snapshot position, but still carries a
+          // plan target weight, exactly like a brand-new model addition.
+          snapshotWeight: 0,
+          snapshotValue: 0,
+          snapshotQuantity: 0,
+          snapshotPrice: 50,
+          planTargetWeight: 0.5,
+          isCash: false,
+        }),
+        makeCashItem({
+          assetId: "cash",
+          priceCurrency: "SGD",
+          snapshotWeight: 0.1,
+          snapshotValue: 1000,
+          planTargetWeight: 0.1,
+        }),
+      ],
+    })
+
+    const { result } = await renderWithExecution(exec)
+
+    const planOnly = result.current.displayItems.find(
+      (i) => i.assetId === "eur-planonly-asset",
+    )
+    // totalPlanTargetWeights (non-cash) = 0.5 + 0.5 = 1.0; availableForAssets
+    // = 0.9; effectiveTarget = (0.5 / 1.0) * 0.9 = 0.45 for both non-cash rows.
+    expect(planOnly?.effectiveTarget).toBeCloseTo(0.45, 10)
+    // targetValue = 10000 * 0.45 = 4500 (SGD); deltaValue = 4500 - 0 = 4500,
+    // even though the asset has never been held and is quoted in EUR.
+    expect(planOnly?.deltaValue).toBeCloseTo(4500, 6)
+    // deltaQuantity = round(4500 / 50) = 90 "shares" -- again the SGD-valued
+    // delta is divided by a EUR-quoted price with no FX applied.
+    expect(planOnly?.deltaQuantity).toBe(90)
+
+    const held = result.current.displayItems.find(
+      (i) => i.assetId === "held-asset",
+    )
+    expect(held?.effectiveTarget).toBeCloseTo(0.45, 10)
+    expect(held?.deltaValue).toBeCloseTo(-4500, 6)
+    expect(held?.deltaQuantity).toBe(-45)
+
+    // This scenario happens to be self-funding (sale of `held` == purchase
+    // of `plan-only`), so cash is untouched and the projected weights land
+    // exactly on the (currency-blind) target weights.
+    expect(result.current.cashSummary.netImpact).toBeCloseTo(0, 6)
+    expect(result.current.cashSummary.projectedCash).toBeCloseTo(1000, 6)
+    expect(planOnly?.projectedWeight).toBeCloseTo(0.45, 6)
+    expect(held?.projectedWeight).toBeCloseTo(0.45, 6)
+  })
+
+  it("c) two portfolios with different native currencies are flattened into one item list with no per-portfolio currency segregation", async () => {
+    // ExecutionDto exposes a single aggregate `currency` field and
+    // ExecutionItemDto carries no portfolioId -- the hook's surface has no
+    // concept of "this item belongs to that portfolio's currency". This
+    // test documents that: with portfolioIds.length === 2, the compute pass
+    // still just sums raw item numbers regardless of each item's own
+    // (notionally per-portfolio) priceCurrency.
+    const exec = makeExecution({
+      portfolioIds: ["portfolio-usd", "portfolio-sgd"],
+      currency: "SGD",
+      totalPortfolioValue: 20000,
+      snapshotCashValue: 2000,
+      items: [
+        makeItem({
+          id: "usd-port-item",
+          assetId: "usd-port-asset",
+          assetCode: "VOO",
+          priceCurrency: "USD",
+          snapshotWeight: 0.4,
+          snapshotValue: 8000,
+          snapshotPrice: 200,
+          planTargetWeight: 0.45,
+          isCash: false,
+        }),
+        makeItem({
+          id: "sgd-port-item",
+          assetId: "sgd-port-asset",
+          assetCode: "ES3",
+          priceCurrency: "SGD",
+          snapshotWeight: 0.5,
+          snapshotValue: 10000,
+          snapshotPrice: 500,
+          planTargetWeight: 0.45,
+          isCash: false,
+        }),
+        makeCashItem({
+          assetId: "cash",
+          priceCurrency: "SGD",
+          snapshotWeight: 0.1,
+          snapshotValue: 2000,
+          planTargetWeight: 0.1,
+        }),
+      ],
+    })
+
+    const { result } = await renderWithExecution(exec)
+    expect(result.current.execution?.portfolioIds).toEqual([
+      "portfolio-usd",
+      "portfolio-sgd",
+    ])
+
+    const usdItem = result.current.displayItems.find(
+      (i) => i.assetId === "usd-port-asset",
+    )
+    const sgdItem = result.current.displayItems.find(
+      (i) => i.assetId === "sgd-port-asset",
+    )
+
+    // totalPlanTargetWeights = 0.45 + 0.45 = 0.9 = availableForAssets, so
+    // effectiveTarget == planTargetWeight for both, unaffected by which
+    // portfolio (or currency) each item nominally came from.
+    expect(usdItem?.effectiveTarget).toBeCloseTo(0.45, 10)
+    expect(sgdItem?.effectiveTarget).toBeCloseTo(0.45, 10)
+
+    // targetValue = 20000 * 0.45 = 9000 for both.
+    expect(usdItem?.deltaValue).toBeCloseTo(1000, 6) // 9000 - 8000
+    expect(sgdItem?.deltaValue).toBeCloseTo(-1000, 6) // 9000 - 10000
+    // deltaQuantity divides the aggregate-currency delta by each item's own
+    // native price -- USD price for the "USD portfolio" item, SGD price for
+    // the "SGD portfolio" item -- with no currency-aware boundary between
+    // the two portfolios' contributions to the flattened items array.
+    expect(usdItem?.deltaQuantity).toBe(5) // round(1000 / 200)
+    expect(sgdItem?.deltaQuantity).toBe(-2) // round(-1000 / 500)
+
+    // Self-funding across the two portfolios' items: cash is untouched.
+    expect(result.current.cashSummary.cashFromSales).toBeCloseTo(1000, 6)
+    expect(result.current.cashSummary.cashForPurchases).toBeCloseTo(1000, 6)
+    expect(result.current.cashSummary.netImpact).toBeCloseTo(0, 6)
+
+    const total = result.current.displayItems.reduce(
+      (sum, item) => sum + (item.projectedWeight ?? 0),
+      0,
+    )
+    expect(total).toBeCloseTo(1, 5)
+  })
+})

--- a/src/lib/utils/api/__tests__/routes/execution-commit.route.test.ts
+++ b/src/lib/utils/api/__tests__/routes/execution-commit.route.test.ts
@@ -1,0 +1,167 @@
+import commitHandler from "@pages/api/rebalance/executions/[id]/commit"
+
+jest.mock("@lib/auth0", () => ({
+  auth0: {
+    getSession: jest.fn().mockResolvedValue({ user: { sub: "test-user" } }),
+    getAccessToken: jest.fn().mockResolvedValue({ token: "test-token" }),
+  },
+}))
+
+jest.mock("@utils/api/fetchHelper", () => ({
+  requestInit: jest.fn(
+    (token: string, method: string) =>
+      ({
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+      }) as unknown,
+  ),
+}))
+
+jest.mock("@utils/api/responseWriter", () => {
+  // Mirrors the real handleResponse's ok/not-ok branch (see
+  // src/lib/utils/api/responseWriter.ts) so error-propagation tests can
+  // exercise the handler's catch -> fetchError path, same as production.
+  const handleResponse = jest
+    .fn()
+    .mockImplementation(
+      async (
+        response: { ok: boolean; status: number; json: () => Promise<unknown> },
+        res: { status: jest.Mock; json: jest.Mock },
+      ) => {
+        if (!response.ok) {
+          throw new Error(`Backend error ${response.status}`)
+        }
+        const data = await response.json()
+        res.status(200).json(data)
+      },
+    )
+  return {
+    __esModule: true,
+    default: handleResponse,
+    handleResponse,
+    fetchError: jest.fn(
+      (
+        _req: unknown,
+        res: { status: jest.Mock; json: jest.Mock },
+        error: { message: string },
+      ) => {
+        res.status(500).json({ error: error.message })
+      },
+    ),
+  }
+})
+
+jest.mock("@utils/api/bcConfig", () => ({
+  getRebalanceUrl: (path: string): string => `http://rebalance.test${path}`,
+}))
+
+const mockFetch = jest
+  .fn()
+  .mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
+global.fetch = mockFetch as unknown as typeof fetch
+
+function makeReq(
+  method: string,
+  id = "exec-1",
+  body?: unknown,
+): {
+  method: string
+  body: unknown
+  query: Record<string, string>
+  headers: Record<string, string>
+} {
+  return { method, body, query: { id }, headers: {} }
+}
+
+function makeRes(): {
+  status: jest.Mock
+  end: jest.Mock
+  json: jest.Mock
+  setHeader: jest.Mock
+} {
+  return {
+    status: jest.fn().mockReturnThis(),
+    end: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("/api/rebalance/executions/[id]/commit route", () => {
+  it("proxies POST to backend /executions/:id/commit with body and the auth header", async () => {
+    const req = makeReq("POST", "exec-1", {
+      portfolioId: "portfolio-1",
+      transactionStatus: "PROPOSED",
+      brokerId: "broker-1",
+    })
+    const res = makeRes()
+
+    await commitHandler(
+      req as unknown as Parameters<typeof commitHandler>[0],
+      res as unknown as Parameters<typeof commitHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://rebalance.test/executions/exec-1/commit",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer test-token" },
+        body: JSON.stringify(req.body),
+      },
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it("uses the id from the route params to build the backend URL", async () => {
+    const req = makeReq("POST", "exec-xyz", { portfolioId: "portfolio-1" })
+    const res = makeRes()
+
+    await commitHandler(
+      req as unknown as Parameters<typeof commitHandler>[0],
+      res as unknown as Parameters<typeof commitHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://rebalance.test/executions/exec-xyz/commit",
+      expect.any(Object),
+    )
+  })
+
+  it("propagates a backend error status via fetchError", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ message: "Commit failed" }),
+    })
+    const req = makeReq("POST", "exec-1", { portfolioId: "portfolio-1" })
+    const res = makeRes()
+
+    await commitHandler(
+      req as unknown as Parameters<typeof commitHandler>[0],
+      res as unknown as Parameters<typeof commitHandler>[1],
+    )
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Backend error 500" }),
+    )
+  })
+
+  it("rejects GET with 405 and does not call the backend", async () => {
+    const req = makeReq("GET")
+    const res = makeRes()
+
+    await commitHandler(
+      req as unknown as Parameters<typeof commitHandler>[0],
+      res as unknown as Parameters<typeof commitHandler>[1],
+    )
+
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", ["POST"])
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/utils/api/__tests__/routes/execution-detail.route.test.ts
+++ b/src/lib/utils/api/__tests__/routes/execution-detail.route.test.ts
@@ -1,0 +1,190 @@
+import executionDetailHandler from "@pages/api/rebalance/executions/[id]/index"
+
+jest.mock("@lib/auth0", () => ({
+  auth0: {
+    getSession: jest.fn().mockResolvedValue({ user: { sub: "test-user" } }),
+    getAccessToken: jest.fn().mockResolvedValue({ token: "test-token" }),
+  },
+}))
+
+jest.mock("@utils/api/fetchHelper", () => ({
+  requestInit: jest.fn(
+    (token: string, method: string) =>
+      ({
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+      }) as unknown,
+  ),
+}))
+
+jest.mock("@utils/api/responseWriter", () => {
+  // Mirrors the real handleResponse's ok/not-ok branch (see
+  // src/lib/utils/api/responseWriter.ts) so error-propagation tests can
+  // exercise the handler's catch -> fetchError path, same as production.
+  const handleResponse = jest
+    .fn()
+    .mockImplementation(
+      async (
+        response: { ok: boolean; status: number; json: () => Promise<unknown> },
+        res: { status: jest.Mock; json: jest.Mock },
+      ) => {
+        if (!response.ok) {
+          throw new Error(`Backend error ${response.status}`)
+        }
+        const data = await response.json()
+        res.status(200).json(data)
+      },
+    )
+  return {
+    __esModule: true,
+    default: handleResponse,
+    handleResponse,
+    fetchError: jest.fn(
+      (
+        _req: unknown,
+        res: { status: jest.Mock; json: jest.Mock },
+        error: { message: string },
+      ) => {
+        res.status(500).json({ error: error.message })
+      },
+    ),
+  }
+})
+
+jest.mock("@utils/api/bcConfig", () => ({
+  getRebalanceUrl: (path: string): string => `http://rebalance.test${path}`,
+}))
+
+const mockFetch = jest
+  .fn()
+  .mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
+global.fetch = mockFetch as unknown as typeof fetch
+
+function makeReq(
+  method: string,
+  id = "exec-1",
+  body?: unknown,
+): {
+  method: string
+  body: unknown
+  query: Record<string, string>
+  headers: Record<string, string>
+} {
+  return { method, body, query: { id }, headers: {} }
+}
+
+function makeRes(): {
+  status: jest.Mock
+  end: jest.Mock
+  json: jest.Mock
+  setHeader: jest.Mock
+} {
+  return {
+    status: jest.fn().mockReturnThis(),
+    end: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("/api/rebalance/executions/[id] route", () => {
+  it("proxies GET to backend /executions/:id with the auth header", async () => {
+    const req = makeReq("GET", "exec-1")
+    const res = makeRes()
+
+    await executionDetailHandler(
+      req as unknown as Parameters<typeof executionDetailHandler>[0],
+      res as unknown as Parameters<typeof executionDetailHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://rebalance.test/executions/exec-1",
+      {
+        method: "GET",
+        headers: { Authorization: "Bearer test-token" },
+      },
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it("proxies PUT with the item-updates body", async () => {
+    const req = makeReq("PUT", "exec-1", {
+      itemUpdates: [{ assetId: "a1", excluded: true }],
+    })
+    const res = makeRes()
+
+    await executionDetailHandler(
+      req as unknown as Parameters<typeof executionDetailHandler>[0],
+      res as unknown as Parameters<typeof executionDetailHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://rebalance.test/executions/exec-1",
+      {
+        method: "PUT",
+        headers: { Authorization: "Bearer test-token" },
+        body: JSON.stringify(req.body),
+      },
+    )
+  })
+
+  it("proxies DELETE without forwarding a JSON body", async () => {
+    const req = makeReq("DELETE", "exec-1")
+    const res = makeRes()
+
+    await executionDetailHandler(
+      req as unknown as Parameters<typeof executionDetailHandler>[0],
+      res as unknown as Parameters<typeof executionDetailHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://rebalance.test/executions/exec-1",
+      {
+        method: "DELETE",
+        headers: { Authorization: "Bearer test-token" },
+      },
+    )
+  })
+
+  it("propagates a backend error status via fetchError", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ message: "Execution not found" }),
+    })
+    const req = makeReq("GET", "missing-exec")
+    const res = makeRes()
+
+    await executionDetailHandler(
+      req as unknown as Parameters<typeof executionDetailHandler>[0],
+      res as unknown as Parameters<typeof executionDetailHandler>[1],
+    )
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Backend error 404" }),
+    )
+  })
+
+  it("rejects PATCH with 405 and does not call the backend", async () => {
+    const req = makeReq("PATCH")
+    const res = makeRes()
+
+    await executionDetailHandler(
+      req as unknown as Parameters<typeof executionDetailHandler>[0],
+      res as unknown as Parameters<typeof executionDetailHandler>[1],
+    )
+
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", [
+      "GET",
+      "PUT",
+      "DELETE",
+    ])
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/utils/api/__tests__/routes/execution-refresh.route.test.ts
+++ b/src/lib/utils/api/__tests__/routes/execution-refresh.route.test.ts
@@ -1,0 +1,146 @@
+import refreshHandler from "@pages/api/rebalance/executions/[id]/refresh"
+
+jest.mock("@lib/auth0", () => ({
+  auth0: {
+    getSession: jest.fn().mockResolvedValue({ user: { sub: "test-user" } }),
+    getAccessToken: jest.fn().mockResolvedValue({ token: "test-token" }),
+  },
+}))
+
+jest.mock("@utils/api/fetchHelper", () => ({
+  requestInit: jest.fn(
+    (token: string, method: string) =>
+      ({
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+      }) as unknown,
+  ),
+}))
+
+jest.mock("@utils/api/responseWriter", () => {
+  // Mirrors the real handleResponse's ok/not-ok branch (see
+  // src/lib/utils/api/responseWriter.ts) so error-propagation tests can
+  // exercise the handler's catch -> fetchError path, same as production.
+  const handleResponse = jest
+    .fn()
+    .mockImplementation(
+      async (
+        response: { ok: boolean; status: number; json: () => Promise<unknown> },
+        res: { status: jest.Mock; json: jest.Mock },
+      ) => {
+        if (!response.ok) {
+          throw new Error(`Backend error ${response.status}`)
+        }
+        const data = await response.json()
+        res.status(200).json(data)
+      },
+    )
+  return {
+    __esModule: true,
+    default: handleResponse,
+    handleResponse,
+    fetchError: jest.fn(
+      (
+        _req: unknown,
+        res: { status: jest.Mock; json: jest.Mock },
+        error: { message: string },
+      ) => {
+        res.status(500).json({ error: error.message })
+      },
+    ),
+  }
+})
+
+jest.mock("@utils/api/bcConfig", () => ({
+  getRebalanceUrl: (path: string): string => `http://rebalance.test${path}`,
+}))
+
+const mockFetch = jest
+  .fn()
+  .mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
+global.fetch = mockFetch as unknown as typeof fetch
+
+function makeReq(
+  method: string,
+  id = "exec-1",
+): {
+  method: string
+  query: Record<string, string>
+  headers: Record<string, string>
+} {
+  return { method, query: { id }, headers: {} }
+}
+
+function makeRes(): {
+  status: jest.Mock
+  end: jest.Mock
+  json: jest.Mock
+  setHeader: jest.Mock
+} {
+  return {
+    status: jest.fn().mockReturnThis(),
+    end: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("/api/rebalance/executions/[id]/refresh route", () => {
+  it("proxies POST to backend /executions/:id/refresh with the auth header", async () => {
+    const req = makeReq("POST", "exec-1")
+    const res = makeRes()
+
+    await refreshHandler(
+      req as unknown as Parameters<typeof refreshHandler>[0],
+      res as unknown as Parameters<typeof refreshHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://rebalance.test/executions/exec-1/refresh",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer test-token" },
+        body: JSON.stringify(undefined),
+      },
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it("propagates a backend error status via fetchError", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({ message: "Refresh unavailable" }),
+    })
+    const req = makeReq("POST", "exec-1")
+    const res = makeRes()
+
+    await refreshHandler(
+      req as unknown as Parameters<typeof refreshHandler>[0],
+      res as unknown as Parameters<typeof refreshHandler>[1],
+    )
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Backend error 503" }),
+    )
+  })
+
+  it("rejects GET with 405 and does not call the backend", async () => {
+    const req = makeReq("GET")
+    const res = makeRes()
+
+    await refreshHandler(
+      req as unknown as Parameters<typeof refreshHandler>[0],
+      res as unknown as Parameters<typeof refreshHandler>[1],
+    )
+
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", ["POST"])
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/utils/api/__tests__/routes/executions-list.route.test.ts
+++ b/src/lib/utils/api/__tests__/routes/executions-list.route.test.ts
@@ -1,0 +1,185 @@
+import executionsHandler from "@pages/api/rebalance/executions/index"
+
+jest.mock("@lib/auth0", () => ({
+  auth0: {
+    getSession: jest.fn().mockResolvedValue({ user: { sub: "test-user" } }),
+    getAccessToken: jest.fn().mockResolvedValue({ token: "test-token" }),
+  },
+}))
+
+jest.mock("@utils/api/fetchHelper", () => ({
+  requestInit: jest.fn(
+    (token: string, method: string) =>
+      ({
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+      }) as unknown,
+  ),
+}))
+
+jest.mock("@utils/api/responseWriter", () => {
+  // Mirrors the real handleResponse's ok/not-ok branch (see
+  // src/lib/utils/api/responseWriter.ts) so error-propagation tests can
+  // exercise the handler's catch -> fetchError path, same as production.
+  const handleResponse = jest
+    .fn()
+    .mockImplementation(
+      async (
+        response: { ok: boolean; status: number; json: () => Promise<unknown> },
+        res: { status: jest.Mock; json: jest.Mock },
+      ) => {
+        if (!response.ok) {
+          throw new Error(`Backend error ${response.status}`)
+        }
+        const data = await response.json()
+        res.status(200).json(data)
+      },
+    )
+  return {
+    __esModule: true,
+    default: handleResponse,
+    handleResponse,
+    fetchError: jest.fn(
+      (
+        _req: unknown,
+        res: { status: jest.Mock; json: jest.Mock },
+        error: { message: string },
+      ) => {
+        res.status(500).json({ error: error.message })
+      },
+    ),
+  }
+})
+
+jest.mock("@utils/api/bcConfig", () => ({
+  getRebalanceUrl: (path: string): string => `http://rebalance.test${path}`,
+}))
+
+const mockFetch = jest
+  .fn()
+  .mockResolvedValue({ status: 200, ok: true, json: () => Promise.resolve({}) })
+global.fetch = mockFetch as unknown as typeof fetch
+
+function makeReq(
+  method: string,
+  body?: unknown,
+): {
+  method: string
+  body: unknown
+  query: Record<string, string>
+  headers: Record<string, string>
+} {
+  return { method, body, query: {}, headers: {} }
+}
+
+function makeRes(): {
+  status: jest.Mock
+  end: jest.Mock
+  json: jest.Mock
+  setHeader: jest.Mock
+} {
+  return {
+    status: jest.fn().mockReturnThis(),
+    end: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("/api/rebalance/executions route", () => {
+  it("proxies GET to backend /executions with the auth header", async () => {
+    const req = makeReq("GET")
+    const res = makeRes()
+
+    await executionsHandler(
+      req as unknown as Parameters<typeof executionsHandler>[0],
+      res as unknown as Parameters<typeof executionsHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith("http://rebalance.test/executions", {
+      method: "GET",
+      headers: { Authorization: "Bearer test-token" },
+    })
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it("proxies POST with the create-execution body (model-based)", async () => {
+    const req = makeReq("POST", {
+      planId: "plan-1",
+      portfolioIds: ["portfolio-1"],
+      filterByModel: true,
+    })
+    const res = makeRes()
+
+    await executionsHandler(
+      req as unknown as Parameters<typeof executionsHandler>[0],
+      res as unknown as Parameters<typeof executionsHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith("http://rebalance.test/executions", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+      body: JSON.stringify(req.body),
+    })
+  })
+
+  it("proxies POST with the create-execution body (ad-hoc)", async () => {
+    const req = makeReq("POST", {
+      mode: "AD_HOC",
+      portfolioIds: ["portfolio-1"],
+      currency: "SGD",
+    })
+    const res = makeRes()
+
+    await executionsHandler(
+      req as unknown as Parameters<typeof executionsHandler>[0],
+      res as unknown as Parameters<typeof executionsHandler>[1],
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://rebalance.test/executions",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(req.body),
+      }),
+    )
+  })
+
+  it("propagates a backend error status via fetchError", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ message: "Invalid create request" }),
+    })
+    const req = makeReq("POST", { portfolioIds: [] })
+    const res = makeRes()
+
+    await executionsHandler(
+      req as unknown as Parameters<typeof executionsHandler>[0],
+      res as unknown as Parameters<typeof executionsHandler>[1],
+    )
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Backend error 400" }),
+    )
+  })
+
+  it("rejects PUT with 405 and does not call the backend", async () => {
+    const req = makeReq("PUT")
+    const res = makeRes()
+
+    await executionsHandler(
+      req as unknown as Parameters<typeof executionsHandler>[0],
+      res as unknown as Parameters<typeof executionsHandler>[1],
+    )
+
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", ["GET", "POST"])
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Part of #1159 (slices 1+2).

## What
- `useRebalanceExecution.test.ts`: new `characterization: mixed-currency client math (#1154/#1156)` describe block (3 cases: USD asset in SGD execution, EUR plan-only asset, two portfolios with differing currencies). Asserts what the hook **currently** produces — pins the currency-blind math for refactors without blessing it; the fix stays backend-side (#1154).
- New route-handler tests for the rebalance API proxies: execution commit, refresh, detail, executions list (17 tests, in `src/lib/utils/api/__tests__/routes/` following the existing pattern; the `responseWriter` mock now exercises the error-propagation path).

## Not here (remaining #1159 slices)
Component tests (SelectPlanDialog/wizard steps — will land with the #1157 behavior changes), e2e happy path. `weights-from-holdings` route test landed in the #1158 PR alongside its hardening.

Tests only — zero production code changed. 255 suites / 2530 tests green; prettier/lint/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kWgaWpybSCajCzVQZdiPk