### PR TITLE
fix(rebalance): clamp weight inputs and gate approve/commit on 100% totals

### DIFF
--- a/__tests__/pages/rebalance/execute-slider.test.tsx
+++ b/__tests__/pages/rebalance/execute-slider.test.tsx
@@ -464,7 +464,7 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
 
   // --- After % column ---
 
-  it("renders the After % column with projected weights, dash for excluded rows, and a 100% total", () => {
+  it("renders the After % column with projected weights, dash for excluded rows, and an included/excluded footer split (#1155)", () => {
     const execution: ExecutionDto = {
       ...makeExecution(),
       totalPortfolioValue: 10000,
@@ -554,8 +554,18 @@ describe("ExecuteRebalancePage — slider weight editing", () => {
     // QUAL: 5200/10000, EXCL: excluded -> dash, cash: 3000/10000
     expect(afterValues).toEqual(["52.00%", "—", "30.00%"])
 
+    // #1155: the footer no longer reports a self-referential 100% that
+    // silently drops EXCL's value out of the picture — it splits the total
+    // into "included" (QUAL + cash, valued against the whole pie) and an
+    // explicit "excluded" call-out for EXCL's own (unchanged) value. This
+    // fixture's QUAL row carries a nonzero deltaValue (200) that the mock's
+    // cash figure doesn't offset, so the "pie" here (10,200) runs slightly
+    // above totalPortfolioValue (10,000) — that's a quirk of this
+    // characterization fixture, not the component under test.
     const footerRow = container.querySelector("tfoot tr")!
-    expect(footerRow.children[afterIdx]?.textContent?.trim()).toBe("82.00%")
+    expect(footerRow.children[afterIdx]?.textContent?.trim()).toBe(
+      "80.4%+19.6% excluded",
+    )
   })
 
   it("shows the funded-by-deposit footnote when projected cash is negative", () => {

--- a/src/__tests__/pages/rebalance/execute/index.test.tsx
+++ b/src/__tests__/pages/rebalance/execute/index.test.tsx
@@ -1,5 +1,12 @@
 import React from "react"
-import { render, screen, fireEvent, within, act } from "@testing-library/react"
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  act,
+  waitFor,
+} from "@testing-library/react"
 import ExecuteRebalancePage, {
   buildDraftContext,
 } from "@pages/rebalance/execute/index"
@@ -827,6 +834,176 @@ describe("ExecuteRebalancePage", () => {
       const finalCall =
         mockSetPageContext.mock.calls[mockSetPageContext.mock.calls.length - 1]
       expect(finalCall[0]).toBeNull()
+    })
+  })
+
+  // --- Footer truthfulness (#1155) ---
+
+  describe("configuration table footer", () => {
+    it("colours the Target-total footer cell red once it drifts more than 0.01 off 100%", () => {
+      mockHookResult([
+        makeItem({
+          assetId: "cash",
+          isCash: true,
+          effectiveTarget: 0.1,
+        }),
+        makeItem({ assetId: "a1", assetCode: "AAPL", effectiveTarget: 0.5 }),
+        // Deliberately unbalanced: 0.1 + 0.5 + 0.365 = 0.965 (96.50%).
+        makeItem({ assetId: "a2", assetCode: "MSFT", effectiveTarget: 0.365 }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      const targetTotalCell = screen.getByText("96.50%")
+      expect(targetTotalCell.className).toContain("text-red-700")
+    })
+
+    it("leaves the Target-total footer cell in the neutral tone when it sums to exactly 100%", () => {
+      mockHookResult([
+        makeItem({ assetId: "cash", isCash: true, effectiveTarget: 0.1 }),
+        makeItem({ assetId: "a1", assetCode: "AAPL", effectiveTarget: 0.5 }),
+        makeItem({ assetId: "a2", assetCode: "MSFT", effectiveTarget: 0.4 }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      const targetTotalCell = screen.getByText("100.00%")
+      expect(targetTotalCell.className).not.toContain("text-red-700")
+    })
+
+    it("shows the included After-% total plus the excluded portion, instead of a self-referential 100% that omits the excluded row's real value", () => {
+      mockHookResult([
+        makeItem({
+          assetId: "cash",
+          isCash: true,
+          projectedValue: 1500,
+          projectedWeight: 0.25,
+        }),
+        makeItem({
+          assetId: "a1",
+          assetCode: "AAPL",
+          projectedValue: 4500,
+          projectedWeight: 0.75,
+        }),
+        // Excluded: still worth 4000 (its unchanged snapshot value), but
+        // projectedWeight is null — the naive `?? 0` sum still reads
+        // 100.00% (0.25+0.75) even though 4000 of the 10000 portfolio is
+        // sitting outside that total entirely.
+        makeItem({
+          assetId: "a2",
+          assetCode: "MSFT",
+          excluded: true,
+          isExcluded: true,
+          snapshotValue: 4000,
+          projectedWeight: null,
+        }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      expect(screen.getByText("60.0%")).toBeInTheDocument()
+      expect(screen.getByText(/\+40\.0% excluded/)).toBeInTheDocument()
+    })
+
+    it("does not render an excluded annotation when nothing is excluded", () => {
+      mockHookResult([
+        makeItem({
+          assetId: "cash",
+          isCash: true,
+          projectedValue: 2500,
+          projectedWeight: 0.25,
+        }),
+        makeItem({
+          assetId: "a1",
+          assetCode: "AAPL",
+          projectedValue: 7500,
+          projectedWeight: 0.75,
+        }),
+      ])
+      render(<ExecuteRebalancePage />)
+
+      expect(screen.queryByText(/excluded/)).not.toBeInTheDocument()
+    })
+  })
+
+  // --- Commit confirmation when targets are off (#1155) ---
+
+  describe("commit confirmation", () => {
+    function goToPreviewStep(): void {
+      fireEvent.click(
+        screen.getByRole("button", { name: /Next.*Review Transactions/i }),
+      )
+    }
+
+    it("requires an explicit confirm stating the total before committing when included targets don't sum to 100%", async () => {
+      const commit = jest.fn().mockResolvedValue({
+        portfolioId: "portfolio-1",
+        transactionStatus: "PROPOSED",
+      })
+      mockHookResult(
+        [
+          makeItem({ assetId: "cash", isCash: true, effectiveTarget: 0.1 }),
+          makeItem({
+            assetId: "a1",
+            assetCode: "AAPL",
+            effectiveTarget: 0.5,
+            deltaValue: 1000,
+          }),
+          makeItem({
+            assetId: "a2",
+            assetCode: "MSFT",
+            effectiveTarget: 0.3,
+            deltaValue: 1000,
+          }),
+        ],
+        { handlers: { commit } },
+      )
+      render(<ExecuteRebalancePage />)
+      goToPreviewStep()
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Execute Transactions/i }),
+      )
+
+      expect(commit).not.toHaveBeenCalled()
+      expect(screen.getByText(/90\.00%/)).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole("button", { name: /Execute Anyway/i }))
+
+      await waitFor(() => expect(commit).toHaveBeenCalledTimes(1))
+    })
+
+    it("commits directly with no confirm dialog when included targets sum to 100%", async () => {
+      const commit = jest.fn().mockResolvedValue({
+        portfolioId: "portfolio-1",
+        transactionStatus: "PROPOSED",
+      })
+      mockHookResult(
+        [
+          makeItem({ assetId: "cash", isCash: true, effectiveTarget: 0.1 }),
+          makeItem({
+            assetId: "a1",
+            assetCode: "AAPL",
+            effectiveTarget: 0.5,
+            deltaValue: 1000,
+          }),
+          makeItem({
+            assetId: "a2",
+            assetCode: "MSFT",
+            effectiveTarget: 0.4,
+            deltaValue: 1000,
+          }),
+        ],
+        { handlers: { commit } },
+      )
+      render(<ExecuteRebalancePage />)
+      goToPreviewStep()
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Execute Transactions/i }),
+      )
+
+      expect(
+        screen.queryByRole("button", { name: /Execute Anyway/i }),
+      ).not.toBeInTheDocument()
+      await waitFor(() => expect(commit).toHaveBeenCalledTimes(1))
     })
   })
 })

--- a/src/__tests__/pages/rebalance/models/[modelId]/plans/[planId].test.tsx
+++ b/src/__tests__/pages/rebalance/models/[modelId]/plans/[planId].test.tsx
@@ -1,0 +1,135 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import PlanDetailPage from "@pages/rebalance/models/[modelId]/plans/[planId]"
+import { useModel } from "@components/features/rebalance/hooks/useModel"
+import { useModelPlan } from "@components/features/rebalance/hooks/useModelPlan"
+import { useModelPlans } from "@components/features/rebalance/hooks/useModelPlans"
+import type { PlanDto, ModelDto, PlanAssetDto } from "types/rebalance"
+
+// --- Mocks ---
+
+jest.mock("@components/features/rebalance/hooks/useModel")
+jest.mock("@components/features/rebalance/hooks/useModelPlan")
+jest.mock("@components/features/rebalance/hooks/useModelPlans")
+
+const mockUseModel = useModel as jest.Mock
+const mockUseModelPlan = useModelPlan as jest.Mock
+const mockUseModelPlans = useModelPlans as jest.Mock
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: { modelId: "model-1", planId: "plan-1" },
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+}))
+
+// --- Fixtures ---
+
+function makeAsset(overrides: Partial<PlanAssetDto> = {}): PlanAssetDto {
+  return {
+    id: "pa-1",
+    assetId: "a1",
+    assetCode: "US:VOO",
+    assetName: "Vanguard 500",
+    weight: 0.5,
+    sortOrder: 0,
+    ...overrides,
+  }
+}
+
+function makePlan(overrides: Partial<PlanDto> = {}): PlanDto {
+  return {
+    id: "plan-1",
+    modelId: "model-1",
+    modelName: "Test Model",
+    version: 1,
+    status: "DRAFT",
+    assets: [makeAsset()],
+    cashWeight: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+const mockModel: ModelDto = {
+  id: "model-1",
+  name: "Test Model",
+  baseCurrency: "USD",
+  risk: 3,
+  shared: false,
+  isOwner: true,
+  planCount: 1,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+}
+
+describe("PlanDetailPage — Approve gate on weight totals", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseModel.mockReturnValue({ model: mockModel })
+    mockUseModelPlans.mockReturnValue({ plans: [] })
+  })
+
+  it("disables Approve and shows the actual total when weights don't sum to 100%", () => {
+    mockUseModelPlan.mockReturnValue({
+      plan: makePlan({
+        assets: [
+          makeAsset({ assetId: "a1", weight: 0.5 }),
+          // 0.5 + 0.465 = 0.965 -> 96.50%, not 100%.
+          makeAsset({ assetId: "a2", assetCode: "US:VXUS", weight: 0.465 }),
+        ],
+      }),
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    render(<PlanDetailPage />)
+
+    const approveButton = screen.getByRole("button", { name: /Approve Plan/i })
+    expect(approveButton).toBeDisabled()
+    expect(
+      screen.getByText("Weights total 96.50% — must equal 100% to approve"),
+    ).toBeInTheDocument()
+  })
+
+  it("enables Approve once weights sum to exactly 100%, with no warning message", () => {
+    mockUseModelPlan.mockReturnValue({
+      plan: makePlan({
+        assets: [
+          makeAsset({ assetId: "a1", weight: 0.6 }),
+          makeAsset({ assetId: "a2", assetCode: "US:VXUS", weight: 0.4 }),
+        ],
+      }),
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    render(<PlanDetailPage />)
+
+    const approveButton = screen.getByRole("button", { name: /Approve Plan/i })
+    expect(approveButton).not.toBeDisabled()
+    expect(
+      screen.queryByText(/must equal 100% to approve/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it("still disables Approve when there are no assets at all (unaffected by the new gate)", () => {
+    mockUseModelPlan.mockReturnValue({
+      plan: makePlan({ assets: [] }),
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    render(<PlanDetailPage />)
+
+    const approveButton = screen.getByRole("button", { name: /Approve Plan/i })
+    expect(approveButton).toBeDisabled()
+    // No misleading "total" message when there's nothing to total.
+    expect(
+      screen.queryByText(/must equal 100% to approve/i),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
+++ b/src/components/features/rebalance/models/AddAssetToModelDialog.tsx
@@ -6,6 +6,7 @@ import { AssetWeightWithDetails } from "types/rebalance"
 import { marketsKey, simpleFetcher } from "@utils/api/fetchHelper"
 import AssetSearch from "@components/features/assets/AssetSearch"
 import { useDialogSubmit } from "@hooks/useDialogSubmit"
+import { clampWeightPercent } from "@lib/rebalance/weights"
 
 interface AddAssetToModelDialogProps {
   modalOpen: boolean
@@ -199,7 +200,9 @@ const AddAssetToModelDialog: React.FC<AddAssetToModelDialogProps> = ({
               max="100"
               step="0.1"
               value={weight}
-              onChange={(e) => setWeight(parseFloat(e.target.value) || 0)}
+              onChange={(e) =>
+                setWeight(clampWeightPercent(parseFloat(e.target.value) || 0))
+              }
               className="w-24 px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
             />
             <span className="text-gray-500">%</span>

--- a/src/components/features/rebalance/models/CreateModelFromHoldingsDialog.tsx
+++ b/src/components/features/rebalance/models/CreateModelFromHoldingsDialog.tsx
@@ -7,6 +7,7 @@ import {
   normalizeWeights,
   weightsSumValid,
   toWeightDecimal,
+  clampWeightPercent,
 } from "@lib/rebalance/weights"
 import { AssetWeightWithDetails, ModelDto } from "types/rebalance"
 import { Holdings, Position } from "types/beancounter"
@@ -282,7 +283,9 @@ const CreateModelFromHoldingsDialog: React.FC<
                     step="0.01"
                     value={weight.weight}
                     onChange={(e) => {
-                      const value = parseFloat(e.target.value) || 0
+                      const value = clampWeightPercent(
+                        parseFloat(e.target.value) || 0,
+                      )
                       const updated = [...weights]
                       updated[index] = {
                         ...updated[index],

--- a/src/components/features/rebalance/models/ImportHoldingsDialog.tsx
+++ b/src/components/features/rebalance/models/ImportHoldingsDialog.tsx
@@ -8,6 +8,7 @@ import {
   normalizeWeights,
   weightsSumValid,
   toWeightPercent,
+  clampWeightPercent,
 } from "@lib/rebalance/weights"
 import { AssetWeightWithDetails } from "types/rebalance"
 import { Portfolio } from "types/beancounter"
@@ -229,7 +230,9 @@ const ImportHoldingsDialog: React.FC<ImportHoldingsDialogProps> = ({
                       step="0.01"
                       value={weight.weight}
                       onChange={(e) => {
-                        const value = parseFloat(e.target.value) || 0
+                        const value = clampWeightPercent(
+                          parseFloat(e.target.value) || 0,
+                        )
                         const updated = [...weights]
                         updated[index] = {
                           ...updated[index],

--- a/src/components/features/rebalance/models/__tests__/CreateModelFromHoldingsDialog.test.tsx
+++ b/src/components/features/rebalance/models/__tests__/CreateModelFromHoldingsDialog.test.tsx
@@ -1,0 +1,57 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import CreateModelFromHoldingsDialog from "../CreateModelFromHoldingsDialog"
+import {
+  makeHoldings,
+  makeHoldingGroup,
+  makePosition,
+  makeAsset,
+} from "@test-fixtures/beancounter"
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+describe("CreateModelFromHoldingsDialog — typed weight-percent input", () => {
+  function renderDialog(): void {
+    const holdings = makeHoldings({
+      holdingGroups: {
+        Equity: makeHoldingGroup({
+          positions: [
+            makePosition({
+              asset: makeAsset({ id: "a1", code: "AAPL" }),
+              moneyValues: { marketValue: 10000 },
+            }),
+          ],
+        }),
+      },
+    })
+    render(
+      <CreateModelFromHoldingsDialog
+        modalOpen={true}
+        onClose={jest.fn()}
+        holdings={holdings}
+        portfolioCode="TEST"
+      />,
+    )
+  }
+
+  it("clamps a typed value above 100 down to 100 instead of storing it verbatim", () => {
+    renderDialog()
+    const weightInput = screen.getByRole("spinbutton")
+    expect(weightInput).toHaveValue(100)
+
+    fireEvent.change(weightInput, { target: { value: "500" } })
+
+    expect(weightInput).toHaveValue(100)
+  })
+
+  it("clamps a typed negative value up to 0", () => {
+    renderDialog()
+    const weightInput = screen.getByRole("spinbutton")
+
+    fireEvent.change(weightInput, { target: { value: "-25" } })
+
+    expect(weightInput).toHaveValue(0)
+  })
+})

--- a/src/lib/utils/rebalance/weights.test.ts
+++ b/src/lib/utils/rebalance/weights.test.ts
@@ -4,6 +4,7 @@ import {
   toWeightPercent,
   toWeightDecimal,
   buildPlanAssetsPayload,
+  clampWeightPercent,
 } from "./weights"
 import { AssetWeightWithDetails } from "types/rebalance"
 
@@ -73,6 +74,52 @@ describe("normalizeWeights", () => {
 
     expect(result).not.toBe(weights)
     expect(result?.[0]).not.toBe(weights[0])
+  })
+
+  it("distributes the remaining hundredths by largest remainder so three equal weights sum to exactly 100.00, not 99.99", () => {
+    const weights = [
+      sampleWeight({ assetId: "a1", weight: 33.33 }),
+      sampleWeight({ assetId: "a2", weight: 33.33 }),
+      sampleWeight({ assetId: "a3", weight: 33.33 }),
+    ]
+
+    const result = normalizeWeights(weights, 99.99)
+
+    expect(result?.map((w) => w.weight)).toEqual([33.34, 33.33, 33.33])
+    expect(result?.reduce((sum, w) => sum + w.weight, 0)).toBeCloseTo(100, 10)
+  })
+
+  it("allocates remaining hundredths to the items with the largest fractional remainder, not by row order", () => {
+    // factor = 100/99.98; exact cents work out to 1000.20004, 2000.40008,
+    // 3000.60012, 3998.79976 — remainders (desc) are item4 > item3 > item2 >
+    // item1, so the 2 leftover cents go to item4 then item3, NOT item1/item2.
+    const weights = [
+      sampleWeight({ assetId: "a1", weight: 10 }),
+      sampleWeight({ assetId: "a2", weight: 20 }),
+      sampleWeight({ assetId: "a3", weight: 30 }),
+      sampleWeight({ assetId: "a4", weight: 39.98 }),
+    ]
+
+    const result = normalizeWeights(weights, 99.98)
+
+    expect(result?.map((w) => w.weight)).toEqual([10, 20, 30.01, 39.99])
+    expect(result?.reduce((sum, w) => sum + w.weight, 0)).toBeCloseTo(100, 10)
+  })
+
+  it("breaks a remainder tie by original index, giving the extra hundredth to the earliest item", () => {
+    // 7 equal weights of 1 (total 7): each scales to 1428.571..., so every
+    // item ties on remainder — the 4 leftover cents must land on indices
+    // 0-3, not some other subset.
+    const weights = Array.from({ length: 7 }, (_, i) =>
+      sampleWeight({ assetId: `a${i}`, weight: 1 }),
+    )
+
+    const result = normalizeWeights(weights, 7)
+
+    expect(result?.map((w) => w.weight)).toEqual([
+      14.29, 14.29, 14.29, 14.29, 14.28, 14.28, 14.28,
+    ])
+    expect(result?.reduce((sum, w) => sum + w.weight, 0)).toBeCloseTo(100, 10)
   })
 })
 
@@ -171,5 +218,31 @@ describe("buildPlanAssetsPayload", () => {
     const payload = buildPlanAssetsPayload(weights)
 
     expect(payload.assets[0].rationale).toBeUndefined()
+  })
+})
+
+describe("clampWeightPercent", () => {
+  it("passes through an in-range value unchanged", () => {
+    expect(clampWeightPercent(42.5)).toBe(42.5)
+    expect(clampWeightPercent(0)).toBe(0)
+    expect(clampWeightPercent(100)).toBe(100)
+  })
+
+  it("clamps a value above 100 down to 100", () => {
+    expect(clampWeightPercent(500)).toBe(100)
+    expect(clampWeightPercent(100.01)).toBe(100)
+  })
+
+  it("clamps a negative value up to 0", () => {
+    expect(clampWeightPercent(-5)).toBe(0)
+  })
+
+  it("treats NaN as 0", () => {
+    expect(clampWeightPercent(NaN)).toBe(0)
+  })
+
+  it("treats Infinity and -Infinity as 0", () => {
+    expect(clampWeightPercent(Infinity)).toBe(0)
+    expect(clampWeightPercent(-Infinity)).toBe(0)
   })
 })

--- a/src/lib/utils/rebalance/weights.ts
+++ b/src/lib/utils/rebalance/weights.ts
@@ -1,9 +1,19 @@
 import { AssetWeightWithDetails } from "types/rebalance"
 
 /**
- * Scale every item's `weight` proportionally so the set sums to 100,
- * rounded to 2dp. Mirrors the "Normalize to 100%" affordance shared by
+ * Scale every item's `weight` proportionally so the set sums to EXACTLY
+ * 100.00. Mirrors the "Normalize to 100%" affordance shared by
  * ModelWeightsEditor, ImportHoldingsDialog, and CreateModelFromHoldingsDialog.
+ *
+ * Rounding each item's scaled weight independently (naive `Math.round`) can
+ * leave the set a hundredth or two short of 100 — e.g. three items at
+ * 33.33/33.33/33.33 round to themselves and sum to 99.99, which trips
+ * `weightsSumValid` and makes "Normalize to 100%" a no-op. Instead this uses
+ * largest-remainder allocation (a.k.a. Hamilton's method): scale every
+ * weight, floor each to 2dp (hundredths), then hand the few 0.01-sized
+ * hundredths still owed out to the items whose floor discarded the largest
+ * fractional remainder — ties broken by original array index — until the
+ * set sums to exactly 100.00.
  *
  * Returns `null` when `totalWeight` is 0 — callers must treat that as a
  * no-op (do not call onChange/setState), matching the original inline
@@ -16,10 +26,38 @@ export function normalizeWeights<T extends { weight: number }>(
   totalWeight: number,
 ): T[] | null {
   if (!Number.isFinite(totalWeight) || totalWeight === 0) return null
+  if (items.length === 0) return []
   const factor = 100 / totalWeight
-  return items.map((item) => ({
+
+  // Work in hundredths (integer cents-of-a-percent) so "the two leftover
+  // hundredths" is an exact integer distribution, not more floating-point
+  // rounding on top of floating-point rounding.
+  const scaled = items.map((item, index) => {
+    const exactCents = item.weight * factor * 100
+    // The tiny epsilon only corrects float representation noise (e.g.
+    // 6666.999999999999 for a true 6667) — far smaller than any genuine
+    // fractional remainder, so it never bumps a real fraction up early.
+    const flooredCents = Math.floor(exactCents + 1e-9)
+    return { index, flooredCents, remainder: exactCents - flooredCents }
+  })
+
+  const totalFlooredCents = scaled.reduce((sum, s) => sum + s.flooredCents, 0)
+  let remainingCents = 10000 - totalFlooredCents
+
+  const byRemainderDesc = [...scaled].sort((a, b) =>
+    b.remainder !== a.remainder ? b.remainder - a.remainder : a.index - b.index,
+  )
+
+  const cents = scaled.map((s) => s.flooredCents)
+  for (const s of byRemainderDesc) {
+    if (remainingCents <= 0) break
+    cents[s.index] += 1
+    remainingCents -= 1
+  }
+
+  return items.map((item, index) => ({
     ...item,
-    weight: Math.round(item.weight * factor * 100) / 100,
+    weight: cents[index] / 100,
   }))
 }
 
@@ -29,6 +67,18 @@ export function normalizeWeights<T extends { weight: number }>(
  */
 export function weightsSumValid(totalWeight: number): boolean {
   return Math.abs(totalWeight - 100) < 0.01
+}
+
+/**
+ * Clamps a typed weight-percent entry to the valid [0, 100] range. A
+ * non-finite input (NaN from an empty/invalid parse, or +-Infinity) clamps
+ * to 0 rather than propagating — mirrors the `|| 0` fallback already used
+ * at every typed-weight call site, just without letting an out-of-range
+ * number (e.g. typing "500") slip through unclamped.
+ */
+export function clampWeightPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(100, Math.max(0, value))
 }
 
 /** Converts a decimal ratio (0-1, as stored server-side) to a percentage

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useEffect, useRef, useCallback } from "react"
 import {
   formatCurrency,
   formatPercent,
+  formatPercentValue,
   formatSignedNumber,
 } from "@lib/formatters"
 import { withPageAuthRequired } from "@auth0/nextjs-auth0/client"
@@ -21,6 +22,8 @@ import {
   DisplayItem,
   CashSummary,
 } from "@hooks/useRebalanceExecution"
+import { clampWeightPercent, weightsSumValid } from "@lib/rebalance/weights"
+import ConfirmDialog from "@components/ui/ConfirmDialog"
 import { Asset } from "types/beancounter"
 import { ExecutionDto } from "types/rebalance"
 
@@ -282,6 +285,10 @@ function ExecuteRebalancePage(): React.ReactElement {
   const [chartTarget, setChartTarget] = useState<DisplayItem | null>(null)
   const [insightTarget, setInsightTarget] = useState<DisplayItem | null>(null)
 
+  // Gate on Execute Transactions: shown instead of committing immediately
+  // when the included targets don't sum to ~100% (see targetTotalValid).
+  const [showCommitConfirm, setShowCommitConfirm] = useState(false)
+
   // Hook handles all data fetching, state, and operations
   const {
     execution,
@@ -485,6 +492,72 @@ function ExecuteRebalancePage(): React.ReactElement {
     cashSummary.netImpact >= 0
       ? "text-green-700 font-medium"
       : "text-red-700 font-medium"
+
+  // --- Footer truthfulness + commit-confirm gate (#1155) ---
+  //
+  // Target total: sum of every row's target weight (cash + assets, whether
+  // excluded or not). The proportional-scaling formula in
+  // useRebalanceExecution pins this at exactly 100% UNLESS the user has
+  // hand-edited one or more targets (slider/typed) into a set that no
+  // longer balances — each edit is clamped to [0,100] individually, but
+  // nothing stops several valid-in-isolation edits from summing wrong
+  // together. Shared by the footer cell below and the pre-commit gate so
+  // the number shown and the number gated on can never drift apart.
+  const targetTotalPercent = displayItems.reduce(
+    (sum, item) => sum + item.effectiveTarget * 100,
+    0,
+  )
+  const targetTotalValid = weightsSumValid(targetTotalPercent)
+
+  // Projected (After %) total: excluded rows sit outside the projected
+  // total's numerator AND denominator (see DisplayItem.projectedWeight), so
+  // the included rows always sum to 100% of THEIR OWN pie even when a
+  // chunk of the portfolio is excluded and untouched — a plain `?? 0` sum
+  // reads a deceptive "100.00%" that quietly omits the excluded rows'
+  // actual value. Split the true (included + excluded) total instead, so
+  // the footer states what fraction of the WHOLE portfolio each side
+  // represents.
+  const excludedValue = displayItems
+    .filter((item) => !item.isCash && item.isExcluded)
+    .reduce((sum, item) => sum + item.snapshotValue, 0)
+  const projectedIncludedValue = displayItems
+    .filter((item) => item.isCash || !item.isExcluded)
+    .reduce((sum, item) => sum + item.projectedValue, 0)
+  const projectedFullValue = projectedIncludedValue + excludedValue
+  const projectedIncludedPercent =
+    projectedFullValue > 0
+      ? (projectedIncludedValue / projectedFullValue) * 100
+      : 0
+  const projectedExcludedPercent =
+    projectedFullValue > 0 ? (excludedValue / projectedFullValue) * 100 : 0
+
+  const runCommit = async (): Promise<void> => {
+    const result = await handlers.commit()
+    if (!result) return
+    // Only land on /trns/proposed when the orders are actually unsettled.
+    // Settled commits go straight to the portfolio holdings.
+    if (result.transactionStatus === "PROPOSED") {
+      router.push("/trns/proposed")
+    } else {
+      router.push(`/trns?portfolioId=${result.portfolioId}`)
+    }
+  }
+
+  const handleExecuteClick = async (): Promise<void> => {
+    // Warn (but don't block) when the user has >1 brokers and didn't tag
+    // the orders — saves a "where's the broker on these trns?" follow-up
+    // later.
+    if (!confirmBrokerSelection(brokers.length, selectedBrokerId)) return
+    // Client-side seatbelt only — backend-side validation is svc-rebalance
+    // #43. Off-100% targets aren't blocked, just confirmed: this is a
+    // what-if surface, and the user may be deliberately parking spare cash
+    // or a partial rebalance.
+    if (!targetTotalValid) {
+      setShowCommitConfirm(true)
+      return
+    }
+    await runCommit()
+  }
 
   return (
     <div className="w-full py-4">
@@ -996,7 +1069,9 @@ function ExecuteRebalancePage(): React.ReactElement {
                               step={sliderStep}
                               value={(item.effectiveTarget * 100).toFixed(2)}
                               onChange={(e) => {
-                                const val = parseFloat(e.target.value) || 0
+                                const val = clampWeightPercent(
+                                  parseFloat(e.target.value) || 0,
+                                )
                                 handlers.targetChange(item.assetId, val / 100)
                                 // Numeric entry re-anchors immediately — the
                                 // user just told us exactly where they want
@@ -1099,20 +1174,24 @@ function ExecuteRebalancePage(): React.ReactElement {
                     </td>
                     <td className="px-3 py-2"></td>
                     <td className="px-3 py-2"></td>
-                    <td className="px-3 py-2 text-right font-semibold text-gray-900 tabular-nums">
-                      {formatPercent(
-                        displayItems.reduce(
-                          (sum, item) => sum + item.effectiveTarget,
-                          0,
-                        ),
-                      )}
+                    <td
+                      className={`px-3 py-2 text-right font-semibold tabular-nums ${
+                        targetTotalValid ? "text-gray-900" : "text-red-700"
+                      }`}
+                      title={
+                        targetTotalValid
+                          ? undefined
+                          : "Target weights don't sum to 100% — some rows were edited independently"
+                      }
+                    >
+                      {formatPercentValue(targetTotalPercent, 2)}
                     </td>
                     <td className="px-3 py-2 text-right font-semibold text-gray-900 tabular-nums">
-                      {formatPercent(
-                        displayItems.reduce(
-                          (sum, item) => sum + (item.projectedWeight ?? 0),
-                          0,
-                        ),
+                      {formatPercentValue(projectedIncludedPercent, 1)}
+                      {excludedValue > 0 && (
+                        <div className="text-[11px] font-normal text-gray-500">
+                          {`+${formatPercentValue(projectedExcludedPercent, 1)} excluded`}
+                        </div>
                       )}
                     </td>
                     <td className="px-3 py-2"></td>
@@ -1323,23 +1402,7 @@ function ExecuteRebalancePage(): React.ReactElement {
               {"Back"}
             </button>
             <button
-              onClick={async () => {
-                // Warn (but don't block) when the user has >1 brokers
-                // and didn't tag the orders — saves a "where's the
-                // broker on these trns?" follow-up later.
-                if (!confirmBrokerSelection(brokers.length, selectedBrokerId))
-                  return
-                const result = await handlers.commit()
-                if (!result) return
-                // Only land on /trns/proposed when the orders are
-                // actually unsettled. Settled commits go straight to
-                // the portfolio holdings.
-                if (result.transactionStatus === "PROPOSED") {
-                  router.push("/trns/proposed")
-                } else {
-                  router.push(`/trns?portfolioId=${result.portfolioId}`)
-                }
-              }}
+              onClick={handleExecuteClick}
               disabled={states.committing || activeItems.length === 0}
               className={`px-4 py-2 rounded text-white transition-colors ${
                 states.committing || activeItems.length === 0
@@ -1354,6 +1417,20 @@ function ExecuteRebalancePage(): React.ReactElement {
             </button>
           </div>
         </>
+      )}
+      {showCommitConfirm && (
+        <ConfirmDialog
+          title={"Targets Don't Total 100%"}
+          message={`Target weights total ${targetTotalPercent.toFixed(2)}% instead of 100%. Execute the transactions anyway?`}
+          confirmLabel={"Execute Anyway"}
+          cancelLabel={"Cancel"}
+          variant="amber"
+          onConfirm={async () => {
+            setShowCommitConfirm(false)
+            await runCommit()
+          }}
+          onCancel={() => setShowCommitConfirm(false)}
+        />
       )}
       {chartTarget && (
         <PriceChartPopup

--- a/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
+++ b/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
@@ -19,7 +19,11 @@ import StatusBadge from "@components/features/rebalance/common/StatusBadge"
 import { PlanAssetDto, AssetWeightWithDetails } from "types/rebalance"
 import { Asset, Market } from "types/beancounter"
 import { escapeCSV, downloadCsv } from "@lib/csvExport"
-import { toWeightPercent, buildPlanAssetsPayload } from "@lib/rebalance/weights"
+import {
+  toWeightPercent,
+  buildPlanAssetsPayload,
+  weightsSumValid,
+} from "@lib/rebalance/weights"
 import { parseWeightsFromCsvText } from "@lib/rebalance/csvImport"
 import ConfirmDialog from "@components/ui/ConfirmDialog"
 import Spinner from "@components/ui/Spinner"
@@ -486,6 +490,14 @@ function PlanDetailPage(): React.ReactElement {
 
   const isDraft = plan.status === "DRAFT"
 
+  // Approve is gated on the weights actually summing to 100% — saving a
+  // draft stays allowed at any total (drafts are work-in-progress), but
+  // locking in an allocation that doesn't sum correctly would ship a
+  // silently wrong plan.
+  const totalWeight = weights.reduce((sum, w) => sum + w.weight, 0)
+  const weightsValid = weightsSumValid(totalWeight)
+  const approveDisabled = approving || weights.length === 0 || !weightsValid
+
   return (
     <div className="w-full py-4">
       <div className="max-w-5xl mx-auto">
@@ -576,7 +588,7 @@ function PlanDetailPage(): React.ReactElement {
               )}
               <button
                 onClick={() => setShowApproveConfirm(true)}
-                disabled={approving || weights.length === 0}
+                disabled={approveDisabled}
                 className={`px-4 py-2 rounded-lg transition-colors flex items-center disabled:opacity-50 ${
                   hasChanges
                     ? "border border-gray-300 text-gray-700 hover:bg-gray-50"
@@ -590,6 +602,11 @@ function PlanDetailPage(): React.ReactElement {
                 )}
                 {"Approve Plan"}
               </button>
+              {weights.length > 0 && !weightsValid && (
+                <span className="text-sm text-red-600">
+                  {`Weights total ${totalWeight.toFixed(2)}% — must equal 100% to approve`}
+                </span>
+              )}
               <button
                 onClick={() => setShowDeleteConfirm(true)}
                 disabled={deleting}


### PR DESCRIPTION
Closes #1155.

- `clampWeightPercent` in `@lib/utils/rebalance/weights` applied to every typed weight-percent path: the execute-screen target input from the issue plus three more unclamped inputs found by sweep (AddAssetToModelDialog, ImportHoldingsDialog, CreateModelFromHoldingsDialog). `min`/`max` attributes never blocked typed/pasted values.
- `normalizeWeights` rewritten with largest-remainder allocation so it lands on exactly 100.00 (3×33.33 → 33.34/33.33/33.33; previously a no-op at 99.99 that left Create Model permanently disabled — the deferred ocr finding from #1162).
- Plan Approve now requires `weightsSumValid` with a visible reason ("Weights total 96.50% — must equal 100% to approve"); draft Save stays unrestricted.
- Execute footer: target-total cell turns red when overrides push the total off 100% (without overrides the scaled targets provably sum to 100 regardless of exclusions); the projected-% footer no longer reads a self-referential 100% when rows are excluded — shows included vs excluded split (e.g. `80.4% / +19.6% excluded`). One pre-existing test expectation encoded the old self-referential behavior and was recomputed.
- Committing with off-100 targets now raises an amber ConfirmDialog stating the actual total ("Execute Anyway" / Cancel). Server-side validation remains svc-rebalance #43.

265 suites / 2615 tests green; prettier/lint/typecheck clean; ocr 0 comments. UI exercised via component tests, not browser — footer/confirm worth an eyeball on kauri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kWgaWpybSCajCzVQZdiPk