### PR TITLE
fix(rebalance): label money values with execution currency and guard mixed-currency selection

### DIFF
--- a/src/__tests__/pages/rebalance/execute/index.test.tsx
+++ b/src/__tests__/pages/rebalance/execute/index.test.tsx
@@ -87,6 +87,9 @@ function makeItem(overrides: Partial<DisplayItem> = {}): DisplayItem {
     snapshotValue: overrides.snapshotValue ?? 5000,
     snapshotQuantity: overrides.snapshotQuantity ?? 50,
     snapshotPrice: overrides.snapshotPrice ?? 281.31,
+    // Absent by default (mirrors a legacy pre-#38 row) — tests exercising the
+    // nativePrice branch pass it explicitly.
+    nativePrice: overrides.nativePrice,
     priceCurrency: overrides.priceCurrency ?? "USD",
     planTargetWeight: overrides.planTargetWeight ?? 0.6,
     returnAdjustedTarget: overrides.returnAdjustedTarget ?? 0.58,
@@ -226,20 +229,87 @@ describe("ExecuteRebalancePage", () => {
     expect(screen.queryByTitle(/return-adjusted/i)).not.toBeInTheDocument()
   })
 
-  it("renders the price column as value + currency, and — when price is null", () => {
-    mockHookResult([
-      makeItem({ assetId: "a1", snapshotPrice: 281.31, priceCurrency: "USD" }),
-      makeItem({
-        assetId: "a2",
-        assetCode: "MSFT",
-        snapshotPrice: undefined,
-        priceCurrency: undefined,
-      }),
-    ])
+  it("renders a single execution-currency badge next to the page title", () => {
+    mockHookResult([makeItem()], {
+      execution: makeExecution({ currency: "SGD" }),
+    })
+    render(<ExecuteRebalancePage />)
+
+    expect(screen.getByTestId("execution-currency-badge")).toHaveTextContent(
+      "SGD",
+    )
+  })
+
+  it("price cell renders nativePrice labelled with the trade currency (priceCurrency) when present", () => {
+    mockHookResult(
+      [
+        makeItem({
+          assetId: "a1",
+          // snapshotPrice is the FX-converted (execution-currency) figure —
+          // must NOT be what's shown once nativePrice is available.
+          snapshotPrice: 300.5,
+          nativePrice: 281.31,
+          priceCurrency: "USD",
+        }),
+      ],
+      { execution: makeExecution({ currency: "NZD" }) },
+    )
     render(<ExecuteRebalancePage />)
 
     expect(screen.getByText("281.31 USD")).toBeInTheDocument()
+    expect(screen.queryByText(/300\.50/)).not.toBeInTheDocument()
+  })
+
+  it("price cell falls back to snapshotPrice labelled with the EXECUTION currency when nativePrice is absent (legacy rows), and — when there is no price at all", () => {
+    mockHookResult(
+      [
+        makeItem({
+          assetId: "a1",
+          snapshotPrice: 281.31,
+          nativePrice: null,
+          // Trade currency — must NOT be used as the label on this branch,
+          // since snapshotPrice is already FX-converted to the execution
+          // currency, not this one.
+          priceCurrency: "USD",
+        }),
+        makeItem({
+          assetId: "a2",
+          assetCode: "MSFT",
+          snapshotPrice: undefined,
+          nativePrice: undefined,
+          priceCurrency: undefined,
+        }),
+      ],
+      { execution: makeExecution({ currency: "NZD" }) },
+    )
+    render(<ExecuteRebalancePage />)
+
+    expect(screen.getByText("281.31 NZD")).toBeInTheDocument()
+    expect(screen.queryByText("281.31 USD")).not.toBeInTheDocument()
     expect(screen.getByText("—")).toBeInTheDocument()
+  })
+
+  it("preview table's price cell applies the same nativePrice/priceCurrency pairing as the configure table", () => {
+    mockHookResult(
+      [
+        makeItem({
+          assetId: "a1",
+          assetCode: "AAPL",
+          snapshotPrice: 300.5,
+          nativePrice: 281.31,
+          priceCurrency: "USD",
+          deltaValue: 1000,
+        }),
+      ],
+      { execution: makeExecution({ currency: "NZD" }) },
+    )
+    render(<ExecuteRebalancePage />)
+    fireEvent.click(
+      screen.getByRole("button", { name: /Next.*Review Transactions/i }),
+    )
+
+    expect(screen.getByText("Proposed Transactions")).toBeInTheDocument()
+    expect(screen.getByText("281.31 USD")).toBeInTheDocument()
   })
 
   it("tints a positive-delta-quantity row green and a negative one red; leaves excluded/zero rows neutral", () => {

--- a/src/components/features/holdings/Rows.tsx
+++ b/src/components/features/holdings/Rows.tsx
@@ -525,8 +525,15 @@ export default function Rows({
                           asset,
                           currentWeight: moneyValues[valueIn].weight * 100,
                           currentQuantity: quantityValues.total,
+                          // A trade is denominated in the asset's own
+                          // currency, so the dialog gets the trade-currency
+                          // price — not the row's display-converted one
+                          // (mirrors the ActionsMenu price prop above; #1156).
                           currentPrice:
-                            moneyValues[valueIn].priceData?.close || 0,
+                            moneyValues["TRADE"]?.priceData?.close ||
+                            moneyValues[valueIn].priceData?.close ||
+                            0,
+                          fxRate: deriveTradeToPortfolioFxRate(moneyValues),
                         })
                       }
                     : undefined

--- a/src/components/features/holdings/TargetWeightDialog.tsx
+++ b/src/components/features/holdings/TargetWeightDialog.tsx
@@ -3,6 +3,7 @@ import { Asset, Portfolio, RebalanceData } from "types/beancounter"
 import MathInput from "@components/ui/MathInput"
 import Dialog from "@components/ui/Dialog"
 import { stripOwnerPrefix } from "@lib/assets/assetUtils"
+import { calculateQuantityFromTargetWeight } from "@lib/trns/tradeFormHelpers"
 
 export type { RebalanceData }
 
@@ -15,6 +16,10 @@ interface TargetWeightDialogProps {
   currentWeight: number
   currentQuantity: number
   currentPrice: number
+  // Trade-currency -> portfolio-currency rate (see WeightClickData.fxRate).
+  // Defaults to 1 — same-currency asset/portfolio, or a caller that hasn't
+  // been updated to supply it yet.
+  fxRate?: number
 }
 
 const TargetWeightDialog: React.FC<TargetWeightDialogProps> = ({
@@ -26,37 +31,48 @@ const TargetWeightDialog: React.FC<TargetWeightDialogProps> = ({
   currentWeight,
   currentQuantity,
   currentPrice,
+  fxRate = 1,
 }) => {
   // Parent (pages/holdings/[code].tsx) conditionally mounts this dialog,
   // so the initial useState already gives fresh state on each open.
   const [targetWeight, setTargetWeight] = useState<number>(currentWeight)
 
-  // Calculate required shares and action type
+  // Calculate required shares and action type. `currentPrice` is the asset's
+  // TRADE currency but `portfolio.marketValue` (and so the weight-derived
+  // valueDiff) is portfolio currency — `calculateQuantityFromTargetWeight`
+  // applies `fxRate` to reconcile them, same fix as the trade dialog's
+  // target-weight sizing (#1156). Without it, a foreign-currency asset's
+  // required-share count is silently wrong by the fx ratio.
   const calculation = useMemo(() => {
     const portfolioValue = portfolio.marketValue
     if (portfolioValue <= 0 || currentPrice <= 0) {
       return { shares: 0, type: "BUY" as const }
     }
 
-    const targetValue = (targetWeight / 100) * portfolioValue
-    const currentValue = (currentWeight / 100) * portfolioValue
-    const valueDiff = targetValue - currentValue
-
     // For selling to 0%, use all current shares
     if (targetWeight === 0 && currentQuantity > 0) {
       return { shares: currentQuantity, type: "SELL" as const }
     }
 
-    const shares = Math.round(Math.abs(valueDiff) / currentPrice)
-    const type = valueDiff >= 0 ? ("BUY" as const) : ("SELL" as const)
+    const result = calculateQuantityFromTargetWeight(
+      targetWeight,
+      currentWeight,
+      currentPrice,
+      portfolioValue,
+      fxRate,
+    )
+    if (!result) {
+      return { shares: 0, type: "BUY" as const }
+    }
 
-    return { shares, type }
+    return { shares: result.quantity, type: result.tradeType }
   }, [
     targetWeight,
     currentWeight,
     portfolio.marketValue,
     currentPrice,
     currentQuantity,
+    fxRate,
   ])
 
   const handleProceed = (): void => {

--- a/src/components/features/holdings/__tests__/TargetWeightDialog.test.tsx
+++ b/src/components/features/holdings/__tests__/TargetWeightDialog.test.tsx
@@ -374,4 +374,73 @@ describe("TargetWeightDialog Component", () => {
       })
     })
   })
+
+  describe("FX-aware sizing (#1156)", () => {
+    // Portfolio in NZD, asset priced/traded in USD (fxRate = USD -> NZD).
+    const nzdPortfolio: Portfolio = makePortfolio({
+      id: "nzd-portfolio-id",
+      currency: { code: "NZD", name: "New Zealand Dollar", symbol: "NZ$" },
+      marketValue: 100000,
+    })
+
+    it("uses the fx-adjusted price, not the naive base-currency-diff / trade-price division", async () => {
+      render(
+        <TargetWeightDialog
+          modalOpen={true}
+          onClose={mockOnClose}
+          onConfirm={mockOnConfirm}
+          asset={mockAsset}
+          portfolio={nzdPortfolio}
+          currentWeight={5}
+          currentQuantity={100}
+          currentPrice={150} // USD, trade currency
+          fxRate={2} // 1 USD = 2 NZD
+        />,
+      )
+
+      const input = screen.getByRole("textbox")
+      fireEvent.change(input, { target: { value: "10" } })
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        // Target 10% of NZ$100,000 = NZ$10,000; current 5% = NZ$5,000.
+        // Diff = NZ$5,000, priced in NZD at $150 USD * fxRate 2 = NZ$300/share.
+        // 5000 / 300 = 16.67 => 17 shares.
+        // The naive (no-fx) calculation would divide by the raw USD price
+        // (5000 / 150 = 33.33 => 33) — asserting 17 is absent proves the fx
+        // adjustment, not just rounding, drove the result.
+        expect(screen.getByText("17")).toBeInTheDocument()
+        expect(screen.queryByText("33")).not.toBeInTheDocument()
+        expect(screen.getByText(/Buy/i)).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText("Proceed"))
+      expect(mockOnConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ quantity: 17, price: 150, type: "BUY" }),
+      )
+    })
+
+    it("defaults to fxRate 1 (same-currency behaviour) when the prop is omitted", async () => {
+      render(
+        <TargetWeightDialog
+          modalOpen={true}
+          onClose={mockOnClose}
+          onConfirm={mockOnConfirm}
+          asset={mockAsset}
+          portfolio={mockPortfolio}
+          currentWeight={5}
+          currentQuantity={100}
+          currentPrice={150}
+        />,
+      )
+
+      const input = screen.getByRole("textbox")
+      fireEvent.change(input, { target: { value: "10" } })
+      fireEvent.blur(input)
+
+      await waitFor(() => {
+        expect(screen.getByText(/33/)).toBeInTheDocument()
+      })
+    })
+  })
 })

--- a/src/components/features/rebalance/models/ImportHoldingsDialog.tsx
+++ b/src/components/features/rebalance/models/ImportHoldingsDialog.tsx
@@ -75,7 +75,12 @@ const ImportHoldingsDialog: React.FC<ImportHoldingsDialogProps> = ({
     setLoadingWeights(true)
     try {
       const portfolio = portfolios.find((p) => p.id === portfolioId)
-      const valueCurrency = portfolio?.currency?.code || "USD"
+      // Fallback only covers a race against a background portfolios refetch
+      // (the dropdown only ever offers ids drawn from `portfolios`, so the
+      // lookup above should always hit) — the first portfolio in the
+      // currently-known list, never a hard-coded country default (#1156).
+      const valueCurrency =
+        portfolio?.currency?.code || portfolios[0]?.currency?.code || ""
 
       const response = await fetch(
         `/api/rebalance/models/${modelId}/plans/weights-from-holdings?portfolioId=${portfolioId}&valueCurrency=${valueCurrency}`,

--- a/src/components/features/rebalance/models/ModelPortfolioForm.tsx
+++ b/src/components/features/rebalance/models/ModelPortfolioForm.tsx
@@ -4,8 +4,8 @@ import { useRouter } from "next/router"
 import useSWR from "swr"
 import Spinner from "@components/ui/Spinner"
 import { ModelDto, CreateModelRequest } from "types/rebalance"
-import { Currency } from "types/beancounter"
-import { ccyKey, simpleFetcher } from "@utils/api/fetchHelper"
+import { Currency, PortfolioResponses } from "types/beancounter"
+import { ccyKey, portfoliosKey, simpleFetcher } from "@utils/api/fetchHelper"
 import ClientSelector from "@components/features/shares/ClientSelector"
 import { useDialogSubmit } from "@hooks/useDialogSubmit"
 
@@ -27,10 +27,19 @@ const ModelPortfolioForm: React.FC<ModelPortfolioFormProps> = ({
   }>(ccyKey, simpleFetcher(ccyKey))
   const currencies = ccyResponse?.data || []
 
+  // Fetch the user's portfolios so a brand-new model can default its base
+  // currency to a portfolio the user actually holds, instead of a
+  // hard-coded country default (#1156).
+  const { data: portfoliosResponse } = useSWR<PortfolioResponses>(
+    portfoliosKey,
+    simpleFetcher(portfoliosKey),
+  )
+  const portfolios = portfoliosResponse?.data || []
+
   const [name, setName] = useState(model?.name || "")
   const [objective, setObjective] = useState(model?.objective || "")
   const [description, setDescription] = useState(model?.description || "")
-  const [baseCurrency, setBaseCurrency] = useState(model?.baseCurrency || "NZD")
+  const [baseCurrency, setBaseCurrency] = useState(model?.baseCurrency || "")
   const [risk, setRisk] = useState<number>(model?.risk ?? 5)
   const [clientId, setClientId] = useState(model?.clientId || "")
   const {
@@ -39,7 +48,20 @@ const ModelPortfolioForm: React.FC<ModelPortfolioFormProps> = ({
     handleSubmit: dialogSubmit,
   } = useDialogSubmit({ fallbackError: "Failed to save model" })
 
-  const isValid = name.trim() !== ""
+  // Resolved at render (not via an effect) since the portfolios list may
+  // still be loading when this form mounts: an explicit pick always wins;
+  // otherwise default to the first portfolio the user actually holds, and
+  // only fall back to empty (nothing to derive from yet) — never a
+  // hard-coded country currency (#1156). Editing an existing model always
+  // keeps its own baseCurrency, since `baseCurrency` state is seeded from it.
+  const resolvedBaseCurrency =
+    baseCurrency || portfolios[0]?.currency.code || ""
+
+  // Empty resolvedBaseCurrency (no portfolios yet, or submitting before the
+  // portfolios SWR resolves) must block submit — the old hard-coded "NZD"
+  // default made this state impossible, so removing it without a matching
+  // gate would let a model persist with baseCurrency: "".
+  const isValid = name.trim() !== "" && resolvedBaseCurrency !== ""
 
   const handleSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault()
@@ -50,7 +72,7 @@ const ModelPortfolioForm: React.FC<ModelPortfolioFormProps> = ({
         name: name.trim(),
         objective: objective.trim() || undefined,
         description: description.trim() || undefined,
-        baseCurrency,
+        baseCurrency: resolvedBaseCurrency,
         clientId: clientId.trim() || undefined,
         risk,
       }
@@ -145,7 +167,7 @@ const ModelPortfolioForm: React.FC<ModelPortfolioFormProps> = ({
         </label>
         <select
           id="baseCurrency"
-          value={baseCurrency}
+          value={resolvedBaseCurrency}
           onChange={(e) => setBaseCurrency(e.target.value)}
           disabled={loadingCurrencies}
           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
@@ -153,11 +175,19 @@ const ModelPortfolioForm: React.FC<ModelPortfolioFormProps> = ({
           {loadingCurrencies ? (
             <option value="">{"Loading..."}</option>
           ) : (
-            currencies.map((currency) => (
-              <option key={currency.code} value={currency.code}>
-                {currency.code}
-              </option>
-            ))
+            <>
+              {/* Real placeholder (not a silently-selected first currency)
+                  for the brief window before a default currency has been
+                  resolved from either the model or the portfolios list. */}
+              {!resolvedBaseCurrency && (
+                <option value="">{"Select a currency..."}</option>
+              )}
+              {currencies.map((currency) => (
+                <option key={currency.code} value={currency.code}>
+                  {currency.code}
+                </option>
+              ))}
+            </>
           )}
         </select>
       </div>

--- a/src/components/features/rebalance/models/__tests__/ModelPortfolioForm.test.tsx
+++ b/src/components/features/rebalance/models/__tests__/ModelPortfolioForm.test.tsx
@@ -1,0 +1,147 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import useSWR from "swr"
+import ModelPortfolioForm from "../ModelPortfolioForm"
+import { ccyKey, portfoliosKey } from "@utils/api/fetchHelper"
+import { makePortfolio } from "@test-fixtures/beancounter"
+import { ModelDto } from "types/rebalance"
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+}))
+
+jest.mock("@components/features/shares/ClientSelector", () => ({
+  __esModule: true,
+  default: (): React.ReactElement => <div data-testid="client-selector" />,
+}))
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+const mockedUseSWR = useSWR as jest.MockedFunction<typeof useSWR>
+
+const CURRENCIES = [
+  { code: "USD", name: "US Dollar", symbol: "$" },
+  { code: "SGD", name: "Singapore Dollar", symbol: "S$" },
+  { code: "EUR", name: "Euro", symbol: "€" },
+  { code: "NZD", name: "New Zealand Dollar", symbol: "NZ$" },
+]
+
+function swrReturn(data: unknown): ReturnType<typeof useSWR> {
+  return {
+    data,
+    error: undefined,
+    isLoading: false,
+    isValidating: false,
+    mutate: jest.fn(),
+  } as unknown as ReturnType<typeof useSWR>
+}
+
+function mockSwrData(portfolios: ReturnType<typeof makePortfolio>[]): void {
+  mockedUseSWR.mockImplementation((key: unknown) => {
+    if (key === ccyKey) return swrReturn({ data: CURRENCIES })
+    if (key === portfoliosKey) return swrReturn({ data: portfolios })
+    return swrReturn(undefined)
+  })
+}
+
+describe("ModelPortfolioForm base-currency default (#1156)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("defaults a brand-new model's base currency to the first portfolio's report currency, not a hard-coded country default", () => {
+    mockSwrData([
+      makePortfolio({
+        id: "p1",
+        currency: { code: "SGD", name: "Singapore Dollar", symbol: "S$" },
+      }),
+      makePortfolio({
+        id: "p2",
+        currency: { code: "EUR", name: "Euro", symbol: "€" },
+      }),
+    ])
+    render(<ModelPortfolioForm />)
+
+    const select = screen.getByLabelText("Base Currency") as HTMLSelectElement
+    expect(select.value).toBe("SGD")
+  })
+
+  it("keeps an existing model's own base currency when editing, regardless of the portfolio list", () => {
+    mockSwrData([
+      makePortfolio({
+        id: "p1",
+        currency: { code: "SGD", name: "Singapore Dollar", symbol: "S$" },
+      }),
+    ])
+    const model: ModelDto = {
+      id: "model-1",
+      name: "Existing Model",
+      baseCurrency: "EUR",
+      risk: 3,
+      shared: false,
+      isOwner: true,
+      planCount: 0,
+      createdAt: "2026-01-01",
+      updatedAt: "2026-01-01",
+    }
+    render(<ModelPortfolioForm model={model} />)
+
+    const select = screen.getByLabelText("Base Currency") as HTMLSelectElement
+    expect(select.value).toBe("EUR")
+  })
+
+  it("shows a real placeholder (not a silently-selected hard-coded currency) when creating a model with no portfolios yet", () => {
+    mockSwrData([])
+    render(<ModelPortfolioForm />)
+
+    const select = screen.getByLabelText("Base Currency") as HTMLSelectElement
+    expect(select.value).toBe("")
+    expect(screen.getByText("Select a currency...")).toBeInTheDocument()
+  })
+
+  describe("submit gating on a resolved base currency", () => {
+    it("keeps submit disabled when no currency can be resolved yet, even with a valid name", () => {
+      mockSwrData([]) // no portfolios -> resolvedBaseCurrency stays ""
+      render(<ModelPortfolioForm />)
+
+      fireEvent.change(screen.getByLabelText(/Model Name/), {
+        target: { value: "New Model" },
+      })
+
+      expect(screen.getByRole("button", { name: "Create" })).toBeDisabled()
+    })
+
+    it("enables submit once a currency is derived from the portfolios list", () => {
+      mockSwrData([
+        makePortfolio({
+          id: "p1",
+          currency: { code: "SGD", name: "Singapore Dollar", symbol: "S$" },
+        }),
+      ])
+      render(<ModelPortfolioForm />)
+
+      fireEvent.change(screen.getByLabelText(/Model Name/), {
+        target: { value: "New Model" },
+      })
+
+      expect(screen.getByRole("button", { name: "Create" })).not.toBeDisabled()
+    })
+
+    it("enables submit once the user explicitly picks a currency, even with no portfolios", () => {
+      mockSwrData([])
+      render(<ModelPortfolioForm />)
+
+      fireEvent.change(screen.getByLabelText(/Model Name/), {
+        target: { value: "New Model" },
+      })
+      fireEvent.change(screen.getByLabelText("Base Currency"), {
+        target: { value: "EUR" },
+      })
+
+      expect(screen.getByRole("button", { name: "Create" })).not.toBeDisabled()
+    })
+  })
+})

--- a/src/components/features/rebalance/wizard/RebalanceWizardContainer.tsx
+++ b/src/components/features/rebalance/wizard/RebalanceWizardContainer.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from "react"
+import useSwr from "swr"
 import Alert from "@components/ui/Alert"
 import { useRouter } from "next/router"
 import Spinner from "@components/ui/Spinner"
@@ -13,6 +14,8 @@ import {
   CreatePlanRequest,
   CreateExecutionRequest,
 } from "types/rebalance"
+import { PortfolioResponses } from "types/beancounter"
+import { portfoliosKey, simpleFetcher } from "@utils/api/fetchHelper"
 import { useDialogSubmit } from "@hooks/useDialogSubmit"
 
 interface RebalanceWizardContainerProps {
@@ -40,6 +43,30 @@ const RebalanceWizardContainer: React.FC<RebalanceWizardContainerProps> = ({
   } = useDialogSubmit({ fallbackError: "Failed to complete wizard" })
 
   const hasApprovedPlan = Boolean(selectedModel?.currentPlanId)
+
+  // Backs the cash-delta currency label in steps 3-4. The model's
+  // baseCurrency is the primary source once one's selected; the fallback (for
+  // the brief window before that, or a defensively-null model) derives from
+  // the selected portfolio's report currency rather than a hard-coded
+  // country default (#1156) — never observable via the wizard's own
+  // navigation gating today (step 3 is unreachable without a model), but the
+  // fallback should still be honest if that ever changes.
+  const { data: portfoliosData } = useSwr<PortfolioResponses>(
+    portfoliosKey,
+    simpleFetcher(portfoliosKey),
+  )
+  const planCurrency = useMemo(() => {
+    if (selectedModel?.baseCurrency) return selectedModel.baseCurrency
+    const portfolios = portfoliosData?.data || []
+    const firstSelectedPortfolio = portfolios.find((p) =>
+      selectedPortfolioIds.includes(p.id),
+    )
+    return (
+      firstSelectedPortfolio?.currency.code ||
+      portfolios[0]?.currency.code ||
+      ""
+    )
+  }, [selectedModel, portfoliosData, selectedPortfolioIds])
 
   // Steps configuration
   const steps = useMemo(
@@ -168,7 +195,7 @@ const RebalanceWizardContainer: React.FC<RebalanceWizardContainerProps> = ({
             onScenarioChange={setScenario}
             cashDelta={cashDelta}
             onCashDeltaChange={setCashDelta}
-            planCurrency={selectedModel?.baseCurrency || "USD"}
+            planCurrency={planCurrency}
           />
         )}
         {currentStep === 4 && (
@@ -179,7 +206,7 @@ const RebalanceWizardContainer: React.FC<RebalanceWizardContainerProps> = ({
             portfolioCount={selectedPortfolioIds.length}
             scenario={scenario}
             cashDelta={cashDelta}
-            planCurrency={selectedModel?.baseCurrency || "USD"}
+            planCurrency={planCurrency}
           />
         )}
       </div>

--- a/src/components/features/rebalance/wizard/__tests__/RebalanceWizardContainer.test.tsx
+++ b/src/components/features/rebalance/wizard/__tests__/RebalanceWizardContainer.test.tsx
@@ -1,12 +1,34 @@
 import React from "react"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
+import useSwr from "swr"
 import { ModelDto, RebalanceScenario } from "types/rebalance"
 
 const mockPush = jest.fn()
 jest.mock("next/router", () => ({
   useRouter: () => ({ push: mockPush, back: jest.fn() }),
 }))
+
+// The container fetches the portfolios list itself (for the currency-fallback
+// derivation, #1156) — mock "swr" directly rather than going through
+// global.fetch, so the extra GET can't collide with the ordered
+// mockFetch.mockResolvedValueOnce() queue the POST-related tests below rely
+// on.
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+const mockedUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
+let mockPortfolios: { id: string; currency: { code: string } }[] = []
+mockedUseSwr.mockImplementation(
+  () =>
+    ({
+      data: { data: mockPortfolios },
+      error: undefined,
+      isLoading: false,
+      mutate: jest.fn(),
+    }) as unknown as ReturnType<typeof useSwr>,
+)
 
 const testModel: ModelDto = {
   id: "model-1",
@@ -49,9 +71,11 @@ jest.mock("../steps/ConfigureScenarioStep", () => ({
   default: ({
     onScenarioChange,
     onCashDeltaChange,
+    planCurrency,
   }: {
     onScenarioChange: (scenario: RebalanceScenario) => void
     onCashDeltaChange: (delta: number) => void
+    planCurrency: string
   }) => (
     <div>
       <button onClick={() => onScenarioChange("REBALANCE")}>
@@ -61,6 +85,7 @@ jest.mock("../steps/ConfigureScenarioStep", () => ({
         set-scenario-invest-cash
       </button>
       <button onClick={() => onCashDeltaChange(5000)}>set-cash-delta</button>
+      <span data-testid="plan-currency">{planCurrency}</span>
     </div>
   ),
 }))
@@ -83,6 +108,7 @@ describe("RebalanceWizardContainer submit", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     modelToSelect = testModel
+    mockPortfolios = []
     global.fetch = mockFetch
   })
 
@@ -255,6 +281,53 @@ describe("RebalanceWizardContainer submit", () => {
       })
 
       expect(mockPush).not.toHaveBeenCalled()
+    })
+  })
+
+  // --- Currency fallback for the Configure step's cash-delta label (#1156) ---
+  //
+  // The wizard's own step gating makes selectedModel non-null (and thus
+  // baseCurrency populated) by the time step 3 renders — so these tests
+  // exercise the fallback with a defensively-malformed model (empty
+  // baseCurrency) to prove it derives from the selected portfolio rather
+  // than silently reaching for a hard-coded country default.
+  describe("planCurrency fallback when the model carries no baseCurrency", () => {
+    const driveToConfigureStep = (): void => {
+      render(<RebalanceWizardContainer />)
+      fireEvent.click(screen.getByText("select-model"))
+      fireEvent.click(screen.getByText("Next")) // -> step 2
+      fireEvent.click(screen.getByText("select-portfolio")) // selects "portfolio-1"
+      fireEvent.click(screen.getByText("Next")) // -> step 3 (Configure)
+    }
+
+    it("uses the selected portfolio's currency, not a hard-coded USD", () => {
+      modelToSelect = { ...testModel, baseCurrency: "" } as ModelDto
+      mockPortfolios = [{ id: "portfolio-1", currency: { code: "SGD" } }]
+
+      driveToConfigureStep()
+
+      expect(screen.getByTestId("plan-currency")).toHaveTextContent("SGD")
+    })
+
+    it("falls back to the first portfolio in the list when the selected id isn't found there yet", () => {
+      modelToSelect = { ...testModel, baseCurrency: "" } as ModelDto
+      mockPortfolios = [
+        { id: "some-other-portfolio", currency: { code: "EUR" } },
+      ]
+
+      driveToConfigureStep()
+
+      expect(screen.getByTestId("plan-currency")).toHaveTextContent("EUR")
+    })
+
+    it("falls back to empty — never a hard-coded currency — when no portfolio data is available", () => {
+      modelToSelect = { ...testModel, baseCurrency: "" } as ModelDto
+      mockPortfolios = []
+
+      driveToConfigureStep()
+
+      expect(screen.getByTestId("plan-currency")).toBeEmptyDOMElement()
+      expect(screen.queryByText("USD")).not.toBeInTheDocument()
     })
   })
 })

--- a/src/components/features/rebalance/wizard/steps/SelectPortfoliosStep.tsx
+++ b/src/components/features/rebalance/wizard/steps/SelectPortfoliosStep.tsx
@@ -61,6 +61,20 @@ const SelectPortfoliosStep: React.FC<SelectPortfoliosStepProps> = ({
 
   const portfolios = data?.data || []
 
+  // Distinct report currencies among the SELECTED portfolios (not the whole
+  // list) — #1156. The wizard doesn't block a mixed-currency selection
+  // (svc-rebalance values the execution in one enforced currency), but the
+  // user should know up front that it's happening rather than discovering it
+  // from unlabelled numbers on the execute screen.
+  const selectedCurrencies = Array.from(
+    new Set(
+      portfolios
+        .filter((p) => selectedPortfolioIds.includes(p.id))
+        .map((p) => p.currency.code),
+    ),
+  )
+  const hasMixedCurrencies = selectedCurrencies.length > 1
+
   if (portfolios.length === 0) {
     return (
       <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
@@ -97,6 +111,12 @@ const SelectPortfoliosStep: React.FC<SelectPortfoliosStepProps> = ({
           {"Select None"}
         </button>
       </div>
+
+      {hasMixedCurrencies && (
+        <Alert variant="warning">
+          {`Selected portfolios report in different currencies (${selectedCurrencies.join(", ")}). This rebalance execution will value everything in a single currency.`}
+        </Alert>
+      )}
 
       {/* Portfolio list */}
       <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">

--- a/src/components/features/rebalance/wizard/steps/__tests__/SelectPortfoliosStep.test.tsx
+++ b/src/components/features/rebalance/wizard/steps/__tests__/SelectPortfoliosStep.test.tsx
@@ -1,0 +1,102 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import useSwr from "swr"
+import SelectPortfoliosStep from "../SelectPortfoliosStep"
+import { makePortfolio } from "@test-fixtures/beancounter"
+import { Portfolio } from "types/beancounter"
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+const mockedUseSwr = useSwr as jest.MockedFunction<typeof useSwr>
+
+function mockPortfolios(portfolios: Portfolio[]): void {
+  mockedUseSwr.mockReturnValue({
+    data: { data: portfolios },
+    error: undefined,
+    isLoading: false,
+    mutate: jest.fn(),
+  } as unknown as ReturnType<typeof useSwr>)
+}
+
+const nzdPortfolio = makePortfolio({
+  id: "p-nzd",
+  code: "NZD1",
+  name: "NZ Portfolio",
+  currency: { code: "NZD", name: "New Zealand Dollar", symbol: "NZ$" },
+})
+const usdPortfolio = makePortfolio({
+  id: "p-usd",
+  code: "USD1",
+  name: "US Portfolio",
+  currency: { code: "USD", name: "US Dollar", symbol: "$" },
+})
+const usdPortfolio2 = makePortfolio({
+  id: "p-usd2",
+  code: "USD2",
+  name: "US Portfolio 2",
+  currency: { code: "USD", name: "US Dollar", symbol: "$" },
+})
+
+describe("SelectPortfoliosStep — mixed-currency guard (#1156)", () => {
+  const onChange = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("shows no currency warning when only one portfolio is selected", () => {
+    mockPortfolios([nzdPortfolio, usdPortfolio])
+    render(
+      <SelectPortfoliosStep
+        selectedPortfolioIds={["p-nzd"]}
+        onChange={onChange}
+      />,
+    )
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
+  it("shows no currency warning when every selected portfolio shares the same currency", () => {
+    mockPortfolios([usdPortfolio, usdPortfolio2])
+    render(
+      <SelectPortfoliosStep
+        selectedPortfolioIds={["p-usd", "p-usd2"]}
+        onChange={onChange}
+      />,
+    )
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
+  it("warns when the selected set spans more than one report currency", () => {
+    mockPortfolios([nzdPortfolio, usdPortfolio])
+    render(
+      <SelectPortfoliosStep
+        selectedPortfolioIds={["p-nzd", "p-usd"]}
+        onChange={onChange}
+      />,
+    )
+
+    const warning = screen.getByRole("alert")
+    expect(warning).toHaveTextContent(/currenc/i)
+    expect(warning).toHaveTextContent("NZD")
+    expect(warning).toHaveTextContent("USD")
+  })
+
+  it("does not block selection — every portfolio checkbox stays enabled while the warning is shown", () => {
+    mockPortfolios([nzdPortfolio, usdPortfolio])
+    render(
+      <SelectPortfoliosStep
+        selectedPortfolioIds={["p-nzd", "p-usd"]}
+        onChange={onChange}
+      />,
+    )
+
+    screen.getAllByRole("checkbox").forEach((checkbox) => {
+      expect(checkbox).not.toBeDisabled()
+    })
+  })
+})

--- a/src/pages/holdings/[code].tsx
+++ b/src/pages/holdings/[code].tsx
@@ -849,6 +849,7 @@ function HoldingsPage(): React.ReactElement {
           currentWeight={weightClickData.currentWeight}
           currentQuantity={weightClickData.currentQuantity}
           currentPrice={weightClickData.currentPrice}
+          fxRate={weightClickData.fxRate}
         />
       )}
       {setCashBalanceData && (

--- a/src/pages/rebalance/execute/index.tsx
+++ b/src/pages/rebalance/execute/index.tsx
@@ -97,6 +97,26 @@ function formatSignedPp(value: number, fractionDigits: number): string {
   return `${sign}${rounded.toFixed(fractionDigits)}`
 }
 
+/** Pairs an execution item's price with the currency it's actually
+ * denominated in (#1156). `nativePrice` — when the backend has populated it —
+ * is the trade-currency price, so it pairs with `priceCurrency`. Pre-#38 rows
+ * carry only the FX-converted `snapshotPrice`, which is quoted in the
+ * execution's own valuation currency, not the asset's trade currency — the
+ * legacy fallback pairs it with `executionCurrency` instead of the
+ * (mismatched) `priceCurrency` a naive read would reach for. */
+function formatItemPrice(
+  item: Pick<DisplayItem, "nativePrice" | "snapshotPrice" | "priceCurrency">,
+  executionCurrency: string,
+): string {
+  if (item.nativePrice != null) {
+    return `${formatCurrency(item.nativePrice)} ${item.priceCurrency || ""}`.trim()
+  }
+  if (item.snapshotPrice != null) {
+    return `${formatCurrency(item.snapshotPrice)} ${executionCurrency}`.trim()
+  }
+  return "—"
+}
+
 /** Builds a minimal Asset for PriceChartPopup from a rebalance display row.
  * The execution DTO only carries id/code/name/price — market and category
  * are never resolved server-side for this flow, so a placeholder satisfies
@@ -574,9 +594,26 @@ function ExecuteRebalancePage(): React.ReactElement {
       <div className="bg-white shadow-sm border border-gray-200 rounded-lg p-6 mb-6">
         <div className="flex items-start justify-between mb-4">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">
-              {execution.modelName ? "Rebalance Portfolio" : "Ad-hoc Rebalance"}
-            </h1>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold text-gray-900">
+                {execution.modelName
+                  ? "Rebalance Portfolio"
+                  : "Ad-hoc Rebalance"}
+              </h1>
+              {/* Single execution-currency indicator for the whole page (#1156)
+                  — monetary amounts/totals below (snapshot values, deltas,
+                  cash summary) are in this currency; price cells are the
+                  exception, labelled per-row with each asset's own trade
+                  currency (see formatItemPrice). A per-cell code for the
+                  amounts would be noise. */}
+              <span
+                data-testid="execution-currency-badge"
+                title="Monetary amounts and totals are in the execution's valuation currency; prices show each asset's trade currency"
+                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700"
+              >
+                {execution.currency}
+              </span>
+            </div>
             <p className="text-sm text-gray-600 mt-1">
               {execution.modelName ? (
                 <>
@@ -943,9 +980,7 @@ function ExecuteRebalancePage(): React.ReactElement {
                           )}
                         </td>
                         <td className="px-3 py-2 text-right text-gray-700 tabular-nums">
-                          {item.snapshotPrice != null
-                            ? `${formatCurrency(item.snapshotPrice)} ${item.priceCurrency || ""}`.trim()
-                            : "—"}
+                          {formatItemPrice(item, execution.currency)}
                         </td>
                         <td className="px-3 py-2 text-right tabular-nums">
                           <button
@@ -1300,9 +1335,7 @@ function ExecuteRebalancePage(): React.ReactElement {
                           {item.deltaQuantity}
                         </td>
                         <td className="px-4 py-3 text-right text-gray-500">
-                          {item.snapshotPrice
-                            ? `${formatCurrency(item.snapshotPrice)} ${item.priceCurrency || ""}`
-                            : "-"}
+                          {formatItemPrice(item, execution.currency)}
                         </td>
                         <td
                           className={`px-4 py-3 text-right font-medium ${valueClass}`}

--- a/types/beancounter.d.ts
+++ b/types/beancounter.d.ts
@@ -61,6 +61,11 @@ export interface WeightClickData {
   currentWeight: number
   currentQuantity: number
   currentPrice: number
+  // Trade-currency -> portfolio-currency rate, so the rebalance dialog can
+  // weigh `currentPrice` (the asset's own trade currency) against
+  // portfolio.marketValue (portfolio currency). Omitted/1 when they already
+  // match. Mirrors QuickSellData.fxRate.
+  fxRate?: number
 }
 
 export interface SetCashBalanceData {

--- a/types/rebalance.d.ts
+++ b/types/rebalance.d.ts
@@ -196,6 +196,8 @@ export interface ExecutionItemDto {
   snapshotValue: number
   snapshotQuantity: number
   snapshotPrice?: number
+  /** Trade-currency (native) price used for booking on commit; null on pre-existing rows */
+  nativePrice?: number | null
   priceCurrency?: string
   planTargetWeight: number
   /** Return-adjusted target accounting for price movements since model creation */


### PR DESCRIPTION
Closes #1156.

- Execution-currency badge next to the page title on the execute screen (both steps); tooltip clarifies amounts/totals are valuation-currency while price cells show trade currency.
- Price cells (configure + preview tables) now render the genuine `nativePrice` labelled with `priceCurrency` (backend field from svc-rebalance #54, live); legacy rows without it fall back to `snapshotPrice` labelled with the EXECUTION currency — the wrong number/label pair is gone. `ExecutionItemDto.nativePrice` added to `types/rebalance.d.ts`.
- Amber warning in the wizard's portfolio step when the selected portfolios span more than one report currency (non-blocking — backend enforces a single valuation currency).
- Hard-coded currency fallbacks removed: ImportHoldingsDialog ("USD"), RebalanceWizardContainer ("USD" ×2 → `planCurrency` memo: model → selected portfolio → first portfolio), ModelPortfolioForm ("NZD" → derived, with a real placeholder option and submit now gated on a resolved currency — previously an empty currency was impossible, now it's unsubmittable).
- TargetWeightDialog quantity is FX-aware via the existing `calculateQuantityFromTargetWeight(..., fxRate)` helper; `Rows.tsx` also passed the wrong price bucket when the holdings view toggle sat on TRADE — fixed, same `deriveTradeToPortfolioFxRate` pattern as ActionsMenu.

Known type drift NOT fixed here (belongs to #1157): `CommitExecutionRequest.brokerId`, `ExecutionItemUpdate.quantity/price`, `CreateExecutionRequest.allocationMethod`, `UpdateExecutionRequest.cashDelta`. Follow-up candidate spotted: TargetWeightDialog's "Required Shares" money line still multiplies native price × portfolio-currency symbol (pre-existing).

267 suites / 2633 tests green; prettier/lint/typecheck clean; ocr findings addressed. Component-tested, not browser-clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kWgaWpybSCajCzVQZdiPk