### PR TITLE
fix(trns): settle income and expense in the cash account they were recorded on

### DIFF
--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -52,6 +52,7 @@ import {
   buildCreateModeValues,
   buildAllCashBalances,
   buildDefaultCashAsset,
+  resolveSelfSettleAccount,
   resolveBrokerSettlementAccount,
   brokerHasSettlementForCurrency,
   resolveSellableQuantity,
@@ -617,6 +618,19 @@ const TradeInputForm: React.FC<{
     [filteredCashAssets, currentTradeCurrency],
   )
 
+  // Money recorded against a cash account belongs in that account — interest
+  // paid into IBRK-USD settles there, not in the generic USD balance.
+  const selfSettleAccount = useMemo(
+    () =>
+      resolveSelfSettleAccount({
+        assetId: transaction?.asset.id ?? initialValues?.assetId,
+        accounts: allBankAccounts as any[],
+      }),
+    [transaction?.asset.id, initialValues?.assetId, allBankAccounts],
+  )
+
+  const preferredCashAsset = selfSettleAccount ?? defaultCashAsset
+
   // Cash assets for dropdown - all currency balances are already included
   const cashAssetsForDropdown = useMemo(() => {
     return allCashBalances
@@ -643,9 +657,9 @@ const TradeInputForm: React.FC<{
       !currentSettlement?.value ||
       currentSettlement.currency !== currentTradeCurrency
     ) {
-      setValue("settlementAccount", defaultCashAsset)
+      setValue("settlementAccount", preferredCashAsset)
     }
-  }, [currentTradeCurrency, defaultCashAsset, setValue, watch, brokers])
+  }, [currentTradeCurrency, preferredCashAsset, setValue, watch, brokers])
 
   // Watch brokerId for auto-selecting settlement account
   const selectedBrokerId = watch("brokerId")
@@ -1413,7 +1427,7 @@ const TradeInputForm: React.FC<{
               {activeTab === "settlement" && (
                 <div className="space-y-4">
                   {/* Settlement Account */}
-                  <div>
+                  <div data-testid="settlement-account">
                     <label className={labelClass}>
                       {isIncome
                         ? "Credit To Account"
@@ -1435,7 +1449,7 @@ const TradeInputForm: React.FC<{
                       }
                       trnType={type?.value || "BUY"}
                       tradeCurrency={currentTradeCurrency}
-                      defaultValue={defaultCashAsset}
+                      defaultValue={preferredCashAsset}
                     />
                   </div>
 

--- a/src/components/features/transactions/TradeInputForm.tsx
+++ b/src/components/features/transactions/TradeInputForm.tsx
@@ -653,13 +653,29 @@ const TradeInputForm: React.FC<{
       return // Don't override broker's settlement account
     }
 
+    // The accounts list arrives after the first render, so the field may already
+    // hold the currency balance this effect seeded a moment ago. That seeded
+    // value has to give way once a better default is known — a value the user
+    // actually chose does not (the effect only re-runs when a default changes).
+    const holdsSeededDefault =
+      currentSettlement?.value === defaultCashAsset.value
+
     if (
       !currentSettlement?.value ||
-      currentSettlement.currency !== currentTradeCurrency
+      currentSettlement.currency !== currentTradeCurrency ||
+      (holdsSeededDefault &&
+        preferredCashAsset.value !== currentSettlement.value)
     ) {
       setValue("settlementAccount", preferredCashAsset)
     }
-  }, [currentTradeCurrency, preferredCashAsset, setValue, watch, brokers])
+  }, [
+    currentTradeCurrency,
+    preferredCashAsset,
+    defaultCashAsset,
+    setValue,
+    watch,
+    brokers,
+  ])
 
   // Watch brokerId for auto-selecting settlement account
   const selectedBrokerId = watch("brokerId")

--- a/src/components/features/transactions/__tests__/TradeInputForm.settlement.test.tsx
+++ b/src/components/features/transactions/__tests__/TradeInputForm.settlement.test.tsx
@@ -1,0 +1,130 @@
+import React from "react"
+import { render, screen, fireEvent, within } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import TradeInputForm from "../TradeInputForm"
+import { makePortfolio, USD } from "@test-fixtures/beancounter"
+
+// Recording income or an expense *against* a cash account (interest paid into
+// IBRK-USD, a fee taken out of it) settles in that account. Defaulting to the
+// generic "USD Cash" balance credits money somewhere the user never chose, and
+// leaves the holding they were looking at flat.
+
+const ibrkUsd = {
+  id: "acct-ibrk-usd",
+  code: "IBRK-USD",
+  name: "IBRK-USD",
+  market: { code: "PRIVATE", currency: { code: "USD" } },
+  assetCategory: { id: "ACCOUNT", name: "Account" },
+  accountingType: { currency: { code: "USD" } },
+}
+
+const apartment = {
+  id: "asset-apt",
+  code: "APT",
+  name: "Apartment",
+  market: { code: "PRIVATE", currency: { code: "USD" } },
+  assetCategory: { id: "RE", name: "Real Estate" },
+}
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    const empty = { data: undefined, error: undefined, isLoading: false }
+    if (!key) return empty
+    if (key.includes("category=ACCOUNT"))
+      return {
+        data: { data: { "acct-ibrk-usd": ibrkUsd } },
+        error: undefined,
+        isLoading: false,
+      }
+    if (key.includes("currencies"))
+      return {
+        data: { data: [{ code: "USD" }] },
+        error: undefined,
+        isLoading: false,
+      }
+    if (key.includes("markets"))
+      return {
+        data: {
+          data: [{ code: "NASDAQ", name: "NASDAQ", currency: { code: "USD" } }],
+        },
+        error: undefined,
+        isLoading: false,
+      }
+    return { data: { data: [] }, error: undefined, isLoading: false }
+  },
+  mutate: jest.fn(),
+}))
+
+jest.mock("@contexts/UserPreferencesContext", () => ({
+  useUserPreferences: () => ({
+    preferences: { id: "u1" },
+    isLoading: false,
+    refetch: jest.fn(),
+  }),
+}))
+
+jest.mock("@components/features/assets/AssetSearch", () => ({
+  __esModule: true,
+  default: () => <input aria-label="Asset" readOnly />,
+}))
+
+const portfolio = makePortfolio({
+  marketValue: 10000,
+  currency: USD,
+  base: USD,
+})
+
+const recordAgainst = (
+  asset: { id: string; code: string },
+  type: "INCOME" | "EXPENSE",
+): void => {
+  render(
+    <TradeInputForm
+      portfolio={portfolio}
+      modalOpen={true}
+      setModalOpen={jest.fn()}
+      initialValues={
+        {
+          asset: asset.code,
+          assetId: asset.id,
+          market: "PRIVATE",
+          quantity: 0,
+          price: 0,
+          currency: "USD",
+          type,
+        } as never
+      }
+    />,
+  )
+  fireEvent.click(screen.getByRole("button", { name: "Settlement" }))
+}
+
+const settlement = (): HTMLElement => screen.getByTestId("settlement-account")
+
+describe("TradeInputForm — settlement default", () => {
+  test("income on a cash account is credited to that account", () => {
+    recordAgainst(ibrkUsd, "INCOME")
+
+    expect(within(settlement()).getByText("Credit To Account")).toBeVisible()
+    expect(within(settlement()).getByText("IBRK-USD (USD)")).toBeVisible()
+  })
+
+  test("an expense on a cash account is debited from that account", () => {
+    recordAgainst(ibrkUsd, "EXPENSE")
+
+    expect(within(settlement()).getByText("Debit From Account")).toBeVisible()
+    expect(within(settlement()).getByText("IBRK-USD (USD)")).toBeVisible()
+  })
+
+  test("an expense on a property still comes out of a cash balance", () => {
+    // Only cash-like assets settle to themselves — property maintenance has to
+    // be paid from real money, never booked against the property itself.
+    recordAgainst(apartment, "EXPENSE")
+
+    expect(within(settlement()).getByText("USD")).toBeVisible()
+    expect(
+      within(settlement()).queryByText("IBRK-USD (USD)"),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/features/transactions/__tests__/TradeInputForm.settlement.test.tsx
+++ b/src/components/features/transactions/__tests__/TradeInputForm.settlement.test.tsx
@@ -26,6 +26,10 @@ const apartment = {
   assetCategory: { id: "RE", name: "Real Estate" },
 }
 
+// The accounts list arrives from SWR, so the dialog renders once before it is
+// known which assets are cash accounts. Flipping this mirrors that second pass.
+let accountsLoaded = true
+
 jest.mock("swr", () => ({
   __esModule: true,
   default: (key: string | null) => {
@@ -33,9 +37,11 @@ jest.mock("swr", () => ({
     if (!key) return empty
     if (key.includes("category=ACCOUNT"))
       return {
-        data: { data: { "acct-ibrk-usd": ibrkUsd } },
+        data: accountsLoaded
+          ? { data: { "acct-ibrk-usd": ibrkUsd } }
+          : undefined,
         error: undefined,
-        isLoading: false,
+        isLoading: !accountsLoaded,
       }
     if (key.includes("currencies"))
       return {
@@ -75,34 +81,62 @@ const portfolio = makePortfolio({
   base: USD,
 })
 
+const dialogFor = (
+  asset: { id: string; code: string },
+  type: "INCOME" | "EXPENSE",
+): React.ReactElement => (
+  <TradeInputForm
+    portfolio={portfolio}
+    modalOpen={true}
+    setModalOpen={jest.fn()}
+    initialValues={
+      {
+        asset: asset.code,
+        assetId: asset.id,
+        market: "PRIVATE",
+        quantity: 0,
+        price: 0,
+        currency: "USD",
+        type,
+      } as never
+    }
+  />
+)
+
 const recordAgainst = (
   asset: { id: string; code: string },
   type: "INCOME" | "EXPENSE",
-): void => {
-  render(
-    <TradeInputForm
-      portfolio={portfolio}
-      modalOpen={true}
-      setModalOpen={jest.fn()}
-      initialValues={
-        {
-          asset: asset.code,
-          assetId: asset.id,
-          market: "PRIVATE",
-          quantity: 0,
-          price: 0,
-          currency: "USD",
-          type,
-        } as never
-      }
-    />,
-  )
+): ReturnType<typeof render> => {
+  const view = render(dialogFor(asset, type))
   fireEvent.click(screen.getByRole("button", { name: "Settlement" }))
+  return view
 }
 
 const settlement = (): HTMLElement => screen.getByTestId("settlement-account")
 
 describe("TradeInputForm — settlement default", () => {
+  beforeEach(() => {
+    accountsLoaded = true
+  })
+
+  test("the account wins once the accounts list arrives", () => {
+    // The dialog opens before /assets?category=ACCOUNT resolves, so the first
+    // pass can only offer the currency balance. Once the accounts land the
+    // seeded default has to give way — otherwise the fix only works when the
+    // list happens to be cached.
+    accountsLoaded = false
+    // One element, rendered twice: the dialog's own props never change while
+    // SWR fills in — re-creating them would reset the form and hide the race.
+    const dialog = dialogFor(ibrkUsd, "INCOME")
+    const { rerender } = render(dialog)
+
+    accountsLoaded = true
+    rerender(dialog)
+    fireEvent.click(screen.getByRole("button", { name: "Settlement" }))
+
+    expect(within(settlement()).getByText("IBRK-USD (USD)")).toBeVisible()
+  })
+
   test("income on a cash account is credited to that account", () => {
     recordAgainst(ibrkUsd, "INCOME")
 

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -483,7 +483,7 @@ export const resolveSelfSettleAccount = (params: {
   const currency = getAssetCurrency(account)
   return {
     value: account.id,
-    label: `${account.name || getDisplayCode(account as never)} (${currency || "?"})`,
+    label: `${account.name || stripOwnerPrefix(account.code)} (${currency || "?"})`,
     currency,
     market: account.market?.code || "PRIVATE",
   }

--- a/src/lib/utils/trns/tradeFormHelpers.ts
+++ b/src/lib/utils/trns/tradeFormHelpers.ts
@@ -465,6 +465,31 @@ export const buildDefaultCashAsset = (
 }
 
 /**
+ * A cash movement recorded *against* a cash account — interest into IBRK-USD,
+ * a fee out of it — settles in that account. Returns the trade asset as a
+ * settlement option when it is one of the user's cash accounts, otherwise null
+ * so the caller falls back to the currency's cash balance. svc-data applies the
+ * same rule server-side (`TrnInputMapper.selfSettleAsset`); this keeps the
+ * dialog honest about where the money is going before it is submitted.
+ */
+export const resolveSelfSettleAccount = (params: {
+  assetId?: string
+  accounts: AssetLike[]
+}): SettlementAccountOption | null => {
+  const { assetId, accounts } = params
+  if (!assetId) return null
+  const account = accounts.find((a) => a.id === assetId)
+  if (!account) return null
+  const currency = getAssetCurrency(account)
+  return {
+    value: account.id,
+    label: `${account.name || getDisplayCode(account as never)} (${currency || "?"})`,
+    currency,
+    market: account.market?.code || "PRIVATE",
+  }
+}
+
+/**
  * Resolve the settlement account for a broker and trade currency.
  * Looks up the broker's settlement mapping, then finds the matching bank account.
  * Falls back to the broker's first settlement account if no currency-specific match.


### PR DESCRIPTION
## Problem

"Record Income" / "Record Expense" on a cash holding (e.g. `IBRK-USD`) opened the
trade dialog with the settlement select defaulted to the currency's generic cash
balance. Submitting sent that account explicitly, so the interest landed in
"USD Cash" and the account it was recorded against stayed flat.

## Change

- `resolveSelfSettleAccount` returns the trade asset as the settlement option when
  it is one of the user's cash accounts; `TradeInputForm` prefers it over the
  currency default, for the select's value and its `defaultValue`.
- The accounts list arrives from SWR *after* the first render, so the seeding effect
  now replaces a value it set itself once a better default is known — a value the
  user picked is still left alone.

Non-cash assets are untouched: a property expense still settles from real cash.

## Tests

`TradeInputForm.settlement.test.tsx` — income and expense on a cash account credit /
debit that account; a property expense still uses the cash balance; and the account
wins once the accounts list arrives late (this one failed before the second commit).

`yarn test` (2637), `yarn prettier`, `yarn lint`, `yarn typecheck` green. `ocr review`
findings both addressed.

Backend counterpart: beancounter #1092 applies the same rule server-side, so a
caller that omits `cashAssetId` lands in the same account.
