### PR TITLE
fix(rebalance): resolve broker settlement on commit, gate on plan status, surface failures

### DIFF
--- a/__tests__/components/features/rebalance/execution/InvestCashDialog.test.tsx
+++ b/__tests__/components/features/rebalance/execution/InvestCashDialog.test.tsx
@@ -143,3 +143,34 @@ describe("InvestCashDialog price editing", () => {
     expect(priceInput().value).toBe("12")
   })
 })
+
+// --- Commit request body shape (#1157) ---
+describe("InvestCashDialog commit request", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: execution }),
+    }) as unknown as typeof fetch
+  })
+
+  it("posts a CommitExecutionRequest body with no stray keys when no broker is selected", async () => {
+    const user = userEvent.setup()
+    await goToPreview(user)
+
+    await user.click(screen.getByText(/Create Proposed/))
+
+    await waitFor(() => {
+      const commitCall = (global.fetch as jest.Mock).mock.calls.find(
+        ([url, opts]: [string, RequestInit]) =>
+          url === "/api/rebalance/executions/exec-1/commit" &&
+          opts?.method === "POST",
+      )
+      expect(commitCall).toBeDefined()
+      const body = JSON.parse(commitCall![1].body as string)
+      expect(body).toEqual({
+        portfolioId: "p1",
+        transactionStatus: "PROPOSED",
+      })
+    })
+  })
+})

--- a/__tests__/components/features/rebalance/execution/SelectPlanDialog.test.tsx
+++ b/__tests__/components/features/rebalance/execution/SelectPlanDialog.test.tsx
@@ -1,0 +1,139 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import SelectPlanDialog from "@components/features/rebalance/execution/SelectPlanDialog"
+import { ModelDto, PlanDto } from "types/rebalance"
+
+const models: ModelDto[] = [
+  {
+    id: "model-1",
+    name: "Growth",
+    baseCurrency: "USD",
+    risk: 3,
+    shared: false,
+    isOwner: true,
+    planCount: 1,
+    createdAt: "2025-01-01",
+    updatedAt: "2025-01-01",
+    currentPlanId: "plan-1",
+    currentPlanVersion: 1,
+    currentPlanStatus: "APPROVED",
+  },
+]
+
+const plan: PlanDto = {
+  id: "plan-1",
+  modelId: "model-1",
+  modelName: "Growth",
+  version: 1,
+  status: "APPROVED",
+  assets: [],
+  cashWeight: 0,
+  createdAt: "2025-01-01",
+  updatedAt: "2025-01-01",
+}
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (key === "/api/rebalance/models") return { data: { data: models } }
+    return { data: undefined }
+  },
+}))
+
+const renderDialog = (
+  overrides: Partial<React.ComponentProps<typeof SelectPlanDialog>> = {},
+): {
+  onSelectPlan: jest.Mock
+  onClose: jest.Mock
+  onCreateNew: jest.Mock
+} => {
+  const onSelectPlan = jest.fn()
+  const onClose = jest.fn()
+  const onCreateNew = jest.fn()
+  render(
+    <SelectPlanDialog
+      modalOpen={true}
+      portfolioId="p1"
+      onClose={onClose}
+      onSelectPlan={onSelectPlan}
+      onCreateNew={onCreateNew}
+      {...overrides}
+    />,
+  )
+  return { onSelectPlan, onClose, onCreateNew }
+}
+
+describe("SelectPlanDialog — fetch failure surfacing (#1157)", () => {
+  it("shows a visible error when the approved-plan fetch responds not-ok, instead of silently doing nothing", async () => {
+    const user = userEvent.setup()
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ message: "Server error" }),
+    }) as unknown as typeof fetch
+    const { onSelectPlan } = renderDialog()
+
+    await user.click(screen.getByText("Growth"))
+
+    expect(await screen.findByText("Server error")).toBeInTheDocument()
+    expect(onSelectPlan).not.toHaveBeenCalled()
+  })
+
+  it("shows a visible error when the approved-plan fetch throws (network failure)", async () => {
+    const user = userEvent.setup()
+    global.fetch = jest
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Network down"),
+      ) as unknown as typeof fetch
+    const { onSelectPlan } = renderDialog()
+
+    await user.click(screen.getByText("Growth"))
+
+    expect(await screen.findByText(/Network down/i)).toBeInTheDocument()
+    expect(onSelectPlan).not.toHaveBeenCalled()
+  })
+
+  it("clears a previous error and proceeds normally when the retry succeeds", async () => {
+    const user = userEvent.setup()
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ message: "Server error" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: plan }),
+      }) as unknown as typeof fetch
+    const { onSelectPlan } = renderDialog()
+
+    await user.click(screen.getByText("Growth"))
+    expect(await screen.findByText("Server error")).toBeInTheDocument()
+
+    await user.click(screen.getByText("Growth"))
+
+    await waitFor(() =>
+      expect(onSelectPlan).toHaveBeenCalledWith(models[0], plan, false),
+    )
+    expect(screen.queryByText("Server error")).not.toBeInTheDocument()
+  })
+
+  it("success path is unchanged: onSelectPlan is called with the fetched plan", async () => {
+    const user = userEvent.setup()
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: plan }),
+    }) as unknown as typeof fetch
+    const { onSelectPlan } = renderDialog()
+
+    await user.click(screen.getByText("Growth"))
+
+    await waitFor(() =>
+      expect(onSelectPlan).toHaveBeenCalledWith(models[0], plan, false),
+    )
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument()
+  })
+})

--- a/__tests__/pages/rebalance/models/[modelId]/plans/planId.test.tsx
+++ b/__tests__/pages/rebalance/models/[modelId]/plans/planId.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 // Controllable router mock — mimics Next.js Pages Router behaviour where, on
@@ -219,5 +219,126 @@ describe("/rebalance/models/[modelId]/plans/[planId] — Copy allocations", () =
 
     expect(writeText).not.toHaveBeenCalled()
     expect(screen.queryByLabelText("Narrative")).not.toBeInTheDocument()
+  })
+})
+
+describe("/rebalance/models/[modelId]/plans/[planId] — Save error surfacing (#1157)", () => {
+  // DRAFT (so the Save/Approve/Delete action row renders at all) and its
+  // weights deliberately don't sum to 100%, so the "Normalize to 100%"
+  // affordance is visible immediately — the simplest UI path to a dirty
+  // (hasChanges=true) plan without driving MathInput keystroke-by-keystroke.
+  const draftPlan = {
+    ...plan,
+    status: "DRAFT",
+    approvedAt: undefined,
+    // 0.5 + 0.465 = 96.5%, not 100%.
+    assets: [
+      { ...plan.assets[0], weight: 0.5 },
+      { ...plan.assets[1], weight: 0.465 },
+    ],
+  }
+
+  function draftSwrByKey(key: unknown): ReturnType<typeof useSwr> {
+    if (!key) return idle as unknown as ReturnType<typeof useSwr>
+    const k = String(key)
+    if (k.endsWith("/plans/plan-1")) {
+      return { ...idle, data: { data: draftPlan } } as unknown as ReturnType<
+        typeof useSwr
+      >
+    }
+    if (k.endsWith("/models/model-1")) {
+      return { ...idle, data: { data: model } } as unknown as ReturnType<
+        typeof useSwr
+      >
+    }
+    if (k.endsWith("/plans")) {
+      return { ...idle, data: { data: [draftPlan] } } as unknown as ReturnType<
+        typeof useSwr
+      >
+    }
+    return idle as unknown as ReturnType<typeof useSwr>
+  }
+
+  beforeEach(() => {
+    mockUseSwr.mockReset()
+    mockUseSwr.mockImplementation((key: unknown) => draftSwrByKey(key))
+    routerState.isReady = true
+    routerState.query = { modelId: "model-1", planId: "plan-1" }
+    global.fetch = jest.fn()
+  })
+
+  const makeDirty = async (
+    user: ReturnType<typeof userEvent.setup>,
+  ): Promise<void> => {
+    await user.click(screen.getByText("Normalize to 100%"))
+    expect(await screen.findByRole("button", { name: /Save/i })).toBeVisible()
+  }
+
+  test("shows a visible error when the save PUT responds not-ok, instead of silently doing nothing", async () => {
+    const { default: PlanDetailPage } =
+      await import("../../../../../../src/pages/rebalance/models/[modelId]/plans/[planId]")
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("boom"),
+    })
+
+    const user = userEvent.setup()
+    render(<PlanDetailPage />)
+    await screen.findByText("Target Allocations")
+
+    await makeDirty(user)
+    await user.click(screen.getByRole("button", { name: /Save/i }))
+
+    expect(await screen.findByText(/Save failed/i)).toBeInTheDocument()
+  })
+
+  test("clears a previous save error and succeeds on retry", async () => {
+    const { default: PlanDetailPage } =
+      await import("../../../../../../src/pages/rebalance/models/[modelId]/plans/[planId]")
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("boom"),
+      })
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve("") })
+
+    const user = userEvent.setup()
+    render(<PlanDetailPage />)
+    await screen.findByText("Target Allocations")
+
+    await makeDirty(user)
+    await user.click(screen.getByRole("button", { name: /Save/i }))
+    expect(await screen.findByText(/Save failed/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /Save/i }))
+
+    await waitFor(() =>
+      expect(screen.queryByText(/Save failed/i)).not.toBeInTheDocument(),
+    )
+  })
+
+  test("success path is unchanged: a successful save clears hasChanges (Save button disappears)", async () => {
+    const { default: PlanDetailPage } =
+      await import("../../../../../../src/pages/rebalance/models/[modelId]/plans/[planId]")
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(""),
+    })
+
+    const user = userEvent.setup()
+    render(<PlanDetailPage />)
+    await screen.findByText("Target Allocations")
+
+    await makeDirty(user)
+    await user.click(screen.getByRole("button", { name: /Save/i }))
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /Save/i }),
+      ).not.toBeInTheDocument(),
+    )
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument()
   })
 })

--- a/src/components/features/rebalance/execution/InvestCashDialog.tsx
+++ b/src/components/features/rebalance/execution/InvestCashDialog.tsx
@@ -19,6 +19,8 @@ import {
   ModelDto,
   ExecutionDto,
   ExecutionItemDto,
+  ExecutionItemUpdate,
+  CommitExecutionRequest,
   PlanDto,
 } from "types/rebalance"
 import { BrokerWithAccounts } from "types/beancounter"
@@ -251,7 +253,7 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
     try {
       // Only send updates if user made edits
       if (Object.keys(itemEdits).length > 0) {
-        const itemUpdates = buyItems
+        const itemUpdates: ExecutionItemUpdate[] = buyItems
           .filter((item) => itemEdits[item.assetId])
           .map((item) => ({
             assetId: item.assetId,
@@ -287,17 +289,18 @@ const InvestCashDialog: React.FC<InvestCashDialogProps> = ({
         }) ?? undefined
 
       // Commit to create transactions
+      const commitRequest: CommitExecutionRequest = {
+        portfolioId,
+        transactionStatus,
+        brokerId: selectedBrokerId,
+        cashAssetId,
+      }
       const response = await fetch(
         `/api/rebalance/executions/${execution.id}/commit`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            portfolioId: portfolioId,
-            transactionStatus,
-            brokerId: selectedBrokerId,
-            cashAssetId,
-          }),
+          body: JSON.stringify(commitRequest),
         },
       )
 

--- a/src/components/features/rebalance/execution/SelectPlanDialog.tsx
+++ b/src/components/features/rebalance/execution/SelectPlanDialog.tsx
@@ -22,6 +22,7 @@ const SelectPlanDialog: React.FC<SelectPlanDialogProps> = ({
   const [selectedModelId, setSelectedModelId] = useState<string | null>(null)
   const [loadingPlan, setLoadingPlan] = useState(false)
   const [filterByModel, setFilterByModel] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   // Fetch models with an approved current plan
   const { approvedModels: modelsWithApprovedPlans, isLoading: loadingModels } =
@@ -32,6 +33,7 @@ const SelectPlanDialog: React.FC<SelectPlanDialogProps> = ({
 
     setSelectedModelId(model.id)
     setLoadingPlan(true)
+    setError(null)
 
     try {
       // Fetch the approved plan
@@ -41,9 +43,17 @@ const SelectPlanDialog: React.FC<SelectPlanDialogProps> = ({
       if (response.ok) {
         const planData = await response.json()
         onSelectPlan(model, planData.data, filterByModel)
+      } else {
+        const errorData = await response.json().catch(() => ({}))
+        setError(
+          typeof errorData.message === "string"
+            ? errorData.message
+            : `Failed to load plan: ${response.status}`,
+        )
       }
     } catch (err) {
       console.error("Failed to fetch plan:", err)
+      setError(err instanceof Error ? err.message : "Failed to fetch plan")
     } finally {
       setLoadingPlan(false)
       setSelectedModelId(null)
@@ -60,6 +70,8 @@ const SelectPlanDialog: React.FC<SelectPlanDialogProps> = ({
       scrollable={true}
       footer={<Dialog.CancelButton onClick={onClose} label={"Cancel"} />}
     >
+      <Dialog.ErrorAlert message={error} />
+
       <p className="text-sm text-gray-600 mb-4">
         {
           "Choose an approved model plan to rebalance against, or create a new model from your current holdings."

--- a/src/components/features/rebalance/hooks/__tests__/useApprovedModels.test.ts
+++ b/src/components/features/rebalance/hooks/__tests__/useApprovedModels.test.ts
@@ -1,6 +1,30 @@
+import React from "react"
 import { renderHook, waitFor } from "@testing-library/react"
+import { SWRConfig } from "swr"
 import { ModelDto } from "types/rebalance"
-import { useApprovedModels } from "../useApprovedModels"
+import {
+  useApprovedModels,
+  UseApprovedModelsResult,
+} from "../useApprovedModels"
+
+// We don't mock `swr` in this file (real SWR runtime resolves the fetcher),
+// so it keeps its normal global cache keyed by `modelsKey` — shared across
+// tests in this file by default. Give each render its own fresh cache
+// (established pattern — see ScenarioContributions.fetcher.test.tsx /
+// OpenBrokerageWizard.test.tsx) so one test's fetch response can't leak
+// into the next test's read of the same key.
+function renderWithFreshSwrCache(
+  enabled: boolean,
+): ReturnType<typeof renderHook<UseApprovedModelsResult, unknown>> {
+  return renderHook(() => useApprovedModels(enabled), {
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        SWRConfig,
+        { value: { provider: () => new Map(), dedupingInterval: 0 } },
+        children,
+      ),
+  })
+}
 
 function makeModel(overrides: Partial<ModelDto> = {}): ModelDto {
   return {
@@ -25,7 +49,7 @@ describe("useApprovedModels", () => {
     global.fetch = mockFetch
   })
 
-  it("filters to models with both currentPlanId and currentPlanVersion set (verbatim gate)", async () => {
+  it("filters to models with a currentPlanId and status APPROVED", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: () =>
@@ -34,16 +58,23 @@ describe("useApprovedModels", () => {
             makeModel({
               id: "approved",
               currentPlanId: "p1",
-              currentPlanVersion: 2,
+              currentPlanStatus: "APPROVED",
             }),
             makeModel({ id: "no-plan-at-all" }),
-            makeModel({ id: "id-without-version", currentPlanId: "p2" }),
-            makeModel({ id: "version-without-id", currentPlanVersion: 1 }),
+            makeModel({
+              id: "draft-status",
+              currentPlanId: "p2",
+              currentPlanStatus: "DRAFT",
+            }),
+            makeModel({
+              id: "status-without-id",
+              currentPlanStatus: "APPROVED",
+            }),
           ],
         }),
     })
 
-    const { result } = renderHook(() => useApprovedModels(true))
+    const { result } = renderWithFreshSwrCache(true)
 
     await waitFor(() => {
       expect(result.current.approvedModels.map((m) => m.id)).toEqual([
@@ -53,8 +84,74 @@ describe("useApprovedModels", () => {
     expect(result.current.models).toHaveLength(4)
   })
 
+  it("excludes a model whose currentPlanId points at a DRAFT plan", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            makeModel({
+              id: "draft",
+              currentPlanId: "p1",
+              currentPlanStatus: "DRAFT",
+            }),
+          ],
+        }),
+    })
+
+    const { result } = renderWithFreshSwrCache(true)
+
+    await waitFor(() => expect(result.current.models).toHaveLength(1))
+    expect(result.current.approvedModels).toEqual([])
+  })
+
+  // Backward compatibility: currentPlanStatus is a newer field
+  // (svc-rebalance #55). A model from a stale cache/older backend response
+  // that predates it carries currentPlanId but no currentPlanStatus at all —
+  // treat that as approved rather than hiding the model, since the backend
+  // has only ever pointed currentPlanId at an APPROVED plan.
+  it("treats a missing currentPlanStatus as approved (backward compatible with a stale cache)", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [makeModel({ id: "legacy", currentPlanId: "p1" })],
+        }),
+    })
+
+    const { result } = renderWithFreshSwrCache(true)
+
+    await waitFor(() => {
+      expect(result.current.approvedModels.map((m) => m.id)).toEqual(["legacy"])
+    })
+  })
+
+  // Strict equality only — no `!== "DRAFT"` catch-all that would silently
+  // trust a future/unexpected status this client doesn't know about yet.
+  it("does not treat an unexpected status value (e.g. ARCHIVED) as approved", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            makeModel({
+              id: "archived",
+              currentPlanId: "p1",
+              currentPlanStatus:
+                "ARCHIVED" as unknown as ModelDto["currentPlanStatus"],
+            }),
+          ],
+        }),
+    })
+
+    const { result } = renderWithFreshSwrCache(true)
+
+    await waitFor(() => expect(result.current.models).toHaveLength(1))
+    expect(result.current.approvedModels).toEqual([])
+  })
+
   it("does not fetch, and returns empty results, when disabled", () => {
-    const { result } = renderHook(() => useApprovedModels(false))
+    const { result } = renderWithFreshSwrCache(false)
 
     expect(mockFetch).not.toHaveBeenCalled()
     expect(result.current.approvedModels).toEqual([])

--- a/src/components/features/rebalance/hooks/useApprovedModels.ts
+++ b/src/components/features/rebalance/hooks/useApprovedModels.ts
@@ -4,11 +4,33 @@ import { ModelDto } from "types/rebalance"
 
 export interface UseApprovedModelsResult {
   models: ModelDto[]
-  /** Models with an approved current plan. Filter kept verbatim
-   *  (`currentPlanId && currentPlanVersion`) — a later PR switches this to
-   *  plan status. */
+  /** Models with a current plan that is actually APPROVED (#1157) — see
+   *  {@link isPlanApproved} for the gate. */
   approvedModels: ModelDto[]
   isLoading: boolean
+}
+
+/**
+ * Whether `model`'s current plan is approved and safe to build an execution
+ * against (#1157) — gated on plan *status*, not merely the presence of a
+ * currentPlanId/Version. `currentPlanId` is still required (a status with
+ * no id is useless). A missing `currentPlanStatus` (stale cache predating
+ * svc-rebalance #55) is treated as approved rather than hiding/blocking —
+ * the backend has only ever pointed `currentPlanId` at an APPROVED plan, so
+ * an absent field can't represent a DRAFT plan today. Any OTHER value
+ * (including a future/unexpected status this client doesn't yet know
+ * about) is deliberately NOT treated as approved — strict equality only,
+ * no `!== "DRAFT"` catch-all that would silently trust it. Single source of
+ * truth shared by useApprovedModels (below) and RebalanceWizardContainer's
+ * hasApprovedPlan, so the two never drift apart.
+ */
+export function isPlanApproved(model: ModelDto): boolean {
+  return (
+    Boolean(model.currentPlanId) &&
+    (model.currentPlanStatus === "APPROVED" ||
+      model.currentPlanStatus === null ||
+      model.currentPlanStatus === undefined)
+  )
 }
 
 /**
@@ -23,8 +45,6 @@ export function useApprovedModels(enabled: boolean): UseApprovedModelsResult {
     simpleFetcher(modelsKey),
   )
   const models: ModelDto[] = data?.data || []
-  const approvedModels = models.filter(
-    (m) => m.currentPlanId && m.currentPlanVersion,
-  )
+  const approvedModels = models.filter(isPlanApproved)
   return { models, approvedModels, isLoading }
 }

--- a/src/components/features/rebalance/wizard/RebalanceWizardContainer.tsx
+++ b/src/components/features/rebalance/wizard/RebalanceWizardContainer.tsx
@@ -11,15 +11,34 @@ import ReviewStep from "./steps/ReviewStep"
 import {
   ModelDto,
   RebalanceScenario,
+  ExecutionMode,
   CreatePlanRequest,
   CreateExecutionRequest,
 } from "types/rebalance"
 import { PortfolioResponses } from "types/beancounter"
 import { portfoliosKey, simpleFetcher } from "@utils/api/fetchHelper"
 import { useDialogSubmit } from "@hooks/useDialogSubmit"
+import { isPlanApproved } from "@components/features/rebalance/hooks/useApprovedModels"
 
 interface RebalanceWizardContainerProps {
   preselectedPortfolioIds?: string[]
+}
+
+// RebalanceScenario ("INVEST_CASH" | "REBALANCE") happens to be a subset of
+// ExecutionMode's members ("REBALANCE" | "INVEST_CASH" | "AD_HOC"), so a bare
+// `mode: scenario` assignment type-checks today — but only because the two
+// unions currently overlap by coincidence. An explicit map means a future
+// change to either type (e.g. ExecutionMode losing a member, or
+// RebalanceScenario gaining one this map doesn't cover) fails to compile
+// here instead of silently relying on structural luck — the `Record<...>`
+// annotation makes TS enforce every RebalanceScenario key is present.
+const SCENARIO_TO_EXECUTION_MODE: Record<RebalanceScenario, ExecutionMode> = {
+  REBALANCE: "REBALANCE",
+  INVEST_CASH: "INVEST_CASH",
+}
+
+function toExecutionMode(scenario: RebalanceScenario): ExecutionMode {
+  return SCENARIO_TO_EXECUTION_MODE[scenario]
 }
 
 const RebalanceWizardContainer: React.FC<RebalanceWizardContainerProps> = ({
@@ -42,7 +61,13 @@ const RebalanceWizardContainer: React.FC<RebalanceWizardContainerProps> = ({
     handleSubmit: dialogSubmit,
   } = useDialogSubmit({ fallbackError: "Failed to complete wizard" })
 
-  const hasApprovedPlan = Boolean(selectedModel?.currentPlanId)
+  // Gate on plan *status*, not merely the presence of a currentPlanId
+  // (#1157) — a currentPlanId can point at a DRAFT plan, which isn't yet
+  // executable. Shared predicate (see isPlanApproved's own doc for the
+  // backward-compat/missing-status rationale) so this can never drift from
+  // useApprovedModels' gate.
+  const hasApprovedPlan =
+    selectedModel !== null && isPlanApproved(selectedModel)
 
   // Backs the cash-delta currency label in steps 3-4. The model's
   // baseCurrency is the primary source once one's selected; the fallback (for
@@ -116,23 +141,25 @@ const RebalanceWizardContainer: React.FC<RebalanceWizardContainerProps> = ({
       return
     }
 
-    // A model with an approved plan goes straight to an execution carrying
-    // the portfolios/scenario/cashDelta from steps 2-3. Without one, only a
-    // draft plan can be created — CreatePlanRequest has no home for those
-    // values; they apply at execution time, once the plan is approved.
+    // A model with an APPROVED current plan goes straight to an execution
+    // carrying the portfolios/scenario/cashDelta from steps 2-3. Without one
+    // (no plan at all, or the current plan is still DRAFT — see
+    // hasApprovedPlan above), only a draft plan can be created —
+    // CreatePlanRequest has no home for those values; they apply at
+    // execution time, once the plan is approved.
     const { currentPlanId, id: modelId } = selectedModel
     const target: {
       url: string
       payload: CreateExecutionRequest | CreatePlanRequest
       route: (id: string) => string
-    } = currentPlanId
+    } = hasApprovedPlan
       ? {
           url: "/api/rebalance/executions",
           payload: {
-            planId: currentPlanId,
+            planId: currentPlanId!,
             portfolioIds: selectedPortfolioIds,
             name: planName.trim(),
-            mode: scenario,
+            mode: toExecutionMode(scenario),
             cashDelta:
               scenario === "REBALANCE" ? cashDelta || undefined : undefined,
             investmentAmount:

--- a/src/components/features/rebalance/wizard/__tests__/RebalanceWizardContainer.test.tsx
+++ b/src/components/features/rebalance/wizard/__tests__/RebalanceWizardContainer.test.tsx
@@ -48,6 +48,32 @@ const testModelWithApprovedPlan: ModelDto = {
   currentPlanId: "plan-approved-1",
 }
 
+// Explicit currentPlanStatus: "APPROVED" — as opposed to
+// testModelWithApprovedPlan above, which omits the field entirely to cover
+// the backward-compatible "missing status" case.
+const testModelWithExplicitlyApprovedPlan: ModelDto = {
+  ...testModel,
+  id: "model-4",
+  currentPlanId: "plan-approved-2",
+  currentPlanStatus: "APPROVED",
+}
+
+const testModelWithDraftPlan: ModelDto = {
+  ...testModel,
+  id: "model-3",
+  currentPlanId: "plan-draft-1",
+  currentPlanStatus: "DRAFT",
+}
+
+// Unexpected status value this client doesn't know about — must NOT be
+// treated as approved (strict equality only, no `!== "DRAFT"` catch-all).
+const testModelWithArchivedPlan: ModelDto = {
+  ...testModel,
+  id: "model-5",
+  currentPlanId: "plan-archived-1",
+  currentPlanStatus: "ARCHIVED" as unknown as ModelDto["currentPlanStatus"],
+}
+
 // The wizard steps are exercised elsewhere (model list, portfolio picker,
 // scenario form) — stubbing them here keeps this test focused on the
 // container's own responsibility: building the create-plan/create-execution
@@ -281,6 +307,104 @@ describe("RebalanceWizardContainer submit", () => {
       })
 
       expect(mockPush).not.toHaveBeenCalled()
+    })
+  })
+
+  // --- Approved = plan status, not presence (#1157) ---
+  //
+  // hasApprovedPlan (button label + which endpoint handleSubmit posts to)
+  // must gate on currentPlanStatus, not merely on currentPlanId being set —
+  // a currentPlanId that points at a DRAFT plan is not yet executable.
+
+  describe("model with a DRAFT current plan", () => {
+    beforeEach(() => {
+      modelToSelect = testModelWithDraftPlan
+    })
+
+    it("shows Create Plan (not Start Execution) even though currentPlanId is set", () => {
+      driveToReview()
+
+      expect(screen.getByText("Create Plan")).toBeInTheDocument()
+      expect(screen.queryByText("Start Execution")).not.toBeInTheDocument()
+    })
+
+    it("posts to the per-model plans endpoint, not /api/rebalance/executions", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: "plan-99" } }),
+      })
+
+      driveToReview()
+      fireEvent.click(screen.getByText("Create Plan"))
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/rebalance/models/model-3/plans",
+          expect.objectContaining({ method: "POST" }),
+        )
+      })
+      expect(mockFetch).not.toHaveBeenCalledWith(
+        "/api/rebalance/executions",
+        expect.anything(),
+      )
+    })
+  })
+
+  describe("model with an unexpected (non-DRAFT, non-APPROVED) plan status", () => {
+    beforeEach(() => {
+      modelToSelect = testModelWithArchivedPlan
+    })
+
+    it("shows Create Plan (not Start Execution) — an unrecognized status is never treated as approved", () => {
+      driveToReview()
+
+      expect(screen.getByText("Create Plan")).toBeInTheDocument()
+      expect(screen.queryByText("Start Execution")).not.toBeInTheDocument()
+    })
+
+    it("posts to the per-model plans endpoint, not /api/rebalance/executions", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: "plan-100" } }),
+      })
+
+      driveToReview()
+      fireEvent.click(screen.getByText("Create Plan"))
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/rebalance/models/model-5/plans",
+          expect.objectContaining({ method: "POST" }),
+        )
+      })
+      expect(mockFetch).not.toHaveBeenCalledWith(
+        "/api/rebalance/executions",
+        expect.anything(),
+      )
+    })
+  })
+
+  describe("model with an explicitly APPROVED current plan", () => {
+    beforeEach(() => {
+      modelToSelect = testModelWithExplicitlyApprovedPlan
+    })
+
+    it("shows Start Execution and posts to /api/rebalance/executions", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: "execution-3" } }),
+      })
+
+      driveToReview({ scenarioButton: "set-scenario-rebalance" })
+      expect(screen.getByText("Start Execution")).toBeInTheDocument()
+      fireEvent.click(screen.getByText("Start Execution"))
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/rebalance/executions",
+          expect.objectContaining({ method: "POST" }),
+        )
+      })
     })
   })
 

--- a/src/hooks/__tests__/useRebalanceExecution.test.ts
+++ b/src/hooks/__tests__/useRebalanceExecution.test.ts
@@ -1447,6 +1447,127 @@ describe("useRebalanceExecution", () => {
   })
 })
 
+// --- Commit: broker settlement cash asset resolution (#1157) ---
+//
+// The execute-screen commit path must resolve cashAssetId the same way
+// InvestCashDialog does (resolveBrokerCashAssetId over brokers +
+// accountAssets), not omit it outright — otherwise broker-tagged trades
+// settle into the generic currency cash asset instead of the broker's own
+// settlement account.
+describe("commit: broker settlement cash asset resolution (#1157)", () => {
+  // This describe is a sibling of the main `describe("useRebalanceExecution")`
+  // block above, not nested inside it, so it does not inherit that block's
+  // beforeEach (mockUseSwr.mockReset / fresh global.fetch) — without its own
+  // reset here, global.fetch (and its mockResolvedValueOnce queue) would
+  // accumulate calls across these tests and findCommitCall() below could
+  // match a previous test's commit request instead of this test's own.
+  beforeEach(() => {
+    mockUseSwr.mockReset()
+    global.fetch = jest.fn()
+  })
+
+  const brokerWithUsdSettlement = {
+    id: "broker-1",
+    name: "IBKR",
+    settlementAccounts: [{ currencyCode: "USD", accountId: "cash-asset-usd" }],
+  }
+  // A second broker so a two-broker fixture never triggers the "exactly one
+  // broker" auto-select convenience — keeps selectedBrokerId under explicit
+  // test control.
+  const otherBroker = {
+    id: "broker-2",
+    name: "Schwab",
+    settlementAccounts: [],
+  }
+
+  const findCommitCall = (): [string, RequestInit] | undefined =>
+    (global.fetch as jest.Mock).mock.calls.find(
+      ([url, opts]: [string, RequestInit]) =>
+        url === "/api/rebalance/executions/exec-1/commit" &&
+        opts?.method === "POST",
+    )
+
+  it("includes the broker's resolved settlement cash asset when a broker with a matching account is selected", async () => {
+    setupSwrMocks({}, [brokerWithUsdSettlement, otherBroker])
+    const exec = makeExecution({ currency: "USD" })
+    const { result } = await renderWithExecution(
+      exec,
+      {},
+      {
+        ok: true,
+        data: { data: { transactionsCreated: 1, transactionIds: ["t1"] } },
+      },
+    )
+
+    act(() => {
+      result.current.setSelectedBrokerId("broker-1")
+    })
+
+    await act(async () => {
+      await result.current.handlers.commit()
+    })
+
+    const call = findCommitCall()
+    expect(call).toBeDefined()
+    const body = JSON.parse(call![1].body as string)
+    expect(body.cashAssetId).toBe("cash-asset-usd")
+    expect(body.brokerId).toBe("broker-1")
+  })
+
+  it("omits cashAssetId when no broker is selected", async () => {
+    setupSwrMocks({}, [brokerWithUsdSettlement, otherBroker])
+    const exec = makeExecution({ currency: "USD" })
+    const { result } = await renderWithExecution(
+      exec,
+      {},
+      {
+        ok: true,
+        data: { data: { transactionsCreated: 1, transactionIds: ["t1"] } },
+      },
+    )
+
+    await act(async () => {
+      await result.current.handlers.commit()
+    })
+
+    const call = findCommitCall()
+    expect(call).toBeDefined()
+    const body = JSON.parse(call![1].body as string)
+    expect(body).not.toHaveProperty("cashAssetId")
+  })
+
+  it("omits cashAssetId when the selected broker has no settlement account for the execution's currency", async () => {
+    // Two brokers (not one) so the "exactly one broker" auto-select
+    // convenience never fires — selectedBrokerId stays under this test's
+    // explicit control.
+    setupSwrMocks({}, [brokerWithUsdSettlement, otherBroker])
+    const exec = makeExecution({ currency: "EUR" })
+    const { result } = await renderWithExecution(
+      exec,
+      {},
+      {
+        ok: true,
+        data: { data: { transactionsCreated: 1, transactionIds: ["t1"] } },
+      },
+    )
+
+    act(() => {
+      result.current.setSelectedBrokerId("broker-1")
+    })
+
+    await act(async () => {
+      await result.current.handlers.commit()
+    })
+
+    const call = findCommitCall()
+    expect(call).toBeDefined()
+    const body = JSON.parse(call![1].body as string)
+    expect(body).not.toHaveProperty("cashAssetId")
+    // Broker is still tagged even though no settlement account matched.
+    expect(body.brokerId).toBe("broker-1")
+  })
+})
+
 // --- Characterization: mixed-currency client math ---
 //
 // `makeItem`/`makeExecution` already default `priceCurrency`/`currency` to

--- a/src/hooks/useRebalanceExecution.ts
+++ b/src/hooks/useRebalanceExecution.ts
@@ -1,13 +1,15 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react"
 import useSwr from "swr"
-import { simpleFetcher } from "@utils/api/fetchHelper"
+import { simpleFetcher, accountsKey } from "@utils/api/fetchHelper"
 import { toErrorMessage } from "@lib/formatters"
+import { resolveBrokerCashAssetId } from "@utils/trns/tradeFormHelpers"
 import {
   ExecutionDto,
   ExecutionItemDto,
   ExecutionItemUpdate,
+  CommitExecutionRequest,
 } from "types/rebalance"
-import { Broker, TrnStatus } from "types/beancounter"
+import { Asset, BrokerWithAccounts, TrnStatus } from "types/beancounter"
 import { TRN_STATUS } from "types/constants"
 
 // --- Public types ---
@@ -78,7 +80,7 @@ export interface UseRebalanceExecutionResult {
   displayItems: DisplayItem[]
   activeItems: DisplayItem[]
   cashSummary: CashSummary
-  brokers: Broker[]
+  brokers: BrokerWithAccounts[]
   selectedBrokerId: string | undefined
   setSelectedBrokerId: (id: string | undefined) => void
   states: {
@@ -188,12 +190,30 @@ export function useRebalanceExecution(
   // --- SWR data ---
 
   const { data: brokersData } = useSwr(
-    "/api/brokers",
-    simpleFetcher("/api/brokers"),
+    "/api/brokers?includeAccounts=true",
+    simpleFetcher("/api/brokers?includeAccounts=true"),
   )
-  const brokers: Broker[] = useMemo(
+  const brokers: BrokerWithAccounts[] = useMemo(
     () => brokersData?.data || [],
     [brokersData],
+  )
+
+  // Account assets (incl. broker settlement lines) — same source
+  // InvestCashDialog uses to resolve a broker's own cash line for commit
+  // (see resolveBrokerCashAssetId below). `Asset` is structurally
+  // compatible with that helper's expected shape (id/code/market.currency/
+  // accountingType.currency/priceSymbol) — verified against types/beancounter's
+  // Asset/Market/AccountingType/Currency, not just assumed.
+  const { data: accountAssetsData } = useSwr(
+    accountsKey,
+    simpleFetcher(accountsKey),
+  )
+  const accountAssets = useMemo(
+    () =>
+      accountAssetsData?.data
+        ? (Object.values(accountAssetsData.data) as Asset[])
+        : [],
+    [accountAssetsData],
   )
 
   // Convenience default: if the user has exactly one broker, pre-select it.
@@ -588,7 +608,12 @@ export function useRebalanceExecution(
     setHasChanges(true)
   }, [])
 
-  // Commit execution - create transactions
+  // Commit execution - create transactions. Routes settlement into the
+  // selected broker's own cash line (e.g. IBRK-USD) when resolvable —
+  // mirrors InvestCashDialog's resolution exactly (same brokers +
+  // accountAssets sources, see resolveBrokerCashAssetId) — otherwise omits
+  // cashAssetId so the backend falls back to the generic CASH/{currency}
+  // asset for the execution's currency.
   const handleCommit = useCallback(async (): Promise<
     | { portfolioId: string; transactionStatus: "PROPOSED" | "SETTLED" }
     | undefined
@@ -601,17 +626,27 @@ export function useRebalanceExecution(
     try {
       const portfolioId = execution.portfolioIds[0]
       const transactionStatus: TrnStatus = TRN_STATUS.PROPOSED
+      const cashAssetId =
+        resolveBrokerCashAssetId({
+          brokerId: selectedBrokerId,
+          currency: execution.currency,
+          brokers,
+          accountAssets,
+        }) ?? undefined
+
+      const commitRequest: CommitExecutionRequest = {
+        portfolioId,
+        transactionStatus,
+        brokerId: selectedBrokerId,
+        cashAssetId,
+      }
 
       const response = await fetch(
         `/api/rebalance/executions/${execution.id}/commit`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            portfolioId,
-            transactionStatus,
-            brokerId: selectedBrokerId,
-          }),
+          body: JSON.stringify(commitRequest),
         },
       )
 
@@ -631,7 +666,7 @@ export function useRebalanceExecution(
     } finally {
       setCommitting(false)
     }
-  }, [execution, selectedBrokerId])
+  }, [execution, selectedBrokerId, brokers, accountAssets])
 
   // --- Computed values ---
 

--- a/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
+++ b/src/pages/rebalance/models/[modelId]/plans/[planId].tsx
@@ -125,6 +125,7 @@ function PlanDetailPage(): React.ReactElement {
 
   const handleSave = async (): Promise<void> => {
     setSaving(true)
+    setActionError(null)
     try {
       const response = await fetch(
         `/api/rebalance/models/${modelId}/plans/${planId}`,
@@ -137,9 +138,15 @@ function PlanDetailPage(): React.ReactElement {
       if (response.ok) {
         mutate()
         setHasChanges(false)
+      } else {
+        const text = await response.text().catch(() => "")
+        setActionError(
+          `Save failed (${response.status})${text ? `: ${text}` : ""}`,
+        )
       }
     } catch (err) {
       console.error("Failed to save plan:", err)
+      setActionError("Save failed — please try again")
     } finally {
       setSaving(false)
     }

--- a/types/rebalance.d.ts
+++ b/types/rebalance.d.ts
@@ -20,6 +20,14 @@ export interface ModelDto {
   isOwner: boolean
   currentPlanId?: string
   currentPlanVersion?: number
+  /**
+   * Status of the plan `currentPlanId` points to ("DRAFT" | "APPROVED").
+   * `null`/absent on a stale cache predating this field (svc-rebalance #55)
+   * — callers gating on "has an approved plan" should treat that as
+   * approved (backend only ever points `currentPlanId` at an APPROVED plan
+   * today), not as a reason to hide the model.
+   */
+  currentPlanStatus?: ModelPlanStatus | null
   planCount: number
   createdAt: string
   updatedAt: string
@@ -250,6 +258,8 @@ export interface CreateExecutionRequest {
   filterByModel?: boolean
   /** Required for AD_HOC mode — the portfolio's report currency */
   currency?: string
+  /** How to distribute cash across items: TARGET_WEIGHT (default) or RETURN_ADJUSTED. INVEST_CASH mode uses this. */
+  allocationMethod?: AllocationMethod
 }
 
 export interface CommitExecutionRequest {
@@ -259,6 +269,8 @@ export interface CommitExecutionRequest {
   transactionStatus?: "PROPOSED" | "SETTLED"
   /** Optional cash asset ID for settlement (e.g., a brokerage account asset) */
   cashAssetId?: string
+  /** Broker tag applied to the created transactions */
+  brokerId?: string
 }
 
 export interface CommitExecutionResponse {
@@ -271,6 +283,8 @@ export interface CommitExecutionResponse {
 
 export interface UpdateExecutionRequest {
   name?: string
+  /** Cash to deploy/remove, applied on top of the execution's existing items */
+  cashDelta?: number
   itemUpdates?: ExecutionItemUpdate[]
 }
 
@@ -278,6 +292,10 @@ export interface ExecutionItemUpdate {
   assetId: string
   effectiveTargetOverride?: number
   excluded?: boolean
+  /** Explicit share quantity override (e.g. INVEST_CASH preview edits) */
+  quantity?: number
+  /** Explicit price override (e.g. INVEST_CASH preview edits) */
+  price?: number
 }
 
 export interface ExecutionApiResponse {


### PR DESCRIPTION
Closes #1157.

- **Broker settlement on the main commit path**: the execute screen now resolves `cashAssetId` via the same `resolveBrokerCashAssetId({brokerId, currency, brokers, accountAssets})` flow InvestCashDialog already used — broker-tagged trades settle into the broker's account instead of the generic currency cash asset. Omitted when no broker/no matching account (backend generic fallback is then correct).
- **Approved = status, not presence**: shared `isPlanApproved` predicate (strict: `currentPlanStatus === "APPROVED"`, with null/undefined treated as approved for pre-#55 backward compat, documented) used by `useApprovedModels` and both wizard sites. Bonus bug fixed: the wizard's `handleSubmit` branched on raw `currentPlanId`, so a DRAFT-plan model showed "Create Plan" yet still POSTed an execution. Unknown statuses (e.g. a future "ARCHIVED") are NOT approved — tested.
- **Silent failures surfaced**: SelectPlanDialog gets `Dialog.ErrorAlert` (message type-coerced), plan save reuses the page's existing `actionError` banner; both cleared on retry.
- **Type drift closed**: `CommitExecutionRequest.brokerId`, `ExecutionItemUpdate.quantity/price`, `CreateExecutionRequest.allocationMethod`, `UpdateExecutionRequest.cashDelta`; `ModelDto.currentPlanStatus: ModelPlanStatus | null`; both commit call sites + item updates typed; wizard's `RebalanceScenario→ExecutionMode` subset-luck assignment replaced with an exhaustive `Record` map.

Deliberately left: `handleApprove`/`handleImportFromPlan`/`handleCreateNewVersion` still swallow errors (issue scoped "plan save" only) — candidates for a follow-up.

268 suites / 2652 tests green; prettier/lint/typecheck clean; ocr findings (5, all low) applied. Component-tested, not browser-clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kWgaWpybSCajCzVQZdiPk